### PR TITLE
[NIFI-198] Prerequisites is not correctly checked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,13 @@
             <archive>http://mail-archives.apache.org/mod_mbox/incubator-nifi-commits</archive>
         </mailingList>
     </mailingLists>
+    <!--
+      ! This marked as deprecated for Maven 3.X. This is checked by maven-enforcer-plugin
+      ! http://jira.codehaus.org/browse/MNG-4840
+      ! http://jira.codehaus.org/browse/MNG-5297
+    -->
     <prerequisites>
-        <maven>${maven.min-version}</maven>
+      <maven>${maven.version}</maven>
     </prerequisites>
     <modules>
         <!--
@@ -80,6 +85,16 @@
         <url>https://issues.apache.org/jira/browse/NIFI</url>
     </issueManagement>
     <properties>
+        <!--
+          ! Configure the maven-compiler-plugin to use 1.7 for source/target.
+        -->
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <!--
+          ! Maven minimum version 3.0.5
+        -->
+        <maven.version>3.0.5</maven.version>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <org.slf4j.version>1.7.8</org.slf4j.version>
@@ -836,11 +851,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.2</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
                         <fork>true</fork>
                         <optimize>true</optimize>
-                        <encoding>UTF-8</encoding>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
                     </configuration>
@@ -928,6 +940,32 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>enforce-maven</id>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <requireSameVersions>
+                        <plugins>
+                          <plugin>org.apache.maven.plugins:maven-surefire-plugin</plugin>
+                          <plugin>org.apache.maven.plugins:maven-failsafe-plugin</plugin>
+                          <plugin>org.apache.maven.plugins:maven-surefire-report-plugin</plugin>
+                        </plugins>
+                      </requireSameVersions>
+                      <requireMavenVersion>
+                        <version>${maven.version}</version>
+                      </requireMavenVersion>
+                    </rules>    
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nar-maven-plugin</artifactId>


### PR DESCRIPTION
 Using maven-enforcer-plugin to check the correct maven version.
