### PR TITLE
NIFI-868 Configure advertised host name of Remote Process Group Input…

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -59,6 +59,7 @@ public class NiFiProperties extends Properties {
     public static final String SENSITIVE_PROPS_ALGORITHM = "nifi.sensitive.props.algorithm";
     public static final String SENSITIVE_PROPS_PROVIDER = "nifi.sensitive.props.provider";
     public static final String H2_URL_APPEND = "nifi.h2.url.append";
+    public static final String REMOTE_INPUT_HOST = "nifi.remote.input.socket.host";
     public static final String REMOTE_INPUT_PORT = "nifi.remote.input.socket.port";
     public static final String SITE_TO_SITE_SECURE = "nifi.remote.input.secure";
     public static final String TEMPLATE_DIRECTORY = "nifi.templates.directory";
@@ -364,6 +365,16 @@ public class NiFiProperties extends Properties {
 
     public String getAdministrativeYieldDuration() {
         return getProperty(ADMINISTRATIVE_YIELD_DURATION, DEFAULT_ADMINISTRATIVE_YIELD_DURATION);
+    }
+
+    /**
+     * The host name that will be given out to clients to connect to the Remote Input Port.
+     *
+     * @return the remote input host name or null if not configured
+     */
+    public String getRemoteInputHost() {
+        final String value = getProperty(REMOTE_INPUT_HOST);
+        return StringUtils.isBlank(value) ? null : value;
     }
 
     /**

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -549,6 +549,7 @@ These properties govern how this instance of NiFi communicates with remote insta
 
 |====
 |*Property*|*Description*
+|nifi.remote.input.socket.host|The host name that will be given out to clients to connect to this NiFi instance for Site-to-Site communication. By default, it is the value from InetAddress.getLocalHost().getHostName(). On UNIX-like operating systems, this is typically the output from the `hostname` command.
 |nifi.remote.input.socket.port|The remote input socket port for Site-to-Site communication. By default, it is blank, but it must have a value in order to use Remote Process Groups.
 |nifi.remote.input.secure|This indicates whether communication between this instance of NiFi and remote NiFi instances should be secure. By default, it is set to _true_. In order for secure site-to-site to work, many Security Properties (below) must also be configured.
 |====

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -95,6 +95,7 @@ nifi.components.status.repository.buffer.size=${nifi.components.status.repositor
 nifi.components.status.snapshot.frequency=${nifi.components.status.snapshot.frequency}
 
 # Site to Site properties
+nifi.remote.input.socket.host=
 nifi.remote.input.socket.port=
 nifi.remote.input.secure=true
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/socket/SocketFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/socket/SocketFlowFileServerProtocol.java
@@ -612,9 +612,15 @@ public class SocketFlowFileServerProtocol implements ServerProtocol {
 
         final NiFiProperties properties = NiFiProperties.getInstance();
 
+        String remoteInputHost = properties.getRemoteInputHost();
+        if (remoteInputHost == null) {
+            remoteInputHost = InetAddress.getLocalHost().getHostName();
+        }
+        logger.debug("{} Advertising Remote Input host name {}", this, peer);
+
         // we have only 1 peer: ourselves.
         dos.writeInt(1);
-        dos.writeUTF(InetAddress.getLocalHost().getHostName());
+        dos.writeUTF(remoteInputHost);
         dos.writeInt(properties.getRemoteInputPort());
         dos.writeBoolean(properties.isSiteToSiteSecure());
         dos.writeInt(0);    // doesn't matter how many FlowFiles we have, because we're the only host.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi.properties
@@ -67,6 +67,7 @@ nifi.components.status.snapshot.frequency=10 secs
 
 # Site to Site properties
 #For testing purposes. Default value should actually be empty!
+nifi.remote.input.socket.host=
 nifi.remote.input.socket.port=
 nifi.remote.input.secure=false
 


### PR DESCRIPTION
… Port

Before this change, the host given out to clients to connect to a Remote
Process Group Input Port is the host where the NiFi instance runs.
However, sometimes the binding host is different from the host that
clients connect to. For example, when a NiFi instance runs inside a
Docker container, a client on a separate machine must connect to the
Docker host which forwards the connection to the container.

Kafka addresses this situation by allowing a broker to configure the
host name given out to producers, consumers, and other brokers to connect to.
Implement something similar in NiFi. 

Add a configuration property to specify the host name to give out to
clients to connect to a Remote Process Group Input Port. If the property
is not configured, then give out the name of host running the NiFi
instance.