### PR TITLE
NIFI-604: Custom Argument Delimiters ExecuteStreamCommand / ExecuteProcess

### DIFF
--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -602,6 +602,34 @@ public class StandardValidators {
         }
     }
 
+    public static class StringLengthValidator implements Validator {
+        private final int minimum;
+        private final int maximum;
+
+        public StringLengthValidator(int minimum, int maximum) {
+            this.minimum = minimum;
+            this.maximum = maximum;
+        }
+
+        @Override
+        public ValidationResult validate(final String subject, final String value, final ValidationContext context) {
+            if (value.length() < minimum || value.length() > maximum) {
+                return new ValidationResult.Builder()
+                  .subject(subject)
+                  .valid(false)
+                  .input(value)
+                  .explanation(String.format("String length invalid [min: %d, max: %d]", minimum, maximum))
+                  .build();
+            } else {
+                return new ValidationResult.Builder()
+                  .valid(true)
+                  .input(value)
+                  .subject(subject)
+                  .build();
+            }
+        }
+    }
+
     public static class DirectoryExistsValidator implements Validator {
 
         private final boolean allowEL;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/ArgumentUtils.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/ArgumentUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ArgumentUtils {
+    private final static char QUOTE = '"';
+    private final static List<Character> DELIMITING_CHARACTERS = new ArrayList<>(3);
+
+    static {
+        DELIMITING_CHARACTERS.add('\t');
+        DELIMITING_CHARACTERS.add('\r');
+        DELIMITING_CHARACTERS.add('\n');
+    }
+
+    public static List<String> splitArgs(final String input, final char definedDelimiter) {
+        if (input == null) {
+            return Collections.emptyList();
+        }
+
+        final List<String> args = new ArrayList<>();
+
+        final String trimmed = input.trim();
+        boolean inQuotes = false;
+        final StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < trimmed.length(); i++) {
+            final char c = trimmed.charAt(i);
+
+            if (DELIMITING_CHARACTERS.contains(c) || c == definedDelimiter) {
+                if (inQuotes) {
+                    sb.append(c);
+                } else {
+                    final String arg = sb.toString().trim();
+                    if (!arg.isEmpty()) {
+                        args.add(arg);
+                    }
+                    sb.setLength(0);
+                }
+                continue;
+            }
+
+            if (c == QUOTE) {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            sb.append(c);
+        }
+
+        final String finalArg = sb.toString().trim();
+
+        if (!finalArg.isEmpty()) {
+            args.add(finalArg);
+        }
+
+        return args;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.standard.util.ArgumentUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -34,28 +35,28 @@ public class TestExecuteProcess {
 
     @Test
     public void testSplitArgs() {
-        final List<String> nullArgs = ExecuteProcess.splitArgs(null);
+        final List<String> nullArgs = ArgumentUtils.splitArgs(null, ' ');
         assertNotNull(nullArgs);
         assertTrue(nullArgs.isEmpty());
 
-        final List<String> zeroArgs = ExecuteProcess.splitArgs("  ");
+        final List<String> zeroArgs = ArgumentUtils.splitArgs("  ", ' ');
         assertNotNull(zeroArgs);
         assertTrue(zeroArgs.isEmpty());
 
-        final List<String> singleArg = ExecuteProcess.splitArgs("    hello   ");
+        final List<String> singleArg = ArgumentUtils.splitArgs("    hello   ", ' ');
         assertEquals(1, singleArg.size());
         assertEquals("hello", singleArg.get(0));
 
-        final List<String> twoArg = ExecuteProcess.splitArgs("   hello    good-bye   ");
+        final List<String> twoArg = ArgumentUtils.splitArgs("   hello    good-bye   ", ' ');
         assertEquals(2, twoArg.size());
         assertEquals("hello", twoArg.get(0));
         assertEquals("good-bye", twoArg.get(1));
 
-        final List<String> singleQuotedArg = ExecuteProcess.splitArgs("  \"hello\" ");
+        final List<String> singleQuotedArg = ArgumentUtils.splitArgs("  \"hello\" ", ' ');
         assertEquals(1, singleQuotedArg.size());
         assertEquals("hello", singleQuotedArg.get(0));
 
-        final List<String> twoQuotedArg = ExecuteProcess.splitArgs("   hello \"good   bye\"");
+        final List<String> twoQuotedArg = ArgumentUtils.splitArgs("   hello \"good   bye\"", ' ');
         assertEquals(2, twoQuotedArg.size());
         assertEquals("hello", twoQuotedArg.get(0));
         assertEquals("good   bye", twoQuotedArg.get(1));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteStreamCommand.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteStreamCommand.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.processors.standard;
 
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.standard.util.ArgumentUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -229,4 +231,24 @@ public class TestExecuteStreamCommand {
         assertTrue("NIFI_TEST_1 environment variable is missing", dynamicEnvironmentVariables.contains("NIFI_TEST_1=testvalue1"));
         assertTrue("NIFI_TEST_2 environment variable is missing", dynamicEnvironmentVariables.contains("NIFI_TEST_2=testvalue2"));
     }
+
+    @Test
+    public void testQuotedArguments() throws Exception {
+        List<String> args = ArgumentUtils.splitArgs("echo -n \"arg1 arg2 arg3\"", ' ');
+        assertEquals(3, args.size());
+        args = ArgumentUtils.splitArgs("echo;-n;\"arg1 arg2 arg3\"", ';');
+        assertEquals(3, args.size());
+    }
+
+    @Test
+    public void testInvalidDelimiter() throws Exception {
+        final TestRunner controller = TestRunners.newTestRunner(ExecuteStreamCommand.class);
+        controller.setProperty(ExecuteStreamCommand.EXECUTION_COMMAND, "echo");
+        controller.assertValid();
+        controller.setProperty(ExecuteStreamCommand.ARG_DELIMITER, "foo");
+        controller.assertNotValid();
+        controller.setProperty(ExecuteStreamCommand.ARG_DELIMITER, "f");
+        controller.assertValid();
+    }
+
 }


### PR DESCRIPTION
- Unified the way ExecuteStreamCommand and ExecuteProcess handle arguments. This enables
  the ExecuteStreamCommand to use semicolons as part of arguments. 

- Argument delimiters can now be specified. Their default being what they were using before (ExecuteStreamCommand -> ';' , ExecuteProcess -> ' ')


