### PR TITLE
New property (wrap as array) in avro2json converter

### DIFF
--- a/nifi-nar-bundles/nifi-avro-bundle/nifi-avro-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-avro-bundle/nifi-avro-processors/pom.xml
@@ -54,6 +54,10 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Create a new property (wrap as array) in ConvertAvroToJson, which determines how stream of records is exposed: either as a sequence of single Objects (false), writing every Object to a new line, or as an array of Objects. Default value is true, meaning that the Avro content is exposed as a sequence of root-level Object entries. False value is useful, when you want to write your records as single instances to a target component (e.g. Kafka).

Let's assume you have an Avro content as stream of records (record1, record2, ...). If wrap as array is false, the converter will expose the records as sequence of single JSON objects:
```
record1
record2
...
recordN
```
Please bear in mind, that the final output is not a valid JSON content. You can then forward this content e.g. to Kafka, where every record will be a single Kafka message.

If wrap as array is true, the output looks like this:
```
[record1,record2,...,recordN]
```
It is useful when you want to convert your Avro content to a valid JSON array.