### PR TITLE
NIFI-984: Bad class used for logging in TestDetectDuplicate

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectDuplicate.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectDuplicate.java
@@ -52,7 +52,7 @@ public class TestDetectDuplicate {
         System.setProperty("org.slf4j.simpleLogger.log.nifi.io.nio", "debug");
         System.setProperty("org.slf4j.simpleLogger.log.nifi.processors.standard.DetectDuplicate", "debug");
         System.setProperty("org.slf4j.simpleLogger.log.nifi.processors.standard.TestDetectDuplicate", "debug");
-        LOGGER = LoggerFactory.getLogger(TestListenUDP.class);
+        LOGGER = LoggerFactory.getLogger(TestDetectDuplicate.class);
     }
 
     @Test


### PR DESCRIPTION
Using TestListenUDP instead of TestDetectDuplicate when creating the logger.