### PR TITLE
NIFI-985: Custom log prefix for LogAttribute processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
@@ -45,6 +45,8 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.Strings;
+import org.eclipse.jetty.util.StringUtil;
 
 @EventDriven
 @SideEffectFree
@@ -132,16 +134,26 @@ public class LogAttribute extends AbstractProcessor {
     protected String processFlowFile(final ProcessorLog logger, final DebugLevels logLevel, final FlowFile flowFile, final ProcessSession session, final ProcessContext context) {
         final Set<String> attributeKeys = getAttributesToLog(flowFile.getAttributes().keySet(), context);
         final ProcessorLog LOG = getLogger();
+        final String dashedLine;
+
         String logPrefix = context.getProperty(LOG_PREFIX).getValue();
+
+        if (StringUtil.isBlank(logPrefix)) {
+            dashedLine = StringUtils.repeat('-', 50);
+        } else {
+            // abbreviate long lines
+            logPrefix = StringUtils.abbreviate(logPrefix, 40);
+            // center the logPrefix and pad with dashes
+            logPrefix = StringUtils.center(logPrefix, 40, '-');
+            // five dashes on the left and right side, plus the dashed logPrefix
+            dashedLine = StringUtils.repeat('-', 5) + logPrefix + StringUtils.repeat('-', 5);
+        }
+
         // Pretty print metadata
         final StringBuilder message = new StringBuilder();
         message.append("logging for flow file ").append(flowFile);
         message.append("\n");
-        if (logPrefix != null) {
-            message.append(logPrefix);
-            message.append(" ");
-        }
-        message.append(FIFTY_DASHES);
+        message.append(dashedLine);
         message.append("\nStandard FlowFile Attributes");
         message.append(String.format("\nKey: '%1$s'\n\tValue: '%2$s'", "entryDate", new Date(flowFile.getEntryDate())));
         message.append(String.format("\nKey: '%1$s'\n\tValue: '%2$s'", "lineageStartDate", new Date(flowFile.getLineageStartDate())));
@@ -151,11 +163,7 @@ public class LogAttribute extends AbstractProcessor {
             message.append(String.format("\nKey: '%1$s'\n\tValue: '%2$s'", key, flowFile.getAttribute(key)));
         }
         message.append("\n");
-        if (logPrefix != null) {
-            message.append(logPrefix);
-            message.append(" ");
-        }
-        message.append(FIFTY_DASHES);
+        message.append(dashedLine);
 
         // The user can request to log the payload
         final boolean logPayload = context.getProperty(LOG_PAYLOAD).asBoolean();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
@@ -135,7 +135,7 @@ public class LogAttribute extends AbstractProcessor {
         final ProcessorLog LOG = getLogger();
         final String dashedLine;
 
-        String logPrefix = context.getProperty(LOG_PREFIX).getValue();
+        String logPrefix = context.getProperty(LOG_PREFIX).evaluateAttributeExpressions().getValue();
 
         if (StringUtil.isBlank(logPrefix)) {
             dashedLine = StringUtils.repeat('-', 50);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
@@ -135,7 +135,7 @@ public class LogAttribute extends AbstractProcessor {
         final ProcessorLog LOG = getLogger();
         final String dashedLine;
 
-        String logPrefix = context.getProperty(LOG_PREFIX).evaluateAttributeExpressions().getValue();
+        String logPrefix = context.getProperty(LOG_PREFIX).evaluateAttributeExpressions(flowFile).getValue();
 
         if (StringUtil.isBlank(logPrefix)) {
             dashedLine = StringUtils.repeat('-', 50);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
@@ -84,6 +84,7 @@ public class LogAttribute extends AbstractProcessor {
             .required(false)
             .description("Log prefix appended to the log lines. It helps to distinguish the output of multiple LogAttribute processors.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(true)
             .build();
 
     public static final String FIFTY_DASHES = "--------------------------------------------------";

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
@@ -45,7 +45,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.util.Strings;
 import org.eclipse.jetty.util.StringUtil;
 
 @EventDriven


### PR DESCRIPTION
When you have a data flow with a bunch of LogAttribute processors it is really hard to identify the right LogAttribute processor in the log file and distinguish the output of different LogAttribute processors.

There is a new property, called log prefix, which helps the user to set a custom log prefix for each Log Attribute processor, which will appear in the log output of the processor. Log prefix appears in the first and the last log line,  padded with dashes to keep the line 50 characters long. If you configure log prefix ' STEP 1:  ' the log output looks like this:
```
--------------------- STEP 1 ---------------------
Standard FlowFile Attributes
Key: 'entryDate'
        Value: 'Tue Sep 22 20:43:38 CEST 2015'
Key: 'lineageStartDate'
        Value: 'Tue Sep 22 20:43:38 CEST 2015'
Key: 'fileSize'
        Value: '48'
FlowFile Attribute Map Content
Key: 'customKey'
        Value: 'custom value'
--------------------- STEP 1 ---------------------
flow file content
```
The following screen shot shows the configuration and the output of the processor:
![nifi_log_prefix_updated](https://cloud.githubusercontent.com/assets/1064211/10028211/66e3f732-616b-11e5-8369-29854a9ae937.png)
