### PR TITLE
NIFI-989: Support size() operation in distributed map cache

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/ExtendedDistributedMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/ExtendedDistributedMapCacheClient.java
@@ -14,24 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.distributed.cache.server.map;
+
+package org.apache.nifi.distributed.cache.client;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
-public interface MapCache {
+/**
+ * This interface defines an extended API that can be used for interacting with a
+ * Distributed Cache that functions similarly to a {@link java.util.Map Map}.
+ *
+ */
+public interface ExtendedDistributedMapCacheClient extends DistributedMapCacheClient {
 
-    MapPutResult putIfAbsent(ByteBuffer key, ByteBuffer value) throws IOException;
+    /**
+     * Returns the number of entries in this map.
+     *
+     * @return The number of entries in this map.
+     * @throws IOException if unable to communicate with the remote instance
+     */
+    int size() throws IOException;;
 
-    MapPutResult put(ByteBuffer key, ByteBuffer value) throws IOException;
-
-    boolean containsKey(ByteBuffer key) throws IOException;
-
-    ByteBuffer get(ByteBuffer key) throws IOException;
-
-    int size() throws IOException;
-
-    ByteBuffer remove(ByteBuffer key) throws IOException;
-
-    void shutdown() throws IOException;
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheServer.java
@@ -110,6 +110,11 @@ public class MapCacheServer extends AbstractCacheServer {
 
                 break;
             }
+            case "size": {
+                final int size = cache.size();
+                dos.writeInt(size);
+                break;
+            }
             case "remove": {
                 final byte[] key = readValue(dis);
                 final boolean removed = cache.remove(ByteBuffer.wrap(key)) != null;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
@@ -113,6 +113,11 @@ public class PersistentMapCache implements MapCache {
     }
 
     @Override
+    public int size() throws IOException {
+        return wrapped.size();
+    }
+
+    @Override
     public ByteBuffer remove(final ByteBuffer key) throws IOException {
         final ByteBuffer removeResult = wrapped.remove(key);
         if (removeResult != null) {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
@@ -168,6 +168,17 @@ public class SimpleMapCache implements MapCache {
     }
 
     @Override
+    public int size() {
+        readLock.lock();
+        try {
+            int size = cache.size();
+            return size;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
     public ByteBuffer remove(ByteBuffer key) throws IOException {
         writeLock.lock();
         try {


### PR DESCRIPTION
The distributed map cache server is a great tool for caching along with the cache client (DistributedMapCacheClientService), but after you configure and enable it, it is a black box. You are unable to get any information from the cache e.g how much entries live in the cache.

The purpose of this PR to create an extended cache interface and associated implementations to support the size() operation, which returns the number of entries in the distributed cache.

It could be a first step in a direction of a more transparent cache, where the user can understand, what happens with the distributed cache. I mean after the size() operation, it could be really helpful to implement a stats() command, which s used to query the server about statistics it
maintains and other internal data (e.g. evictions, hit rates, ...).

Similar to:
- memcached : https://docs.oracle.com/cd/E17952_01/refman-5.0-en/ha-memcached-stats-general.html
- couchbase: http://blog.couchbase.com/monitoring-couchbase-cluster
- redis: http://haydenjames.io/using-redis-stat-for-redis-statistics-tracking/

I implemented a really simple command line tool, which can interact with the cache server from the command line, e.g. get a cache entry and it also able to get the size of the cache, which could be useful, when you would like to debug cache related problems, or just get basic interaction with the cache.
