### PR TITLE
NIFI-1016: Use centralized priority attribute name in PriorityAttributePrioritizer

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-prioritizers/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-prioritizers/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <scope>test</scope>
         </dependency>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizer.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.FlowFilePrioritizer;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
 
 /**
  * This prioritizer checks each FlowFile for a "priority" attribute and lets
@@ -33,8 +34,6 @@ import org.apache.nifi.flowfile.FlowFilePrioritizer;
  */
 public class PriorityAttributePrioritizer implements FlowFilePrioritizer {
 
-    public static final String PRIORITY_ATTR = "priority";
-
     private static final Pattern intPattern = Pattern.compile("-?\\d+");
 
     @Override
@@ -47,8 +46,8 @@ public class PriorityAttributePrioritizer implements FlowFilePrioritizer {
             return 1;
         }
 
-        String o1Priority = o1.getAttribute(PRIORITY_ATTR);
-        String o2Priority = o2.getAttribute(PRIORITY_ATTR);
+        String o1Priority = o1.getAttribute(CoreAttributes.PRIORITY.key());
+        String o2Priority = o2.getAttribute(CoreAttributes.PRIORITY.key());
         if (o1Priority == null && o2Priority == null) {
             return -1; // this is not 0 to match FirstInFirstOut
         } else if (o2Priority == null) {


### PR DESCRIPTION
There is a special enum, `CoreAttributes`, containing the core attribute names of a flow file, like `uuid`,`path` and `priority`. This enum is used by tons of other Java classes, and this issue suggests to use `CoreAttributes.PRIORITY` in `PriorityAttributePrioritizer`, instead of a local static String to avoid duplicates and possible misconceptions, or renames.

