### PR TITLE
NIFI-1021 added support for Provenance event streaming

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/provenance/AbstractProvenanceRepository.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/AbstractProvenanceRepository.java
@@ -1,0 +1,129 @@
+package org.apache.nifi.provenance;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base implementation of ProvenanceEventRepository.
+ * Handles common operations
+ */
+public abstract class AbstractProvenanceRepository implements ProvenanceEventRepository {
+	
+	private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+	
+	private final List<ProvenanceEventSubscriber> eventSubscribers;
+	
+	/**
+	 * 
+	 */
+	public AbstractProvenanceRepository(){
+		List<ProvenanceEventConsumer> eventConsumers = this.discoverAndLoadConsumers();
+		if (eventConsumers != null){
+			this.eventSubscribers = new ArrayList<>();	
+			for (ProvenanceEventConsumer provenanceEventConsumer : eventConsumers) {
+				ProvenanceEventSubscriber eventSubscriber = new ProvenanceEventSubscriber(provenanceEventConsumer);
+				eventSubscriber.start();
+				this.eventSubscribers.add(eventSubscriber);
+			}
+		}
+		else {
+			// no need to create one if there are no consumers
+			this.eventSubscribers = null;
+		}
+	}
+
+	/**
+	 * 
+	 */
+	@Override
+	public void registerEvent(ProvenanceEventRecord event) {
+		if (this.eventSubscribers != null){
+			for (ProvenanceEventSubscriber eventSubscriber : this.eventSubscribers) {
+				eventSubscriber.receive(event);
+			}
+		}
+		this.doRegisterEvent(event);
+	}
+	
+	@Override
+	public void registerEvents(Iterable<ProvenanceEventRecord> events) {
+		if (this.eventSubscribers != null){
+			events = this.toReusableIterable(events);
+			for (ProvenanceEventSubscriber eventSubscriber : this.eventSubscribers) {
+				for (ProvenanceEventRecord event : events) {
+					eventSubscriber.receive(event);
+				}
+			}
+		}
+		/*
+		 * This is primarily to support current implementation of PersistentProvenanceRepository
+		 * which calls private persistRecord(..) which accepts collection, so delegating
+		 * to doRegisterEvent(singular) wouldn't be efficient since it creates a single entry 
+		 * collection for each event.
+		 */
+		this.doRegisterEvents(events);
+	}
+	
+	/**
+	 * 
+	 */
+	public void close() throws IOException {
+		if (this.eventSubscribers != null){
+			for (ProvenanceEventSubscriber eventSubscriber : this.eventSubscribers) {
+				eventSubscriber.stop();
+			}
+		}
+		
+		this.doClose();
+	}
+	
+	/**
+	 * 
+	 */
+	protected abstract void doRegisterEvent(ProvenanceEventRecord event);
+	
+	/**
+	 * 
+	 */
+	protected abstract void doRegisterEvents(Iterable<ProvenanceEventRecord> events);
+	
+	/**
+	 * 
+	 */
+	protected abstract void doClose() throws IOException;
+	
+	/**
+	 * Will discover all available {@link ProvenanceEventConsumer}s
+	 */
+	private List<ProvenanceEventConsumer> discoverAndLoadConsumers(){
+		List<ProvenanceEventConsumer> eventConsumers = null;
+		Iterator<ProvenanceEventConsumer> sl = ServiceLoader
+	            .load(ProvenanceEventConsumer.class, ClassLoader.getSystemClassLoader()).iterator();
+		if (sl.hasNext()){
+			eventConsumers = new ArrayList<>();
+			while (sl.hasNext()){
+				ProvenanceEventConsumer consumer = sl.next();
+				logger.info("Registering provenance event consumer - " + consumer);
+				eventConsumers.add(consumer);
+			}
+		}
+		return eventConsumers;
+	}
+	
+	/**
+	 * Will produce an {@link Iterable} that can be iterated more then once.
+	 */
+	private Iterable<ProvenanceEventRecord> toReusableIterable(Iterable<ProvenanceEventRecord> events) {
+		List<ProvenanceEventRecord> eventList = new ArrayList<>();
+		for (ProvenanceEventRecord provenanceEventRecord : events) {
+			eventList.add(provenanceEventRecord);
+		}
+		return eventList;
+	}
+}

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventConsumer.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventConsumer.java
@@ -1,0 +1,16 @@
+package org.apache.nifi.provenance;
+
+/**
+ * Strategy for implementing generic consumers.
+ *
+ * @param <T> the type of elements to consume.
+ */
+public interface ProvenanceEventConsumer {
+
+	/**
+	 * Consumes provided element
+	 *
+	 * @param element element of type T to be consumed
+	 */
+	void consume(ProvenanceEventRecord event);
+}

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventSubscriber.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventSubscriber.java
@@ -1,0 +1,131 @@
+package org.apache.nifi.provenance;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A generic subscriber which implements a direct-handoff message
+ * passing interface (MPI) by asynchronously handing off events received from
+ * the event stream to a provided consumer.<br>
+ * <br>
+ * Unlike conventional direct-handoff MPI, this implementation will never
+ * block while receiving events, since it relies on {@link WeakReferenceRingBuffer} which 
+ * will overflow onto itself in cases where consumer is not able to keep up with the 
+ * rate of incoming events resulting in event loss. This means that event streaming 
+ * should be used for specialized use cases only where event loss is either acceptable 
+ * or consumer implements appropriate safe-guards to ensure that buffer doesn't overflow.
+ * <br>
+ * While this implementation does not prevent event loss it does provide safe-guards
+ * to ensure sequential correctness and no-duplicates. See {@link WeakReferenceRingBuffer} 
+ * documentation for more details.
+ *
+ */
+final class ProvenanceEventSubscriber {
+	
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	private final ExecutorService executor;
+
+	private final WeakReferenceRingBuffer<ProvenanceEventRecord> eventBuffer;
+
+	private final ProvenanceEventConsumer consumer;
+	
+	private volatile boolean running;
+
+	/**
+	 * Constructs an instance of the subscriber with a provided {@link ProvenanceEventConsumer}.
+	 */
+	ProvenanceEventSubscriber(ProvenanceEventConsumer consumer) {
+		this.executor = new ThreadPoolExecutor(1, 1,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(1));
+		this.consumer = consumer;
+		this.eventBuffer = new WeakReferenceRingBuffer<>(1024);
+	}
+	
+	/**
+	 * Starts this subscriber by setting its state to running and initiating 
+	 * consumer task.
+	 */
+	void start(){
+		if (!this.running){
+			this.running = true;
+			this.executor.execute(new Runnable() {	
+				@Override
+				public void run() {
+					try {
+						while (running){
+							consumer.consume(eventBuffer.next());
+						}
+					} catch (Exception e) {
+						logger.error("Consumer threw exception, subscriber will be stopped", e);
+						asyncStop();
+					}
+				}
+			});
+		} else {
+			logger.warn("Subscriber is already running");
+		}
+	}
+	
+	/**
+	 * Will stop this subscriber. Subsequent calls to this method 
+	 * will have no effect if this subscriber is already stopped.
+	 */
+	void stop(){
+		if (this.running){
+			this.running = false;
+			this.executor.shutdown();
+			try {
+				this.executor.awaitTermination(100, TimeUnit.MILLISECONDS);
+			} 
+			catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+				logger.warn("Interrupted while shutting down executor");
+			}
+		}
+	}
+	
+	/**
+	 * 
+	 * @return
+	 */
+	boolean isStopped(){
+		return !this.running;
+	}
+	
+	/**
+	 * Receives events from the event stream and places them on the event buffer.
+	 */
+	final void receive(ProvenanceEventRecord event) {
+		try {
+			if (this.running){
+				this.eventBuffer.add(event);
+			}
+			else {
+				logger.warn("Subscriber is not started");
+			}
+		} catch (Exception e) {
+			// realistically should never happen, yet if it does must not shut down NiFi 
+			logger.error("Subscriber threw exception and will be stopped.", e);
+			this.asyncStop();
+		}
+	}
+	
+	/**
+	 * 
+	 */
+	private void asyncStop(){
+		new Thread(new Runnable() {
+			@Override
+			public void run() {
+				stop();
+			}
+		}).start();
+	}
+}

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/WeakReferenceRingBuffer.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/WeakReferenceRingBuffer.java
@@ -1,0 +1,118 @@
+package org.apache.nifi.provenance;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+/**
+ * A non-blocking buffer that it will never block on the add(..) call 
+ * essentially overflowing on itself by overriding values which may not 
+ * have been retrieved yet. <br>
+ * For example:<br>
+ * Assume at certain state buffer looks like this - [1, 2, 3, 4]
+ * The consuming thread managed to retrieve [1, 2]. And while processing [2]
+ * the subscriber added [5, 6], making the buffer look like this [5, 6, 3, 4].
+ * If consumer is capable to keep up, it will continue with [3, 4] and then [5, 6]. 
+ * However if by the time consumer had finished processing [2], the subscriber 
+ * added [7, 8], the next value seen by the consumer will be [5] and so on.
+ * <br> 
+ * This buffer implementation also ensures that newest events are not followed by 
+ * older events. <br>
+ * For example, assume before consumer was able to retrieve the first event the buffer 
+ * state is [5, 6, 3, 4]. On the first attempt to access the buffer the consumer will 
+ * get [3] and [4] followed by [5] and [6], thus ensuring the sequential ordering.
+ *
+ * @param <T>
+ */
+final class WeakReferenceRingBuffer<T> {
+
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	private final T[] buffer;
+
+	private final int mask;
+
+	private volatile int writeCounter;
+
+	private volatile int readCounter;
+
+	private final ReadWriteLock lock = new ReentrantReadWriteLock();
+	
+	private final Semaphore readPermits;
+
+	/**
+	 * 
+	 * @param size
+	 */
+	@SuppressWarnings("unchecked")
+	public WeakReferenceRingBuffer(int size) {
+		if (!(size > 1 && ((size & (size - 1)) == 0))) {
+			throw new IllegalArgumentException("'size' must be > 1 and power of 2; was " + size);
+		}
+
+		this.buffer = (T[]) new Object[size];
+		this.mask = size - 1;
+		this.readPermits = new Semaphore(size);
+		this.readPermits.tryAcquire(size);
+	}
+
+	/**
+	 * 
+	 * @param object
+	 */
+	public void add(T reference) {
+		try {
+			this.lock.writeLock().lockInterruptibly();
+			try {
+				this.buffer[this.writeCounter++ & this.mask] = reference;
+				this.readPermits.release();
+			} catch (Exception e) {
+				logger.error("Failure while adding value to buffer", e);
+			} finally {
+				this.lock.writeLock().unlock();
+			}
+		} catch (InterruptedException e) {
+			logger.warn("Current thread is interrupted", e);
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	/**
+	 * Retrieves and removes the head of this queue. 
+	 *
+	 * @return the head of this queue
+	 * @throws NoSuchElementException
+	 *             if this queue is empty
+	 */
+	public T next() {
+		T result = null;
+		try {
+			this.readPermits.acquire();
+			this.lock.readLock().lockInterruptibly();
+			try {
+				if (this.readCounter < this.writeCounter) {
+					int diff = this.writeCounter - this.readCounter;
+					if (diff > this.buffer.length) {
+						this.readCounter += (diff - this.buffer.length);
+					}
+					result = this.buffer[this.readCounter & this.mask];
+				}
+			} catch (Exception e) {
+				logger.error("Failure while retrieving value from the buffer", e);
+			} finally {
+				this.lock.readLock().unlock();
+			}
+		} catch (InterruptedException e) {
+			logger.warn("Current thread is interrupted", e);
+			Thread.currentThread().interrupt();
+		}
+
+		if (result != null) {
+			this.readCounter++;
+		}
+
+		return result;
+	}
+}

--- a/nifi-api/src/test/java/org/apache/nifi/provenance/ProvenanceEventSubscriberTests.java
+++ b/nifi-api/src/test/java/org/apache/nifi/provenance/ProvenanceEventSubscriberTests.java
@@ -1,0 +1,163 @@
+package org.apache.nifi.provenance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ProvenanceEventSubscriberTests {
+	
+	private final AtomicInteger counter = new AtomicInteger();
+	
+	private final Random random = new Random();
+
+	
+	@Test
+	/**
+	 * This test validates that events are not distributed to the consumer if subscriber is 
+	 * not started or stopped.
+	 * It also validates that while subscriber may end up to be in invalid state (not started or stopped) 
+	 * it will not bring NiFi to its knees.
+	 */
+	public void testNonStartedOrSoppedSubscriberWontThrowException() throws Exception {
+		ProvenanceEventSubscriber subscriber = new ProvenanceEventSubscriber(new TestFastConsumer());
+		ProvenanceEventRecord event = Mockito.mock(ProvenanceEventRecord.class);
+		for (int i = 0; i < 4; i++) {
+			subscriber.receive(event);
+		}
+		Thread.sleep(10); // give some time for consumer to process what's there for testing purposes
+		assertEquals(0, counter.get());
+		subscriber.stop();
+		for (int i = 0; i < 4; i++) {
+			subscriber.receive(event);
+		}
+		assertEquals(0, counter.get());
+	}
+	
+	@Test
+	public void testAllEventsConsumedIfLessThenBufferSize() throws Exception {// 1024 buffer size
+		ProvenanceEventSubscriber subscriber = new ProvenanceEventSubscriber(new TestFastConsumer());
+		subscriber.start();
+		ProvenanceEventRecord event = Mockito.mock(ProvenanceEventRecord.class);
+		for (int i = 0; i < 1024; i++) {
+			subscriber.receive(event);
+		}
+		Thread.sleep(10); // give some time for consumer to process what's there for testing purposes
+		assertEquals(1024, counter.get());
+	}
+	
+	@Test
+	/**
+	 * Validates that any exception thrown by the consumer will simply stop the subscriber 
+	 * without halting the NiFi. Preferably, consumer exceptions have to be handled within
+	 * the consumers themselves. 
+	 */
+	public void testExceptionThrowingConsumer() throws Exception {
+		ProvenanceEventSubscriber subscriber = new ProvenanceEventSubscriber(new TestExceptionThrowingConsumer());
+		subscriber.start();
+		ProvenanceEventRecord event = Mockito.mock(ProvenanceEventRecord.class);
+		for (int i = 0; i < 20; i++) {
+			subscriber.receive(event);
+		}
+		Thread.sleep(10); // give some time for consumer to process what's there for testing purposes
+		assertEquals(11, counter.get());
+		assertTrue(subscriber.isStopped());
+	}
+	
+	@Test
+	/**
+	 * Should never happen, but still worth checking
+	 */
+	public void testExceptionThrowingSubscriber() throws Exception {
+		ProvenanceEventSubscriber subscriber = new ProvenanceEventSubscriber(new TestFastConsumer());
+		Field eventBufferField = ProvenanceEventSubscriber.class.getDeclaredField("eventBuffer");
+		eventBufferField.setAccessible(true);
+		subscriber.start();
+		ProvenanceEventRecord event = Mockito.mock(ProvenanceEventRecord.class);
+		for (int i = 0; i < 20; i++) {
+			subscriber.receive(event);
+			if (i == 10){
+				eventBufferField.set(subscriber, null);// will force NPE on the next iteration
+			}
+		}
+		Thread.sleep(10); // give some time for consumer to process what's there for testing purposes
+		assertEquals(11, counter.get());
+		assertTrue(subscriber.isStopped());
+	}
+	
+	@Test
+	/**
+	 * This test demonstrates the ability of the subscriber to distribute ~2M events in under 1 second
+	 * to the consumer which can also process them (providing relatively simple processing logic)
+	 * without any event loss (an equally fast consumer). 
+	 * 
+	 * This test may not perform if executed on ancient hardware.
+	 */
+	public void testHighThroughputWithDefaultBufferSize() throws Exception {
+		ProvenanceEventSubscriber subscriber = new ProvenanceEventSubscriber(new TestFastConsumer());
+		subscriber.start();
+		ProvenanceEventRecord event = Mockito.mock(ProvenanceEventRecord.class);
+		int eventsToConsume = 2000000;
+		long start = System.currentTimeMillis();
+		for (int i = 0; i < eventsToConsume; i++) {
+			subscriber.receive(event);
+		}
+		long stop = System.currentTimeMillis();
+		System.out.println("Distributed " + eventsToConsume + " in " + (stop-start) + " millis");
+		assertTrue((stop-start) < 1000);
+		Thread.sleep(100);
+		assertEquals(eventsToConsume, counter.get());
+	}
+	
+	@Test
+	/**
+	 * This test is primarily to validate that the speed of event distribution will
+	 * not be affected by the speed of event consumption.
+	 */
+	public void testSlowConsumer() throws Exception {
+		ProvenanceEventSubscriber subscriber = new ProvenanceEventSubscriber(new TestSlowConsumer());
+		subscriber.start();
+		ProvenanceEventRecord event = Mockito.mock(ProvenanceEventRecord.class);
+		int eventsToConsume = 2000000;
+		long start = System.currentTimeMillis();
+		for (int i = 0; i < eventsToConsume; i++) {
+			subscriber.receive(event);
+		}
+		long stop = System.currentTimeMillis();
+		System.out.println("Distributed " + eventsToConsume + " in " + (stop-start) + " millis");
+		assertTrue((stop-start) < 1000);
+		Thread.sleep(100);
+		assertTrue(counter.get() < eventsToConsume); // events were lost
+	}
+	
+	private class TestFastConsumer implements ProvenanceEventConsumer {
+		@Override
+		public void consume(ProvenanceEventRecord event) {
+			counter.incrementAndGet();
+		}
+	}
+	
+	private class TestSlowConsumer implements ProvenanceEventConsumer {
+		@Override
+		public void consume(ProvenanceEventRecord event) {
+			counter.incrementAndGet();
+			LockSupport.parkNanos(random.nextInt(100));
+		}
+	}
+	
+	private class TestExceptionThrowingConsumer implements ProvenanceEventConsumer {
+		@Override
+		public void consume(ProvenanceEventRecord event) {
+			counter.incrementAndGet();
+			if (counter.get() > 10){
+				throw new RuntimeException("Intentional for testing");
+			}
+		}
+	}
+}

--- a/nifi-api/src/test/java/org/apache/nifi/provenance/WeakReferenceRingBufferTests.java
+++ b/nifi-api/src/test/java/org/apache/nifi/provenance/WeakReferenceRingBufferTests.java
@@ -1,0 +1,98 @@
+package org.apache.nifi.provenance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class WeakReferenceRingBufferTests {
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testBoundGreaterThenOneAndPowerOfTwo(){
+		new WeakReferenceRingBuffer<>(3);
+	}
+	
+	@Test
+	public void testWillNotBlockWhenOverCapacity(){
+		WeakReferenceRingBuffer<Integer> queue = new WeakReferenceRingBuffer<>(2);
+		for (int i = 0; i < 10; i++) {
+			queue.add(i);
+		}
+		// last two should be 8, 9 and then null
+		assertEquals(new Integer(8), queue.next());
+		assertEquals(new Integer(9), queue.next());
+		assertNull(queue.next());
+	}
+	
+	@Test
+	public void testSequenceOrderingAfterOverflow(){
+		WeakReferenceRingBuffer<Integer> queue = new WeakReferenceRingBuffer<>(4);
+		for (int i = 0; i < 6; i++) {
+			queue.add(i);
+		}
+		
+		assertEquals(new Integer(2), queue.next());
+		assertEquals(new Integer(3), queue.next());
+		assertEquals(new Integer(4), queue.next());
+		assertEquals(new Integer(5), queue.next());
+		assertNull(queue.next());
+	}
+	
+	@Test
+	public void testNoDuplicatesWithAsyncRetrievalSmallBuffer() throws Exception {
+		this.testNoDuplicatesWithAsyncRetrieval(256);
+	}
+	
+	@Test
+	public void testNoDuplicatesWithAsyncRetrievalLargeBuffer() throws Exception {
+		this.testNoDuplicatesWithAsyncRetrieval(524288);
+	}
+	
+	public void testNoDuplicatesWithAsyncRetrieval(int bufferSize) throws Exception {
+		final WeakReferenceRingBuffer<Integer> queue = new WeakReferenceRingBuffer<>(262144);
+		final ArrayList<Integer> values = new ArrayList<>();
+		ExecutorService exe = Executors.newSingleThreadExecutor();
+		final AtomicBoolean continueRead = new AtomicBoolean(true);
+		exe.execute(new Runnable() {
+			@Override
+			public void run() {
+				while (continueRead.get()){
+					Integer value = queue.next();
+					if (value != null){
+						values.add(value);
+					}
+				}
+			}
+		});
+		int eventsToProduce = 3000000;
+		long start = System.currentTimeMillis();
+		for (int i = 0; i < eventsToProduce; i++) {
+			queue.add(i);
+		}
+		long stop = System.currentTimeMillis();
+		System.out.println("Added " + eventsToProduce + " events in " + (stop-start) + " millis");
+		continueRead.set(false);
+		exe.shutdown();
+		if (exe.awaitTermination(1000, TimeUnit.MILLISECONDS)){
+			int lastValue = -1;
+			for (Integer integer : values) {
+				if (integer > lastValue){
+					lastValue = integer;
+				}
+				else {
+					fail();
+				}
+			}
+		}
+		else {
+			fail();
+		}
+	}
+}

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/PersistentProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/PersistentProvenanceRepository.java
@@ -102,7 +102,7 @@ import org.apache.nifi.util.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PersistentProvenanceRepository implements ProvenanceEventRepository {
+public class PersistentProvenanceRepository extends AbstractProvenanceRepository {
 
     public static final String DEPRECATED_CLASS_NAME = "nifi.controller.repository.provenance.PersistentProvenanceRepository";
     public static final String EVENT_CATEGORY = "Provenance Repository";
@@ -381,12 +381,12 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
     }
 
     @Override
-    public void registerEvent(final ProvenanceEventRecord event) {
+    protected void doRegisterEvent(final ProvenanceEventRecord event) {
         persistRecord(Collections.singleton(event));
     }
 
     @Override
-    public void registerEvents(final Iterable<ProvenanceEventRecord> events) {
+    protected void doRegisterEvents(final Iterable<ProvenanceEventRecord> events) {
         persistRecord(events);
     }
 
@@ -629,7 +629,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    protected synchronized void doClose() throws IOException {
         this.closed.set(true);
         writeLock.lock();
         try {

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
@@ -56,7 +56,7 @@ import org.apache.nifi.util.RingBuffer.Filter;
 import org.apache.nifi.util.RingBuffer.ForEachEvaluator;
 import org.apache.nifi.util.RingBuffer.IterationDirection;
 
-public class VolatileProvenanceRepository implements ProvenanceEventRepository {
+public class VolatileProvenanceRepository extends AbstractProvenanceRepository {
 
     // properties
     public static final String BUFFER_SIZE = "nifi.provenance.repository.buffer.size";
@@ -117,15 +117,15 @@ public class VolatileProvenanceRepository implements ProvenanceEventRepository {
     }
 
     @Override
-    public void registerEvent(final ProvenanceEventRecord event) {
+    protected void doRegisterEvent(final ProvenanceEventRecord event) {
         final long id = idGenerator.getAndIncrement();
         ringBuffer.add(new IdEnrichedProvEvent(event, id));
     }
 
     @Override
-    public void registerEvents(final Iterable<ProvenanceEventRecord> events) {
+    protected void doRegisterEvents(final Iterable<ProvenanceEventRecord> events) {
         for (final ProvenanceEventRecord event : events) {
-            registerEvent(event);
+            doRegisterEvent(event);
         }
     }
 
@@ -168,7 +168,7 @@ public class VolatileProvenanceRepository implements ProvenanceEventRepository {
     }
 
     @Override
-    public void close() throws IOException {
+    protected void doClose() throws IOException {
         queryExecService.shutdownNow();
         scheduledExecService.shutdown();
     }


### PR DESCRIPTION
SUMMARY:
Current implementation is based on requiring user to implement org.apache.nifi.provenance.ProvenanceEventConsumer
strategy, declare it as service in META-INF/services and drop the resulting JAR
in the 'lib' directory of NiFi distribution.
Upon startup each consumer is discovered by ProvenanceRepository via standard ServiceLoader
after which every provenance event is sent to such consumer.
To simplify things base implementation of ProvenanceRepository was provided with two existing
implementations modified to extend from it.