### PR TITLE
NIFI-1051 Allowed FileSystemRepository to skip un-readable entries.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -309,6 +309,12 @@ public class FileSystemRepository implements ContentRepository {
                     // the path already exists, so scan the path to find any files and update maxIndex to the max of
                     // all filenames seen.
                     Files.walkFileTree(realPath, new SimpleFileVisitor<Path>() {
+                    	
+						public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+							LOG.warn("Content repository contains un-readable file or directory '" + file.getFileName() + "'. Skipping. ", exc);
+							return FileVisitResult.SKIP_SUBTREE;
+						}
+                    		 
                         @Override
                         public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
                             if (attrs.isDirectory()) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
@@ -71,6 +71,24 @@ public class TestFileSystemRepository {
     public void shutdown() throws IOException {
         repository.shutdown();
     }
+    
+    @Test
+    public void testBogusFile() throws IOException {
+    	repository.shutdown();
+    	System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, "src/test/resources/nifi.properties");
+        
+        File bogus = new File(rootFile, "bogus");
+        try {
+        	 bogus.mkdir();
+             bogus.setReadable(false);
+        
+             repository = new FileSystemRepository();
+             repository.initialize(new StandardResourceClaimManager());
+		} finally {
+			bogus.setReadable(true);
+			assertTrue(bogus.delete());
+		}
+    }
 
     @Test
     public void testCreateContentClaim() throws IOException {


### PR DESCRIPTION
The exception was caused due to basic file permissions. This fix overrides
'visitFileFailed' method of SimpleFileVisitor to log WARN message and allow
FileSystemRepository to continue.