### PR TITLE
NIFI-1099 fixed the handling of InterruptedException

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NiFiListener.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NiFiListener.java
@@ -84,6 +84,7 @@ public class NiFiListener {
             try {
                 executor.awaitTermination(3, TimeUnit.SECONDS);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
             }
 
             serverSocket.close();

--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NotificationServiceManager.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NotificationServiceManager.java
@@ -226,6 +226,7 @@ public class NotificationServiceManager {
                     try {
                         Thread.sleep(1000L);
                     } catch (final InterruptedException ie) {
+                    	Thread.currentThread().interrupt();
                     }
                 }
             }

--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
@@ -689,6 +689,7 @@ public class RunNiFi {
                             try {
                                 Thread.sleep(2000L);
                             } catch (final InterruptedException ie) {
+                            	Thread.currentThread().interrupt();
                             }
                         }
                     }
@@ -950,6 +951,7 @@ public class RunNiFi {
                 try {
                     Thread.sleep(1000L);
                 } catch (final InterruptedException ie) {
+                	Thread.currentThread().interrupt();
                 }
             } else {
                 try {
@@ -1097,6 +1099,7 @@ public class RunNiFi {
                 try {
                     startupCondition.await(1, TimeUnit.SECONDS);
                 } catch (final InterruptedException ie) {
+                	Thread.currentThread().interrupt();
                     return false;
                 }
 

--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/ShutdownHook.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/ShutdownHook.java
@@ -81,6 +81,7 @@ public class ShutdownHook extends Thread {
                 try {
                     Thread.sleep(1000L);
                 } catch (final InterruptedException ie) {
+                	Thread.currentThread().interrupt();
                 }
             }
         }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/socket/ssl/SSLSocketChannel.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/socket/ssl/SSLSocketChannel.java
@@ -131,6 +131,7 @@ public class SSLSocketChannel implements Closeable {
                         try {
                             Thread.sleep(50L);
                         } catch (final InterruptedException e) {
+                        	Thread.currentThread().interrupt();
                         }
                     }
                 }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/stream/io/LeakyBucketStreamThrottler.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/stream/io/LeakyBucketStreamThrottler.java
@@ -52,6 +52,7 @@ public class LeakyBucketStreamThrottler implements StreamThrottler {
             // we will just ignore it and return
             executorService.awaitTermination(2, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+        	Thread.currentThread().interrupt();
         }
     }
 
@@ -161,6 +162,7 @@ public class LeakyBucketStreamThrottler implements StreamThrottler {
                 try {
                     transferred = requestQueue.offer(request, 1000, TimeUnit.MILLISECONDS);
                 } catch (final InterruptedException e) {
+                	Thread.currentThread().interrupt();
                     throw new IOException("Interrupted", e);
                 }
             }
@@ -174,6 +176,7 @@ public class LeakyBucketStreamThrottler implements StreamThrottler {
                     }
                     response = responseQueue.poll(1000L, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
+                	Thread.currentThread().interrupt();
                     throw new IOException("Interrupted", e);
                 }
             }
@@ -245,6 +248,7 @@ public class LeakyBucketStreamThrottler implements StreamThrottler {
                         responseQueue.put(response);
                     }
                 } catch (InterruptedException e) {
+                	Thread.currentThread().interrupt();
                 }
             }
         }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/DebugDisabledTimedLock.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/DebugDisabledTimedLock.java
@@ -47,6 +47,7 @@ public class DebugDisabledTimedLock implements DebuggableTimedLock {
         try {
             return lock.tryLock(timeout, timeUnit);
         } catch (InterruptedException e) {
+        	Thread.currentThread().interrupt();
             return false;
         }
     }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/DebugEnabledTimedLock.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/DebugEnabledTimedLock.java
@@ -71,6 +71,7 @@ public class DebugEnabledTimedLock implements DebuggableTimedLock {
         try {
             success = lock.tryLock(timeout, timeUnit);
         } catch (final InterruptedException ie) {
+        	Thread.currentThread().interrupt();
             return false;
         }
 

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
@@ -510,7 +510,7 @@ public class FileUtils {
         try {
             Thread.sleep(millis);
         } catch (final InterruptedException ex) {
-            /* do nothing */
+        	Thread.currentThread().interrupt();
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/EventDrivenWorkerQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/EventDrivenWorkerQueue.java
@@ -69,6 +69,7 @@ public class EventDrivenWorkerQueue implements WorkerQueue {
                     try {
                         workMonitor.wait(timeLeft);
                     } catch (final InterruptedException ignored) {
+                    	Thread.currentThread().interrupt();
                     }
                 } else {
                     // Decrement the amount of work there is to do for this worker.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1124,6 +1124,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
                 this.timerDrivenEngineRef.get().awaitTermination(gracefulShutdownSeconds / 2, TimeUnit.SECONDS);
                 this.eventDrivenEngineRef.get().awaitTermination(gracefulShutdownSeconds / 2, TimeUnit.SECONDS);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
                 LOG.info("Interrupted while waiting for controller termination.");
             }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -303,6 +303,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                 try {
                     graceful = executorService.awaitTermination(gracefulShutdownSeconds, TimeUnit.SECONDS);
                 } catch (final InterruptedException e) {
+                	Thread.currentThread().interrupt();
                     graceful = false;
                 }
 
@@ -660,6 +661,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                         try {
                             Thread.sleep(response.getTryLaterSeconds() * 1000);
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                             // we were interrupted, so finish quickly
                             break;
                         }
@@ -675,6 +677,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                         try {
                             Thread.sleep(connectionRetryMillis);
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                             break;
                         }
                     } else {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -353,12 +353,14 @@ public class FileSystemRepository implements ContentRepository {
                 if (oldestDate < oldestArchiveDate.get()) {
                     oldestArchiveDate.set(oldestDate);
                 }
-            } catch (final ExecutionException | InterruptedException e) {
+            } catch (final ExecutionException e) {
                 if (e.getCause() instanceof IOException) {
                     throw (IOException) e.getCause();
                 } else {
                     throw new RuntimeException(e);
                 }
+            } catch (InterruptedException e){
+            	Thread.currentThread().interrupt();
             }
         }
 
@@ -1063,6 +1065,7 @@ public class FileSystemRepository implements ContentRepository {
                                 }
                             }
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                             LOG.warn("Failed to clean up {} because thread was interrupted", claim);
                         }
                     }
@@ -1609,6 +1612,7 @@ public class FileSystemRepository implements ContentRepository {
                         LOG.info("Unable to write to container {} due to archive file size constraints; waiting for archive cleanup", containerName);
                         condition.await();
                     } catch (final InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                     }
                 }
             } finally {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/claim/StandardResourceClaimManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/claim/StandardResourceClaimManager.java
@@ -116,6 +116,7 @@ public class StandardResourceClaimManager implements ResourceClaimManager {
             while (!destructableClaims.offer(claim, 30, TimeUnit.MINUTES)) {
             }
         } catch (final InterruptedException ie) {
+        	Thread.currentThread().interrupt();
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/EventDrivenSchedulingAgent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/EventDrivenSchedulingAgent.java
@@ -289,6 +289,7 @@ public class EventDrivenSchedulingAgent implements SchedulingAgent {
                     try {
                         Thread.sleep(FormatUtils.getTimeDuration(adminYieldDuration, TimeUnit.MILLISECONDS));
                     } catch (final InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                     }
 
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -215,6 +215,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                         try {
                             Thread.sleep(administrativeYieldMillis);
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                         }
                     }
                 }
@@ -262,6 +263,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                         try {
                             Thread.sleep(administrativeYieldMillis);
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                         }
                     }
 
@@ -750,6 +752,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                             try {
                                 Thread.sleep(administrativeYieldMillis);
                             } catch (final InterruptedException ie) {
+                            	Thread.currentThread().interrupt();
                             }
                         } finally {
                             service.setState(ControllerServiceState.DISABLED);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceProvider.java
@@ -361,6 +361,7 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
                                 try {
                                     Thread.sleep(100L);
                                 } catch (final InterruptedException ie) {
+                                	Thread.currentThread().interrupt();
                                 }
                             }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ContinuallyRunConnectableTask.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ContinuallyRunConnectableTask.java
@@ -88,6 +88,7 @@ public class ContinuallyRunConnectableTask implements Callable<Boolean> {
                     try {
                         Thread.sleep(10000L);
                     } catch (final InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                     }
 
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/engine/FlowEngine.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/engine/FlowEngine.java
@@ -106,6 +106,7 @@ public final class FlowEngine extends ScheduledThreadPoolExecutor {
                     logger.debug("A flow controller execution task '{}' has been cancelled.", runnable);
                 }
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
                 if (logger.isDebugEnabled()) {
                     logger.debug("A flow controller execution task has been interrupted.", ie);
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -952,6 +952,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
                     try {
                         Thread.sleep(50L);
                     } catch (final InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                     }
                 }
             }
@@ -961,6 +962,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
                     try {
                         Thread.sleep(50L);
                     } catch (final InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                     }
                 }
             }
@@ -988,6 +990,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
                 try {
                     Thread.sleep(50L);
                 } catch (final InterruptedException e) {
+                	Thread.currentThread().interrupt();
                 }
             }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -89,6 +89,7 @@ public class TestStandardFlowFileQueue {
         try {
             Thread.sleep(100L);
         } catch (final InterruptedException ie) {
+        	Thread.currentThread().interrupt();
         }
 
         final Set<FlowFileRecord> expiredRecords = new HashSet<>(100);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/util/DiskUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/util/DiskUtils.java
@@ -70,6 +70,7 @@ public class DiskUtils {
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException e) {
+            	Thread.currentThread().interrupt();
             }
         }
         return toDelete;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
@@ -106,6 +106,7 @@ public class TestStandardControllerServiceProvider {
             try {
                 Thread.sleep(50L);
             } catch (final InterruptedException e) {
+            	Thread.currentThread().interrupt();
             }
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/util/FileUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/util/FileUtils.java
@@ -180,7 +180,7 @@ public class FileUtils {
         try {
             Thread.sleep(millis);
         } catch (final InterruptedException ex) {
-            /* do nothing */
+        	Thread.currentThread().interrupt();
         }
     }
 }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/PersistentProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/PersistentProvenanceRepository.java
@@ -816,6 +816,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
             }
         }
 
@@ -1120,6 +1121,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException e) {
+            	Thread.currentThread().interrupt();
             }
         }
     }
@@ -1228,6 +1230,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
                             try {
                                 Thread.sleep(10L);
                             } catch (final InterruptedException ie) {
+                            	Thread.currentThread().interrupt();
                             }
                         }
 
@@ -1289,6 +1292,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
                         try {
                             Thread.sleep(100L);
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                         }
                     }
 
@@ -1598,6 +1602,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
                                         try {
                                             tuple = eventQueue.poll(10, TimeUnit.MILLISECONDS);
                                         } catch (final InterruptedException ie) {
+                                        	Thread.currentThread().interrupt();
                                             continue;
                                         }
 
@@ -1629,6 +1634,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
                                 try {
                                     accepted = eventQueue.offer(new Tuple<>(record, blockIndex), 10, TimeUnit.MILLISECONDS);
                                 } catch (final InterruptedException ie) {
+                                	Thread.currentThread().interrupt();
                                 }
                             }
                             maxId = record.getEventId();
@@ -1667,6 +1673,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
 
                             throw new RuntimeException(t);
                         } catch (final InterruptedException e) {
+                        	Thread.currentThread().interrupt();
                             throw new RuntimeException("Thread interrupted");
                         }
                     }
@@ -1784,6 +1791,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
             }
         }
 
@@ -1916,6 +1924,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
                     docs.clear();
                 }
             } catch (final ExecutionException | InterruptedException ee) {
+            	Thread.currentThread().interrupt();
                 throw new RuntimeException(ee);
             }
         }
@@ -2035,6 +2044,7 @@ public class PersistentProvenanceRepository implements ProvenanceEventRepository
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
             }
         }
 

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestPersistentProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestPersistentProvenanceRepository.java
@@ -133,6 +133,7 @@ public class TestPersistentProvenanceRepository {
                         try {
                             Thread.sleep(1000L);
                         } catch (final InterruptedException ie) {
+                        	Thread.currentThread().interrupt();
                         }
                     }
                 }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
@@ -190,6 +190,7 @@ public class VolatileProvenanceRepository implements ProvenanceEventRepository {
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
             }
         }
 
@@ -383,6 +384,7 @@ public class VolatileProvenanceRepository implements ProvenanceEventRepository {
             try {
                 Thread.sleep(100L);
             } catch (final InterruptedException ie) {
+            	Thread.currentThread().interrupt();
             }
         }
 


### PR DESCRIPTION
In many places current code simply swallows InterruptedException without allowing
calling thread to be notified  of the interrupt. We should not be doing this as it could lead to
various side-effects (e.g., Thread pool waiting for completion of the interrupted task, a completion that).