### PR TITLE
NIFI-1061 fixed deadlock caused by DBCPConnectionPool.onConfigured()

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -603,9 +603,12 @@ public final class StandardProcessScheduler implements ProcessScheduler {
     }
 
     /**
-     * Returns the ScheduleState that is registered for the given component; if no ScheduleState current is registered, one is created and registered atomically, and then that value is returned.
+     * Returns the ScheduleState that is registered for the given component; if
+     * no ScheduleState current is registered, one is created and registered
+     * atomically, and then that value is returned.
      *
-     * @param schedulable schedulable
+     * @param schedulable
+     *            schedulable
      * @return scheduled state
      */
     private ScheduleState getScheduleState(final Object schedulable) {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
@@ -132,7 +132,13 @@ public class DBCPConnectionPool extends AbstractControllerService implements DBC
     }
 
     /**
-     * Create new pool, open some connections ready to be used
+     * Configures connection pool by creating an instance of the
+     * {@link BasicDataSource} based on configuration provided with
+     * {@link ConfigurationContext}.
+     *
+     * This operation makes no guarantees that the actual connection could be
+     * made since the underlying system may still go off-line during normal
+     * operation of the connection pool.
      *
      * @param context
      *            the configuration context
@@ -163,17 +169,6 @@ public class DBCPConnectionPool extends AbstractControllerService implements DBC
         dataSource.setUrl(dburl);
         dataSource.setUsername(user);
         dataSource.setPassword(passw);
-
-        // verify connection can be established.
-        try {
-            final Connection con = dataSource.getConnection();
-            if (con == null) {
-                throw new InitializationException("Connection to database cannot be established.");
-            }
-            con.close();
-        } catch (final SQLException e) {
-            throw new InitializationException(e);
-        }
     }
 
     /**


### PR DESCRIPTION
Current implementation of DBCPConnectionPool was attempting to test if connection could be obtained via dataSource.getConnection().
Such call is naturally a blocking call and the duration of the block is dependent on driver implementation. Some drivers (e.g., Phoenix - https://phoenix.apache.org/installation.html)
attempts numerous retries before failing creating a deadlock when attempt was made to disable DBCPConnectionPool which was still being enabled.

This fix removes the connection test from DBCPConnectionPool.onConfigured() operation returning successfully upon creation of DataSource.
For more details see comments in https://issues.apache.org/jira/browse/NIFI-1061
