### PR TITLE
NIFI-1124 NIFI-1062 Fixed PutHDFS processor to properly route failures.

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -345,7 +345,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                 }
             }
             getLogger().error("Failed to write to HDFS due to {}", t);
-            session.rollback();
+            session.transfer(flowFile, REL_FAILURE);
             context.yield();
         }
     }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -345,7 +345,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                 }
             }
             getLogger().error("Failed to write to HDFS due to {}", t);
-            session.transfer(flowFile, REL_FAILURE);
+            session.transfer(session.penalize(flowFile), REL_FAILURE);
             context.yield();
         }
     }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -157,19 +157,18 @@ public class PutHDFSTest {
         }
     }
 
-    // The following only seems to work from cygwin...something about not finding the 'chmod' command.
     @Test
     public void testPutFile() throws IOException {
         TestRunner runner = TestRunners.newTestRunner(PutHDFS.class);
         runner.setProperty(PutHDFS.DIRECTORY, "target/test-classes");
         runner.setProperty(PutHDFS.CONFLICT_RESOLUTION, "replace");
         runner.setValidateExpressionUsage(false);
-        FileInputStream fis = new FileInputStream("src/test/resources/testdata/randombytes-1");
-        Map<String, String> attributes = new HashMap<String, String>();
-        attributes.put(CoreAttributes.FILENAME.key(), "randombytes-1");
-        runner.enqueue(fis, attributes);
-        runner.run();
-        fis.close();
+        try (FileInputStream fis = new FileInputStream("src/test/resources/testdata/randombytes-1");) {
+            Map<String, String> attributes = new HashMap<String, String>();
+            attributes.put(CoreAttributes.FILENAME.key(), "randombytes-1");
+            runner.enqueue(fis, attributes);
+            runner.run();
+        }
 
         Configuration config = new Configuration();
         FileSystem fs = FileSystem.get(config);
@@ -198,12 +197,13 @@ public class PutHDFSTest {
         runner.setProperty(PutHDFS.DIRECTORY, dirName);
         runner.setProperty(PutHDFS.CONFLICT_RESOLUTION, "replace");
         runner.setValidateExpressionUsage(false);
-        FileInputStream fis = new FileInputStream("src/test/resources/testdata/randombytes-1");
-        Map<String, String> attributes = new HashMap<String, String>();
-        attributes.put(CoreAttributes.FILENAME.key(), "randombytes-1");
-        runner.enqueue(fis, attributes);
-        runner.run();
-        fis.close();
+
+        try (FileInputStream fis = new FileInputStream("src/test/resources/testdata/randombytes-1");) {
+            Map<String, String> attributes = new HashMap<String, String>();
+            attributes.put(CoreAttributes.FILENAME.key(), "randombytes-1");
+            runner.enqueue(fis, attributes);
+            runner.run();
+        }
 
         List<MockFlowFile> failedFlowFiles = runner
                 .getFlowFilesForRelationship(new Relationship.Builder().name("failure").build());

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -208,6 +208,7 @@ public class PutHDFSTest {
         List<MockFlowFile> failedFlowFiles = runner
                 .getFlowFilesForRelationship(new Relationship.Builder().name("failure").build());
         assertFalse(failedFlowFiles.isEmpty());
+        assertTrue(failedFlowFiles.get(0).isPenalized());
 
         fs.setPermission(p, new FsPermission(FsAction.EXECUTE, FsAction.EXECUTE, FsAction.EXECUTE));
         fs.delete(p, true);


### PR DESCRIPTION
Ensured that during put failures the FlowFile is routed to 'failure' relationship.
Added validation test
Re-enabled previously ignored test.