### PR TITLE
NIFI-1107 - Create new PutS3ObjectMultipart processor

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-nar/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>nifi-aws-processors</artifactId>
             <version>0.4.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-ssl-context-service-nar</artifactId>
+            <type>nar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>nifi-processor-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-ssl-context-service-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSProcessor.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSProcessor.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.http.conn.ssl.SdkTLSSocketFactory;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -47,6 +48,11 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.PropertiesCredentials;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
+import org.apache.nifi.ssl.SSLContextService;
+
+import javax.net.ssl.SSLContext;
+
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 public abstract class AbstractAWSProcessor<ClientType extends AmazonWebServiceClient> extends AbstractProcessor {
 
@@ -90,6 +96,20 @@ public abstract class AbstractAWSProcessor<ClientType extends AmazonWebServiceCl
             .required(true)
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("30 secs")
+            .build();
+
+    public static final PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
+            .name("SSL Context Service")
+            .description("Specifies an optional SSL Context Service that, if provided, will be used to create connections")
+            .required(false)
+            .identifiesControllerService(SSLContextService.class)
+            .build();
+
+    public static final PropertyDescriptor ENDPOINT_OVERRIDE = new PropertyDescriptor.Builder()
+            .name("Endpoint Override URL")
+            .description("Endpoint URL to use instead of the AWS default including scheme, host, port, and path.")
+            .required(false)
+            .addValidator(StandardValidators.URL_VALIDATOR)
             .build();
 
     private volatile ClientType client;
@@ -146,6 +166,13 @@ public abstract class AbstractAWSProcessor<ClientType extends AmazonWebServiceCl
         config.setConnectionTimeout(commsTimeout);
         config.setSocketTimeout(commsTimeout);
 
+        final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
+        if (sslContextService != null) {
+            final SSLContext sslContext = sslContextService.createSSLContext(SSLContextService.ClientAuth.NONE);
+            SdkTLSSocketFactory sdkTLSSocketFactory = new SdkTLSSocketFactory(sslContext, null);
+            config.getApacheHttpClientConfig().setSslSocketFactory(sdkTLSSocketFactory);
+        }
+
         return config;
     }
 
@@ -163,6 +190,13 @@ public abstract class AbstractAWSProcessor<ClientType extends AmazonWebServiceCl
             } else{
                 this.region = null;
             }
+        }
+
+        // if the endpoint override has been configured, set the endpoint.
+        // (per Amazon docs this should only be configured at client creation)
+        final String urlstr = trimToEmpty(context.getProperty(ENDPOINT_OVERRIDE).getValue());
+        if (!urlstr.isEmpty()) {
+            this.client.setEndpoint(urlstr);
         }
     }
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
@@ -38,7 +38,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 
 @SupportsBatching
-@SeeAlso({PutS3Object.class})
+@SeeAlso({PutS3Object.class,FetchS3Object.class,PutS3ObjectMultipart.class})
 @Tags({"Amazon", "S3", "AWS", "Archive", "Delete"})
 @CapabilityDescription("Deletes FlowFiles on an Amazon S3 Bucket. " +
         "If attempting to delete a file that does not exist, FlowFile is routed to success.")

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -46,7 +46,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 
 @SupportsBatching
-@SeeAlso({PutS3Object.class})
+@SeeAlso({PutS3Object.class, PutS3ObjectMultipart.class, DeleteS3Object.class})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"Amazon", "S3", "AWS", "Get", "Fetch"})
 @CapabilityDescription("Retrieves the contents of an S3 Object and writes it to the content of a FlowFile")
@@ -73,7 +73,7 @@ public class FetchS3Object extends AbstractS3Processor {
             .build();
 
     public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
-            Arrays.asList(BUCKET, KEY, REGION, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, TIMEOUT, VERSION_ID));
+            Arrays.asList(BUCKET, KEY, ENDPOINT_OVERRIDE, REGION, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, TIMEOUT, VERSION_ID));
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -55,12 +55,12 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.StorageClass;
 
 @SupportsBatching
-@SeeAlso({FetchS3Object.class})
+@SeeAlso({FetchS3Object.class, PutS3ObjectMultipart.class, DeleteS3Object.class})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"Amazon", "S3", "AWS", "Archive", "Put"})
 @CapabilityDescription("Puts FlowFiles to an Amazon S3 Bucket")
 @DynamicProperty(name = "The name of a User-Defined Metadata field to add to the S3 Object", value = "The value of a User-Defined Metadata field to add to the S3 Object",
-    description = "Allows user-defined metadata to be added to the S3 object as key/value pairs", supportsExpressionLanguage = true)
+        description = "Allows user-defined metadata to be added to the S3 object as key/value pairs", supportsExpressionLanguage = true)
 @ReadsAttribute(attribute = "filename", description = "Uses the FlowFile's filename as the filename for the S3 object")
 @WritesAttributes({
     @WritesAttribute(attribute = "s3.version", description = "The version of the S3 Object that was put to S3"),
@@ -84,8 +84,8 @@ public class PutS3Object extends AbstractS3Processor {
         .build();
 
     public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
-        Arrays.asList(KEY, BUCKET, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, STORAGE_CLASS, REGION, TIMEOUT, EXPIRATION_RULE_ID,
-            FULL_CONTROL_USER_LIST, READ_USER_LIST, WRITE_USER_LIST, READ_ACL_LIST, WRITE_ACL_LIST, OWNER));
+            Arrays.asList(KEY, BUCKET, ENDPOINT_OVERRIDE, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, SSL_CONTEXT_SERVICE, STORAGE_CLASS, REGION, TIMEOUT, EXPIRATION_RULE_ID,
+                    FULL_CONTROL_USER_LIST, READ_USER_LIST, WRITE_USER_LIST, READ_ACL_LIST, WRITE_ACL_LIST, OWNER));
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -174,7 +174,7 @@ public class PutS3Object extends AbstractS3Processor {
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
             session.getProvenanceReporter().send(flowFile, url, millis);
 
-            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", new Object[] {ff, millis});
+            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", new Object[]{ff, millis});
         } catch (final ProcessException | AmazonClientException pe) {
             getLogger().error("Failed to put {} to Amazon S3 due to {}", new Object[] {flowFile, pe});
             flowFile = session.penalize(flowFile);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3ObjectMultipart.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3ObjectMultipart.java
@@ -1,0 +1,550 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.s3;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.stream.io.BufferedInputStream;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@SeeAlso({FetchS3Object.class, PutS3Object.class, DeleteS3Object.class})
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@Tags({"Amazon", "S3", "AWS", "Archive", "Put", "Multi", "Multipart", "Upload"})
+@CapabilityDescription("Puts FlowFiles to an Amazon S3 Bucket using the MultipartUpload API method.  " +
+        "This upload consists of three steps 1) initiate upload, 2) upload the parts, and 3) complete the upload.\n" +
+        "Since the intent for this processor involves large files, the processor saves state locally after each step " +
+        "so that an upload can be resumed without having to restart from the beginning of the file.\n" +
+        "The AWS libraries default to using standard AWS regions but the 'Endpoint Override URL' allows this to be " +
+        "overridden.")
+@DynamicProperty(name = "The name of a User-Defined Metadata field to add to the S3 Object",
+        value = "The value of a User-Defined Metadata field to add to the S3 Object",
+        description = "Allows user-defined metadata to be added to the S3 object as key/value pairs",
+        supportsExpressionLanguage = true)
+@ReadsAttribute(attribute = "filename", description = "Uses the FlowFile's filename as the filename for the S3 object")
+@WritesAttributes({
+        @WritesAttribute(attribute = "s3.bucket", description = "The S3 bucket where the Object was put in S3"),
+        @WritesAttribute(attribute = "s3.key", description = "The S3 key within where the Object was put in S3"),
+        @WritesAttribute(attribute = "s3.version", description = "The version of the S3 Object that was put to S3"),
+        @WritesAttribute(attribute = "s3.etag", description = "The ETag of the S3 Object"),
+        @WritesAttribute(attribute = "s3.uploadId", description = "The uploadId used to upload the Object to S3"),
+        @WritesAttribute(attribute = "s3.expiration", description = "A human-readable form of the expiration date of " +
+                "the S3 object, if one is set"),
+        @WritesAttribute(attribute = "s3.usermetadata", description = "A human-readable form of the User Metadata " +
+                "of the S3 object, if any was set")
+})
+public class PutS3ObjectMultipart extends AbstractS3Processor {
+
+    public static final long MIN_BYTES_INCLUSIVE = 50L * 1024L * 1024L;
+    public static final long MAX_BYTES_INCLUSIVE = 5L * 1024L * 1024L * 1024L;
+    public static final String PERSISTENCE_ROOT = "conf/state/";
+
+    public static final PropertyDescriptor EXPIRATION_RULE_ID = new PropertyDescriptor.Builder()
+            .name("Expiration Time Rule")
+            .required(false)
+            .expressionLanguageSupported(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor STORAGE_CLASS = new PropertyDescriptor.Builder()
+            .name("Storage Class")
+            .required(true)
+            .allowableValues(StorageClass.Standard.name(), StorageClass.ReducedRedundancy.name())
+            .defaultValue(StorageClass.Standard.name())
+            .build();
+
+    public static final PropertyDescriptor PART_SIZE = new PropertyDescriptor.Builder()
+            .name("Part Size")
+            .description("Specifies the Part Size to be used for the S3 Multipart Upload API.  The flow file will be " +
+                    "broken into Part Size chunks during upload.  Part size must be at least 50MB and no more than " +
+                    "5GB, but the final part can be less than 50MB.")
+            .required(true)
+            .defaultValue("5 GB")
+            .addValidator(StandardValidators.createDataSizeBoundsValidator(MIN_BYTES_INCLUSIVE, MAX_BYTES_INCLUSIVE))
+            .build();
+
+    public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
+            Arrays.asList(KEY, BUCKET, PART_SIZE, ENDPOINT_OVERRIDE, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE,
+                    SSL_CONTEXT_SERVICE, STORAGE_CLASS, REGION, TIMEOUT, EXPIRATION_RULE_ID,
+                    FULL_CONTROL_USER_LIST, READ_USER_LIST, WRITE_USER_LIST, READ_ACL_LIST, WRITE_ACL_LIST, OWNER));
+
+    final static String S3_BUCKET_KEY = "s3.bucket";
+    final static String S3_OBJECT_KEY = "s3.key";
+    final static String S3_UPLOAD_ID_ATTR_KEY = "s3.uploadId";
+    final static String S3_VERSION_ATTR_KEY = "s3.version";
+    final static String S3_ETAG_ATTR_KEY = "s3.etag";
+    final static String S3_EXPIRATION_ATTR_KEY = "s3.expiration";
+    final static String S3_USERMETA_ATTR_KEY = "s3.usermetadata";
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .expressionLanguageSupported(true)
+                .dynamic(true)
+                .build();
+    }
+
+    protected File getPersistenceFile() {
+        return new File(PERSISTENCE_ROOT + getIdentifier());
+    }
+
+    @Override
+    public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
+        if ( descriptor.equals(KEY)
+                || descriptor.equals(BUCKET)
+                || descriptor.equals(ENDPOINT_OVERRIDE)
+                || descriptor.equals(STORAGE_CLASS)
+                || descriptor.equals(REGION)) {
+            destroyState();
+        }
+    }
+
+    protected MultipartState getState(final String s3ObjectKey) throws IOException {
+        // get local state if it exists
+        MultipartState currState = null;
+        final File persistenceFile = getPersistenceFile();
+        if (persistenceFile.exists()) {
+            try (final FileInputStream fis = new FileInputStream(persistenceFile)) {
+                final Properties props = new Properties();
+                props.load(fis);
+                if (props.containsKey(s3ObjectKey)) {
+                    final String localSerialState = props.getProperty(s3ObjectKey);
+                    if (localSerialState != null) {
+                        currState = new MultipartState(localSerialState);
+                        getLogger().info("Local state for {} loaded with uploadId {} and {} partETags",
+                                new Object[]{s3ObjectKey, currState.uploadId, currState.partETags.size()});
+                    }
+                }
+            } catch (IOException ioe) {
+                getLogger().warn("Failed to recover local state for {} due to {}. Assuming no local state and " +
+                                "restarting upload.", new Object[]{s3ObjectKey, ioe.getMessage()});
+            }
+        }
+        return currState;
+    }
+
+    protected void persistState(final String s3ObjectKey, final MultipartState currState) throws IOException {
+        final String currStateStr = (currState == null) ? null : currState.toString();
+        final File persistenceFile = getPersistenceFile();
+        final File parentDir = persistenceFile.getParentFile();
+        if (!parentDir.exists() && !parentDir.mkdirs()) {
+            throw new IOException("Could not create persistence directory " + parentDir.getAbsolutePath() +
+                " needed to store local state.");
+        }
+        final Properties props = new Properties();
+        if (persistenceFile.exists()) {
+            try (final FileInputStream fis = new FileInputStream(persistenceFile)) {
+                props.load(fis);
+            }
+        }
+        if (currStateStr != null) {
+            props.setProperty(s3ObjectKey, currStateStr);
+        } else {
+            props.remove(s3ObjectKey);
+        }
+
+        try (final FileOutputStream fos = new FileOutputStream(persistenceFile)) {
+            props.store(fos, null);
+        } catch (IOException ioe) {
+            getLogger().error("Could not store state {} due to {}.",
+                    new Object[]{persistenceFile.getAbsolutePath(), ioe.getMessage()});
+        }
+    }
+
+    protected void removeState(final String s3ObjectKey) throws IOException {
+        persistState(s3ObjectKey, null);
+    }
+
+    protected void destroyState() {
+        final File persistenceFile = getPersistenceFile();
+        if (persistenceFile.exists()) {
+            if (!persistenceFile.delete()) {
+                getLogger().warn("Could not delete state file {}, attempting to delete contents.",
+                        new Object[]{persistenceFile.getAbsolutePath()});
+            } else {
+                try (final FileOutputStream fos = new FileOutputStream(persistenceFile)) {
+                    new Properties().store(fos, null);
+                } catch (IOException ioe) {
+                    getLogger().error("Could not store empty state file {} due to {}.",
+                            new Object[]{persistenceFile.getAbsolutePath(), ioe.getMessage()});
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final long startNanos = System.nanoTime();
+
+        final String bucket = context.getProperty(BUCKET).evaluateAttributeExpressions(flowFile).getValue();
+        final String key = context.getProperty(KEY).evaluateAttributeExpressions(flowFile).getValue();
+        final String cacheKey = getIdentifier() + "/" + bucket + "/" + key;
+
+        final AmazonS3 s3 = getClient();
+        final FlowFile ff = flowFile;
+        final String ffFilename = ff.getAttributes().get(CoreAttributes.FILENAME.key());
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(S3_BUCKET_KEY, bucket);
+        attributes.put(S3_OBJECT_KEY, key);
+
+        try {
+            session.read(flowFile, new InputStreamCallback() {
+                @Override
+                public void process(final InputStream rawIn) throws IOException {
+                    try (final InputStream in = new BufferedInputStream(rawIn)) {
+                        final ObjectMetadata objectMetadata = new ObjectMetadata();
+                        objectMetadata.setContentDisposition(ff.getAttribute(CoreAttributes.FILENAME.key()));
+                        objectMetadata.setContentLength(ff.getSize());
+                        final String expirationRule = context.getProperty(EXPIRATION_RULE_ID)
+                                .evaluateAttributeExpressions(ff).getValue();
+                        if (expirationRule != null) {
+                            objectMetadata.setExpirationTimeRuleId(expirationRule);
+                        }
+                        final Map<String, String> userMetadata = new HashMap<>();
+                        for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
+                            if (entry.getKey().isDynamic()) {
+                                final String value = context.getProperty(entry.getKey())
+                                        .evaluateAttributeExpressions(ff).getValue();
+                                userMetadata.put(entry.getKey().getName(), value);
+                            }
+                        }
+                        if (!userMetadata.isEmpty()) {
+                            objectMetadata.setUserMetadata(userMetadata);
+                        }
+
+                        // load or create persistent state
+                        //------------------------------------------------------------
+                        MultipartState currentState;
+                        try {
+                            currentState = getState(cacheKey);
+                            if (currentState != null) {
+                                if (currentState.partETags.size() > 0) {
+                                    final PartETag lastETag = currentState.partETags.get(currentState.partETags.size() - 1);
+                                    getLogger().info("RESUMING UPLOAD for flowfile='{}' bucket='{}' key='{}' " +
+                                                    "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
+                                                    "contentLength='{}' partsLoaded={} lastPart={}/{}",
+                                            new Object[]{ffFilename, bucket, key, currentState.uploadId,
+                                                    currentState.filePosition, currentState.partSize,
+                                                    currentState.storageClass.toString(), currentState.contentLength,
+                                                    currentState.partETags.size(),
+                                                    Integer.toString(lastETag.getPartNumber()), lastETag.getETag()});
+                                } else {
+                                    getLogger().info("RESUMING UPLOAD for flowfile='{}' bucket='{}' key='{}' " +
+                                                    "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
+                                                    "contentLength='{}' no partsLoaded",
+                                            new Object[]{ffFilename, bucket, key, currentState.uploadId,
+                                                    currentState.filePosition, currentState.partSize,
+                                                    currentState.storageClass.toString(), currentState.contentLength});
+                                }
+                            } else {
+                                currentState = new MultipartState();
+                                currentState.setPartSize(context.getProperty(PART_SIZE).asDataSize(DataUnit.B).longValue());
+                                currentState.setStorageClass(StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
+                                currentState.setContentLength(ff.getSize());
+                                persistState(cacheKey, currentState);
+                                getLogger().info("STARTING NEW UPLOAD for flowfile='{}' bucket='{}' key='{}'",
+                                        new Object[]{ffFilename, bucket, key});
+                            }
+                        } catch (IOException e) {
+                            getLogger().error("Processing flow files, IOException initiating cache state: " + e.getMessage());
+                            throw(e);
+                        }
+
+                        // initiate upload or find position in file
+                        //------------------------------------------------------------
+                        if (currentState.uploadId.isEmpty()) {
+                            final InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, key, objectMetadata);
+                            initiateRequest.setStorageClass(currentState.storageClass);
+                            final AccessControlList acl = createACL(context, ff);
+                            if (acl != null) {
+                                initiateRequest.setAccessControlList(acl);
+                            }
+                            try {
+                                final InitiateMultipartUploadResult initiateResult = s3.initiateMultipartUpload(initiateRequest);
+                                currentState.setUploadId(initiateResult.getUploadId());
+                                currentState.partETags.clear();
+                                currentState.uploadETag = "";
+                                try {
+                                    persistState(cacheKey, currentState);
+                                } catch (Exception e) {
+                                    getLogger().info("Processing flow file, Exception saving cache state: " + e.getMessage());
+                                }
+                                getLogger().info("SUCCESS initiate upload flowfile={} available={} position={} " +
+                                        "length={} bucket={} key={} uploadId={}", new Object[]{ffFilename, in.available(),
+                                        currentState.filePosition, currentState.contentLength, bucket, key, currentState.uploadId});
+                                if (initiateResult.getUploadId() != null) {
+                                    attributes.put(S3_UPLOAD_ID_ATTR_KEY, initiateResult.getUploadId());
+                                }
+                            } catch (AmazonClientException e) {
+                                getLogger().info("FAILURE initiate upload flowfile={} bucket={} key={} reason={}",
+                                        new Object[]{ffFilename, bucket, key, e.getMessage()});
+                            }
+                        } else {
+                            if (currentState.filePosition > 0) {
+                                try {
+                                    final long skipped = in.skip(currentState.filePosition);
+                                    if (skipped != currentState.filePosition) {
+                                        getLogger().info("FAILURE skipping to resume upload flowfile={} bucket={} key={} position={} skipped={}",
+                                                new Object[]{ffFilename, bucket, key, currentState.filePosition, skipped});
+                                    }
+                                } catch (Exception e) {
+                                    getLogger().info("FAILURE skipping to resume upload flowfile={} bucket={} key={} position={} reason={}",
+                                            new Object[]{ffFilename, bucket, key, currentState.filePosition, e.getMessage()});
+                                }
+                            }
+                        }
+
+                        // upload parts
+                        //------------------------------------------------------------
+                        long thisPartSize;
+                        for (int part = currentState.partETags.size() + 1;
+                             currentState.filePosition < currentState.contentLength; part++) {
+                            if (!PutS3ObjectMultipart.this.isScheduled()) {
+                                getLogger().info("PARTSIZE stopping download, processor unscheduled flowfile={} part={} uploadId={}",
+                                        new Object[]{ ffFilename, part, currentState.uploadId });
+                                session.rollback();
+                                return;
+                            }
+                            thisPartSize = Math.min(currentState.partSize, (currentState.contentLength - currentState.filePosition));
+                            UploadPartRequest uploadRequest = new UploadPartRequest()
+                                    .withBucketName(bucket)
+                                    .withKey(key)
+                                    .withUploadId(currentState.uploadId)
+                                    .withInputStream(in)
+                                    .withPartNumber(part)
+                                    .withPartSize(thisPartSize);
+                            try {
+                                UploadPartResult uploadPartResult = s3.uploadPart(uploadRequest);
+                                currentState.addPartETag(uploadPartResult.getPartETag());
+                                currentState.filePosition += thisPartSize;
+                                try {
+                                    persistState(cacheKey, currentState);
+                                } catch (Exception e) {
+                                    getLogger().info("Processing flow file, Exception saving cache state: " + e.getMessage());
+                                }
+                                getLogger().info("SUCCESS upload flowfile={} part={} available={} etag={} uploadId={}",
+                                        new Object[]{ffFilename, part, in.available(), uploadPartResult.getETag(),
+                                                currentState.uploadId});
+                            } catch (AmazonClientException e) {
+                                getLogger().info("FAILURE upload flowfile={} part={} bucket={} key={} reason={}",
+                                        new Object[]{ffFilename, part, bucket, key, e.getMessage()});
+                                e.printStackTrace();
+                            }
+                        }
+
+                        // complete upload
+                        //------------------------------------------------------------
+                        CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+                                bucket, key, currentState.uploadId, currentState.partETags);
+                        try {
+                            CompleteMultipartUploadResult completeResult = s3.completeMultipartUpload(completeRequest);
+                            getLogger().info("SUCCESS complete upload flowfile={} etag={} uploadId={}",
+                                    new Object[]{ffFilename, completeResult.getETag(), currentState.uploadId});
+                            currentState.setUploadETag(completeResult.getETag());
+                            if (completeResult.getVersionId() != null) {
+                                attributes.put(S3_VERSION_ATTR_KEY, completeResult.getVersionId());
+                            }
+                            if (completeResult.getETag() != null) {
+                                attributes.put(S3_ETAG_ATTR_KEY, completeResult.getETag());
+                            }
+                            if (completeResult.getExpirationTime() != null) {
+                                attributes.put(S3_EXPIRATION_ATTR_KEY, completeResult.getExpirationTime().toString());
+                            }
+                            if (userMetadata.size() > 0) {
+                                StringBuilder userMetaBldr = new StringBuilder();
+                                for (String userKey : userMetadata.keySet()) {
+                                    userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
+                                }
+                                attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
+                            }
+                        } catch (AmazonClientException e) {
+                            getLogger().info("FAILURE complete upload flowfile={} bucket={} key={} reason={}",
+                                    new Object[]{ffFilename, bucket, key, e.getMessage()});
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            });
+
+            if (!attributes.isEmpty()) {
+                flowFile = session.putAllAttributes(flowFile, attributes);
+            }
+
+            final String url = ((AmazonS3Client)s3).getResourceUrl(bucket, key);
+            final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            session.getProvenanceReporter().send(flowFile, url, millis);
+            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", new Object[]{ff, millis});
+
+            session.transfer(flowFile, REL_SUCCESS);
+            try {
+                removeState(cacheKey);
+            } catch (IOException e) {
+                getLogger().info("Error trying to delete from cache: " + e.getMessage());
+            }
+        } catch (final ProcessException | AmazonClientException pe) {
+            getLogger().error("Failed to put {} to Amazon S3 due to {}", new Object[]{flowFile, pe});
+            getLogger().error(pe.getMessage());
+            session.transfer(flowFile, REL_FAILURE);
+            try {
+                removeState(cacheKey);
+            } catch (IOException e) {
+                getLogger().info("Error trying to delete key {} from cache: {}",
+                        new Object[]{cacheKey, e.getMessage()});
+            }
+        }
+    }
+
+    public static class MultipartState implements Serializable {
+
+        public static final String SEPARATOR = "#";
+
+        public String uploadId;
+        public Long filePosition;
+        public List<PartETag> partETags;
+        public String uploadETag;
+        public Long partSize;
+        public StorageClass storageClass;
+        public Long contentLength;
+
+        public MultipartState() {
+            uploadId = "";
+            filePosition = 0L;
+            partETags = new ArrayList<>();
+            uploadETag = "";
+            partSize = 0L;
+            storageClass = StorageClass.Standard;
+            contentLength = 0L;
+        }
+
+        // create from a previous toString() result
+        public MultipartState(String buf) {
+            String[] fields = buf.split(SEPARATOR);
+            uploadId = fields[0];
+            filePosition = Long.parseLong(fields[1]);
+            partETags = new ArrayList<>();
+            for (String part : fields[2].split(",")) {
+                if (part != null && !part.isEmpty()) {
+                    String[] partFields = part.split("/");
+                    partETags.add(new PartETag(Integer.parseInt(partFields[0]), partFields[1]));
+                }
+            }
+            uploadETag = fields[3];
+            partSize = Long.parseLong(fields[4]);
+            storageClass = StorageClass.fromValue(fields[5]);
+            contentLength = Long.parseLong(fields[6]);
+        }
+
+        public void setUploadId(String id) {
+            uploadId = id;
+        }
+        public void setFilePosition(Long pos) {
+            filePosition = pos;
+        }
+        public void addPartETag(PartETag tag) {
+            partETags.add(tag);
+        }
+        public void setUploadETag(String tag) {
+            uploadETag = tag;
+        }
+        public void setPartSize(Long size) {
+            partSize = size;
+        }
+        public void setStorageClass(StorageClass aClass) {
+            storageClass = aClass;
+        }
+        public void setContentLength(Long length) {
+            contentLength = length;
+        }
+
+        public String toString() {
+            StringBuilder buf = new StringBuilder();
+            buf.append(uploadId).append(SEPARATOR)
+                    .append(filePosition.toString()).append(SEPARATOR);
+            if (partETags.size() > 0) {
+                boolean first = true;
+                for (PartETag tag : partETags) {
+                    if (!first) {
+                        buf.append(",");
+                    } else {
+                        first = false;
+                    }
+                    buf.append(String.format("%d/%s", tag.getPartNumber(), tag.getETag()));
+                }
+            }
+            buf.append(SEPARATOR)
+                .append(uploadETag).append(SEPARATOR)
+                .append(partSize.toString()).append(SEPARATOR)
+                .append(storageClass.toString()).append(SEPARATOR)
+                .append(contentLength.toString());
+            return buf.toString();
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -14,6 +14,7 @@
 # limitations under the License.
 org.apache.nifi.processors.aws.s3.FetchS3Object
 org.apache.nifi.processors.aws.s3.PutS3Object
+org.apache.nifi.processors.aws.s3.PutS3ObjectMultipart
 org.apache.nifi.processors.aws.s3.DeleteS3Object
 org.apache.nifi.processors.aws.sns.PutSNS
 org.apache.nifi.processors.aws.sqs.GetSQS

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3ObjectMultipart.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3ObjectMultipart.java
@@ -1,0 +1,452 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.s3;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestPutS3ObjectMultipart {
+
+    ProcessContext context;
+    TestRunner runner;
+    PutS3ObjectMultipart processor;
+
+    final String TEST_CREDFILE = "dummyCreds.txt";
+    final String TEST_ENDPOINT = "https://endpoint.com";
+    final String TEST_BUCKET = "bucket";
+    final String TEST_TRANSIT_URI = "https://bucket.endpoint.com";
+    final String TEST_KEY = "key";
+    final String TEST_PARTSIZE = "50 mb";
+    final Long   TEST_PARTSIZE_LONG = 50L * 1024L * 1024L;
+    final String LINESEP = System.getProperty("line.separator");
+
+    private void createDummyCreds() throws IOException {
+        File dummyCreds = new File(TEST_CREDFILE);
+        if (dummyCreds.exists()) {
+            assertTrue(dummyCreds.delete());
+        }
+        assertTrue(dummyCreds.createNewFile());
+        FileOutputStream fos = new FileOutputStream(dummyCreds);
+        fos.write(("accessKey=access" + LINESEP + "secretKey=secret" + LINESEP).getBytes());
+        fos.close();
+    }
+
+    @Before
+    public void before() throws InitializationException, IOException {
+        createDummyCreds();
+
+        processor = new TestablePutS3ObjectMultipart();
+        runner = TestRunners.newTestRunner(processor);
+        context = runner.getProcessContext();
+
+        runner.setProperty(PutS3ObjectMultipart.BUCKET, TEST_BUCKET);
+        runner.setProperty(PutS3ObjectMultipart.KEY, TEST_KEY);
+        runner.setProperty(PutS3ObjectMultipart.ENDPOINT_OVERRIDE, TEST_ENDPOINT);
+        runner.setProperty(PutS3ObjectMultipart.CREDENTIALS_FILE, TEST_CREDFILE);
+        runner.setProperty(PutS3ObjectMultipart.PART_SIZE, TEST_PARTSIZE);
+    }
+
+    @After
+    public void after() {
+        File[] stateFiles = new File(PutS3ObjectMultipart.PERSISTENCE_ROOT).listFiles();
+        if (stateFiles != null) {
+            for (File f : stateFiles) {
+                assertTrue(f.delete());
+            }
+        }
+        File credfile = new File(TEST_CREDFILE);
+        if (credfile.exists()) {
+            assertTrue(credfile.delete());
+        }
+    }
+
+    @Test
+    public void testStateDefaults() {
+        PutS3ObjectMultipart.MultipartState state1 = new PutS3ObjectMultipart.MultipartState();
+        assertEquals(state1.uploadId, "");
+        assertEquals(state1.filePosition, (Long) 0L);
+        assertEquals(state1.partETags.size(), 0L);
+        assertEquals(state1.uploadETag, "");
+        assertEquals(state1.partSize, (Long) 0L);
+        assertEquals(state1.storageClass.toString(), StorageClass.Standard.toString());
+        assertEquals(state1.contentLength, (Long) 0L);
+    }
+
+    @Test
+    public void testStateToString() {
+        final String target = "UID-test1234567890#10001#1/PartETag-1,2/PartETag-2,3/PartETag-3,4/PartETag-4#UploadETag-test0987654321#20002#REDUCED_REDUNDANCY#30003";
+        PutS3ObjectMultipart.MultipartState state2 = new PutS3ObjectMultipart.MultipartState();
+        state2.setUploadId("UID-test1234567890");
+        state2.setFilePosition(10001L);
+        for (Integer partNum = 1; partNum < 5; partNum++) {
+            state2.addPartETag(new PartETag(partNum, "PartETag-" + partNum.toString()));
+        }
+        state2.setUploadETag("UploadETag-test0987654321");
+        state2.setPartSize(20002L);
+        state2.setStorageClass(StorageClass.ReducedRedundancy);
+        state2.setContentLength(30003L);
+        assertEquals(target, state2.toString());
+    }
+
+    @Test
+    public void testProperties() throws IOException {
+//        runner.setProperty(PutS3ObjectMultipart.BUCKET, "anonymous-test-bucket-00000000");
+//        runner.setProperty(PutS3ObjectMultipart.KEY, "folder/1.txt");
+//        runner.setProperty(PutS3ObjectMultipart.ENDPOINT_OVERRIDE, "https://endpoint.com");
+//        runner.setProperty(PutS3ObjectMultipart.ACCESS_KEY, "access");
+//        runner.setProperty(PutS3ObjectMultipart.SECRET_KEY, "secret");
+//        runner.setProperty(PutS3ObjectMultipart.CREDENTIALS_FILE, "creds");
+//        runner.setProperty(PutS3ObjectMultipart.PART_SIZE, "50 mb");
+
+        assertEquals(TEST_BUCKET, context.getProperty(PutS3ObjectMultipart.BUCKET).toString());
+        assertEquals(TEST_KEY, context.getProperty(PutS3ObjectMultipart.KEY).toString());
+        assertEquals(TEST_ENDPOINT, context.getProperty(PutS3ObjectMultipart.ENDPOINT_OVERRIDE).toString());
+//        assertNull(context.getProperty(PutS3ObjectMultipart.ACCESS_KEY).toString());
+//        assertNull(context.getProperty(PutS3ObjectMultipart.SECRET_KEY).toString());
+        assertEquals(TEST_CREDFILE, context.getProperty(PutS3ObjectMultipart.CREDENTIALS_FILE).toString());
+        assertEquals(TEST_PARTSIZE_LONG.longValue(),
+                context.getProperty(PutS3ObjectMultipart.PART_SIZE).asDataSize(DataUnit.B).longValue());
+    }
+
+    @Test
+    public void testPersistence() throws IOException {
+        final String bucket = runner.getProcessContext().getProperty(PutS3ObjectMultipart.BUCKET).getValue();
+        final String key = runner.getProcessContext().getProperty(PutS3ObjectMultipart.KEY).getValue();
+        final String cacheKey1 = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key;
+        final String cacheKey2 = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key + "-v2";
+        final String cacheKey3 = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key + "-v3";
+
+        /*
+         * store 3 versions of state
+         */
+        PutS3ObjectMultipart.MultipartState state1orig = new PutS3ObjectMultipart.MultipartState();
+        processor.persistState(cacheKey1, state1orig);
+
+        PutS3ObjectMultipart.MultipartState state2orig = new PutS3ObjectMultipart.MultipartState();
+        state2orig.uploadId = "1234";
+        state2orig.setContentLength(1234L);
+        processor.persistState(cacheKey2, state2orig);
+
+        PutS3ObjectMultipart.MultipartState state3orig = new PutS3ObjectMultipart.MultipartState();
+        state3orig.uploadId = "5678";
+        state3orig.setContentLength(5678L);
+        processor.persistState(cacheKey3, state3orig);
+
+        /*
+         * reload and validate stored state
+         */
+        final PutS3ObjectMultipart.MultipartState state1new = processor.getState(cacheKey1);
+        assertEquals("", state1new.uploadId);
+        assertEquals(0L, state1new.filePosition.longValue());
+        assertEquals(new ArrayList<PartETag>(), state1new.partETags);
+        assertEquals("", state1new.uploadETag);
+        assertEquals(0L, state1new.partSize.longValue());
+        assertEquals(StorageClass.fromValue(StorageClass.Standard.toString()), state1new.storageClass);
+        assertEquals(0L, state1new.contentLength.longValue());
+
+        final PutS3ObjectMultipart.MultipartState state2new = processor.getState(cacheKey2);
+        assertEquals("1234", state2new.uploadId);
+        assertEquals(0L, state2new.filePosition.longValue());
+        assertEquals(new ArrayList<PartETag>(), state2new.partETags);
+        assertEquals("", state2new.uploadETag);
+        assertEquals(0L, state2new.partSize.longValue());
+        assertEquals(StorageClass.fromValue(StorageClass.Standard.toString()), state2new.storageClass);
+        assertEquals(1234L, state2new.contentLength.longValue());
+
+        final PutS3ObjectMultipart.MultipartState state3new = processor.getState(cacheKey3);
+        assertEquals("5678", state3new.uploadId);
+        assertEquals(0L, state3new.filePosition.longValue());
+        assertEquals(new ArrayList<PartETag>(), state3new.partETags);
+        assertEquals("", state3new.uploadETag);
+        assertEquals(0L, state3new.partSize.longValue());
+        assertEquals(StorageClass.fromValue(StorageClass.Standard.toString()), state3new.storageClass);
+        assertEquals(5678L, state3new.contentLength.longValue());
+    }
+
+    @Test
+    public void testStatePersistsETags() throws IOException {
+        final String bucket = runner.getProcessContext().getProperty(PutS3ObjectMultipart.BUCKET).getValue();
+        final String key = runner.getProcessContext().getProperty(PutS3ObjectMultipart.KEY).getValue();
+        final String cacheKey1 = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key + "-bv1";
+        final String cacheKey2 = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key + "-bv2";
+        final String cacheKey3 = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key + "-bv3";
+
+        /*
+         * store 3 versions of state
+         */
+        PutS3ObjectMultipart.MultipartState state1orig = new PutS3ObjectMultipart.MultipartState();
+        processor.persistState(cacheKey1, state1orig);
+
+        PutS3ObjectMultipart.MultipartState state2orig = new PutS3ObjectMultipart.MultipartState();
+        state2orig.uploadId = "1234";
+        state2orig.setContentLength(1234L);
+        processor.persistState(cacheKey2, state2orig);
+
+        PutS3ObjectMultipart.MultipartState state3orig = new PutS3ObjectMultipart.MultipartState();
+        state3orig.uploadId = "5678";
+        state3orig.setContentLength(5678L);
+        processor.persistState(cacheKey3, state3orig);
+
+        /*
+         * persist state to caches so that
+         *      1. v2 has 2 and then 4 tags
+         *      2. v3 has 4 and then 2 tags
+         */
+        state2orig.partETags.add(new PartETag(1, "state 2 tag one"));
+        state2orig.partETags.add(new PartETag(2, "state 2 tag two"));
+        processor.persistState(cacheKey2, state2orig);
+        state2orig.partETags.add(new PartETag(3, "state 2 tag three"));
+        state2orig.partETags.add(new PartETag(4, "state 2 tag four"));
+        processor.persistState(cacheKey2, state2orig);
+
+        state3orig.partETags.add(new PartETag(1, "state 3 tag one"));
+        state3orig.partETags.add(new PartETag(2, "state 3 tag two"));
+        state3orig.partETags.add(new PartETag(3, "state 3 tag three"));
+        state3orig.partETags.add(new PartETag(4, "state 3 tag four"));
+        processor.persistState(cacheKey3, state3orig);
+        state3orig.partETags.remove(state3orig.partETags.size() - 1);
+        state3orig.partETags.remove(state3orig.partETags.size() - 1);
+        processor.persistState(cacheKey3, state3orig);
+
+        /*
+         * load state and validate that
+         *     1. v2 restore shows 4 tags
+         *     2. v3 restore shows 2 tags
+         */
+        final PutS3ObjectMultipart.MultipartState state2new = processor.getState(cacheKey2);
+        assertEquals("1234", state2new.uploadId);
+        assertEquals(4, state2new.partETags.size());
+
+        final PutS3ObjectMultipart.MultipartState state3new = processor.getState(cacheKey3);
+        assertEquals("5678", state3new.uploadId);
+        assertEquals(2, state3new.partETags.size());
+    }
+
+    @Test
+    public void testStateRemove() throws IOException {
+        final String bucket = runner.getProcessContext().getProperty(PutS3ObjectMultipart.BUCKET).getValue();
+        final String key = runner.getProcessContext().getProperty(PutS3ObjectMultipart.KEY).getValue();
+        final String cacheKey = runner.getProcessor().getIdentifier() + "/" + bucket + "/" + key + "-sr";
+
+        /*
+         * store state, retrieve and validate, remove and validate
+         */
+        PutS3ObjectMultipart.MultipartState stateOrig = new PutS3ObjectMultipart.MultipartState();
+        stateOrig.uploadId = "1234";
+        stateOrig.setContentLength(1234L);
+        processor.persistState(cacheKey, stateOrig);
+
+        PutS3ObjectMultipart.MultipartState state1 = processor.getState(cacheKey);
+        assertEquals("1234", state1.uploadId);
+        assertEquals(1234L, state1.contentLength.longValue());
+
+        processor.persistState(cacheKey, null);
+        PutS3ObjectMultipart.MultipartState state2 = processor.getState(cacheKey);
+        assertNull(state2);
+    }
+
+    @Test
+    public void testApiInteractions() throws IOException {
+        final String FILE1_NAME = "file1";
+        final String ALPHA_LF = "abcdefghijklmnopqrstuvwxyz\n";
+        final String ALPHA_6x = ALPHA_LF + ALPHA_LF + ALPHA_LF + ALPHA_LF + ALPHA_LF + ALPHA_LF;
+        final String FILE1_CONTENTS = ALPHA_6x + ALPHA_6x + ALPHA_6x + ALPHA_6x + ALPHA_6x + ALPHA_6x;
+
+        runner.setProperty(PutS3ObjectMultipart.BUCKET, TEST_BUCKET);
+        runner.setProperty(PutS3ObjectMultipart.KEY, TEST_KEY);
+        runner.setProperty(PutS3ObjectMultipart.ENDPOINT_OVERRIDE, TEST_ENDPOINT);
+        runner.setProperty(PutS3ObjectMultipart.CREDENTIALS_FILE, TEST_CREDFILE);
+        runner.setProperty(PutS3ObjectMultipart.PART_SIZE, TEST_PARTSIZE);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), FILE1_NAME);
+        runner.enqueue(FILE1_CONTENTS.getBytes(), attributes);
+
+        runner.assertValid();
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutS3ObjectMultipart.REL_SUCCESS);
+        final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(PutS3ObjectMultipart.REL_SUCCESS);
+        assertEquals(1, successFiles.size());
+        final List<MockFlowFile> failureFiles = runner.getFlowFilesForRelationship(PutS3ObjectMultipart.REL_FAILURE);
+        assertEquals(0, failureFiles.size());
+        MockFlowFile ff1 = successFiles.get(0);
+        assertEquals(FILE1_NAME, ff1.getAttribute(CoreAttributes.FILENAME.key()));
+        assertEquals(TEST_BUCKET, ff1.getAttribute(PutS3ObjectMultipart.S3_BUCKET_KEY));
+        assertEquals(TEST_KEY, ff1.getAttribute(PutS3ObjectMultipart.S3_OBJECT_KEY));
+        assertEquals(((TestablePutS3ObjectMultipart)processor).MOCK_CLIENT_UPLOADID,
+                ff1.getAttribute(PutS3ObjectMultipart.S3_UPLOAD_ID_ATTR_KEY));
+        assertEquals(((TestablePutS3ObjectMultipart)processor).MOCK_CLIENT_FILE_ETAG_PREFIX +
+                ((TestablePutS3ObjectMultipart)processor).MOCK_CLIENT_UPLOADID,
+                ff1.getAttribute(PutS3ObjectMultipart.S3_ETAG_ATTR_KEY));
+        assertEquals(((TestablePutS3ObjectMultipart)processor).MOCK_CLIENT_VERSION,
+                ff1.getAttribute(PutS3ObjectMultipart.S3_VERSION_ATTR_KEY));
+    }
+
+    @Test
+    public void testDynamicProperty() throws IOException {
+        final String DYNAMIC_ATTRIB_KEY = "fs.runTimestamp";
+        final String DYNAMIC_ATTRIB_VALUE = "${now():toNumber()}";
+
+        runner.setProperty(PutS3ObjectMultipart.BUCKET, TEST_BUCKET);
+        runner.setProperty(PutS3ObjectMultipart.KEY, TEST_KEY);
+        runner.setProperty(PutS3ObjectMultipart.ENDPOINT_OVERRIDE, TEST_ENDPOINT);
+        runner.setProperty(PutS3ObjectMultipart.CREDENTIALS_FILE, TEST_CREDFILE);
+        runner.setProperty(PutS3ObjectMultipart.PART_SIZE, TEST_PARTSIZE);
+        PropertyDescriptor testAttrib = processor.getSupportedDynamicPropertyDescriptor(DYNAMIC_ATTRIB_KEY);
+        runner.setProperty(testAttrib, DYNAMIC_ATTRIB_VALUE);
+
+        final String FILE1_NAME = "file1";
+        Map<String, String> attribs = new HashMap<>();
+        attribs.put(CoreAttributes.FILENAME.key(), FILE1_NAME);
+        runner.enqueue("123".getBytes(), attribs);
+
+        runner.assertValid();
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutS3ObjectMultipart.REL_SUCCESS);
+        final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(PutS3ObjectMultipart.REL_SUCCESS);
+        assertEquals(1, successFiles.size());
+        MockFlowFile ff1 = successFiles.get(0);
+
+        Long now = System.currentTimeMillis();
+        String millisNow = Long.toString(now);
+        String millisOneSecAgo = Long.toString(now - 1000L);
+        String usermeta = ff1.getAttribute(PutS3ObjectMultipart.S3_USERMETA_ATTR_KEY);
+        String[] usermetaLine0 = usermeta.split(LINESEP)[0].split("=");
+        String usermetaKey0 = usermetaLine0[0];
+        String usermetaValue0 = usermetaLine0[1];
+        assertEquals(DYNAMIC_ATTRIB_KEY, usermetaKey0);
+        assertTrue(usermetaValue0.compareTo(millisOneSecAgo) >=0 && usermetaValue0.compareTo(millisNow) <= 0);
+    }
+
+    @Test
+    public void testProvenance() throws InitializationException {
+        final String PROV1_FILE = "provfile1";
+
+        Map<String, String> attribs = new HashMap<>();
+        attribs.put(CoreAttributes.FILENAME.key(), PROV1_FILE);
+        runner.enqueue("prov1 contents".getBytes(), attribs);
+
+        runner.assertValid();
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutS3ObjectMultipart.REL_SUCCESS);
+        final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(PutS3ObjectMultipart.REL_SUCCESS);
+        assertEquals(1, successFiles.size());
+
+        final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
+        assertEquals(1, provenanceEvents.size());
+        ProvenanceEventRecord provRec1 = provenanceEvents.get(0);
+        assertEquals(ProvenanceEventType.SEND, provRec1.getEventType());
+        assertEquals(processor.getIdentifier(), provRec1.getComponentId());
+        assertEquals(TEST_TRANSIT_URI + "/" + TEST_KEY, provRec1.getTransitUri());
+        assertEquals(9, provRec1.getUpdatedAttributes().size());
+    }
+
+    public class TestablePutS3ObjectMultipart extends PutS3ObjectMultipart {
+        public final String MOCK_CLIENT_UPLOADID = UUID.nameUUIDFromBytes("UPLOADID".getBytes()).toString();
+        public final String MOCK_CLIENT_PART_ETAG_PREFIX = UUID.nameUUIDFromBytes("PARTETAG".getBytes()).toString();
+        public final String MOCK_CLIENT_FILE_ETAG_PREFIX = UUID.nameUUIDFromBytes("FILEETAG".getBytes()).toString();
+        public final String MOCK_CLIENT_VERSION = "mock-version";
+
+        @Override
+        protected AmazonS3Client createClient(ProcessContext context, AWSCredentials credentials,
+                                              ClientConfiguration config) {
+            return new MockAWSClient(MOCK_CLIENT_UPLOADID, MOCK_CLIENT_PART_ETAG_PREFIX, MOCK_CLIENT_FILE_ETAG_PREFIX,
+                    MOCK_CLIENT_VERSION);
+        }
+    }
+
+    private class MockAWSClient extends AmazonS3Client {
+        private String uploadId;
+        private String partETag;
+        private String fileETag;
+        private String version;
+
+        public MockAWSClient(String uploadId, String partEtag, String fileEtag, String version) {
+            this.uploadId = uploadId;
+            this.partETag = partEtag;
+            this.fileETag = fileEtag;
+            this.version = version;
+        }
+
+        @Override
+        public InitiateMultipartUploadResult initiateMultipartUpload(InitiateMultipartUploadRequest initiateMultipartUploadRequest) throws AmazonClientException {
+            InitiateMultipartUploadResult result = new InitiateMultipartUploadResult();
+            result.setBucketName(initiateMultipartUploadRequest.getBucketName());
+            result.setKey(initiateMultipartUploadRequest.getKey());
+            result.setUploadId(uploadId);
+            return result;
+        }
+
+        @Override
+        public UploadPartResult uploadPart(UploadPartRequest uploadPartRequest) throws AmazonClientException {
+            UploadPartResult result = new UploadPartResult();
+            result.setPartNumber(uploadPartRequest.getPartNumber());
+            result.setETag(partETag + Integer.toString(result.getPartNumber()) + "-" + uploadPartRequest.getUploadId());
+            return result;
+        }
+
+        @Override
+        public CompleteMultipartUploadResult completeMultipartUpload(CompleteMultipartUploadRequest completeMultipartUploadRequest) throws AmazonClientException {
+            CompleteMultipartUploadResult result = new CompleteMultipartUploadResult();
+            result.setBucketName(completeMultipartUploadRequest.getBucketName());
+            result.setKey(completeMultipartUploadRequest.getKey());
+            result.setETag(fileETag + completeMultipartUploadRequest.getUploadId());
+            Date date1 = new Date();
+            date1.setTime(System.currentTimeMillis());
+            result.setExpirationTime(date1);
+            result.setVersionId(version);
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Changes to create new PutS3ObjectMultipart processor.  This includes extending other S3 processor classes to support SSL connection service, enable new ENDPOINT_OVERRIDE property, and update processor reference annotations.
    * Add nifi-ssl-context-service-api dependency to nifi-aws-processors.
    * Add nifi-ssl-context-service-nar to nifi-aws-nar.
    * Add PutS3ObjectMultipart to META-INF/services/org.apache.nifi.processor.Processors.
    * New class PutS3ObjectMultipart.java and test TestPutS3ObjectMultipart.java.
    * Add ENDPOINT_OVERRIDE to allow use of S3 processors with S3 compatible services in addition to Amazon.
