### PR TITLE
NIFI-1164 decreased the chances of race condition

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -168,8 +168,9 @@ public class StandardControllerServiceNode extends AbstractConfiguredComponent i
 
     @Override
     public void verifyCanEnable() {
-        if (getState() != ControllerServiceState.DISABLED) {
-            throw new IllegalStateException(implementation + " cannot be enabled because it is not disabled");
+        if (this.getState() == ControllerServiceState.ENABLING || this.getState() == ControllerServiceState.ENABLED) {
+            throw new IllegalStateException(
+                    implementation + " cannot be enabled because it is already " + this.getState().name());
         }
 
         if (!isValid()) {
@@ -179,9 +180,6 @@ public class StandardControllerServiceNode extends AbstractConfiguredComponent i
 
     @Override
     public void verifyCanEnable(final Set<ControllerServiceNode> ignoredReferences) {
-        if (getState() != ControllerServiceState.DISABLED) {
-            throw new IllegalStateException(implementation + " cannot be enabled because it is not disabled");
-        }
 
         final Set<String> ids = new HashSet<>();
         for (final ControllerServiceNode node : ignoredReferences) {


### PR DESCRIPTION
Removed checks for 'if (getState() != ControllerServiceState.DISABLED)’ from StandardControllerServiceNode.verifyCanEnable(..) operations based on the discussion that we had in NIFI-1143 where ‘enablable’ service is the one that is not ENABLED or ENABLING.
On top of that the actual state check is redundant since it is going  to be checked again when isValid() is invoked.
Cleaned up the code in StandardControllerServiceProvider.enableReferencingServices(..) since:
1. It had the same check ordering issue on service state between ENABLING and ENABLED as was described in NIFI-1143.
2. Removed redundant recursiveReferences computation
3. There was two loops iterating over the same collection, so merged that into one
4. Removed redundant state check in the loop since it would be checked again as part of 'verifyCanEnable'