### PR TITLE
NIFI-1193: Add Hive support to Kite storage processor.

### DIFF
--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/pom.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <!--
+      Licensed to the Apache Software Foundation (ASF) under one or more
+      contributor license agreements.  See the NOTICE file distributed with
+      this work for additional information regarding copyright ownership.
+      The ASF licenses this file to You under the Apache License, Version 2.0
+      (the "License"); you may not use this file except in compliance with
+      the License.  You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>nifi-hive-dataset</artifactId>
+
+  <parent>
+      <groupId>org.apache.nifi</groupId>
+      <artifactId>nifi-kite-bundle</artifactId>
+      <version>0.3.1-SNAPSHOT</version>
+  </parent>
+
+  <name>NiFi Hive Dataset Module</name>
+  <description>
+    This module provides a wrapper around Kite's FileSystem dataset that works with Hive.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.google.guava:guava</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <exclude>commons-codec:commons-codec</exclude>
+                  <exclude>commons-io:commons-io</exclude>
+                  <exclude>commons-lang:commons-lang</exclude>
+                </excludes>
+                <includes>
+                  <include>*:*</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>org/kitesdk/shaded/com/google/common/**</exclude>
+                    <exclude>com/google/common/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.apache.hive:hive-exec</artifact>
+                  <excludes>
+                    <exclude>org/apache/avro/**</exclude>
+                    <exclude>org/codehaus/jackson/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <echo message="Create empty javadoc JAR to satisfy Maven central" />
+                <mkdir dir="target/apidocs" />
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-core</artifactId>
+      <version>${kite.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.opencsv</groupId>
+          <artifactId>opencsv</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Hadoop -->
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-hadoop-dependencies</artifactId>
+      <version>${kite.version}</version>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-hadoop-compatibility</artifactId>
+      <version>${kite.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Hive -->
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive.version}</version>
+      <!-- this is only used to talk with the metastore -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.jolbox</groupId>
+          <artifactId>bonecp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.derby</groupId>
+          <artifactId>derby</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-pool</groupId>
+          <artifactId>commons-pool</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-dbcp</groupId>
+          <artifactId>commons-dbcp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-cli</groupId>
+          <artifactId>commons-cli</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-serde</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive.shims</groupId>
+          <artifactId>hive-shims-0.20S</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive.shims</groupId>
+          <artifactId>hive-shims-scheduler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>apache-log4j-extras</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr-runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>ST4</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>apache-curator</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-avatica</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Misc -->
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test Dependencies -->
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractDatasetRepository.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractDatasetRepository.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.net.URI;
+import javax.annotation.Nullable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.DatasetNotFoundException;
+import org.kitesdk.data.spi.filesystem.FileSystemDatasetRepository;
+import org.kitesdk.data.spi.MetadataProvider;
+
+class HiveAbstractDatasetRepository extends FileSystemDatasetRepository {
+
+  private final MetadataProvider provider;
+  private final URI repoUri;
+
+  /**
+   * Create an HCatalog dataset repository with external tables.
+   */
+  HiveAbstractDatasetRepository(Configuration conf, Path rootDirectory,
+                                MetadataProvider provider) {
+    super(conf, rootDirectory, provider);
+    this.provider = provider;
+    this.repoUri = getRepositoryUri(conf, rootDirectory);
+  }
+
+  /**
+   * Create an HCatalog dataset repository with managed tables.
+   */
+  HiveAbstractDatasetRepository(Configuration conf, MetadataProvider provider) {
+    // Because the managed provider overrides dataset locations, the only time
+    // the storage path is used is to create temporary dataset repositories
+    super(conf, new Path("/tmp"), provider);
+    this.provider = provider;
+    this.repoUri = getRepositoryUri(conf, null);
+  }
+
+  @Override
+  public boolean delete(String namespace, String name) {
+    try {
+      if (isManaged(namespace, name)) {
+        // avoids calling fsRepository.delete, which deletes the data path
+        return getMetadataProvider().delete(namespace, name);
+      }
+      return super.delete(namespace, name);
+    } catch (DatasetNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public URI getUri() {
+    return repoUri;
+  }
+
+  @VisibleForTesting
+  MetadataProvider getMetadataProvider() {
+    return provider;
+  }
+
+  private boolean isManaged(String namespace, String name) {
+    MetadataProvider provider = getMetadataProvider();
+    if (provider instanceof HiveAbstractMetadataProvider) {
+      return ((HiveAbstractMetadataProvider) provider).isManaged(namespace, name);
+    }
+    // if the provider isn't talking to Hive, then it isn't managed
+    return false;
+  }
+
+  private URI getRepositoryUri(Configuration conf,
+                               @Nullable Path rootDirectory) {
+    String hiveMetaStoreUriProperty = conf.get(Loader.HIVE_METASTORE_URI_PROP);
+    StringBuilder uri = new StringBuilder("repo:hive");
+    if (hiveMetaStoreUriProperty != null) {
+      URI hiveMetaStoreUri = URI.create(hiveMetaStoreUriProperty);
+      Preconditions.checkArgument(hiveMetaStoreUri.getScheme().equals("thrift"),
+          "Metastore URI scheme must be 'thrift'.");
+      uri.append("://").append(hiveMetaStoreUri.getAuthority());
+    }
+    if (rootDirectory != null) {
+      if (hiveMetaStoreUriProperty == null) {
+        uri.append(":");
+      }
+      URI rootUri = rootDirectory.toUri();
+      uri.append(rootUri.getPath());
+      if (rootUri.getHost() != null) {
+        uri.append("?").append("hdfs:host").append("=").append(rootUri.getHost());
+        if (rootUri.getPort() != -1) {
+          uri.append("&").append("hdfs:port").append("=").append(rootUri.getPort());
+        }
+      }
+    }
+    return URI.create(uri.toString());
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractMetadataProvider.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractMetadataProvider.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetException;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.DatasetNotFoundException;
+import org.kitesdk.data.URIBuilder;
+import org.kitesdk.data.spi.AbstractMetadataProvider;
+import org.kitesdk.data.spi.Compatibility;
+import org.kitesdk.data.spi.PartitionListener;
+import org.kitesdk.data.spi.filesystem.SchemaManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class HiveAbstractMetadataProvider extends AbstractMetadataProvider implements
+    PartitionListener {
+
+  static final String SCHEMA_DIRECTORY = ".metadata/schemas";
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(HiveAbstractMetadataProvider.class);
+
+  protected final Configuration conf;
+  private MetaStoreUtil metastore;
+
+  HiveAbstractMetadataProvider(Configuration conf) {
+    Preconditions.checkNotNull(conf, "Configuration cannot be null");
+    this.conf = conf;
+  }
+
+  protected MetaStoreUtil getMetaStoreUtil() {
+    if (metastore == null) {
+      metastore = MetaStoreUtil.get(conf);
+    }
+    return metastore;
+  }
+
+  protected abstract URI expectedLocation(String namespace, String name);
+
+  /**
+   * Returns whether the table is a managed hive table.
+   * @param name a Table name
+   * @return true if the table is managed, false otherwise
+   * @throws DatasetNotFoundException If the table does not exist in Hive
+   */
+  protected boolean isManaged(String namespace, String name) {
+    String resolved = resolveNamespace(namespace, name);
+    if (resolved != null) {
+      return isManaged(getMetaStoreUtil().getTable(resolved, name));
+    }
+    return false;
+  }
+
+  /**
+   * Returns whether the table is a managed hive table.
+   * @param name a Table name
+   * @return true if the table is managed, false otherwise
+   * @throws DatasetNotFoundException If the table does not exist in Hive
+   */
+  protected boolean isExternal(String namespace, String name) {
+    String resolved = resolveNamespace(namespace, name);
+    if (resolved != null) {
+      return isExternal(getMetaStoreUtil().getTable(resolved, name));
+    }
+    return false;
+  }
+
+  @Override
+  public DatasetDescriptor load(String namespace, String name) {
+    Compatibility.checkDatasetName(namespace, name);
+
+    String resolved = resolveNamespace(namespace, name);
+    if (resolved != null) {
+      return HiveUtils.descriptorForTable(
+          conf, getMetaStoreUtil().getTable(resolved, name));
+    }
+    throw new DatasetNotFoundException(
+        "Hive table not found: " + namespace + "." + name);
+  }
+
+  @Override
+  public DatasetDescriptor update(String namespace, String name, DatasetDescriptor descriptor) {
+    Compatibility.checkDatasetName(namespace, name);
+    Compatibility.checkDescriptor(descriptor);
+
+    String resolved = resolveNamespace(namespace, name);
+    if (resolved != null) {
+      Table table = getMetaStoreUtil().getTable(resolved, name);
+
+      Path managerPath = new Path(new Path(table.getSd().getLocation()),
+          SCHEMA_DIRECTORY);
+
+      SchemaManager manager = SchemaManager.create(conf, managerPath);
+
+      DatasetDescriptor newDescriptor;
+
+      try {
+        URI schemaURI = manager.writeSchema(descriptor.getSchema());
+
+        newDescriptor = new DatasetDescriptor.Builder(descriptor)
+            .schemaUri(schemaURI).build();
+
+      } catch (IOException e) {
+        throw new DatasetIOException("Unable to create schema", e);
+      }
+
+      HiveUtils.updateTableSchema(table, newDescriptor);
+      getMetaStoreUtil().alterTable(table);
+      return descriptor;
+    }
+    throw new DatasetNotFoundException(
+        "Hive table not found: " + namespace + "." + name);
+  }
+
+  @Override
+  public boolean delete(String namespace, String name) {
+    Compatibility.checkDatasetName(namespace, name);
+    String resolved = resolveNamespace(namespace, name);
+    if (resolved != null) {
+      getMetaStoreUtil().dropTable(resolved, name);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean exists(String namespace, String name) {
+    Compatibility.checkDatasetName(namespace, name);
+    return (resolveNamespace(namespace, name) != null);
+  }
+
+  @Override
+  public Collection<String> namespaces() {
+    Collection<String> databases = getMetaStoreUtil().getAllDatabases();
+    List<String> databasesWithDatasets = Lists.newArrayList();
+    for (String db : databases) {
+      if (isNamespace(db)) {
+        databasesWithDatasets.add(db);
+      }
+    }
+    return databasesWithDatasets;
+  }
+
+  @Override
+  public Collection<String> datasets(String namespace) {
+    Collection<String> tables = getMetaStoreUtil().getAllTables(namespace);
+    List<String> readableTables = Lists.newArrayList();
+    for (String name : tables) {
+      if (isReadable(namespace, name)) {
+        readableTables.add(name);
+      }
+    }
+    return readableTables;
+  }
+
+  /**
+   * Returns true if there is at least one table in the give database that can
+   * be read.
+   *
+   * @param database a Hive database name
+   * @return {@code true} if there is at least one readable table in database
+   * @see {@link #isReadable(String, String)}
+   */
+  private boolean isNamespace(String database) {
+    Collection<String> tables = getMetaStoreUtil().getAllTables(database);
+    for (String name : tables) {
+      if (isReadable(database, name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns true if the given table exists and can be read by this library.
+   *
+   * @param namespace a Hive database name
+   * @param name a table name
+   * @return {@code true} if the table exists and is supported
+   */
+  private boolean isReadable(String namespace, String name) {
+    Table table = getMetaStoreUtil().getTable(namespace, name);
+    if (isManaged(table) || isExternal(table)) { // readable table types
+      try {
+        // get a descriptor for the table. if this succeeds, it is readable
+        HiveUtils.descriptorForTable(conf, table);
+        return true;
+      } catch (DatasetException e) {
+        // not a readable table
+      } catch (IllegalStateException e) {
+        // not a readable table
+      } catch (IllegalArgumentException e) {
+        // not a readable table
+      } catch (UnsupportedOperationException e) {
+        // not a readable table
+      }
+    }
+    return false;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void partitionAdded(String namespace, String name, String path) {
+    getMetaStoreUtil().addPartition(namespace, name, path);
+  }
+
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void partitionDeleted(String namespace, String name, String path) {
+
+    getMetaStoreUtil().dropPartition(namespace, name, path);
+  }
+
+  /**
+   * Checks whether the Hive table {@code namespace.name} exists or if
+   * {@code default.name} exists and should be used.
+   *
+   * @param namespace the requested namespace
+   * @param name the table name
+   * @return if namespace.name exists, namespace. if not and default.name
+   *          exists, then default. {@code null} otherwise.
+   */
+  protected String resolveNamespace(String namespace, String name) {
+    return resolveNamespace(namespace, name, null);
+  }
+
+  /**
+   * Checks whether the Hive table {@code namespace.name} exists or if
+   * {@code default.name} exists and should be used.
+   *
+   * @param namespace the requested namespace
+   * @param name the table name
+   * @param location location that should match or null to check the default
+   * @return if namespace.name exists, namespace. if not and default.name
+   *          exists, then default. {@code null} otherwise.
+   */
+  protected String resolveNamespace(String namespace, String name,
+                                    @Nullable URI location) {
+    if (getMetaStoreUtil().exists(namespace, name)) {
+      return namespace;
+    }
+    try {
+      DatasetDescriptor descriptor = HiveUtils.descriptorForTable(
+          conf, getMetaStoreUtil().getTable(URIBuilder.NAMESPACE_DEFAULT, name));
+      URI expectedLocation = location;
+      if (location == null) {
+        expectedLocation = expectedLocation(namespace, name);
+      }
+      if ((expectedLocation == null) ||
+          pathsEquivalent(expectedLocation, descriptor.getLocation())) {
+        // table in the default db has the location that would have been used
+        return URIBuilder.NAMESPACE_DEFAULT;
+      }
+      // fall through and return null
+    } catch (DatasetNotFoundException e) {
+      // fall through and return null
+    }
+    return null;
+  }
+
+  private static boolean pathsEquivalent(URI left, @Nullable URI right) {
+    if (right == null) {
+      return false;
+    }
+    String leftAuth = left.getAuthority();
+    String rightAuth = right.getAuthority();
+    if (leftAuth != null && rightAuth != null && !leftAuth.equals(rightAuth)) {
+      // but authority sections are set, but do not match
+      return false;
+    }
+    return (Objects.equal(left.getScheme(), right.getScheme()) &&
+        Objects.equal(left.getPath(), right.getPath()));
+  }
+
+  @VisibleForTesting
+  static boolean isManaged(Table table) {
+    return TableType.MANAGED_TABLE.toString().equals(table.getTableType());
+  }
+
+  @VisibleForTesting
+  static boolean isExternal(Table table) {
+    return TableType.EXTERNAL_TABLE.toString().equals(table.getTableType());
+  }
+
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveExternalDatasetRepository.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveExternalDatasetRepository.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kitesdk.data.spi.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.spi.MetadataProvider;
+
+class HiveExternalDatasetRepository extends HiveAbstractDatasetRepository {
+
+  /**
+   * Create an HCatalog dataset repository with external tables.
+   */
+  HiveExternalDatasetRepository(Configuration conf, Path rootDirectory) {
+    super(conf, rootDirectory,
+        new HiveExternalMetadataProvider(conf, rootDirectory));
+  }
+
+  /**
+   * Create an HCatalog dataset repository with external tables.
+   */
+  HiveExternalDatasetRepository(Configuration conf, Path rootDirectory,
+                                MetadataProvider provider) {
+    super(conf, rootDirectory, provider);
+  }
+
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetExistsException;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.spi.Compatibility;
+import org.kitesdk.data.spi.filesystem.FileSystemUtil;
+import org.kitesdk.data.spi.filesystem.SchemaManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class HiveExternalMetadataProvider extends HiveAbstractMetadataProvider {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(HiveExternalMetadataProvider.class);
+  private final Path rootDirectory;
+  private final FileSystem rootFileSystem;
+
+  public HiveExternalMetadataProvider(Configuration conf, Path rootDirectory) {
+    super(conf);
+    Preconditions.checkNotNull(rootDirectory, "Root cannot be null");
+
+    try {
+      this.rootFileSystem = rootDirectory.getFileSystem(conf);
+      this.rootDirectory = rootFileSystem.makeQualified(rootDirectory);
+    } catch (IOException ex) {
+      throw new DatasetIOException("Could not get FileSystem for root path", ex);
+    }
+  }
+
+  @Override
+  public DatasetDescriptor create(String namespace, String name, DatasetDescriptor descriptor) {
+    Compatibility.checkDatasetName(namespace, name);
+    Compatibility.checkDescriptor(descriptor);
+
+    String resolved = resolveNamespace(
+        namespace, name, descriptor.getLocation());
+    if (resolved != null) {
+      if (resolved.equals(namespace)) {
+        // the requested dataset already exists
+        throw new DatasetExistsException(
+            "Metadata already exists for dataset: " + namespace + "." + name);
+      } else {
+        // replacing old default.name table
+        LOG.warn("Creating table {}.{} for {}: replaces default.{}",
+            new Object[]{
+                namespace, name, pathForDataset(namespace, name), name});
+        // validate that the new metadata can read the existing data
+        Compatibility.checkUpdate(load(resolved, name), descriptor);
+      }
+    }
+
+    LOG.info("Creating an external Hive table: {}.{}", namespace, name);
+
+    DatasetDescriptor newDescriptor = descriptor;
+
+    if (descriptor.getLocation() == null) {
+      // create a new descriptor with the dataset's location
+      newDescriptor = new DatasetDescriptor.Builder(descriptor)
+          .location(pathForDataset(namespace, name))
+          .build();
+    }
+
+    Path managerPath = new Path(new Path(newDescriptor.getLocation().toString()),
+        SCHEMA_DIRECTORY);
+
+    // Store the schema with the schema manager and use the
+    // managed URI moving forward.
+    SchemaManager manager = SchemaManager.create(conf, managerPath);
+
+    URI managedSchemaUri = manager.writeSchema(descriptor.getSchema());
+
+    try {
+      newDescriptor = new DatasetDescriptor.Builder(newDescriptor)
+          .schemaUri(managedSchemaUri)
+          .build();
+    } catch (IOException e) {
+      throw new DatasetIOException("Unable to load schema", e);
+    }
+
+    // create the data directory first so it is owned by the current user, not Hive
+    FileSystemUtil.ensureLocationExists(newDescriptor, conf);
+
+    // this object will be the table metadata
+    Table table = HiveUtils.tableForDescriptor(
+        namespace, name, newDescriptor, true /* external table */);
+
+    // assign the location of the the table
+    getMetaStoreUtil().createTable(table);
+
+    return newDescriptor;
+  }
+
+  @Override
+  protected URI expectedLocation(String namespace, String name) {
+    return pathForDataset(namespace, name).toUri();
+  }
+
+  private Path pathForDataset(String namespace, String name) {
+    Preconditions.checkState(rootDirectory != null,
+        "Dataset repository root directory can not be null");
+
+    return rootFileSystem.makeQualified(
+        HiveUtils.pathForDataset(rootDirectory, namespace, name));
+  }
+
+  @Override
+  public void partitionAdded(String namespace, String name, String path) {
+    Path partitionPath = new Path(pathForDataset(namespace, name), path);
+    try {
+      rootFileSystem.mkdirs(partitionPath);
+    } catch (IOException ex) {
+      throw new DatasetIOException(
+        "Unable to create partition directory  " + partitionPath, ex);
+    }
+    super.partitionAdded(namespace, name, path);
+  }
+
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveManagedDatasetRepository.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveManagedDatasetRepository.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kitesdk.data.spi.hive;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
+import org.kitesdk.data.spi.MetadataProvider;
+import org.kitesdk.data.spi.filesystem.FileSystemDataset;
+
+/**
+ * <p>
+ * A {@link DatasetRepository} that uses the Hive/HCatalog metastore for metadata,
+ * and stores data in a Hadoop {@link FileSystem}.
+ * </p>
+ * <p>
+ * The location of the data directory is either chosen by Hive/HCatalog (so called
+ * "managed tables"), or specified when creating an instance of this class by providing
+ * a {@link FileSystem}, and a root directory in the constructor ("external tables").
+ * </p>
+ * <p>
+ * The primary methods of interest will be
+ * {@link #create(String, String, DatasetDescriptor)}, {@link #load(String, String)}, and
+ * {@link #delete(String, String)} which create a new dataset, load an existing
+ * dataset, or delete an existing dataset, respectively. Once a dataset has been created
+ * or loaded, users can invoke the appropriate {@link Dataset} methods to get a reader
+ * or writer as needed.
+ * </p>
+ *
+ * @see DatasetRepository
+ * @see Dataset
+ */
+public class HiveManagedDatasetRepository extends HiveAbstractDatasetRepository {
+
+  /**
+   * Create an HCatalog dataset repository with managed tables.
+   */
+  HiveManagedDatasetRepository(Configuration conf) {
+    super(conf, new HiveManagedMetadataProvider(conf));
+  }
+
+  /**
+   * Create an HCatalog dataset repository with managed tables.
+   */
+  HiveManagedDatasetRepository(Configuration conf, MetadataProvider provider) {
+    super(conf, provider);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <E> Dataset<E> create(String namespace, String name, DatasetDescriptor descriptor) {
+    // avoids calling fsRepository.create, which creates the data path
+    getMetadataProvider().create(namespace, name, descriptor);
+    FileSystemDataset<E> dataset = (FileSystemDataset<E>) load(namespace, name);
+    return dataset;
+  }
+
+  @Override
+  public <E> Dataset<E> create(String namespace, String name, DatasetDescriptor descriptor, Class<E> type) {
+    // avoids calling fsRepository.create, which creates the data path
+    getMetadataProvider().create(namespace, name, descriptor);
+    return load(namespace, name, type);
+  }
+
+  /**
+   * A fluent builder to aid in the construction of {@link HiveManagedDatasetRepository}
+   * instances.
+   * @since 0.3.0
+   */
+  public static class Builder {
+
+    private Path rootDirectory;
+    private Configuration configuration;
+
+    /**
+     * The root directory for dataset files.
+     */
+    public Builder rootDirectory(Path path) {
+      this.rootDirectory = path;
+      return this;
+    }
+
+    /**
+     * The root directory for dataset files.
+     */
+    public Builder rootDirectory(URI uri) {
+      this.rootDirectory = new Path(uri);
+      return this;
+    }
+
+    /**
+     * The root directory for metadata and dataset files.
+     *
+     * @param uri a String to parse as a URI
+     * @return this Builder for method chaining.
+     * @throws URISyntaxException
+     *
+     * @since 0.8.0
+     */
+    public Builder rootDirectory(String uri) throws URISyntaxException {
+      this.rootDirectory = new Path(new URI(uri));
+      return this;
+    }
+
+    /**
+     * The {@link Configuration} used to find the {@link FileSystem}. Optional. If not
+     * specified, the default configuration will be used.
+     */
+    public Builder configuration(Configuration configuration) {
+      this.configuration = configuration;
+      return this;
+    }
+
+    /**
+     * Build an instance of the configured {@link HiveManagedDatasetRepository}.
+     *
+     * @since 0.9.0
+     */
+    @SuppressWarnings("deprecation")
+    public DatasetRepository build() {
+
+      if (configuration == null) {
+        this.configuration = DefaultConfiguration.get();
+      }
+
+      if (rootDirectory != null) {
+        return new HiveExternalDatasetRepository(configuration, rootDirectory);
+      } else {
+        return new HiveManagedDatasetRepository(configuration);
+      }
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveManagedMetadataProvider.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveManagedMetadataProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kitesdk.data.spi.hive;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetExistsException;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.spi.Compatibility;
+import org.kitesdk.data.spi.filesystem.FileSystemUtil;
+import org.kitesdk.data.spi.filesystem.SchemaManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class HiveManagedMetadataProvider extends HiveAbstractMetadataProvider {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(HiveManagedMetadataProvider.class);
+
+  public HiveManagedMetadataProvider(Configuration conf) {
+    super(conf);
+  }
+
+  @Override
+  public DatasetDescriptor create(String namespace, String name, DatasetDescriptor descriptor) {
+    Compatibility.checkDatasetName(namespace, name);
+    Compatibility.checkDescriptor(descriptor);
+
+    URI location = descriptor.getLocation();
+    String resolved = resolveNamespace(namespace, name, location);
+    if (resolved != null) {
+      if (resolved.equals(namespace)) {
+        // the requested dataset already exists
+        throw new DatasetExistsException(
+            "Metadata already exists for dataset: " + namespace + "." + name);
+      } else if (location != null) {
+        // if the location was set and matches an existing dataset, then this
+        // dataset is replacing the existing and using its data
+        DatasetDescriptor loaded = load(resolved, name);
+        // replacing old default.name table
+        LOG.warn("Creating table managed table {}.{}: replaces default.{}",
+            new Object[]{namespace, name, name});
+        // validate that the new metadata can read the existing data
+        Compatibility.checkUpdate(loaded, descriptor);
+        // if the table in the default namespace matches, then the location is
+        // either null (and should be set to the existing) or matches. either
+        // way, use the loaded location.
+        location = loaded.getLocation();
+      }
+    }
+
+    LOG.info("Creating a managed Hive table named: " + name);
+
+    boolean isExternal = (location != null);
+
+    DatasetDescriptor toCreate = descriptor;
+    if (isExternal) {
+      // add the location to the descriptor that will be used
+      toCreate = new DatasetDescriptor.Builder(descriptor)
+          .location(location)
+          .build();
+    }
+
+    // construct the table metadata from a descriptor, but without the Avro schema
+    // since we don't yet know its final location.
+    Table table = HiveUtils.tableForDescriptor(
+        namespace, name, toCreate, isExternal, false);
+
+    // create it
+    getMetaStoreUtil().createTable(table);
+
+    // load the created table to get the final data location
+    Table newTable = getMetaStoreUtil().getTable(namespace, name);
+
+    Path managerPath = new Path(new Path(newTable.getSd().getLocation()), SCHEMA_DIRECTORY);
+
+    // Write the Avro schema to that location and update the table appropriately.
+    SchemaManager manager = SchemaManager.create(conf, managerPath);
+
+    URI schemaLocation = manager.writeSchema(descriptor.getSchema());
+
+    DatasetDescriptor newDescriptor = null;
+
+    try {
+      newDescriptor = new DatasetDescriptor.Builder(descriptor)
+          .location(newTable.getSd().getLocation())
+          .schemaUri(schemaLocation)
+          .build();
+    } catch (IOException e) {
+      throw new DatasetIOException("Unable to set schema.", e);
+    }
+
+    // Add the schema now that it exists at an established URI.
+    HiveUtils.updateTableSchema(newTable, newDescriptor);
+
+    getMetaStoreUtil().alterTable(newTable);
+
+    if (isExternal) {
+      FileSystemUtil.ensureLocationExists(newDescriptor, conf);
+    }
+
+    return newDescriptor;
+  }
+
+  @Override
+  protected URI expectedLocation(String namespace, String name) {
+    return null;
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveSchemaConverter.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveSchemaConverter.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
+import org.codehaus.jackson.node.NullNode;
+import org.kitesdk.compat.DynConstructors;
+import org.kitesdk.compat.DynMethods;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.impl.Accessor;
+import org.kitesdk.data.spi.FieldPartitioner;
+import org.kitesdk.data.spi.SchemaUtil;
+
+public class HiveSchemaConverter {
+
+  private static final DynMethods.StaticMethod primitiveTypeForName =
+      new DynMethods.Builder("getPrimitiveTypeInfo")
+          .impl(TypeInfoFactory.class, String.class)
+          .buildStatic();
+
+  private static final DynMethods.StaticMethod parseTypeInfo =
+      new DynMethods.Builder("getTypeInfoFromTypeString")
+          .impl(TypeInfoUtils.class, String.class)
+          .buildStatic();
+
+  private static Class<?> findTypeInfoClass(String className) {
+    try {
+      return new DynConstructors.Builder(TypeInfo.class)
+          .impl(className).buildChecked().getConstructedClass();
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  // TypeInfo classes that may not be present at runtime
+  @VisibleForTesting
+  static final Class<?> charClass = findTypeInfoClass(
+      "org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo");
+  @VisibleForTesting
+  static final Class<?> varcharClass = findTypeInfoClass(
+      "org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo");
+  @VisibleForTesting
+  static final Class<?> decimalClass = findTypeInfoClass(
+      "org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo");
+
+  private static final ImmutableMap<String, Schema.Type> TYPEINFO_TO_TYPE =
+      ImmutableMap.<String, Schema.Type>builder()
+          .put("boolean", Schema.Type.BOOLEAN)
+          .put("tinyint", Schema.Type.INT)
+          .put("smallint", Schema.Type.INT)
+          .put("int", Schema.Type.INT)
+          .put("bigint", Schema.Type.LONG)
+          .put("float", Schema.Type.FLOAT)
+          .put("double", Schema.Type.DOUBLE)
+          .put("string", Schema.Type.STRING)
+          .put("binary", Schema.Type.BYTES)
+          .put("void", Schema.Type.NULL) // void columns are placeholders
+          .build();
+
+  static final ImmutableMap<Schema.Type, TypeInfo> TYPE_TO_TYPEINFO =
+      ImmutableMap.<Schema.Type, TypeInfo>builder()
+          .put(Schema.Type.BOOLEAN, primitiveTypeInfo("boolean"))
+          .put(Schema.Type.INT, primitiveTypeInfo("int"))
+          .put(Schema.Type.LONG, primitiveTypeInfo("bigint"))
+          .put(Schema.Type.FLOAT, primitiveTypeInfo("float"))
+          .put(Schema.Type.DOUBLE, primitiveTypeInfo("double"))
+          .put(Schema.Type.STRING, primitiveTypeInfo("string"))
+          .put(Schema.Type.ENUM, primitiveTypeInfo("string"))
+          .put(Schema.Type.BYTES, primitiveTypeInfo("binary"))
+          .put(Schema.Type.FIXED, primitiveTypeInfo("binary"))
+          .build();
+
+  private static final Schema NULL = Schema.create(Schema.Type.NULL);
+  @VisibleForTesting
+  static final NullNode NULL_DEFAULT = NullNode.getInstance();
+  @VisibleForTesting
+  static final Collection<String[]> NO_REQUIRED_FIELDS = ImmutableList.of();
+
+  private static TypeInfo primitiveTypeInfo(String type) {
+    return primitiveTypeForName.invoke(type);
+  }
+
+  public static TypeInfo parseTypeInfo(String type) {
+    return parseTypeInfo.invoke(type);
+  }
+
+  public static Schema convertTable(String table, Collection<FieldSchema> columns,
+                                    @Nullable PartitionStrategy strategy) {
+    ArrayList<String> fieldNames = Lists.newArrayList();
+    ArrayList<TypeInfo> fieldTypes = Lists.newArrayList();
+    LinkedList<String> start = Lists.newLinkedList();
+    Collection<String[]> requiredFields = requiredFields(strategy);
+
+    List<Schema.Field> fields = Lists.newArrayList();
+    for (FieldSchema column : columns) {
+      // pass null for the initial path to exclude the table name
+      TypeInfo type = parseTypeInfo(column.getType());
+      fieldNames.add(column.getName());
+      fieldTypes.add(type);
+      fields.add(convertField(start, column.getName(), type, requiredFields));
+    }
+
+    StructTypeInfo struct = new StructTypeInfo();
+    struct.setAllStructFieldNames(fieldNames);
+    struct.setAllStructFieldTypeInfos(fieldTypes);
+
+    Schema recordSchema = Schema.createRecord(table, doc(struct), null, false);
+    recordSchema.setFields(fields);
+
+    return recordSchema;
+  }
+
+  private static Schema convert(LinkedList<String> path, String name,
+                                StructTypeInfo type,
+                                Collection<String[]> required) {
+    List<String> names = type.getAllStructFieldNames();
+    List<TypeInfo> types = type.getAllStructFieldTypeInfos();
+    Preconditions.checkArgument(names.size() == types.size(),
+        "Cannot convert struct: %s names != %s types",
+        names.size(), types.size());
+
+    List<Schema.Field> fields = Lists.newArrayList();
+    for (int i = 0; i < names.size(); i += 1) {
+      path.addLast(name);
+      fields.add(convertField(path, names.get(i), types.get(i), required));
+      path.removeLast();
+    }
+
+    Schema recordSchema = Schema.createRecord(name, doc(type), null, false);
+    recordSchema.setFields(fields);
+
+    return recordSchema;
+  }
+
+  private static Schema.Field convertField(LinkedList<String> path, String name,
+                                           TypeInfo type,
+                                           Collection<String[]> required) {
+    // filter the required fields with the current name
+    Collection<String[]> matchingRequired = filterByStartsWith(required, path, name);
+
+    Schema schema = convert(path, name, type, matchingRequired);
+    boolean isOptional = (schema.getType() == Schema.Type.UNION);
+
+    if (!isOptional && matchingRequired.size() < 1) {
+      // not already an optional union and not required, make it optional.
+      // this doesn't complain if a required field is already optional because
+      // the minimum required fields are validated by DatasetDescriptor.
+      schema  = optional(schema);
+      isOptional = true;
+    }
+
+    return new Schema.Field(name, schema, doc(type),
+        isOptional ? NULL_DEFAULT : null);
+  }
+
+  @VisibleForTesting
+  static Schema convert(LinkedList<String> path, String name,
+                        TypeInfo type, Collection<String[]> required) {
+    switch (type.getCategory()) {
+      case PRIMITIVE:
+        if (type.getClass() == charClass || type.getClass() == varcharClass) {
+          // this is required because type name includes length
+          return Schema.create(Schema.Type.STRING);
+        }
+
+        String typeInfoName = type.getTypeName();
+        Preconditions.checkArgument(TYPEINFO_TO_TYPE.containsKey(typeInfoName),
+            "Cannot convert unsupported type: %s", typeInfoName);
+        return Schema.create(TYPEINFO_TO_TYPE.get(typeInfoName));
+
+      case LIST:
+        return Schema.createArray(optional(convert(path, name,
+            ((ListTypeInfo) type).getListElementTypeInfo(), required)));
+
+      case MAP:
+        MapTypeInfo mapType = (MapTypeInfo) type;
+        Preconditions.checkArgument(
+            "string".equals(mapType.getMapKeyTypeInfo().toString()),
+            "Non-String map key type: %s", mapType.getMapKeyTypeInfo());
+
+        return Schema.createMap(optional(convert(path, name,
+            mapType.getMapValueTypeInfo(), required)));
+
+      case STRUCT:
+        return convert(path, name, (StructTypeInfo) type, required);
+
+      case UNION:
+        List<TypeInfo> unionTypes = ((UnionTypeInfo) type)
+            .getAllUnionObjectTypeInfos();
+
+        // add NULL so all union types are optional
+        List<Schema> types = Lists.newArrayList(NULL);
+        for (int i = 0; i < unionTypes.size(); i += 1) {
+          // types within unions cannot be required
+          types.add(convert(
+              path, name + "_" + i, unionTypes.get(i), NO_REQUIRED_FIELDS));
+        }
+
+        return Schema.createUnion(types);
+
+      default:
+        throw new IllegalArgumentException(
+            "Unknown TypeInfo category: " + type.getCategory());
+    }
+  }
+
+  @VisibleForTesting
+  static Schema optional(Schema schema) {
+    return Schema.createUnion(Lists.newArrayList(NULL, schema));
+  }
+
+  private static String doc(TypeInfo type) {
+    if (type instanceof StructTypeInfo) {
+      // don't add struct<a:t1,b:t2> when fields a and b will have doc strings
+      return null;
+    }
+    return "Converted from '" + String.valueOf(type) + "'";
+  }
+
+  public static List<FieldSchema> convertSchema(Schema avroSchema) {
+    List<FieldSchema> columns = Lists.newArrayList();
+    if (Schema.Type.RECORD.equals(avroSchema.getType())) {
+      for (Schema.Field field : avroSchema.getFields()) {
+        columns.add(new FieldSchema(
+            field.name(), convert(field.schema()).getTypeName(), field.doc()));
+      }
+    } else {
+      columns.add(new FieldSchema(
+          "column", convert(avroSchema).getTypeName(), avroSchema.getDoc()));
+    }
+    return columns;
+  }
+
+  @VisibleForTesting
+  static TypeInfo convert(Schema schema) {
+    return SchemaUtil.visit(schema, new Converter());
+  }
+
+  private static class Converter extends SchemaUtil.SchemaVisitor<TypeInfo> {
+    public TypeInfo record(Schema record, List<String> names, List<TypeInfo> types) {
+      return TypeInfoFactory.getStructTypeInfo(names, types);
+    }
+
+    @Override
+    public TypeInfo union(Schema union, List<TypeInfo> options) {
+      // so no need to keep track of whether the avro type is nullable because
+      // all Hive types are nullable
+      List<TypeInfo> nonNullTypes = Lists.newArrayList();
+      for (TypeInfo type : options) {
+        if (type != null) {
+          nonNullTypes.add(type);
+        }
+      }
+
+      // handle a single field in the union
+      if (nonNullTypes.size() == 1) {
+        return nonNullTypes.get(0);
+      }
+
+      return TypeInfoFactory.getUnionTypeInfo(nonNullTypes);
+    }
+
+    @Override
+    public TypeInfo array(Schema array, TypeInfo element) {
+      return TypeInfoFactory.getListTypeInfo(element);
+    }
+
+    @Override
+    public TypeInfo map(Schema map, TypeInfo value) {
+      return TypeInfoFactory.getMapTypeInfo(
+          TYPE_TO_TYPEINFO.get(Schema.Type.STRING), value);
+    }
+
+    @Override
+    public TypeInfo primitive(Schema primitive) {
+      return TYPE_TO_TYPEINFO.get(primitive.getType());
+    }
+  }
+
+  private static Collection<String[]> filterByStartsWith(
+      Collection<String[]> fields, LinkedList<String> path, String name) {
+    path.addLast(name);
+
+    List<String[]> startsWithCollection = Lists.newArrayList();
+    for (String[] field : fields) {
+      if (startsWith(field, path)) {
+        startsWithCollection.add(field);
+      }
+    }
+
+    path.removeLast();
+
+    return startsWithCollection;
+  }
+
+  /**
+   * Returns true if left starts with right.
+   */
+  private static boolean startsWith(String[] left, List<String> right) {
+    // short circuit if a match isn't possible
+    if (left.length < right.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < right.size(); i += 1) {
+      if (!left[i].equals(right.get(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static Collection<String[]> requiredFields(@Nullable PartitionStrategy strategy) {
+    if (strategy == null) {
+      return NO_REQUIRED_FIELDS;
+    }
+
+    List<String[]> requiredFields = Lists.newArrayList();
+    for (FieldPartitioner fp : Accessor.getDefault().getFieldPartitioners(strategy)) {
+      // source name is not present for provided partitioners
+      if (fp.getSourceName() != null) {
+        requiredFields.add(fp.getSourceName().split("\\."));
+      }
+    }
+
+    return requiredFields;
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Order;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.SkewedInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.kitesdk.compat.DynMethods;
+import org.kitesdk.compat.Hadoop;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetException;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.DatasetOperationException;
+import org.kitesdk.data.Format;
+import org.kitesdk.data.Formats;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.UnknownFormatException;
+import org.kitesdk.data.impl.Accessor;
+import org.kitesdk.data.spi.FieldPartitioner;
+import org.kitesdk.data.spi.SchemaUtil;
+
+class HiveUtils {
+  static final String HDFS_SCHEME = "hdfs";
+
+  private static final String CUSTOM_PROPERTIES_PROPERTY_NAME = "kite.custom.property.names";
+  private static final String PARTITION_EXPRESSION_PROPERTY_NAME = "kite.partition.expression";
+  private static final String COMPRESSION_TYPE_PROPERTY_NAME = "kite.compression.type";
+  private static final String OLD_CUSTOM_PROPERTIES_PROPERTY_NAME = "cdk.custom.property.names";
+  private static final String OLD_PARTITION_EXPRESSION_PROPERTY_NAME = "cdk.partition.expression";
+  private static final String AVRO_SCHEMA_URL_PROPERTY_NAME = "avro.schema.url";
+  private static final String AVRO_SCHEMA_LITERAL_PROPERTY_NAME = "avro.schema.literal";
+
+  private static final Splitter NAME_SPLITTER = Splitter.on(',');
+  private static final Joiner NAME_JOINER = Joiner.on(',');
+
+  private static final Map<Format, String> FORMAT_TO_SERDE = ImmutableMap
+      .<Format, String>builder()
+      .put(Formats.AVRO, "org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+      .put(Formats.PARQUET, getHiveParquetSerde())
+      .build();
+  private static final Map<String, Format> SERDE_TO_FORMAT = ImmutableMap
+      .<String, Format>builder()
+      .put("org.apache.hadoop.hive.serde2.avro.AvroSerDe", Formats.AVRO)
+      .put("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+           Formats.PARQUET)
+      .put("parquet.hive.serde.ParquetHiveSerDe", Formats.PARQUET)
+      .build();
+  private static final Map<Format, String> FORMAT_TO_INPUT_FORMAT = ImmutableMap
+      .<Format, String>builder()
+      .put(Formats.AVRO,
+           "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+      .put(Formats.PARQUET, getHiveParquetInputFormat())
+      .build();
+  private static final Map<Format, String> FORMAT_TO_OUTPUT_FORMAT = ImmutableMap
+      .<Format, String>builder()
+      .put(Formats.AVRO,
+           "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+      .put(Formats.PARQUET, getHiveParquetOutputFormat())
+      .build();
+
+  static DatasetDescriptor descriptorForTable(Configuration conf, Table table) {
+    final DatasetDescriptor.Builder builder = new DatasetDescriptor.Builder();
+
+    Format format;
+    final String serializationLib = table.getSd().getSerdeInfo().getSerializationLib();
+    if (SERDE_TO_FORMAT.containsKey(serializationLib)) {
+      format = SERDE_TO_FORMAT.get(serializationLib);
+      builder.format(format);
+    } else {
+      // TODO: should this use an "unknown" format? others fail in open()
+      throw new UnknownFormatException(
+          "Unknown format for serde:" + serializationLib);
+    }
+
+    final Path dataLocation = new Path(table.getSd().getLocation());
+    final FileSystem fs = fsForPath(conf, dataLocation);
+
+    builder.location(fs.makeQualified(dataLocation));
+
+    // custom properties
+    Map<String, String> properties = table.getParameters();
+    String namesProperty = coalesce(
+        properties.get(CUSTOM_PROPERTIES_PROPERTY_NAME),
+        properties.get(OLD_CUSTOM_PROPERTIES_PROPERTY_NAME));
+    if (namesProperty != null) {
+      for (String property : NAME_SPLITTER.split(namesProperty)) {
+        builder.property(property, properties.get(property));
+      }
+    }
+
+    PartitionStrategy partitionStrategy = null;
+    if (isPartitioned(table)) {
+      String partitionProperty = coalesce(
+          properties.get(PARTITION_EXPRESSION_PROPERTY_NAME),
+          properties.get(OLD_PARTITION_EXPRESSION_PROPERTY_NAME));
+      if (partitionProperty != null) {
+        partitionStrategy = Accessor.getDefault()
+            .fromExpression(partitionProperty);
+      } else {
+        // build a partition strategy for the table from the Hive strategy
+        partitionStrategy = fromPartitionColumns(getPartCols(table));
+      }
+      builder.partitionStrategy(partitionStrategy);
+    }
+
+    String schemaUrlString = properties.get(AVRO_SCHEMA_URL_PROPERTY_NAME);
+    if (schemaUrlString != null) {
+      try {
+        // URI.create is safe because this library wrote the URI
+        builder.schemaUri(URI.create(schemaUrlString));
+      } catch (IOException e) {
+        throw new DatasetIOException("Could not read schema", e);
+      }
+    } else {
+      String schemaLiteral = properties.get(AVRO_SCHEMA_LITERAL_PROPERTY_NAME);
+      if (schemaLiteral != null) {
+        builder.schemaLiteral(schemaLiteral);
+      } else {
+        builder.schema(HiveSchemaConverter.convertTable(
+            table.getTableName(), table.getSd().getCols(),
+            partitionStrategy));
+      }
+    }
+
+    String compressionType = properties.get(COMPRESSION_TYPE_PROPERTY_NAME);
+    if (compressionType != null) {
+      builder.compressionType(compressionType);
+    }
+
+    try {
+      return builder.build();
+    } catch (IllegalStateException ex) {
+      throw new DatasetException("Cannot find schema: missing metadata");
+    }
+  }
+
+  private static boolean isPartitioned(Table table) {
+    return (getPartCols(table).size() != 0);
+  }
+
+  private static List<FieldSchema> getPartCols(Table table) {
+    List<FieldSchema> partKeys = table.getPartitionKeys();
+    if (partKeys == null) {
+      partKeys = new ArrayList<FieldSchema>();
+      table.setPartitionKeys(partKeys);
+    }
+    return partKeys;
+  }
+
+  /**
+   * Returns the first non-null value from the sequence or null if there is no
+   * non-null value.
+   */
+  private static <T> T coalesce(T... values) {
+    for (T value : values) {
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  static Table tableForDescriptor(String namespace, String name,
+                                  DatasetDescriptor descriptor,
+                                  boolean external) {
+
+    return tableForDescriptor(namespace, name, descriptor, external, true);
+  }
+
+  static Table tableForDescriptor(String namespace, String name,
+                                  DatasetDescriptor descriptor,
+                                  boolean external,
+                                  boolean includeSchema) {
+    final Table table = createEmptyTable(namespace, name);
+
+    if (external) {
+      // you'd think this would do it...
+      table.setTableType(TableType.EXTERNAL_TABLE.toString());
+      // but it doesn't work without some additional magic:
+      table.getParameters().put("EXTERNAL", "TRUE");
+      table.getSd().setLocation(descriptor.getLocation().toString());
+    } else {
+      table.setTableType(TableType.MANAGED_TABLE.toString());
+    }
+
+    addPropertiesForDescriptor(table, descriptor);
+
+    // translate from Format to SerDe
+    final Format format = descriptor.getFormat();
+    if (FORMAT_TO_SERDE.containsKey(format)) {
+      table.getSd().getSerdeInfo().setSerializationLib(FORMAT_TO_SERDE.get(format));
+      table.getSd().setInputFormat(FORMAT_TO_INPUT_FORMAT.get(format));
+      table.getSd().setOutputFormat(FORMAT_TO_OUTPUT_FORMAT.get(format));
+    } else {
+      throw new UnknownFormatException(
+          "No known serde for format:" + format.getName());
+    }
+
+    if (includeSchema) {
+      URL schemaURL = descriptor.getSchemaUrl();
+      if (useSchemaURL(schemaURL)) {
+        table.getParameters().put(
+            AVRO_SCHEMA_URL_PROPERTY_NAME,
+            descriptor.getSchemaUrl().toExternalForm());
+      } else {
+        table.getParameters().put(
+            AVRO_SCHEMA_LITERAL_PROPERTY_NAME,
+            descriptor.getSchema().toString());
+      }
+    }
+
+    table.getParameters().put(COMPRESSION_TYPE_PROPERTY_NAME,
+        descriptor.getCompressionType().getName());
+
+    // convert the schema to Hive columns
+    table.getSd().setCols(HiveSchemaConverter.convertSchema(descriptor.getSchema()));
+
+    // copy partitioning info
+    if (descriptor.isPartitioned()) {
+      PartitionStrategy ps = descriptor.getPartitionStrategy();
+      table.getParameters().put(PARTITION_EXPRESSION_PROPERTY_NAME,
+          Accessor.getDefault().toExpression(ps));
+      table.setPartitionKeys(partitionColumns(ps, descriptor.getSchema()));
+    }
+
+    return table;
+  }
+
+  private static boolean useSchemaURL(@Nullable URL schemaURL) {
+    try {
+      return ((schemaURL != null) &&
+          HDFS_SCHEME.equals(schemaURL.toURI().getScheme()));
+    } catch (URISyntaxException ex) {
+      return false;
+    }
+  }
+
+  static Table createEmptyTable(String namespace, String name) {
+    Table table = new Table();
+    table.setDbName(namespace);
+    table.setTableName(name);
+    table.setPartitionKeys(new ArrayList<FieldSchema>());
+    table.setParameters(new HashMap<String, String>());
+
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setSerdeInfo(new SerDeInfo());
+    sd.setNumBuckets(-1);
+    sd.setBucketCols(new ArrayList<String>());
+    sd.setCols(new ArrayList<FieldSchema>());
+    sd.setParameters(new HashMap<String, String>());
+    sd.setSortCols(new ArrayList<Order>());
+    sd.getSerdeInfo().setParameters(new HashMap<String, String>());
+    SkewedInfo skewInfo = new SkewedInfo();
+    skewInfo.setSkewedColNames(new ArrayList<String>());
+    skewInfo.setSkewedColValues(new ArrayList<List<String>>());
+    skewInfo.setSkewedColValueLocationMaps(new HashMap<List<String>, String>());
+    sd.setSkewedInfo(skewInfo);
+    table.setSd(sd);
+
+    return table;
+  }
+
+  public static void updateTableSchema(Table table, DatasetDescriptor descriptor) {
+    URL schemaURL = descriptor.getSchemaUrl();
+
+    if (table.getParameters().get(AVRO_SCHEMA_LITERAL_PROPERTY_NAME) != null) {
+      if (useSchemaURL(schemaURL)) {
+        table.getParameters().remove(AVRO_SCHEMA_LITERAL_PROPERTY_NAME);
+        table.getParameters().put(AVRO_SCHEMA_URL_PROPERTY_NAME,
+            schemaURL.toExternalForm());
+      } else {
+        table.getParameters().put(
+            AVRO_SCHEMA_LITERAL_PROPERTY_NAME,
+            descriptor.getSchema().toString());
+      }
+
+    } else if (table.getParameters().get(AVRO_SCHEMA_URL_PROPERTY_NAME) != null) {
+      if (schemaURL == null) {
+        throw new DatasetOperationException(
+            "Cannot update " + AVRO_SCHEMA_URL_PROPERTY_NAME +
+            " since descriptor schema URL is not set.");
+      }
+      table.getParameters().put(
+          AVRO_SCHEMA_URL_PROPERTY_NAME,
+          schemaURL.toExternalForm());
+
+    } else {
+      // neither the literal or the URL are set, so add the URL if specified
+      // and the schema literal if not.
+      if (useSchemaURL(schemaURL)) {
+        table.getParameters().put(
+                AVRO_SCHEMA_URL_PROPERTY_NAME,
+                schemaURL.toExternalForm());
+
+      } else if (descriptor.getSchema() != null) {
+        table.getParameters().put(
+                AVRO_SCHEMA_LITERAL_PROPERTY_NAME,
+                descriptor.getSchema().toString());
+      } else {
+        throw new DatasetException("Table schema cannot be updated since it is" +
+                " not set on the descriptor.");
+      }
+    }
+
+    // copy partitioning info
+    if (descriptor.isPartitioned()) {
+      PartitionStrategy ps = descriptor.getPartitionStrategy();
+      table.getParameters().put(PARTITION_EXPRESSION_PROPERTY_NAME,
+          Accessor.getDefault().toExpression(ps));
+      // no need to set the partition columns; no changes to the Hive side
+    }
+
+    // keep the custom properties up-to-date
+    addPropertiesForDescriptor(table, descriptor);
+
+    // keep the table DDL up to-to-date with the Schema
+    table.getSd().setCols(
+        HiveSchemaConverter.convertSchema(descriptor.getSchema()));
+  }
+
+  static FileSystem fsForPath(Configuration conf, Path path) {
+    try {
+      return path.getFileSystem(conf);
+    } catch (IOException ex) {
+      throw new DatasetIOException("Cannot access FileSystem for uri:" + path, ex);
+    }
+  }
+
+  private static void addPropertiesForDescriptor(Table table,
+                                                 DatasetDescriptor descriptor) {
+    // copy custom properties to the table
+    if (!descriptor.listProperties().isEmpty()) {
+      for (String property : descriptor.listProperties()) {
+        // no need to check the reserved list, those are not set on descriptors
+        table.getParameters().put(property, descriptor.getProperty(property));
+      }
+      // set which properties are custom and should be set on descriptors
+      table.getParameters().put(CUSTOM_PROPERTIES_PROPERTY_NAME,
+          NAME_JOINER.join(descriptor.listProperties()));
+    }
+  }
+
+  /**
+   * Returns the correct dataset path for the given name and root directory.
+   *
+   * @param root A Path
+   * @param namespace A String namespace, or logical group
+   * @param name A String dataset name
+   * @return the correct dataset Path
+   */
+  static Path pathForDataset(Path root, String namespace, String name) {
+    Preconditions.checkNotNull(namespace, "Namespace cannot be null");
+    Preconditions.checkNotNull(name, "Dataset name cannot be null");
+
+    // Why replace '.' here? Is this a namespacing hack?
+    return new Path(root, new Path(namespace, name.replace('.', Path.SEPARATOR_CHAR)));
+  }
+
+  @SuppressWarnings("deprecation")
+  static List<FieldSchema> partitionColumns(PartitionStrategy strategy, Schema schema) {
+    List<FieldSchema> columns = Lists.newArrayList();
+    for (FieldPartitioner<?, ?> fp : Accessor.getDefault().getFieldPartitioners(strategy)) {
+      columns.add(new FieldSchema(fp.getName(),
+          getHiveType(SchemaUtil.getPartitionType(fp, schema)),
+          "Partition column derived from '" + fp.getSourceName() + "' column, " +
+              "generated by Kite."));
+    }
+    return columns;
+  }
+
+  private static final Map<String, String> PROVIDED_TYPES = ImmutableMap
+      .<String, String>builder()
+      .put("tinyint", "int")
+      .put("smallint", "int")
+      .put("int", "int")
+      .put("bigint", "long")
+      .build();
+
+  /**
+   * Builds a {@link PartitionStrategy} from a list of Hive partition fields.
+   *
+   * @param fields a List of FieldSchemas
+   * @return a PartitionStrategy for the Hive partitions
+   */
+  @VisibleForTesting
+  static PartitionStrategy fromPartitionColumns(List<FieldSchema> fields) {
+    PartitionStrategy.Builder builder = new PartitionStrategy.Builder();
+    for (FieldSchema hiveSchema : fields) {
+      TypeInfo type = HiveSchemaConverter.parseTypeInfo(hiveSchema.getType());
+      // any types not in the map will be treated as Strings
+      builder.provided(hiveSchema.getName(),
+          PROVIDED_TYPES.get(type.getTypeName()));
+    }
+    return builder.build();
+  }
+
+  private static String getHiveType(Class<?> type) {
+    String typeName = PrimitiveObjectInspectorUtils.getTypeNameFromPrimitiveJava(type);
+    if (typeName == null) {
+      throw new DatasetException("Unsupported FieldPartitioner type: " + type);
+    }
+    return typeName;
+  }
+
+  private static String getHiveParquetInputFormat() {
+    String newClass = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat";
+    String oldClass = "parquet.hive.DeprecatedParquetInputFormat";
+
+    try {
+      Class.forName(newClass);
+      return newClass;
+    } catch (ClassNotFoundException ex) {
+      return oldClass;
+    }
+  }
+
+  private static String getHiveParquetOutputFormat() {
+    String newClass = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat";
+    String oldClass = "parquet.hive.DeprecatedParquetOutputFormat";
+
+    try {
+      Class.forName(newClass);
+      return newClass;
+    } catch (java.lang.NoClassDefFoundError ex) {
+      return newClass;
+    } catch (ClassNotFoundException ex) {
+      return oldClass;
+    }
+  }
+
+  private static String getHiveParquetSerde() {
+    String newClass = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe";
+    String oldClass = "parquet.hive.serde.ParquetHiveSerDe";
+
+    try {
+      Class.forName(newClass);
+      return newClass;
+    } catch (java.lang.NoClassDefFoundError ex) {
+      return newClass;
+    } catch (ClassNotFoundException ex) {
+      return oldClass;
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/Loader.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/Loader.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import org.kitesdk.compat.DynConstructors;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.DatasetOperationException;
+import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
+import org.kitesdk.data.spi.Loadable;
+import org.kitesdk.data.spi.OptionBuilder;
+import org.kitesdk.data.spi.Registration;
+import org.kitesdk.data.spi.URIPattern;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Loader implementation to register URIs for FileSystemDatasetRepositories.
+ */
+public class Loader implements Loadable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Loader.class);
+
+  public static final String HIVE_METASTORE_URI_PROP = "hive.metastore.uris";
+  private static final int UNSPECIFIED_PORT = -1;
+  private static final String NOT_SET = "not-set";
+  private static final String HDFS_HOST = "hdfs:host";
+  private static final String HDFS_PORT = "hdfs:port";
+  private static final String OLD_HDFS_HOST = "hdfs-host";
+  private static final String OLD_HDFS_PORT = "hdfs-port";
+
+  private static DynConstructors.Ctor<Configuration> HIVE_CONF;
+
+  /**
+   * This class builds configured instances of
+   * {@code FileSystemDatasetRepository} from a Map of options. This is for the
+   * URI system.
+   */
+  private static class ExternalBuilder implements OptionBuilder<DatasetRepository> {
+
+    @Override
+    public DatasetRepository getFromOptions(Map<String, String> match) {
+      LOG.debug("External URI options: {}", match);
+      final Path root;
+      String path = match.get("path");
+      if (match.containsKey("absolute")
+          && Boolean.valueOf(match.get("absolute"))) {
+        root = (path == null || path.isEmpty()) ? new Path("/") : new Path("/", path);
+      } else {
+        root = (path == null || path.isEmpty()) ? new Path(".") : new Path(path);
+      }
+
+      // make a modifiable copy (it may be changed)
+      Configuration conf = newHiveConf(DefaultConfiguration.get());
+      FileSystem fs;
+      try {
+        fs = FileSystem.get(fileSystemURI(match, conf), conf);
+      } catch (IOException e) {
+        // "Incomplete HDFS URI, no host" => add a helpful suggestion
+        if (e.getMessage().startsWith("Incomplete")) {
+          throw new DatasetIOException("Could not get a FileSystem: " +
+              "make sure the default " + match.get(URIPattern.SCHEME) +
+              " URI is configured.", e);
+        }
+        throw new DatasetIOException("Could not get a FileSystem", e);
+      }
+
+      // setup the MetaStore URI
+      setMetaStoreURI(conf, match);
+
+      return new HiveManagedDatasetRepository.Builder()
+          .configuration(conf)
+          .rootDirectory(fs.makeQualified(root))
+          .build();
+    }
+  }
+
+  private static class ManagedBuilder implements OptionBuilder<DatasetRepository> {
+    @Override
+    public DatasetRepository getFromOptions(Map<String, String> match) {
+      LOG.debug("Managed URI options: {}", match);
+      // make a modifiable copy and setup the MetaStore URI
+      Configuration conf = newHiveConf(DefaultConfiguration.get());
+      // sanity check the URI
+      setMetaStoreURI(conf, match);
+      return new HiveManagedDatasetRepository.Builder()
+          .configuration(conf)
+          .build();
+    }
+  }
+
+  @Override
+  public void load() {
+    checkHiveDependencies();
+
+    OptionBuilder<DatasetRepository> managedBuilder = new ManagedBuilder();
+    OptionBuilder<DatasetRepository> externalBuilder = new ExternalBuilder();
+
+    Registration.register(
+        new URIPattern("hive"),
+        new URIPattern("hive::namespace/:dataset"),
+        managedBuilder);
+    Registration.register(
+        new URIPattern("hive"),
+        new URIPattern("hive::dataset?namespace=default"),
+        managedBuilder);
+    Registration.register(
+        new URIPattern("hive"),
+        new URIPattern("hive?namespace=default"),
+        managedBuilder);
+
+    Registration.register(
+        new URIPattern("hive://" + NOT_SET),
+        new URIPattern("hive:/:namespace/:dataset"),
+        managedBuilder);
+    Registration.register(
+        new URIPattern("hive://" + NOT_SET),
+        new URIPattern("hive:/:dataset?namespace=default"),
+        managedBuilder);
+    Registration.register(
+        new URIPattern("hive://" + NOT_SET),
+        new URIPattern("hive://" + NOT_SET + "?namespace=default"),
+        managedBuilder);
+
+    Registration.register(
+        new URIPattern("hive:/*path?absolute=true"),
+        new URIPattern("hive:/*path/:namespace/:dataset?absolute=true"),
+        externalBuilder);
+    Registration.register(
+        new URIPattern("hive:*path"),
+        new URIPattern("hive:*path/:namespace/:dataset"),
+        externalBuilder);
+  }
+
+  private static Configuration newHiveConf(Configuration base) {
+    checkHiveDependencies(); // ensure HIVE_CONF is present
+    Configuration conf = HIVE_CONF.newInstance(base, HIVE_CONF.getConstructedClass());
+
+    // Add everything in base back in to work around a bug in HiveConf
+    addResource(conf, base);
+    return conf;
+  }
+
+  public static void addResource(Configuration hiveConf, Configuration conf) {
+    for (Map.Entry<String, String> entry : conf) {
+      hiveConf.set(entry.getKey(), entry.getValue());
+    }
+  }
+
+  private synchronized static void checkHiveDependencies() {
+    if (Loader.HIVE_CONF == null) {
+      // check that Hive is available by resolving the HiveConf constructor
+      // this is also needed by newHiveConf(Configuration)
+      Loader.HIVE_CONF = new DynConstructors.Builder()
+          .impl("org.apache.hadoop.hive.conf.HiveConf", Configuration.class, Class.class)
+          .build();
+    }
+  }
+
+  private static URI fileSystemURI(Map<String, String> match, Configuration conf) {
+    final String userInfo;
+    if (match.containsKey(URIPattern.USERNAME)) {
+      if (match.containsKey(URIPattern.PASSWORD)) {
+        userInfo = match.get(URIPattern.USERNAME) + ":" +
+            match.get(URIPattern.PASSWORD);
+      } else {
+        userInfo = match.get(URIPattern.USERNAME);
+      }
+    } else {
+      userInfo = null;
+    }
+
+    try {
+      if (match.containsKey(HDFS_HOST) || match.containsKey(OLD_HDFS_HOST)) {
+        int port = UNSPECIFIED_PORT;
+        if (match.containsKey(HDFS_PORT) || match.containsKey(OLD_HDFS_PORT)) {
+          try {
+            port = Integer.parseInt(first(match, HDFS_PORT, OLD_HDFS_PORT));
+          } catch (NumberFormatException e) {
+            port = UNSPECIFIED_PORT;
+          }
+        }
+        return new URI("hdfs", userInfo, first(match, HDFS_HOST, OLD_HDFS_HOST),
+            port, "/", null, null);
+      } else {
+        String defaultScheme;
+        try {
+          defaultScheme = FileSystem.get(conf).getUri().getScheme();
+        } catch (IOException e) {
+          throw new DatasetIOException("Cannot determine the default FS", e);
+        }
+        return new URI(defaultScheme, userInfo, "", UNSPECIFIED_PORT, "/", null, null);
+      }
+    } catch (URISyntaxException ex) {
+      throw new DatasetOperationException("Could not build FS URI", ex);
+    }
+  }
+
+  /**
+   * Sets the MetaStore URI in the given Configuration, if there is a host in
+   * the match arguments. If there is no host, then the conf is not changed.
+   *
+   * @param conf a Configuration that will be used to connect to the MetaStore
+   * @param match URIPattern match results
+   */
+  private static void setMetaStoreURI(
+      Configuration conf, Map<String, String> match) {
+    try {
+      // If the host is set, construct a new MetaStore URI and set the property
+      // in the Configuration. Otherwise, do not change the MetaStore URI.
+      String host = match.get(URIPattern.HOST);
+      if (host != null && !NOT_SET.equals(host)) {
+        int port;
+        try {
+          port = Integer.parseInt(match.get(URIPattern.PORT));
+        } catch (NumberFormatException e) {
+          port = UNSPECIFIED_PORT;
+        }
+        conf.set(HIVE_METASTORE_URI_PROP,
+            new URI("thrift", null, host, port, null, null, null).toString());
+      }
+    } catch (URISyntaxException ex) {
+      throw new DatasetOperationException(
+          "Could not build metastore URI", ex);
+    }
+  }
+
+  private static String first(Map<String, String> data, String... keys) {
+    for (String key : keys) {
+      if (data.containsKey(key)) {
+        return data.get(key);
+      }
+    }
+    return null;
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/MetaStoreUtil.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/java/org/kitesdk/data/spi/hive/MetaStoreUtil.java
@@ -1,0 +1,491 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kitesdk.data.spi.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.thrift.TException;
+import org.kitesdk.compat.Hadoop;
+import org.kitesdk.data.DatasetExistsException;
+import org.kitesdk.data.DatasetNotFoundException;
+import org.kitesdk.data.DatasetOperationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.ProxyFileSystem;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.shims.Hadoop23Shims;
+import org.apache.hadoop.hive.shims.HadoopShimsSecure;
+
+public class MetaStoreUtil {
+
+  static {
+    ProxyFileSystem.class.getName();
+    Hadoop23Shims.class.getName();
+    HadoopShimsSecure.class.getName();
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetaStoreUtil.class);
+  private static final String ALLOW_LOCAL_METASTORE = "kite.hive.allow-local-metastore";
+  private static final List<String> EMPTY_LIST = Collections.unmodifiableList(
+      new ArrayList<String>());
+
+  private final HiveMetaStoreClient client;
+  private final HiveConf hiveConf;
+
+  private static interface ClientAction<R> {
+    R call() throws TException;
+  }
+
+  private <R> R doWithRetry(ClientAction<R> action) throws TException {
+    try {
+      synchronized (client) {
+        return action.call();
+      }
+    } catch (TException e) {
+      try {
+        synchronized (client) {
+          client.reconnect();
+        }
+      } catch (MetaException swallowedException) {
+        // reconnect failed, throw the original exception
+        throw e;
+      }
+      synchronized (client) {
+        // retry the action. if this fails, its exception is propagated
+        return action.call();
+      }
+    }
+  }
+
+  public static final Map<String, MetaStoreUtil> INSTANCES =
+      new HashMap<String, MetaStoreUtil>();
+
+  public static MetaStoreUtil get(Configuration conf) {
+    HiveConf hiveConf = new HiveConf(conf, HiveConf.class);
+    // Add the passed configuration back into the HiveConf to work around
+    // a Hive bug that resets to defaults
+    addResource(hiveConf, conf);
+
+    if (isEmpty(hiveConf, "hive.metastore.uris")) {
+      if (allowLocalMetaStore(hiveConf)) {
+        return new MetaStoreUtil(hiveConf);
+      } else {
+        LOG.warn("Aborting use of local MetaStore. " +
+                "Allow local MetaStore by setting {}=true in HiveConf",
+            ALLOW_LOCAL_METASTORE);
+        throw new IllegalArgumentException(
+            "Missing Hive MetaStore connection URI");
+      }
+    }
+
+    // get the URI and cache instances to a non-local metastore
+    String uris = hiveConf.get("hive.metastore.uris");
+    MetaStoreUtil util;
+    synchronized (INSTANCES) {
+      util = INSTANCES.get(uris);
+      if (util == null) {
+        util = new MetaStoreUtil(hiveConf);
+        INSTANCES.put(uris, util);
+      }
+    }
+
+    return util;
+  }
+
+  @Deprecated
+  public MetaStoreUtil(Configuration conf) {
+    this.hiveConf = new HiveConf(conf, HiveConf.class);
+    // Add the passed configuration back into the HiveConf to work around
+    // a Hive bug that resets to defaults
+    addResource(hiveConf, conf);
+    if (!allowLocalMetaStore(hiveConf) &&
+        isEmpty(hiveConf, "hive.metastore.uris")) {
+      LOG.warn("Aborting use of local MetaStore. " +
+          "Allow local MetaStore by setting {}=true in HiveConf",
+          ALLOW_LOCAL_METASTORE);
+      throw new IllegalArgumentException(
+          "Missing Hive MetaStore connection URI");
+    }
+    try {
+      this.client = new HiveMetaStoreClient(hiveConf);
+    } catch (TException e) {
+      throw new DatasetOperationException("Hive metastore exception", e);
+    }
+  }
+
+  private MetaStoreUtil(HiveConf conf) {
+    this.hiveConf = conf;
+    try {
+      this.client = new HiveMetaStoreClient(hiveConf);
+    } catch (TException e) {
+      throw new DatasetOperationException("Hive metastore exception", e);
+    }
+  }
+
+  private static boolean allowLocalMetaStore(HiveConf conf) {
+    return conf.getBoolean(ALLOW_LOCAL_METASTORE, false);
+  }
+
+  private static boolean isEmpty(HiveConf conf, String prop) {
+    String value = conf.get(prop);
+    return (value == null || value.isEmpty());
+  }
+
+  public Table getTable(final String dbName, final String tableName) {
+    ClientAction<Table> getTable =
+        new ClientAction<Table>() {
+          @Override
+          public Table call() throws TException {
+            return new Table(client.getTable(dbName, tableName));
+          }
+        };
+
+    Table table;
+    try {
+      table = doWithRetry(getTable);
+    } catch (NoSuchObjectException e) {
+      throw new DatasetNotFoundException(
+          "Hive table not found: " + dbName + "." + tableName);
+    } catch (MetaException e) {
+      throw new DatasetNotFoundException("Hive table lookup exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+
+    if (table == null) {
+      throw new DatasetNotFoundException("Could not find info for table: " + tableName);
+    }
+    return table;
+  }
+  
+  public boolean tableExists(final String dbName, final String tableName) {
+    ClientAction<Boolean> exists =
+        new ClientAction<Boolean>() {
+          @Override
+          public Boolean call() throws TException {
+            return client.tableExists(dbName, tableName);
+          }
+        };
+
+    try {
+      return doWithRetry(exists);
+    } catch (UnknownDBException e) {
+      return false;
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public void createDatabase(final String dbName) {
+    ClientAction<Void> create =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.createDatabase(
+                new Database(dbName, "Database created by Kite",
+                    null /* default location */,
+                    null /* no custom parameters */ ));
+            return null;
+          }
+        };
+
+    try {
+      doWithRetry(create);
+    } catch (AlreadyExistsException e) {
+      throw new DatasetExistsException(
+          "Hive database already exists: " + dbName, e);
+    } catch (InvalidObjectException e) {
+      throw new DatasetOperationException("Invalid database: " + dbName, e);
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public void createTable(final Table tbl) {
+    ClientAction<Void> create =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.createTable(tbl);
+            return null;
+          }
+        };
+
+    try {
+      createDatabase(tbl.getDbName());
+    } catch (DatasetExistsException e) {
+      // not a problem, use the existing database
+    }
+
+    try {
+      doWithRetry(create);
+    } catch (NoSuchObjectException e) {
+      throw new DatasetNotFoundException("Hive table not found: " +
+          tbl.getDbName() + "." + tbl.getTableName());
+    } catch (AlreadyExistsException e) {
+      throw new DatasetExistsException("Hive table already exists: " +
+          tbl.getDbName() + "." + tbl.getTableName(), e);
+    } catch (InvalidObjectException e) {
+      throw new DatasetOperationException("Invalid table", e);
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public void alterTable(final Table tbl) {
+    ClientAction<Void> alter =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.alter_table(
+                tbl.getDbName(), tbl.getTableName(), tbl);
+            return null;
+          }
+        };
+
+    try {
+      doWithRetry(alter);
+    } catch (NoSuchObjectException e) {
+      throw new DatasetNotFoundException("Hive table not found: " +
+          tbl.getDbName() + "." + tbl.getTableName());
+    } catch (InvalidObjectException e) {
+      throw new DatasetOperationException("Invalid table", e);
+    } catch (InvalidOperationException e) {
+      throw new DatasetOperationException("Invalid table change", e);
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+  
+  public void dropTable(final String dbName, final String tableName) {
+    ClientAction<Void> drop =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.dropTable(dbName, tableName, true /* deleteData */,
+                true /* ignoreUnknownTable */);
+            return null;
+          }
+        };
+
+    try {
+      doWithRetry(drop);
+    } catch (NoSuchObjectException e) {
+      // this is okay
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public void addPartition(final String dbName, final String tableName,
+                           final String path) {
+    ClientAction<Void> addPartition =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            // purposely don't check if the partition already exists because
+            // getPartition(db, table, path) will throw an exception to indicate the
+            // partition doesn't exist also. this way, it's only one call.
+              client.appendPartition(dbName, tableName, path);
+            return null;
+          }
+        };
+
+    try {
+      doWithRetry(addPartition);
+    } catch (AlreadyExistsException e) {
+      // this is okay
+    } catch (InvalidObjectException e) {
+      throw new DatasetOperationException(
+          "Invalid partition for " + dbName + "." + tableName + ": " + path, e);
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public void dropPartition(final String dbName, final String tableName,
+                            final String path) {
+    ClientAction<Void> dropPartition =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+
+            client.dropPartition(dbName, tableName, path, false);
+            return null;
+          }
+        };
+
+    try {
+      doWithRetry(dropPartition);
+    } catch (NoSuchObjectException e) {
+      // this is okay
+    } catch (InvalidObjectException e) {
+      throw new DatasetOperationException(
+          "Invalid partition for " + dbName + "." + tableName + ": " + path, e);
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public List<String> listPartitions(final String dbName,
+                                     final String tableName,
+                                     final short max) {
+    ClientAction<List<String>> listPartitions =
+        new ClientAction<List<String>>() {
+          @Override
+          public List<String> call() throws TException {
+            List<Partition> partitions =
+                client.listPartitions(dbName, tableName, max);
+            List<String> paths = new ArrayList<String>();
+            for (Partition partition : partitions) {
+              paths.add(partition.getSd().getLocation());
+            }
+            return paths;
+          }
+        };
+    try {
+      return doWithRetry(listPartitions);
+    } catch (NoSuchObjectException e) {
+      return EMPTY_LIST;
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+
+  public boolean exists(String dbName, String tableName) {
+    return tableExists(dbName, tableName);
+  }
+
+  public List<String> getAllTables(final String dbName) {
+    ClientAction<List<String>> create =
+        new ClientAction<List<String>>() {
+          @Override
+          public List<String> call() throws TException {
+            return client.getAllTables(dbName);
+          }
+        };
+
+    try {
+      return doWithRetry(create);
+    } catch (NoSuchObjectException e) {
+      return EMPTY_LIST;
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public List<String> getAllDatabases() {
+    ClientAction<List<String>> create =
+        new ClientAction<List<String>>() {
+          @Override
+          public List<String> call() throws TException {
+            return client.getAllDatabases();
+          }
+        };
+
+    try {
+      return doWithRetry(create);
+    } catch (NoSuchObjectException e) {
+      return EMPTY_LIST;
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public void dropDatabase(final String name, final boolean deleteData) {
+    ClientAction<Void> drop =
+        new ClientAction<Void>() {
+
+        @Override
+        public Void call() throws TException {
+          client.dropDatabase(name, deleteData, true);
+          return null;
+        }
+      };
+
+    try {
+      doWithRetry(drop);
+    } catch (NoSuchObjectException e) {
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
+
+  public static void addResource(Configuration hiveConf, Configuration conf) {
+    for (Map.Entry<String, String> entry : conf) {
+      hiveConf.set(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/resources/META-INF/services/org.kitesdk.data.spi.Loadable
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-hive-dataset/src/main/resources/META-INF/services/org.kitesdk.data.spi.Loadable
@@ -1,0 +1,16 @@
+#
+# Copyright 2013 Cloudera Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.kitesdk.data.spi.hive.Loader

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-nar/pom.xml
@@ -76,8 +76,24 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-mapreduce-client-app</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
@@ -25,7 +25,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <kite.version>1.0.0</kite.version>
         <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     </properties>
 
@@ -58,19 +57,21 @@
 
         <dependency>
             <groupId>org.kitesdk</groupId>
+            <artifactId>kite-hadoop-compatibility</artifactId>
+            <version>${kite.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-hive-dataset</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kitesdk</groupId>
             <artifactId>kite-hadoop-dependencies</artifactId>
             <type>pom</type>
             <version>${kite.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-app</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/nifi-nar-bundles/nifi-kite-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/pom.xml
@@ -28,8 +28,14 @@
 
     <modules>
         <module>nifi-kite-processors</module>
+        <module>nifi-hive-dataset</module>
         <module>nifi-kite-nar</module>
     </modules>
+
+    <properties>
+        <kite.version>1.0.0</kite.version>
+        <hive.version>1.1.0</hive.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This adds a Hive dataset implementation that shades and minimizes the
classes needed to connect to the Hive MetaStore.

To test this:

1. Create a table in Hive: `create table test (id bigint, s string) stored as avro`
2. Create a simple pipeline: GetFile to ConvertCSVToAvro to StoreInKiteDataset
3. Configure ConvertCSVToAvro with this schema: 
```json
{
  "type" : "record",
  "name" : "test",
  "fields" : [ {
    "name" : "id",
    "type" : [ "null", "long" ],
    "doc" : "Converted from 'bigint'",
    "default" : null
  }, {
    "name" : "s",
    "type" : [ "null", "string" ],
    "doc" : "Converted from 'string'",
    "default" : null
  } ]
}
```
4. Configure StoreInKiteDataset to use a dataset URI for the Hive table you created: `dataset:hive://metastore-host:9083/test`
5. Drop a CSV file into the GetFile's directory:
```
1,hello
2,world
```
6. Validate the data shows up in the test table: `select * from test;`