### PR TITLE
NIFI-1243 added null check for 'currentReadClaimStream'

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -1806,7 +1806,7 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
                 reader.process(ffais);
 
                 // Allow processors to close the file after reading to avoid too many files open or do smart session stream management.
-                if(!allowSessionStreamManagement){
+                if (this.currentReadClaimStream != null && !allowSessionStreamManagement) {
                     currentReadClaimStream.close();
                     currentReadClaimStream = null;
                 }


### PR DESCRIPTION
. . .before it is being closed