### PR TITLE
NIFI-1240: Removed seeding of SecureRandom

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/PasswordBasedEncryptor.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/PasswordBasedEncryptor.java
@@ -16,24 +16,19 @@
  */
 package org.apache.nifi.processors.standard.util;
 
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.StreamCallback;
+import org.apache.nifi.processors.standard.EncryptContent.Encryptor;
+import org.apache.nifi.stream.io.StreamUtils;
+
+import javax.crypto.*;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.SecureRandom;
-
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-import javax.crypto.spec.PBEParameterSpec;
-
-import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.processor.io.StreamCallback;
-import org.apache.nifi.processors.standard.EncryptContent.Encryptor;
-import org.apache.nifi.stream.io.StreamUtils;
 
 public class PasswordBasedEncryptor implements Encryptor {
 
@@ -65,8 +60,7 @@ public class PasswordBasedEncryptor implements Encryptor {
     public StreamCallback getEncryptionCallback() throws ProcessException {
         try {
             byte[] salt = new byte[saltSize];
-            SecureRandom secureRandom = SecureRandom.getInstance(SECURE_RANDOM_ALGORITHM);
-            secureRandom.setSeed(System.currentTimeMillis());
+            SecureRandom secureRandom = SecureRandom.getInstance(SECURE_RANDOM_ALGORITHM, "SUN");
             secureRandom.nextBytes(salt);
             return new EncryptCallback(salt);
         } catch (Exception e) {


### PR DESCRIPTION
Added explicit reference to Sun Java Cryptographic Service Provider in PasswordBasedEncryptor.
Removed manual seeding of SecureRandom in PasswordBasedEncryptor.