### PR TITLE
NIFI-1289 added support for refreshing properties

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -241,10 +241,27 @@ public class NiFiProperties extends Properties {
     }
 
     /**
-     * This is the method through which the NiFiProperties object should be obtained.
+     * Factory method to create and return a new instance of
+     * {@link NiFiProperties}. Unlike its {@link #getInstance()} counterpart
+     * which may return you a cached instance of {@link NiFiProperties} this
+     * method creates new instance every time it's called. It is suitable for
+     * cases where properties may change at runtime.
      *
-     * @return the NiFiProperties object to use
-     * @throws RuntimeException if unable to load properties file
+     * @return new instance of {@link NiFiProperties}
+     */
+    public static synchronized NiFiProperties getNewInstance() {
+        instance = null;
+        return getInstance();
+    }
+
+    /**
+     * Factory method to create and return a new instance of
+     * {@link NiFiProperties}. Unlike its {@link #getNewInstance()} counterpart
+     * which always creates a new instance of {@link NiFiProperties}, this
+     * method employs a standard singleton pattern by caching the instance if it
+     * was already obtained
+     *
+     * @return instance of {@link NiFiProperties}
      */
     public static synchronized NiFiProperties getInstance() {
         if (null == instance) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
@@ -48,6 +48,7 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.reporting.ReportingContext;
 import org.apache.nifi.reporting.ReportingInitializationContext;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.util.NiFiProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -60,6 +61,7 @@ public class TestStandardProcessScheduler {
     @Before
     public void setup() throws InitializationException {
         System.setProperty("nifi.properties.file.path", "src/test/resources/nifi.properties");
+        NiFiProperties.getNewInstance(); // ensures that properties have been reloaded
         scheduler = new StandardProcessScheduler(Mockito.mock(Heartbeater.class), Mockito.mock(ControllerServiceProvider.class), null);
         scheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, Mockito.mock(SchedulingAgent.class));
 


### PR DESCRIPTION
- Added _getNewInstance()_ operation to NiFiProperties to ensure there is a way to refresh/reload NiFi properties
- Fixed javadocs