### PR TITLE
NIFI-1289 reverted changes to NiFiProperties

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -241,23 +241,7 @@ public class NiFiProperties extends Properties {
     }
 
     /**
-     * Factory method to create and return a new instance of
-     * {@link NiFiProperties}. Unlike its {@link #getInstance()} counterpart
-     * which may return you a cached instance of {@link NiFiProperties} this
-     * method creates new instance every time it's called. It is suitable for
-     * cases where properties may change at runtime.
-     *
-     * @return new instance of {@link NiFiProperties}
-     */
-    public static synchronized NiFiProperties getNewInstance() {
-        instance = null;
-        return getInstance();
-    }
-
-    /**
-     * Factory method to create and return a new instance of
-     * {@link NiFiProperties}. Unlike its {@link #getNewInstance()} counterpart
-     * which always creates a new instance of {@link NiFiProperties}, this
+     * Factory method to create an instance of the {@link NiFiProperties}. This
      * method employs a standard singleton pattern by caching the instance if it
      * was already obtained
      *

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
@@ -18,6 +18,7 @@ package org.apache.nifi.controller.scheduling;
 
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -61,7 +62,7 @@ public class TestStandardProcessScheduler {
     @Before
     public void setup() throws InitializationException {
         System.setProperty("nifi.properties.file.path", "src/test/resources/nifi.properties");
-        NiFiProperties.getNewInstance(); // ensures that properties have been reloaded
+        this.refreshNiFiProperties();
         scheduler = new StandardProcessScheduler(Mockito.mock(Heartbeater.class), Mockito.mock(ControllerServiceProvider.class), null);
         scheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, Mockito.mock(SchedulingAgent.class));
 
@@ -156,6 +157,16 @@ public class TestStandardProcessScheduler {
 
         @Override
         public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        }
+    }
+
+    private void refreshNiFiProperties() {
+        try {
+            Field instanceField = NiFiProperties.class.getDeclaredField("instance");
+            instanceField.setAccessible(true);
+            instanceField.set(null, null);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
         }
     }
 }


### PR DESCRIPTION
in favor of the localized relection call in test to refresh properties.

polish javadoc