### PR TITLE
NIFI-1212 Handling text/csv files as plain text within the content viewer

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
@@ -49,20 +49,21 @@ public class StandardContentViewerController extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         final ViewableContent content = (ViewableContent) request.getAttribute(ViewableContent.CONTENT_REQUEST_ATTRIBUTE);
 
-        // handle json/xml
-        if ("application/json".equals(content.getContentType()) || "application/xml".equals(content.getContentType()) || "text/plain".equals(content.getContentType())) {
+        // handle json/xml specifically, treat others as plain text
+        final String contentType = content.getContentType();
+        if ("application/json".equals(contentType) || "application/xml".equals(contentType) || "text/plain".equals(contentType) || "text/csv".equals(contentType)) {
             final String formatted;
 
             // leave the content alone if specified
             if (DisplayMode.Original.equals(content.getDisplayMode())) {
                 formatted = content.getContent();
             } else {
-                if ("application/json".equals(content.getContentType())) {
+                if ("application/json".equals(contentType)) {
                     // format json
                     final ObjectMapper mapper = new ObjectMapper();
                     final Object objectJson = mapper.readValue(content.getContentStream(), Object.class);
                     formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectJson);
-                } else if ("application/xml".equals(content.getContentType())) {
+                } else if ("application/xml".equals(contentType)) {
                     // format xml
                     final StringWriter writer = new StringWriter();
 
@@ -89,12 +90,12 @@ public class StandardContentViewerController extends HttpServlet {
             }
 
             // defer to the jsp
-            request.setAttribute("mode", content.getContentType());
+            request.setAttribute("mode", contentType);
             request.setAttribute("content", formatted);
             request.getRequestDispatcher("/WEB-INF/jsp/codemirror.jsp").include(request, response);
         } else {
             final PrintWriter out = response.getWriter();
-            out.println("Unexpected content type: " + content.getContentType());
+            out.println("Unexpected content type: " + contentType);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/webapp/META-INF/nifi-content-viewer
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/webapp/META-INF/nifi-content-viewer
@@ -15,3 +15,4 @@
 application/xml
 application/json
 text/plain
+text/csv


### PR DESCRIPTION
Perhaps not as full featured as desired with something like a grid viewer, but this creates handling of text/csv files as plain text files so they can be viewed within the StandardContentViewerController.