### PR TITLE
NIFI-1145 Unit tests timeout in some environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: false
 
 os:
   - linux
@@ -9,8 +8,12 @@ jdk:
   - oraclejdk7
   - openjdk7
 
-# Workaround for non-existent Maven repository as per: https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-131214465
+# before_install aids in a couple workarounds for issues within the Travis-CI environment
+#   1. Workaround for buffer overflow issues with OpenJDK versions of java as per https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165135711
+#   2. Workaround for non-existent Maven repository as per: https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-131214465
 before_install:
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 
 script: mvn clean install -Pcontrib-check

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-# Apache NiFi [![Build Status](https://travis-ci.org/apache/nifi.svg)](https://travis-ci.org/apache/nifi)
+# Apache NiFi [![Build Status](https://travis-ci.org/apache/nifi.svg?branch=master)](https://travis-ci.org/apache/nifi)
 
 Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -367,7 +367,7 @@ public class TestStandardFlowFileQueue {
         queue.poll(exp);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 120000)
     public void testDropSwappedFlowFiles() {
         for (int i = 1; i <= 210000; i++) {
             queue.put(new TestFlowFile());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
@@ -352,14 +352,14 @@ public class TestStandardProcessScheduler {
                     scheduler.enableControllerService(serviceNode);
                 }
             });
-            Thread.sleep(2); // ensure that enable gets initiated before disable
+            Thread.sleep(10); // ensure that enable gets initiated before disable
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
                     scheduler.disableControllerService(serviceNode);
                 }
             });
-            Thread.sleep(25);
+            Thread.sleep(100);
             assertFalse(serviceNode.isActive());
             assertTrue(serviceNode.getState() == ControllerServiceState.DISABLED);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
@@ -414,11 +414,11 @@ public class TestStandardProcessScheduler {
         LongEnablingService ts = (LongEnablingService) serviceNode.getControllerServiceImplementation();
         ts.setLimit(3000);
         scheduler.enableControllerService(serviceNode);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertTrue(serviceNode.isActive());
         assertEquals(1, ts.enableInvocationCount());
 
-        Thread.sleep(100);
+        Thread.sleep(500);
         scheduler.disableControllerService(serviceNode);
         assertFalse(serviceNode.isActive());
         assertEquals(ControllerServiceState.DISABLING, serviceNode.getState());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
@@ -117,7 +117,7 @@ public class TestStandardControllerServiceProvider {
      * {@link PropertyDescriptor}.isDependentServiceEnableable() as well as
      * https://issues.apache.org/jira/browse/NIFI-1143
      */
-    @Test(timeout = 10000)
+    @Test(timeout = 60000)
     public void testConcurrencyWithEnablingReferencingServicesGraph() {
         final ProcessScheduler scheduler = createScheduler();
         for (int i = 0; i < 10000; i++) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpSSL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpSSL.java
@@ -47,6 +47,8 @@ public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
         server = createServer();
         server.startServer();
 
+        // Allow time for the server to start
+        Thread.sleep(500);
         // this is the base url with the random port
         url = server.getSecureUrl();
     }
@@ -63,6 +65,13 @@ public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
         runner.addControllerService("ssl-context", sslService, sslProperties);
         runner.enableControllerService(sslService);
         runner.setProperty(InvokeHTTP.PROP_SSL_CONTEXT_SERVICE, "ssl-context");
+
+        // Allow time for the controller service to fully initialize
+        Thread.sleep(500);
+
+        // Provide more time to setup and run
+        runner.setProperty(InvokeHTTP.PROP_READ_TIMEOUT, "30 secs");
+        runner.setProperty(InvokeHTTP.PROP_CONNECT_TIMEOUT, "30 secs");
 
         server.clearHandlers();
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
@@ -126,6 +126,9 @@ public class TestListenSyslog {
         final ProcessContext context = runner.getProcessContext();
         proc.onScheduled(context);
 
+        // Allow time for the processor to perform its scheduled start
+        Thread.sleep(500);
+
         final int numMessages = 20;
         final int port = proc.getPort();
         Assert.assertTrue(port > 0);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestServer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestServer.java
@@ -70,6 +70,8 @@ public class TestServer {
     private void createConnector() {
         final ServerConnector http = new ServerConnector(jetty);
         http.setPort(0);
+        // Severely taxed environments may have significant delays when executing.
+        http.setIdleTimeout(30000L);
         jetty.addConnector(http);
     }
 
@@ -100,6 +102,8 @@ public class TestServer {
 
         // set host and port
         https.setPort(0);
+        // Severely taxed environments may have significant delays when executing.
+        https.setIdleTimeout(30000L);
 
         // add the connector
         jetty.addConnector(https);


### PR DESCRIPTION
In order to get more meaningful information from our integration with travis CI established in NIFI-1211, there were certain tests that had issues with timing that were drawn out in severely taxed environments.  These have been worked out and we are in a state where we are getting consistent passing builds on Travis for the associated code in this PR.

@markap14 had provided an initial patch, included, for the test that was first to fail.  Through several iterations, I was able to track the others down that had similar timing quirks as well as addressing some OpenJDK 7 issues in the Travis containerized (sudo: false) environment as per https://github.com/travis-ci/travis-ci/issues/5227.

Passing build (mvn clean install -Pcontrib-check):  https://travis-ci.org/apiri/incubator-nifi/builds/100745961