### PR TITLE
Removed duplicated dependency for nifi-mock

### DIFF
--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/pom.xml
@@ -55,10 +55,5 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>org.apache.nifi</groupId>
-			<artifactId>nifi-mock</artifactId>
-            <scope>test</scope>
-		</dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Causing issue during build...

[WARNING] Some problems were encountered while building the effective model for org.apache.nifi:nifi-couchbase-processors:jar:0.4.2-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.nifi:nifi-mock:jar -> duplicate declaration of version (?) @ org.apache.nifi:nifi-couchbase-processors:[unknown-version], T:\git\nifi\nifi-nar-bundles\nifi-couchbase-bundle\nifi-couchbase-processors\pom.xml, line 58, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.