### PR TITLE
NIFI-1393 Providing the ability to send using gzip Content-Encoding

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/CaptureServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/CaptureServlet.java
@@ -71,6 +71,9 @@ public class CaptureServlet extends HttpServlet {
     protected void doHead(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
         response.setHeader("Accept", "application/flowfile-v3,application/flowfile-v2");
         response.setHeader("x-nifi-transfer-protocol-version", "1");
-        response.setHeader("Accept-Encoding", "gzip");
+        // Unless an acceptGzip parameter is explicitly set to false, respond that this server accepts gzip
+        if (!Boolean.toString(false).equalsIgnoreCase(request.getParameter("acceptGzip"))) {
+            response.setHeader("Accept-Encoding", "gzip");
+        }
     }
 }


### PR DESCRIPTION
NIFI-1393 Providing the ability to send using gzip Content-Encoding in PostHTTP if the endpoint server supports it regardless if the processor is configured to send as a FlowFile