### PR TITLE
NIFI-1406 Collecting the number of bytes sent regardless of send type

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PostHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PostHTTP.java
@@ -552,14 +552,14 @@ public class PostHTTP extends AbstractProcessor {
                 }
             }
 
-            // if we are not sending as flowfile, or if the destination doesn't accept V3 or V2 (streaming) format,
-            // then only use a single FlowFile
-            if (!sendAsFlowFile || !destinationAccepts.isFlowFileV3Accepted() && !destinationAccepts.isFlowFileV2Accepted()) {
+            bytesToSend += flowFile.getSize();
+            if (bytesToSend > maxBatchBytes.longValue()) {
                 break;
             }
 
-            bytesToSend += flowFile.getSize();
-            if (bytesToSend > maxBatchBytes.longValue()) {
+            // if we are not sending as flowfile, or if the destination doesn't accept V3 or V2 (streaming) format,
+            // then only use a single FlowFile
+            if (!sendAsFlowFile || !destinationAccepts.isFlowFileV3Accepted() && !destinationAccepts.isFlowFileV2Accepted()) {
                 break;
             }
         }


### PR DESCRIPTION
Providing counting of all bytes sent to remove bug where PostHTTP would not have non-zero rate if not configured to send as a FlowFile.