### PR TITLE
Give extra info about input dir for Windows users.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
@@ -96,7 +96,7 @@ public class GetFile extends AbstractProcessor {
 
     public static final PropertyDescriptor DIRECTORY = new PropertyDescriptor.Builder()
             .name("Input Directory")
-            .description("The input directory from which to pull files")
+            .description("The input directory from which to pull files. This needs to end with a trailing slash \ on Windows.")
             .required(true)
             .addValidator(StandardValidators.createDirectoryExistsValidator(true, false))
             .expressionLanguageSupported(true)


### PR DESCRIPTION
Windows users typically don't have to worry about supplying a trailing slash....until they work with some Java programs like Nifi.
An input path such as "E:\git\nifi\nifi-nar-bundles\nifi-standard-bundle\nifi-standard-processors\src\test\resources\CharacterSetConversionSamples\TestInput" that does not have a trailing slash will cause NiFi to parse everything in CharacterSetConversionSamples....not the TestInput folder.  To remedy the situation, Windows users just need to add the trailing slash \ such as "E:\git\nifi\nifi-nar-bundles\nifi-standard-bundle\nifi-standard-processors\src\test\resources\CharacterSetConversionSamples\TestInput\" and then NiFi is able to use the correct path and not pickup extra files from the unexpected parent folder.

Giving this extra hint for Windows users is an easier workaround for now than doing Windows OS detection with http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS and providing workarounds.

I think most Windows users and developers are aware of this kind of issue that we deal with everyday, and the extra hint should be enough.