### PR TITLE
NIFI-1436 Fixing race condition in SocketChannelDispatcher 

### DIFF
--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventProcessor.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventProcessor.java
@@ -212,7 +212,6 @@ public abstract class AbstractListenEventProcessor<E extends Event> extends Abst
     @OnUnscheduled
     public void onUnscheduled() {
         if (dispatcher != null) {
-            dispatcher.stop();
             dispatcher.close();
         }
     }

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/ChannelDispatcher.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/ChannelDispatcher.java
@@ -39,11 +39,6 @@ public interface ChannelDispatcher extends Runnable {
     int getPort();
 
     /**
-     * Stops the main dispatcher thread.
-     */
-    void stop();
-
-    /**
      * Closes all listeners and stops all handler threads.
      */
     void close();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
@@ -309,7 +309,6 @@ public class ListenSyslog extends AbstractSyslogProcessor {
     @OnUnscheduled
     public void onUnscheduled() {
         if (channelDispatcher != null) {
-            channelDispatcher.stop();
             channelDispatcher.close();
         }
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/handler/TestRELPSocketChannelHandler.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/handler/TestRELPSocketChannelHandler.java
@@ -165,7 +165,6 @@ public class TestRELPSocketChannelHandler {
 
         } finally {
             // stop the dispatcher thread and ensure we shut down handler threads
-            dispatcher.stop();
             dispatcher.close();
         }
     }


### PR DESCRIPTION
From looking at the test failure that was reported, it was a ConcurrentModificationException in the close() method of SocketChannelDispatcher, which happens when looping over selector.keys().

When the processor is unscheduled it calls stop() then close(). The stop method sets a stopped flag that the run method uses as an exit condition, and then calls selector.wakeup(). It appears that it would be possible for the run method to have not fully finished before close() is called, making it possible for the selector's keys to get modified while close() is happening.

I was never able to produce the test failure locally, so if someone who encountered it could test this change it would be helpful.