### PR TITLE
NIFI-1417 Exposing several connection settings on the Solr processors…

### DIFF
--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/GetSolr.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/GetSolr.java
@@ -139,6 +139,12 @@ public class GetSolr extends SolrProcessor {
         descriptors.add(SORT_CLAUSE);
         descriptors.add(DATE_FIELD);
         descriptors.add(BATCH_SIZE);
+        descriptors.add(SOLR_SOCKET_TIMEOUT);
+        descriptors.add(SOLR_CONNECTION_TIMEOUT);
+        descriptors.add(SOLR_MAX_CONNECTIONS);
+        descriptors.add(SOLR_MAX_CONNECTIONS_PER_HOST);
+        descriptors.add(ZK_CLIENT_TIMEOUT);
+        descriptors.add(ZK_CONNECTION_TIMEOUT);
         this.descriptors = Collections.unmodifiableList(descriptors);
 
         final Set<Relationship> relationships = new HashSet<>();

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/PutSolrContentStream.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/PutSolrContentStream.java
@@ -123,6 +123,12 @@ public class PutSolrContentStream extends SolrProcessor {
         descriptors.add(CONTENT_STREAM_PATH);
         descriptors.add(CONTENT_TYPE);
         descriptors.add(COMMIT_WITHIN);
+        descriptors.add(SOLR_SOCKET_TIMEOUT);
+        descriptors.add(SOLR_CONNECTION_TIMEOUT);
+        descriptors.add(SOLR_MAX_CONNECTIONS);
+        descriptors.add(SOLR_MAX_CONNECTIONS_PER_HOST);
+        descriptors.add(ZK_CLIENT_TIMEOUT);
+        descriptors.add(ZK_CONNECTION_TIMEOUT);
         this.descriptors = Collections.unmodifiableList(descriptors);
 
         final Set<Relationship> relationships = new HashSet<>();

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestPutSolrContentStream.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestPutSolrContentStream.java
@@ -101,7 +101,7 @@ public class TestPutSolrContentStream {
         try (FileInputStream fileIn = new FileInputStream(SOLR_JSON_MULTIPLE_DOCS_FILE)) {
             runner.enqueue(fileIn);
 
-            runner.run();
+            runner.run(1, false);
             runner.assertTransferCount(PutSolrContentStream.REL_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_CONNECTION_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_SUCCESS, 1);
@@ -133,7 +133,7 @@ public class TestPutSolrContentStream {
         try (FileInputStream fileIn = new FileInputStream(CUSTOM_JSON_SINGLE_DOC_FILE)) {
             runner.enqueue(fileIn);
 
-            runner.run();
+            runner.run(1, false);
             runner.assertTransferCount(PutSolrContentStream.REL_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_CONNECTION_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_SUCCESS, 1);
@@ -159,7 +159,7 @@ public class TestPutSolrContentStream {
         try (FileInputStream fileIn = new FileInputStream(CSV_MULTIPLE_DOCS_FILE)) {
             runner.enqueue(fileIn);
 
-            runner.run();
+            runner.run(1, false);
             runner.assertTransferCount(PutSolrContentStream.REL_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_CONNECTION_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_SUCCESS, 1);
@@ -185,7 +185,7 @@ public class TestPutSolrContentStream {
         try (FileInputStream fileIn = new FileInputStream(XML_MULTIPLE_DOCS_FILE)) {
             runner.enqueue(fileIn);
 
-            runner.run();
+            runner.run(1, false);
             runner.assertTransferCount(PutSolrContentStream.REL_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_CONNECTION_FAILURE, 0);
             runner.assertTransferCount(PutSolrContentStream.REL_SUCCESS, 1);
@@ -225,7 +225,7 @@ public class TestPutSolrContentStream {
 
         // run the processor with a delete-by-query command
         runner.enqueue("<delete><query>first:bob</query></delete>".getBytes("UTF-8"));
-        runner.run();
+        runner.run(1, false);
 
         // prove the document got deleted
         qResponse = solrClient.query(query);
@@ -344,6 +344,7 @@ public class TestPutSolrContentStream {
         runner.setProperty(PutSolrContentStream.COLLECTION, "someCollection1");
         runner.assertValid();
     }
+
 
     @Test
     public void testSolrTypeStandardShouldNotRequireCollection() {


### PR DESCRIPTION
I was not able to reproduce the exact scenario described in this ticket, but based on the stack trace I believe exposing some of the connection setting on the Solr processors would resolve this issue.

The properties exposed are:

Solr Socket Timeout = The socket timeout on the underlying HttpClient
Solr Connection Timeout = The connection timeout on the underlying HttpClient
Solr Maximum Connections = The max connections on the underlying HttpClient
Solr Maximum Connections Per Host = The max connections per host on the underlying HttpClient
ZooKeeper Timeout = The timeout on the ZK client
ZooKeeper Connection Timeout = The timeout on the ZK client connecting

It seemed kinda of redundant to prefix some of them with "Solr ..." but I wanted to be clear which connection the property was for (ZK vs Solr).

The Max Connections and Max Connections Per Host were not totally necessary, however SolrJ was specifically setting these when using standard Solr and not passing in an HttpClient. So now that we are passing in a custom HttpClient, I was worried about not providing a way to control these values.