### PR TITLE
NIFI-1460 Test Performance improvement. test Timeout Mitigation. less IO, less depen…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -533,12 +533,13 @@ public class TestStandardFlowFileQueue {
             this.size = size;
 
             if (!attributes.containsKey(CoreAttributes.UUID.key())) {
-                attributes.put(CoreAttributes.UUID.key(), createFakeUUID().toString());
+                attributes.put(CoreAttributes.UUID.key(), createFakeUUID());
             }
         }
 
-        private static Long createFakeUUID(){
-            return idGenerator.incrementAndGet();
+        private static String createFakeUUID(){
+            final String s=Long.toHexString(idGenerator.incrementAndGet());
+            return new StringBuffer("00000000-0000-0000-0000000000000000".substring(0,(35-s.length()))+s).insert(23, '-').toString();
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -533,10 +533,13 @@ public class TestStandardFlowFileQueue {
             this.size = size;
 
             if (!attributes.containsKey(CoreAttributes.UUID.key())) {
-                attributes.put(CoreAttributes.UUID.key(), UUID.randomUUID().toString());
+                attributes.put(CoreAttributes.UUID.key(), createFakeUUID().toString());
             }
         }
 
+        private static Long createFakeUUID(){
+            return idGenerator.incrementAndGet();
+        }
 
         @Override
         public long getId() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -537,8 +537,8 @@ public class TestStandardFlowFileQueue {
             }
         }
 
-        private static String createFakeUUID(){
-            final String s=Long.toHexString(idGenerator.incrementAndGet());
+        private  String createFakeUUID(){
+            final String s=Long.toHexString(id);
             return new StringBuffer("00000000-0000-0000-0000000000000000".substring(0,(35-s.length()))+s).insert(23, '-').toString();
         }
 


### PR DESCRIPTION
Performance improvement. test Timeout Mitigation. less IO, less dependency on /dev/(u)random.
Stats are as follows for my linux desktop for org.apache.nifi.controller.TestStandardFlowFileQueue
:

- Without RNGD, no mouse move or key-press -- Timeout Exception
- With RNGD -- 26.5 Seconds
- With this PR, Without RNGD, no mouse move or key-press -- 19.6 Seconds