### PR TITLE
NIFI-210: Add support for multiple module paths for scripting

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ExecuteScript.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ExecuteScript.java
@@ -31,6 +31,7 @@ import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.util.StringUtils;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -121,7 +122,12 @@ public class ExecuteScript extends AbstractScriptProcessor {
         scriptEngineName = context.getProperty(SCRIPT_ENGINE).getValue();
         scriptPath = context.getProperty(SCRIPT_FILE).evaluateAttributeExpressions().getValue();
         scriptBody = context.getProperty(SCRIPT_BODY).getValue();
-        modulePath = context.getProperty(MODULES).evaluateAttributeExpressions().getValue();
+        String modulePath = context.getProperty(MODULES).getValue();
+        if (!StringUtils.isEmpty(modulePath)) {
+            modules = modulePath.split(",");
+        } else {
+            modules = new String[0];
+        }
         super.setup();
         scriptToRun = scriptBody;
 
@@ -182,11 +188,11 @@ public class ExecuteScript extends AbstractScriptProcessor {
 
                 // Execute any engine-specific configuration before the script is evaluated
                 ScriptEngineConfigurator configurator =
-                        scriptEngineConfiguratorMap.get(scriptEngineName);
+                        scriptEngineConfiguratorMap.get(scriptEngineName.toLowerCase());
 
                 // Evaluate the script with the configurator (if it exists) or the engine
                 if (configurator != null) {
-                    configurator.eval(scriptEngine, scriptToRun, modulePath);
+                    configurator.eval(scriptEngine, scriptToRun, modules);
                 } else {
                     scriptEngine.eval(scriptToRun);
                 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptEngineConfigurator.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptEngineConfigurator.java
@@ -17,8 +17,11 @@
 package org.apache.nifi.processors.script;
 
 
+import org.apache.nifi.logging.ComponentLog;
+
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
+import java.net.URL;
 
 /**
  * This interface describes callback methods used by the ExecuteScript/InvokeScript processors to perform
@@ -28,8 +31,10 @@ public interface ScriptEngineConfigurator {
 
     String getScriptEngineName();
 
-    Object init(ScriptEngine engine, String modulePath) throws ScriptException;
+    URL[] getModuleURLsForClasspath(String[] modulePaths, ComponentLog log);
 
-    Object eval(ScriptEngine engine, String scriptBody, String modulePath) throws ScriptException;
+    Object init(ScriptEngine engine, String[] modulePaths) throws ScriptException;
+
+    Object eval(ScriptEngine engine, String scriptBody, String[] modulePaths) throws ScriptException;
 
 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/impl/AbstractModuleClassloaderConfigurator.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/impl/AbstractModuleClassloaderConfigurator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.script.impl;
+
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processors.script.ScriptEngineConfigurator;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This base class provides a common implementation for the getModuleURLsForClasspath method of the
+ * ScriptEngineConfigurator interface
+ */
+public abstract class AbstractModuleClassloaderConfigurator implements ScriptEngineConfigurator {
+
+    /**
+     * Scans the given module paths for JARs. The path itself (whether a directory or file) will be added to the list
+     * of returned module URLs, and if a directory is specified, it is scanned for JAR files (files ending with .jar).
+     * Any JAR files found are added to the list of module URLs. This is a convenience method for adding directories
+     * full of JAR files to an ExecuteScript or InvokeScriptedProcessor instance, rather than having to enumerate each
+     * JAR's URL.
+     * @param modulePaths An array of module paths to scan/add
+     * @param log A logger for the calling component, to provide feedback for missing files, e.g.
+     * @return An array of URLs corresponding to all modules determined from the input set of module paths.
+     */
+    @Override
+    public URL[] getModuleURLsForClasspath(String[] modulePaths, ComponentLog log) {
+        List<URL> additionalClasspath = new LinkedList<>();
+        if (modulePaths != null) {
+            for (String modulePathString : modulePaths) {
+                File modulePath = new File(modulePathString);
+
+                if (modulePath.exists()) {
+                    // Add the URL of this path
+                    try {
+                        additionalClasspath.add(modulePath.toURI().toURL());
+                    } catch (MalformedURLException mue) {
+                        log.warn("{} is not a valid file/folder, ignoring", new Object[]{modulePath.getAbsolutePath()}, mue);
+                    }
+
+                    // If the path is a directory, we need to scan for JARs and add them to the classpath
+                    if (modulePath.isDirectory()) {
+                        File[] jarFiles = modulePath.listFiles(new FilenameFilter() {
+                            @Override
+                            public boolean accept(File dir, String name) {
+                                return (name != null && name.endsWith(".jar"));
+                            }
+                        });
+
+                        if (jarFiles != null) {
+                            // Add each to the classpath
+                            for (File jarFile : jarFiles) {
+                                try {
+                                    additionalClasspath.add(jarFile.toURI().toURL());
+
+                                } catch (MalformedURLException mue) {
+                                    log.warn("{} is not a valid file/folder, ignoring", new Object[]{modulePath.getAbsolutePath()}, mue);
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    log.warn("{} does not exist, ignoring", new Object[]{modulePath.getAbsolutePath()});
+                }
+            }
+        }
+        return additionalClasspath.toArray(new URL[additionalClasspath.size()]);
+    }
+}

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/impl/GroovyScriptEngineConfigurator.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/impl/GroovyScriptEngineConfigurator.java
@@ -16,12 +16,10 @@
  */
 package org.apache.nifi.processors.script.impl;
 
-import org.apache.nifi.processors.script.ScriptEngineConfigurator;
-
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
-public class GroovyScriptEngineConfigurator implements ScriptEngineConfigurator {
+public class GroovyScriptEngineConfigurator extends AbstractModuleClassloaderConfigurator {
 
     private static final String PRELOADS =
             "import org.apache.nifi.components.*\n"
@@ -41,14 +39,16 @@ public class GroovyScriptEngineConfigurator implements ScriptEngineConfigurator 
         return "Groovy";
     }
 
+
+
     @Override
-    public Object init(ScriptEngine engine, String modulePath) throws ScriptException {
+    public Object init(ScriptEngine engine, String[] modulePaths) throws ScriptException {
         scriptEngine = engine;
         return scriptEngine;
     }
 
     @Override
-    public Object eval(ScriptEngine engine, String scriptBody, String modulePath) throws ScriptException {
+    public Object eval(ScriptEngine engine, String scriptBody, String[] modulePaths) throws ScriptException {
         scriptEngine = engine;
         return engine.eval(PRELOADS + scriptBody);
     }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/impl/JavascriptScriptEngineConfigurator.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/impl/JavascriptScriptEngineConfigurator.java
@@ -16,48 +16,27 @@
  */
 package org.apache.nifi.processors.script.impl;
 
-import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.processors.script.ScriptEngineConfigurator;
-
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
-import java.net.URL;
 
 /**
- * A helper class to configure the Jython engine with any specific requirements
+ * This class offers methods to perform Javascript-specific operations during the script engine lifecycle.
  */
-public class JythonScriptEngineConfigurator implements ScriptEngineConfigurator {
+public class JavascriptScriptEngineConfigurator extends AbstractModuleClassloaderConfigurator {
 
     @Override
     public String getScriptEngineName() {
-        return "python";
-    }
-
-    @Override
-    public URL[] getModuleURLsForClasspath(String[] modulePaths, ComponentLog log) {
-        // We don't need to add the module paths to the classpath, they will be added via sys.path.append
-        return new URL[0];
+        return "ECMAScript";
     }
 
     @Override
     public Object init(ScriptEngine engine, String[] modulePaths) throws ScriptException {
-        return null;
+        // No initialization methods needed at present
+        return engine;
     }
 
     @Override
     public Object eval(ScriptEngine engine, String scriptBody, String[] modulePaths) throws ScriptException {
-        Object returnValue = null;
-        if (engine != null) {
-            // Need to import the module path inside the engine, in order to pick up
-            // other Python/Jython modules
-            engine.eval("import sys");
-            if (modulePaths != null) {
-                for (String modulePath : modulePaths) {
-                    engine.eval("sys.path.append('" + modulePath + "')");
-                }
-            }
-            returnValue = engine.eval(scriptBody);
-        }
-        return returnValue;
+        return engine.eval(scriptBody);
     }
 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/resources/META-INF/services/org.apache.nifi.processors.script.ScriptEngineConfigurator
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/resources/META-INF/services/org.apache.nifi.processors.script.ScriptEngineConfigurator
@@ -15,3 +15,4 @@
 
 org.apache.nifi.processors.script.impl.JythonScriptEngineConfigurator
 org.apache.nifi.processors.script.impl.GroovyScriptEngineConfigurator
+org.apache.nifi.processors.script.impl.JavascriptScriptEngineConfigurator

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
@@ -103,7 +103,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
         runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ExecuteScript.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
This allows more than one module path to be set for scripts to use. Each language that has a specific configurator can deal with the module paths as they see fit. For example, the Groovy configurator can use a list of paths and look for JARs in any folders specified (rather than having to enumerate each JAR).