### PR TITLE
Fixed: ExecuteStreamCommand when expressions in command arguments are…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
@@ -302,8 +302,8 @@ public class ExecuteStreamCommand extends AbstractProcessor {
         final String commandArguments = context.getProperty(EXECUTION_ARGUMENTS).getValue();
         final boolean ignoreStdin = Boolean.parseBoolean(context.getProperty(IGNORE_STDIN).getValue());
         if (!StringUtils.isBlank(commandArguments)) {
-            for (String arg : ArgumentUtils.splitArgs(commandArguments, context.getProperty(ARG_DELIMITER).getValue().charAt(0))) {
-                args.add(context.newPropertyValue(arg).evaluateAttributeExpressions(inputFlowFile).getValue());
+            for (String arg : ArgumentUtils.splitArgs(context.newPropertyValue(commandArguments).evaluateAttributeExpressions(inputFlowFile).getValue(), context.getProperty(ARG_DELIMITER).getValue().charAt(0))) {
+                args.add(arg);
             }
         }
         final String workingDir = context.getProperty(WORKING_DIR).evaluateAttributeExpressions(inputFlowFile).getValue();


### PR DESCRIPTION
… used, contents are not splitted by command separator

To reproduce the problem:
1. Create DataFlow
2. Add GenerateFlowFile processor, File Size: 10kB
3. Connect GenerateFlowFile -> success -> UpdateAttribute processor
4. In UpdateAttribute: create attribute optionalArgs with contents: "-c 5"
5. Connect UpdateAttribute -> success -> ExecuteStreamCommand
6. Configure ExecuteStreamCommand to execute Command Path: "ping", Command Arguments: "${optionalArgs} google.com", Argument Delimiter: " " (spacebar), Ignore STDIN: true, auto terminate: original
7. Connect ExecuteStreamCommand -> output stream - > LogAttribute to see some output. LogAttribute auto terminate: success, Log Level: error, Log Payload: true.
8. Run the flow.

Expected output:
1. ExecuteStreamCommand issues command ping with args: "-c", "5", "google.com"

Actual output:
1. ExecuteStreamCommand puts the "-c 5" into single arg for ProcessBuilder
This behavior is no problem for ping utility, but there are tools (like snmpwalk in my case), which are dumb enough not to parse command line arguments properly, when they are sent inproperly by ProcessBuilder.