### PR TITLE
A relationship can be auto-terminable. In this case the processor wil…

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/Relationship.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/Relationship.java
@@ -41,9 +41,17 @@ public final class Relationship implements Comparable<Relationship> {
      */
     private final int hashCode;
 
+    /**
+     * The flag which tells the controller to auto terminate this
+     * relationship, so that the processor can be run even if it does
+     * not have connections from this relationship
+     */
+    private final boolean isAutoTerminate;
+
     protected Relationship(final Builder builder) {
         this.name = builder.name == null ? null : builder.name.intern();
         this.description = builder.description;
+        this.isAutoTerminate = builder.autoTerminate;
         this.hashCode = 301 + this.name.hashCode(); // compute only once, since it gets called a bunch and will never change
     }
 
@@ -71,6 +79,7 @@ public final class Relationship implements Comparable<Relationship> {
 
         private String name = "";
         private String description = "";
+        private boolean autoTerminate = false;
 
         public Builder name(final String name) {
             if (null != name) {
@@ -86,6 +95,11 @@ public final class Relationship implements Comparable<Relationship> {
             return this;
         }
 
+        public Builder autoTerminateDefault(boolean autoTerminate) {
+            this.autoTerminate = autoTerminate;
+            return this;
+        }
+
         public Relationship build() {
             return new Relationship(this);
         }
@@ -97,6 +111,10 @@ public final class Relationship implements Comparable<Relationship> {
 
     public String getDescription() {
         return this.description;
+    }
+
+    public boolean isAutoTerminated() {
+        return this.isAutoTerminate;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -304,6 +304,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
     @Override
     public boolean isAutoTerminated(final Relationship relationship) {
+        if (relationship.isAutoTerminated() && getConnections(relationship).isEmpty())
+            return true;
         final Set<Relationship> terminatable = undefinedRelationshipsToTerminate.get();
         if (terminatable == null) {
             return false;


### PR DESCRIPTION
> I have worked on NiFi to solve the issue
>
> https://issues.apache.org/jira/browse/NIFI-1003
>
> and I enclose here a patch which I have tested
> with the current 0.5 snapshot tree.
>
> It adds a flag to the relationship. This flag tells the
> processor to terminate it automatically, so in this
> case we can add new relationships to a processor
> and make the processor still runnable (otherwise the
> framework will report a validation error).