### PR TITLE
nifi-1514 - Fixed: ExecuteStreamCommand does not split command line arguments by provided separator when these come from expression language evaluation

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
@@ -302,8 +302,10 @@ public class ExecuteStreamCommand extends AbstractProcessor {
         final String commandArguments = context.getProperty(EXECUTION_ARGUMENTS).getValue();
         final boolean ignoreStdin = Boolean.parseBoolean(context.getProperty(IGNORE_STDIN).getValue());
         if (!StringUtils.isBlank(commandArguments)) {
-            for (String arg : ArgumentUtils.splitArgs(commandArguments, context.getProperty(ARG_DELIMITER).getValue().charAt(0))) {
-                args.add(context.newPropertyValue(arg).evaluateAttributeExpressions(inputFlowFile).getValue());
+            for (String arg : ArgumentUtils.splitArgs(
+                    context.newPropertyValue(commandArguments).evaluateAttributeExpressions(inputFlowFile).getValue(),
+                    context.getProperty(ARG_DELIMITER).getValue().charAt(0))) {
+                args.add(arg);
             }
         }
         final String workingDir = context.getProperty(WORKING_DIR).evaluateAttributeExpressions(inputFlowFile).getValue();


### PR DESCRIPTION
nifi-1514 - Fixed: ExecuteStreamCommand does not split command line arguments by provided separator when these come from expression language evaluation

Resolves https://issues.apache.org/jira/browse/NIFI-1514