### PR TITLE
NIFI-1529 Forcing hadoop-libraries-nar to version 4.2.5 of httpclient…

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -732,14 +732,6 @@ The following binary components are provided under the Apache Software License v
             Apache Software Foundation that were originally developed at iClick, Inc.,
             software copyright (c) 1999.
 
-    (ASLv2) Google Guice
-      The following NOTICE information applies:
-        Google Guice - Core Library
-        Copyright 2006-2011 Google, Inc.
-
-        Google Guice - Extensions - Servlet
-        Copyright 2006-2011 Google, Inc.
-
     (ASLv2) Metadata-Extractor
       The following NOTICE information applies:
         Metadata-Extractor
@@ -855,7 +847,6 @@ The following binary components are provided under the Common Development and Di
     (CDDL 1.0) JavaServlet(TM) Specification (javax.servlet:servlet-api:jar:2.5 - no url available)
     (CDDL 1.0) (GPL3) Streaming API For XML (javax.xml.stream:stax-api:jar:1.0-2 - no url provided)
     (CDDL 1.0) JavaBeans Activation Framework (JAF) (javax.activation:activation:jar:1.1 - http://java.sun.com/products/javabeans/jaf/index.jsp)
-    (CDDL 1.0) JavaServer Pages(TM) API (javax.servlet.jsp:jsp-api:jar:2.1 - http://jsp.java.net)
     (CDDL 1.0) JSR311 API (javax.ws.rs:jsr311-api:jar:1.1.1 - https://jsr311.dev.java.net)
 
 ************************

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
@@ -25,26 +25,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-yarn-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-mapreduce-client-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/src/main/resources/META-INF/NOTICE
@@ -148,10 +148,6 @@ The following binary components are provided under the Apache Software License v
       Apache Commons Collections
       Copyright 2001-2008 The Apache Software Foundation	
 
-  (ASLv2) Jettison
-    The following NOTICE information applies:
-         Copyright 2006 Envoi Solutions LLC
-
   (ASLv2) Apache Commons Logging
     The following NOTICE information applies:
       Apache Commons Logging
@@ -169,11 +165,14 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Apache HttpComponents
     The following NOTICE information applies:
-      Apache HttpClient
-      Copyright 1999-2015 The Apache Software Foundation
-      
-      Apache HttpComponents HttpCore
-      Copyright 2005-2011 The Apache Software Foundation
+      Apache HttpComponents Client
+      Copyright 1999-2012 The Apache Software Foundation
+
+      Apache HttpComponents Core
+      Copyright 2005-2013 The Apache Software Foundation
+
+      This project contains annotations derived from JCIP-ANNOTATIONS
+      Copyright (c) 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
 
   (ASLv2) Apache Commons Configuration
     The following NOTICE information applies:
@@ -254,19 +253,6 @@ The following binary components are provided under the Apache Software License v
           Apache Software Foundation that were originally developed at iClick, Inc.,
           software copyright (c) 1999.
 
-  (ASLv2) Apache Commons EL
-    The following NOTICE information applies:
-      Apache Commons EL
-      Copyright 1999-2007 The Apache Software Foundation
-
-      EL-8 patch - Copyright 2004-2007 Jamie Taylor
-      http://issues.apache.org/jira/browse/EL-8
-
-   (ASLv2) Jetty
-     The following NOTICE information applies:
-        Jetty Web Container
-        Copyright 1995-2015 Mort Bay Consulting Pty Ltd.
-
   (ASLv2) Apache Tomcat
     The following NOTICE information applies:
       Apache Tomcat
@@ -282,14 +268,6 @@ The following binary components are provided under the Apache Software License v
         related infomation is available at
         http://www.eclipse.org.
 
-  (ASLv2) Google Guice
-    The following NOTICE information applies:
-      Google Guice - Core Library
-      Copyright 2006-2011 Google, Inc.
-
-      Google Guice - Extensions - Servlet
-      Copyright 2006-2011 Google, Inc.
-
   (ASLv2) Google GSON
     The following NOTICE information applies:
       Copyright 2008 Google Inc.
@@ -300,12 +278,8 @@ Common Development and Distribution License 1.1
 
 The following binary components are provided under the Common Development and Distribution License 1.1. See project link for details.
 
-    (CDDL 1.1) (GPL2 w/ CPE) jersey-server (com.sun.jersey:jersey-server:jar:1.19 - https://jersey.java.net/jersey-server/)
     (CDDL 1.1) (GPL2 w/ CPE) jersey-client (com.sun.jersey:jersey-client:jar:1.19 - https://jersey.java.net/jersey-client/)
     (CDDL 1.1) (GPL2 w/ CPE) jersey-core (com.sun.jersey:jersey-core:jar:1.19 - https://jersey.java.net/jersey-core/)
-    (CDDL 1.1) (GPL2 w/ CPE) jersey-json (com.sun.jersey:jersey-json:jar:1.19 - https://jersey.java.net/index.html)
-    (CDDL 1.1) (GPL2 w/ CPE) jersey-juice (com.sun.jersey:jersey-juice:jar:1.9 - https://jersey.java.net/index.html)
-    (CDDL 1.1) (GPL2 w/ CPE) Old JAXB Runtime (com.sun.xml.bind:jaxb-impl:jar:2.2.3-1 - http://jaxb.java.net/)
     (CDDL 1.1) (GPL2 w/ CPE) Java Architecture For XML Binding (javax.xml.bind:jaxb-api:jar:2.2.2 - https://jaxb.dev.java.net/)
 
 ************************
@@ -317,7 +291,6 @@ The following binary components are provided under the Common Development and Di
     (CDDL 1.0) JavaServlet(TM) Specification (javax.servlet:servlet-api:jar:2.5 - no url available)
     (CDDL 1.0) (GPL3) Streaming API For XML (javax.xml.stream:stax-api:jar:1.0-2 - no url provided)
     (CDDL 1.0) JavaBeans Activation Framework (JAF) (javax.activation:activation:jar:1.1 - http://java.sun.com/products/javabeans/jaf/index.jsp)
-    (CDDL 1.0) JavaServer Pages(TM) API (javax.servlet.jsp:jsp-api:jar:2.1 - http://jsp.java.net)
     (CDDL 1.0) JSR311 API (javax.ws.rs:jsr311-api:jar:1.1.1 - https://jsr311.dev.java.net)
 
 *****************

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -35,6 +35,17 @@
                 <artifactId>guava</artifactId>
                 <version>${hadoop.guava.version}</version>
             </dependency>
+            <!-- the top-level pom forces 4.4.1, but Hadoop 2.6 normally brings in 4.2.5 -->
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${hadoop.http.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>${hadoop.http.client.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@ language governing permissions and limitations under the License. -->
         <jersey.version>1.19</jersey.version>
         <hadoop.version>2.6.2</hadoop.version>
         <hadoop.guava.version>12.0.1</hadoop.guava.version>
+        <hadoop.http.client.version>4.2.5</hadoop.http.client.version>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
     </properties>
 


### PR DESCRIPTION
… and httpcore since that is what hadoop-client 2.6.2 normally brings in, and also removing dependencies from the nar pom that should be transitively brought in by hadoop-client

See the JIRA comments for a further description of the issue and solution:
https://issues.apache.org/jira/browse/NIFI-1529