### PR TITLE
NIFI-1542 PutS3Object Processor Logs Errors Without ListBucketMultipartUploads Permission

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -695,8 +696,19 @@ public class PutS3Object extends AbstractS3Processor {
                 ageoffLocalState(ageCutoff);
                 lastS3AgeOff.set(System.currentTimeMillis());
             } catch(AmazonClientException e) {
-                getLogger().error("Error checking S3 Multipart Upload list for {}: {}",
-                        new Object[]{bucket, e.getMessage()});
+                if (e instanceof AmazonS3Exception &&
+                        ((AmazonS3Exception)e).getStatusCode() == 403 &&
+                        ((AmazonS3Exception) e).getErrorCode().equals("AccessDenied")) {
+                    getLogger().warn("AccessDenied checking S3 Multipart Upload list for {}: {} " +
+                            "** The configured user does not have the s3:ListBucketMultipartUploads permission " +
+                            "for this bucket, S3 age off cannot occur without this permission.  Next Age Off check " +
+                            "time is being advanced by interval to prevent checking on every upload **",
+                            new Object[]{bucket, e.getMessage()});
+                    lastS3AgeOff.set(System.currentTimeMillis());
+                } else {
+                    getLogger().error("Error checking S3 Multipart Upload list for {}: {}",
+                            new Object[]{bucket, e.getMessage()});
+                }
             } finally {
                 s3BucketLock.unlock();
             }


### PR DESCRIPTION
Update how PutS3Object handles a 403 AccessDenied response to a S3 ListMultipartUploads request.
* Change log message from error to warning and added note about S3 permissions.
* Advance the AgeOff check time by the check interval as if the request succeeded to prevent re-checking on every upload when permission does not exist.