### PR TITLE
NIFI-1539 - Add normalization of content type for content viewing

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/web/ViewableContent.java
+++ b/nifi-api/src/main/java/org/apache/nifi/web/ViewableContent.java
@@ -59,7 +59,13 @@ public interface ViewableContent {
     String getFileName();
 
     /**
-     * @return mime type of the content
+     * @return mime type of the content, value is lowercase and stripped of all parameters if there were any
      */
     String getContentType();
+
+    /**
+     * @return unchanged mime type of the content
+     */
+    String getRawContentType();
+
 }


### PR DESCRIPTION
Pull request for [NIFI-1539](https://issues.apache.org/jira/browse/NIFI-1539)

Add code to ContentViewerController to strip content type of any trailing parameters and lowercase the type and subtype.

Added function to ViewableContent to enable retrieving the original value of the content type if needed.