### PR TITLE
NIFI-1180: Modify PutS3Object to enable encryption

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -61,6 +61,7 @@ import com.amazonaws.services.s3.model.S3Object;
     @WritesAttribute(attribute = "s3.etag", description = "The ETag that can be used to see if the file has changed"),
     @WritesAttribute(attribute = "s3.expirationTime", description = "If the file has an expiration date, this attribute will be set, containing the milliseconds since epoch in UTC time"),
     @WritesAttribute(attribute = "s3.expirationTimeRuleId", description = "The ID of the rule that dictates this object's expiration time"),
+    @WritesAttribute(attribute = "s3.sseAlgorithm", description = "The server side encryption algorithm of the object"),
     @WritesAttribute(attribute = "s3.version", description = "The version of the S3 object"),})
 public class FetchS3Object extends AbstractS3Processor {
 
@@ -136,6 +137,9 @@ public class FetchS3Object extends AbstractS3Processor {
             }
             if (metadata.getUserMetadata() != null) {
                 attributes.putAll(metadata.getUserMetadata());
+            }
+            if (metadata.getSSEAlgorithm() != null) {
+                attributes.put("s3.sseAlgorithm", metadata.getSSEAlgorithm());
             }
             if (metadata.getVersionId() != null) {
                 attributes.put("s3.version", metadata.getVersionId());

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/groovy/org.apache.nifi.processors.aws.s3/PutS3ObjectTest.groovy
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/groovy/org.apache.nifi.processors.aws.s3/PutS3ObjectTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.s3
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@RunWith(JUnit4.class)
+class PutS3ObjectTest extends GroovyTestCase {
+    private static final Logger logger = LoggerFactory.getLogger(PutS3ObjectTest.class);
+
+    private static long mockFlowFileId = 0
+    private PutS3Object putS3Object
+
+    @BeforeClass
+    static void setUpOnce() {
+        logger.metaClass.methodMissing = { String name, args ->
+            logger.info("[${name?.toUpperCase()}] ${(args as List).join(" ")}")
+        }
+    }
+
+    @Before
+    void setUp() {
+        super.setUp()
+
+        putS3Object = new PutS3Object()
+
+    }
+
+    @After
+    void tearDown() {
+
+    }
+
+    @Test
+    void testShouldIncludeServerSideEncryptionAlgorithmProperty() {
+        // Arrange
+
+        // Act
+        def propertyDescriptors = putS3Object.getSupportedPropertyDescriptors()
+        def ssePropertyDescriptor = propertyDescriptors.find { it.name =~ "server-side-encryption" }
+
+        // Assert
+        assert ssePropertyDescriptor
+        assert ssePropertyDescriptor.name == "server-side-encryption"
+        assert ssePropertyDescriptor.displayName == "Server Side Encryption"
+    }
+
+    @Test
+    void testShouldValidateServerSideEncryptionDefaultsToNone() {
+        // Arrange
+
+        // Act
+        def propertyDescriptors = putS3Object.getSupportedPropertyDescriptors()
+        def ssePropertyDescriptor = propertyDescriptors.find { it.name =~ "server-side-encryption" }
+
+        // Assert
+        assert ssePropertyDescriptor
+        assert ssePropertyDescriptor.defaultValue == putS3Object.NO_SERVER_SIDE_ENCRYPTION
+    }
+
+    @Test
+    void testShouldValidateServerSideEncryptionAllowableValues() {
+        // Arrange
+
+        // Act
+        def propertyDescriptors = putS3Object.getSupportedPropertyDescriptors()
+        def ssePropertyDescriptor = propertyDescriptors.find { it.name =~ "server-side-encryption" }
+
+        // Assert
+        assert ssePropertyDescriptor
+        assert ssePropertyDescriptor.allowableValues*.toString() == [putS3Object.NO_SERVER_SIDE_ENCRYPTION, ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION]
+    }
+}

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/AbstractS3IT.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/AbstractS3IT.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
 import com.amazonaws.services.s3.model.DeleteBucketRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.apache.nifi.util.file.FileUtils;
@@ -128,6 +129,14 @@ public abstract class AbstractS3IT {
 
     protected void putTestFile(String key, File file) throws AmazonS3Exception {
         PutObjectRequest putRequest = new PutObjectRequest(BUCKET_NAME, key, file);
+
+        client.putObject(putRequest);
+    }
+
+    protected void putTestFileEncrypted(String key, File file) throws AmazonS3Exception, FileNotFoundException {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        PutObjectRequest putRequest = new PutObjectRequest(BUCKET_NAME, key, new FileInputStream(file), objectMetadata);
 
         client.putObject(putRequest);
     }


### PR DESCRIPTION
This adds a property to set server side encryption on PutS3Object. In addition, it adds `s3.sseAlgorithm` to `FetchS3Object` so users of that processor will know if object encryption is turned on.