### PR TITLE
NIFI-1573 Allow programmatic access to a Processor's name

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessContext.java
@@ -160,4 +160,9 @@ public interface ProcessContext {
      * @return the StateManager that can be used to store and retrieve state for this component
      */
     StateManager getStateManager();
+
+    /**
+     * @return the configured name of this processor
+     */
+    String getName();
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessContext.java
@@ -355,4 +355,9 @@ public class MockProcessContext extends MockControllerServiceLookup implements S
     public StateManager getStateManager() {
         return stateManager;
     }
+
+    @Override
+    public String getName() {
+        return "";
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/mock/MockProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/mock/MockProcessContext.java
@@ -108,4 +108,9 @@ public class MockProcessContext implements ProcessContext {
     public StateManager getStateManager() {
         return null;
     }
+
+    @Override
+    public String getName() {
+        return null;
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/ConnectableProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/ConnectableProcessContext.java
@@ -243,4 +243,9 @@ public class ConnectableProcessContext implements ProcessContext {
     public StateManager getStateManager() {
         return stateManager;
     }
+
+    @Override
+    public String getName() {
+        return connectable.getName();
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
@@ -216,4 +216,9 @@ public class StandardProcessContext implements ProcessContext, ControllerService
     public StateManager getStateManager() {
         return stateManager;
     }
+
+    @Override
+    public String getName() {
+        return procNode.getName();
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardSchedulingContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardSchedulingContext.java
@@ -147,4 +147,9 @@ public class StandardSchedulingContext implements SchedulingContext {
     public StateManager getStateManager() {
         return stateManager;
     }
+
+    @Override
+    public String getName() {
+        return processorNode.getName();
+    }
 }


### PR DESCRIPTION
I've added a `getName()` method to `ProcessContext` which means that a `Processor` can access the name that was configured in the UI.