### PR TITLE
NIFI-1596: ExecuteSQL Error Creating Schema

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JdbcCommon.java
@@ -130,7 +130,7 @@ public class JdbcCommon {
         String tableName = "NiFi_ExecuteSQL_Record";
         if(nrOfColumns > 0) {
             String tableNameFromMeta = meta.getTableName(1);
-            if (!StringUtils.isBlank(tableName)) {
+            if (!StringUtils.isBlank(tableNameFromMeta)) {
                 tableName = tableNameFromMeta;
             }
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJdbcCommon.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJdbcCommon.java
@@ -124,6 +124,25 @@ public class TestJdbcCommon {
     }
 
     @Test
+    public void testCreateSchemaNoTableName() throws ClassNotFoundException, SQLException {
+
+        final ResultSet resultSet = mock(ResultSet.class);
+        final ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
+        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+        when(resultSetMetaData.getColumnCount()).thenReturn(1);
+        when(resultSetMetaData.getTableName(1)).thenReturn("");
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(resultSetMetaData.getColumnName(1)).thenReturn("ID");
+
+        final Schema schema = JdbcCommon.createSchema(resultSet);
+        assertNotNull(schema);
+
+        // records name, should be result set first column table name
+        assertEquals("NiFi_ExecuteSQL_Record", schema.getName());
+
+    }
+
+    @Test
     public void testConvertToBytes() throws ClassNotFoundException, SQLException, IOException {
         // remove previous test database, if any
         folder.delete();


### PR DESCRIPTION
I ran the unit test before making the change, verified it fails, then made the fix and the test passes. Also tried in a full NiFi build against Oracle (where the problem was first noticed).