### PR TITLE
NIFI-1605 Adjust documentation and resources to reflect nifi.provenance.repository.rollover.time default

### DIFF
--- a/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.blank.properties
+++ b/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.blank.properties
@@ -55,7 +55,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.missing.properties
+++ b/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.missing.properties
@@ -53,7 +53,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.properties
+++ b/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.properties
@@ -55,7 +55,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -1270,7 +1270,7 @@ nifi.provenance.repository.directory.provenance2=/repos/provenance2 +
 Providing three total locations, including  _nifi.provenance.repository.directory.default_.
 |nifi.provenance.repository.max.storage.time|The maximum amount of time to keep data provenance information. The default value is 24 hours.
 |nifi.provenance.repository.max.storage.size|The maximum amount of data provenance information to store at a time. The default is 1 GB.
-|nifi.provenance.repository.rollover.time|The amount of time to wait before rolling over the latest data provenance information so that it is available in the User Interface. The default value is 5 mins.
+|nifi.provenance.repository.rollover.time|The amount of time to wait before rolling over the latest data provenance information so that it is available in the User Interface. The default value is 30 secs.
 |nifi.provenance.repository.rollover.size|The amount of information to roll over at a time. The default value is 100 MB.
 |nifi.provenance.repository.query.threads|The number of threads to use for Provenance Repository queries. The default value is 2.
 |nifi.provenance.repository.index.threads|The number of threads to use for indexing Provenance events so that they are searchable. The default value is 1.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/resources/conf/nifi.properties
@@ -56,7 +56,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/conf/nifi.properties
@@ -54,7 +54,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/nifi-with-remote.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/nifi-with-remote.properties
@@ -54,7 +54,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/nifi.properties
@@ -54,7 +54,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/test/resources/NarUnpacker/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/test/resources/NarUnpacker/conf/nifi.properties
@@ -56,7 +56,7 @@ nifi.content.repository.directory.default=./target/content_repository
 nifi.provenance.repository.storage.directory=./target/provenance_repository
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Site to Site properties

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi.properties
@@ -63,7 +63,7 @@ nifi.provenance.repository.directory.default=./target/provenance_repository
 nifi.provenance.repository.query.threads=2
 nifi.provenance.repository.max.storage.time=24 hours
 nifi.provenance.repository.max.storage.size=1 GB
-nifi.provenance.repository.rollover.time=5 mins
+nifi.provenance.repository.rollover.time=30 secs
 nifi.provenance.repository.rollover.size=100 MB
 
 # Component Status Repository


### PR DESCRIPTION
Adjust documentation and resources to reflect nifi.provenance.repository.rollover.time default of "30 secs"