### PR TITLE
NIFI-1607 Fixing issue in ListenRELP where it could commit the session before all flow files were transferred

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenRELP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenRELP.java
@@ -18,8 +18,11 @@ package org.apache.nifi.processors.standard;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSessionFactory;
+import org.apache.nifi.processor.util.listen.dispatcher.ChannelDispatcher;
+import org.apache.nifi.processor.util.listen.response.ChannelResponder;
 import org.apache.nifi.processors.standard.relp.event.RELPEvent;
 import org.apache.nifi.processors.standard.relp.frame.RELPEncoder;
 import org.apache.nifi.processors.standard.relp.frame.RELPFrame;
@@ -35,13 +38,16 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 
 public class TestListenRELP {
 
@@ -78,7 +84,7 @@ public class TestListenRELP {
         encoder = new RELPEncoder(StandardCharsets.UTF_8);
         proc = new ResponseCapturingListenRELP();
         runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(ListenSyslog.PORT, "0");
+        runner.setProperty(ListenRELP.PORT, "0");
     }
 
     @Test
@@ -169,6 +175,37 @@ public class TestListenRELP {
         run(frames, 5, 5, sslContextService);
     }
 
+    @Test
+    public void testNoEventsAvailable() throws IOException, InterruptedException {
+        MockListenRELP mockListenRELP = new MockListenRELP(new ArrayList<RELPEvent>());
+        runner = TestRunners.newTestRunner(mockListenRELP);
+        runner.setProperty(ListenRELP.PORT, "1");
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(ListenRELP.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testBatchingWithDifferentSenders() throws IOException, InterruptedException {
+        final String sender1 = "sender1";
+        final String sender2 = "sender2";
+        final ChannelResponder<SocketChannel> responder = Mockito.mock(ChannelResponder.class);
+
+        final List<RELPEvent> mockEvents = new ArrayList<>();
+        mockEvents.add(new RELPEvent(sender1, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+        mockEvents.add(new RELPEvent(sender1, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+        mockEvents.add(new RELPEvent(sender2, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+        mockEvents.add(new RELPEvent(sender2, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+
+        MockListenRELP mockListenRELP = new MockListenRELP(mockEvents);
+        runner = TestRunners.newTestRunner(mockListenRELP);
+        runner.setProperty(ListenRELP.PORT, "1");
+        runner.setProperty(ListenRELP.MAX_BATCH_SIZE, "10");
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(ListenRELP.REL_SUCCESS, 2);
+    }
+
     protected void run(final List<RELPFrame> frames, final int expectedTransferred, final int expectedResponses, final SSLContextService sslContextService)
             throws IOException, InterruptedException {
 
@@ -248,6 +285,29 @@ public class TestListenRELP {
             this.responses.add(relpResponse);
             super.respond(event, relpResponse);
         }
+    }
+
+    // Extend ListenRELP to mock the ChannelDispatcher and allow us to return staged events
+    private static class MockListenRELP extends ListenRELP {
+
+        private List<RELPEvent> mockEvents;
+
+        public MockListenRELP(List<RELPEvent> mockEvents) {
+            this.mockEvents = mockEvents;
+        }
+
+        @OnScheduled
+        @Override
+        public void onScheduled(ProcessContext context) throws IOException {
+            super.onScheduled(context);
+            events.addAll(mockEvents);
+        }
+
+        @Override
+        protected ChannelDispatcher createDispatcher(ProcessContext context, BlockingQueue<RELPEvent> events) throws IOException {
+            return Mockito.mock(ChannelDispatcher.class);
+        }
+
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/RELPFrameProducer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/RELPFrameProducer.java
@@ -86,6 +86,8 @@ public class RELPFrameProducer {
                     }
                 }
 
+                Thread.sleep(5000);
+
                 // send the close frame
                 out.write(encoder.encode(CLOSE_FRAME));
 


### PR DESCRIPTION
Was able to reproduce this exception by writing a unit test that simulated data coming from two senders and had batching turned on, which caused the code to try and commit the session in a loop that was processing the data for each sender.

Moved the session.commit() outside the while loop, and acknowledged all messages after successful commit. The above unit test passes now.