### PR TITLE
NIFI-899 Rewrite of ListenUDP to use new listener framework, includes…

### DIFF
--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventBatchingProcessor.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventBatchingProcessor.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util.listen;
+
+import static org.apache.nifi.processor.util.listen.ListenerProperties.NETWORK_INTF_NAME;
+
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.OutputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processor.util.listen.event.Event;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An abstract processor that extends from AbstractListenEventProcessor and adds common functionality for
+ * batching events into a single FlowFile.
+ *
+ * @param <E> the type of Event
+ */
+public abstract class AbstractListenEventBatchingProcessor<E extends Event> extends AbstractListenEventProcessor<E> {
+
+    public static final PropertyDescriptor MAX_BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("Max Batch Size")
+            .description(
+                    "The maximum number of messages to add to a single FlowFile. If multiple messages are available, they will be concatenated along with "
+                            + "the <Message Delimiter> up to this configured maximum number of messages")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .expressionLanguageSupported(false)
+            .defaultValue("1")
+            .required(true)
+            .build();
+    public static final PropertyDescriptor MESSAGE_DELIMITER = new PropertyDescriptor.Builder()
+            .name("Message Delimiter")
+            .displayName("Batching Message Delimiter")
+            .description("Specifies the delimiter to place between messages when multiple messages are bundled together (see <Max Batch Size> property).")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("\\n")
+            .required(true)
+            .build();
+
+    // it is only the array reference that is volatile - not the contents.
+    protected volatile byte[] messageDemarcatorBytes;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(NETWORK_INTF_NAME);
+        descriptors.add(PORT);
+        descriptors.add(RECV_BUFFER_SIZE);
+        descriptors.add(MAX_MESSAGE_QUEUE_SIZE);
+        descriptors.add(MAX_SOCKET_BUFFER_SIZE);
+        descriptors.add(CHARSET);
+        descriptors.add(MAX_BATCH_SIZE);
+        descriptors.add(MESSAGE_DELIMITER);
+        descriptors.addAll(getAdditionalProperties());
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<>();
+        relationships.add(REL_SUCCESS);
+        relationships.addAll(getAdditionalRelationships());
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    @OnScheduled
+    public void onScheduled(ProcessContext context) throws IOException {
+        super.onScheduled(context);
+        final String msgDemarcator = context.getProperty(MESSAGE_DELIMITER).getValue().replace("\\n", "\n").replace("\\r", "\r").replace("\\t", "\t");
+        messageDemarcatorBytes = msgDemarcator.getBytes(charset);
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        final int maxBatchSize = context.getProperty(MAX_BATCH_SIZE).asInteger();
+        final Map<String,FlowFileEventBatch> batches = getBatches(session, maxBatchSize, messageDemarcatorBytes);
+
+        // if the size is 0 then there was nothing to process so return
+        // we don't need to yield here because we have a long poll in side of getBatches
+        if (batches.size() == 0) {
+            return;
+        }
+
+        final List<E> allEvents = new ArrayList<>();
+
+        for (Map.Entry<String,FlowFileEventBatch> entry : batches.entrySet()) {
+            FlowFile flowFile = entry.getValue().getFlowFile();
+            final List<E> events = entry.getValue().getEvents();
+
+            if (flowFile.getSize() == 0L || events.size() == 0) {
+                session.remove(flowFile);
+                getLogger().debug("No data written to FlowFile from batch {}; removing FlowFile", new Object[] {entry.getKey()});
+                continue;
+            }
+
+            final Map<String,String> attributes = getAttributes(entry.getValue());
+            flowFile = session.putAllAttributes(flowFile, attributes);
+
+            getLogger().debug("Transferring {} to success", new Object[] {flowFile});
+            session.transfer(flowFile, REL_SUCCESS);
+            session.adjustCounter("FlowFiles Transferred to Success", 1L, false);
+
+            // the sender and command will be the same for all events based on the batch key
+            final String transitUri = getTransitUri(entry.getValue());
+            session.getProvenanceReporter().receive(flowFile, transitUri);
+
+            allEvents.addAll(events);
+        }
+
+        // let sub-classes take any additional actions
+        postProcess(context, session, allEvents);
+    }
+
+    /**
+     * Creates the attributes for the FlowFile of the given batch.
+     *
+     * @param batch the current batch
+     * @return the Map of FlowFile attributes
+     */
+    protected abstract Map<String,String> getAttributes(final FlowFileEventBatch batch);
+
+    /**
+     * Creates the transit uri to be used when reporting a provenance receive event for the given batch.
+     *
+     * @param batch the current batch
+     * @return the transit uri string
+     */
+    protected abstract String getTransitUri(final FlowFileEventBatch batch);
+
+    /**
+     * Called at the end of onTrigger to allow sub-classes to take post processing action on the events
+     *
+     * @param context the current context
+     * @param session the current session
+     * @param events the list of all events processed by the current execution of onTrigger
+     */
+    protected void postProcess(ProcessContext context, ProcessSession session, final List<E> events) {
+        // empty implementation so sub-classes only have to override if necessary
+    }
+
+    /**
+     * Batches together up to the batchSize events. Events are grouped together based on a batch key which
+     * by default is the sender of the event, but can be override by sub-classes.
+     *
+     * This method will return when batchSize has been reached, or when no more events are available on the queue.
+     *
+     * @param session the current session
+     * @param totalBatchSize the total number of events to process
+     * @param messageDemarcatorBytes the demarcator to put between messages when writing to a FlowFile
+     *
+     * @return a Map from the batch key to the FlowFile and events for that batch, the size of events in all
+     *              the batches will be <= batchSize
+     */
+    protected Map<String,FlowFileEventBatch> getBatches(final ProcessSession session, final int totalBatchSize,
+                                                        final byte[] messageDemarcatorBytes) {
+
+        final Map<String,FlowFileEventBatch> batches = new HashMap<>();
+        for (int i=0; i < totalBatchSize; i++) {
+            final E event = getMessage(true, true, session);
+            if (event == null) {
+                break;
+            }
+
+            final String batchKey = getBatchKey(event);
+            FlowFileEventBatch batch = batches.get(batchKey);
+
+            // if we don't have a batch for this key then create a new one
+            if (batch == null) {
+                batch = new FlowFileEventBatch(session.create(), new ArrayList<E>());
+                batches.put(batchKey, batch);
+            }
+
+            // add the current event to the batch
+            batch.getEvents().add(event);
+
+            // append the event's data to the FlowFile, write the demarcator first if not on the first event
+            final boolean writeDemarcator = (i > 0);
+            try {
+                final byte[] rawMessage = event.getData();
+                FlowFile appendedFlowFile = session.append(batch.getFlowFile(), new OutputStreamCallback() {
+                    @Override
+                    public void process(final OutputStream out) throws IOException {
+                        if (writeDemarcator) {
+                            out.write(messageDemarcatorBytes);
+                        }
+
+                        out.write(rawMessage);
+                    }
+                });
+
+                // update the FlowFile reference in the batch object
+                batch.setFlowFile(appendedFlowFile);
+
+            } catch (final Exception e) {
+                getLogger().error("Failed to write contents of the message to FlowFile due to {}; will re-queue message and try again",
+                        new Object[] {e.getMessage()}, e);
+                errorEvents.offer(event);
+                break;
+            }
+        }
+
+        return batches;
+    }
+
+    /**
+     * @param event an event that was pulled off the queue
+     *
+     * @return a key to use for batching events together, by default this uses the sender of the
+     *              event, but sub-classes should override this to batch by something else
+     */
+    protected String getBatchKey(final E event) {
+        return event.getSender();
+    }
+
+    /**
+     * Wrapper to hold a FlowFile and the events that have been appended to it.
+     */
+    protected final class FlowFileEventBatch {
+
+        private FlowFile flowFile;
+        private List<E> events;
+
+        public FlowFileEventBatch(final FlowFile flowFile, final List<E> events) {
+            this.flowFile = flowFile;
+            this.events = events;
+        }
+
+        public FlowFile getFlowFile() {
+            return flowFile;
+        }
+
+        public List<E> getEvents() {
+            return events;
+        }
+
+        public void setFlowFile(FlowFile flowFile) {
+            this.flowFile = flowFile;
+        }
+    }
+
+}

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/ListenerProperties.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/ListenerProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util.listen;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.AttributeExpression;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Shared properties.
+ */
+public class ListenerProperties {
+
+    private static final Set<String> interfaceSet = new HashSet<>();
+
+    static {
+        try {
+            final Enumeration<NetworkInterface> interfaceEnum = NetworkInterface.getNetworkInterfaces();
+            while (interfaceEnum.hasMoreElements()) {
+                final NetworkInterface ifc = interfaceEnum.nextElement();
+                interfaceSet.add(ifc.getName());
+            }
+        } catch (SocketException e) {
+        }
+    }
+
+    public static final PropertyDescriptor NETWORK_INTF_NAME = new PropertyDescriptor.Builder()
+            .name("Local Network Interface")
+            .description("The name of a local network interface to be used to restrict listening to a specific LAN.")
+            .addValidator(new Validator() {
+                @Override
+                public ValidationResult validate(String subject, String input, ValidationContext context) {
+                    ValidationResult result = new ValidationResult.Builder()
+                            .subject("Local Network Interface").valid(true).input(input).build();
+                    if (interfaceSet.contains(input.toLowerCase())) {
+                        return result;
+                    }
+
+                    String message;
+                    String realValue = input;
+                    try {
+                        if (context.isExpressionLanguagePresent(input)) {
+                            AttributeExpression ae = context.newExpressionLanguageCompiler().compile(input);
+                            realValue = ae.evaluate();
+                        }
+
+                        if (interfaceSet.contains(realValue.toLowerCase())) {
+                            return result;
+                        }
+
+                        message = realValue + " is not a valid network name. Valid names are " + interfaceSet.toString();
+
+                    } catch (IllegalArgumentException e) {
+                        message = "Not a valid AttributeExpression: " + e.getMessage();
+                    }
+                    result = new ValidationResult.Builder().subject("Local Network Interface")
+                            .valid(false).input(input).explanation(message).build();
+
+                    return result;
+                }
+            })
+            .expressionLanguageSupported(true)
+            .build();
+
+}

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/ChannelDispatcher.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/ChannelDispatcher.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processor.util.listen.dispatcher;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 /**
  * Dispatches handlers for a given channel.
@@ -27,11 +28,16 @@ public interface ChannelDispatcher extends Runnable {
      * Opens the dispatcher listening on the given port and attempts to set the
      * OS socket buffer to maxBufferSize.
      *
+     * @param nicAddress the local network interface to listen on, if null will listen on the wildcard address
+     *                   which means listening on all local network interfaces
+     *
      * @param port the port to listen on
+     *
      * @param maxBufferSize the size to set the OS socket buffer to
+     *
      * @throws IOException if an error occurred listening on the given port
      */
-    void open(int port, int maxBufferSize) throws IOException;
+    void open(InetAddress nicAddress, int port, int maxBufferSize) throws IOException;
 
     /**
      * @return the port being listened to

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/SocketChannelDispatcher.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/SocketChannelDispatcher.java
@@ -27,6 +27,7 @@ import org.apache.nifi.security.util.SslContextFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
@@ -104,7 +105,7 @@ public class SocketChannelDispatcher<E extends Event<SocketChannel>> implements 
     }
 
     @Override
-    public void open(final int port, int maxBufferSize) throws IOException {
+    public void open(final InetAddress nicAddress, final int port, final int maxBufferSize) throws IOException {
         stopped = false;
         executor = Executors.newFixedThreadPool(maxConnections);
 
@@ -119,7 +120,9 @@ public class SocketChannelDispatcher<E extends Event<SocketChannel>> implements 
                         + "maximum receive buffer");
             }
         }
-        serverSocketChannel.socket().bind(new InetSocketAddress(port));
+
+        serverSocketChannel.socket().bind(new InetSocketAddress(nicAddress, port));
+
         selector = Selector.open();
         serverSocketChannel.register(selector, SelectionKey.OP_ACCEPT);
     }

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/event/EventQueue.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/event/EventQueue.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util.listen.event;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.nifi.logging.ProcessorLog;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wraps a BlockingQueue to centralize logic for offering events across UDP, TCP, and SSL.
+ *
+ * @param <E> the type of event
+ */
+public class EventQueue<E extends Event> {
+
+    /**
+     * The default number of milliseconds to wait when offering new events to the queue.
+     */
+    public static final long DEFAULT_OFFER_WAIT_MS = 100;
+
+    private final long offerWaitMs;
+    private final BlockingQueue<E> events;
+    private final ProcessorLog logger;
+
+    public EventQueue(final BlockingQueue<E> events, final ProcessorLog logger) {
+        this(events, DEFAULT_OFFER_WAIT_MS, logger);
+    }
+
+    public EventQueue(final BlockingQueue<E> events, final long offerWaitMs, final ProcessorLog logger) {
+        this.events = events;
+        this.offerWaitMs = offerWaitMs;
+        this.logger = logger;
+        Validate.notNull(this.events);
+        Validate.notNull(this.logger);
+    }
+
+    /**
+     * Offers the given event to the events queue with a wait time, if the offer fails the event
+     * is dropped an error is logged.
+     *
+     * @param event the event to offer
+     * @throws InterruptedException if interrupted while waiting to offer
+     */
+    public void offer(final E event) throws InterruptedException {
+        boolean queued = events.offer(event, offerWaitMs, TimeUnit.MILLISECONDS);
+        if (!queued) {
+            logger.error("Internal queue at maximum capacity, could not queue event");
+        }
+    }
+
+}

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/event/StandardEventFactory.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/event/StandardEventFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util.listen.event;
+
+import org.apache.nifi.processor.util.listen.response.ChannelResponder;
+
+import java.util.Map;
+
+/**
+ * EventFactory to create StandardEvent instances.
+ */
+public class StandardEventFactory implements EventFactory<StandardEvent> {
+
+    @Override
+    public StandardEvent create(final byte[] data, final Map<String, String> metadata, final ChannelResponder responder) {
+        String sender = null;
+        if (metadata != null && metadata.containsKey(EventFactory.SENDER_KEY)) {
+            sender = metadata.get(EventFactory.SENDER_KEY);
+        }
+        return new StandardEvent(sender, data, responder);
+    }
+
+}

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/handler/ChannelHandler.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/handler/ChannelHandler.java
@@ -20,6 +20,7 @@ import org.apache.nifi.logging.ProcessorLog;
 import org.apache.nifi.processor.util.listen.dispatcher.ChannelDispatcher;
 import org.apache.nifi.processor.util.listen.event.Event;
 import org.apache.nifi.processor.util.listen.event.EventFactory;
+import org.apache.nifi.processor.util.listen.event.EventQueue;
 
 import java.nio.channels.SelectionKey;
 import java.nio.charset.Charset;
@@ -34,7 +35,7 @@ public abstract class ChannelHandler<E extends Event, D extends ChannelDispatche
     protected final D dispatcher;
     protected final Charset charset;
     protected final EventFactory<E> eventFactory;
-    protected final BlockingQueue<E> events;
+    protected final EventQueue<E> events;
     protected final ProcessorLog logger;
 
 
@@ -48,8 +49,8 @@ public abstract class ChannelHandler<E extends Event, D extends ChannelDispatche
         this.dispatcher = dispatcher;
         this.charset = charset;
         this.eventFactory = eventFactory;
-        this.events = events;
         this.logger = logger;
+        this.events = new EventQueue<E>(events, logger);
     }
 
 }

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/handler/socket/SSLSocketChannelHandler.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/handler/socket/SSLSocketChannelHandler.java
@@ -135,10 +135,8 @@ public class SSLSocketChannelHandler<E extends Event<SocketChannel>> extends Soc
                 if (currBytes.size() > 0) {
                     final SSLSocketChannelResponder response = new SSLSocketChannelResponder(socketChannel, sslSocketChannel);
                     final Map<String, String> metadata = EventFactoryUtil.createMapWithSender(sender.toString());
-
-                    // queue the raw event blocking until space is available, reset the temporary buffer
                     final E event = eventFactory.create(currBytes.toByteArray(), metadata, response);
-                    events.put(event);
+                    events.offer(event);
                     currBytes.reset();
                 }
             } else {

--- a/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/handler/socket/StandardSocketChannelHandler.java
+++ b/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/listen/handler/socket/StandardSocketChannelHandler.java
@@ -137,10 +137,8 @@ public class StandardSocketChannelHandler<E extends Event<SocketChannel>> extend
                 if (currBytes.size() > 0) {
                     final SocketChannelResponder response = new SocketChannelResponder(socketChannel);
                     final Map<String, String> metadata = EventFactoryUtil.createMapWithSender(sender.toString());
-
-                    // queue the raw event blocking until space is available, reset the buffer
                     final E event = eventFactory.create(currBytes.toByteArray(), metadata, response);
-                    events.put(event);
+                    events.offer(event);
                     currBytes.reset();
 
                     // Mark this as the start of the next message

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenUDP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenUDP.java
@@ -16,198 +16,54 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
-import org.apache.nifi.annotation.behavior.TriggerWhenEmpty;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.lifecycle.OnStopped;
-import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
-import org.apache.nifi.expression.AttributeExpression;
-import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.io.nio.BufferPool;
-import org.apache.nifi.io.nio.ChannelListener;
-import org.apache.nifi.io.nio.consumer.StreamConsumer;
-import org.apache.nifi.io.nio.consumer.StreamConsumerFactory;
-import org.apache.nifi.logging.ProcessorLog;
-import org.apache.nifi.processor.AbstractSessionFactoryProcessor;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessSessionFactory;
-import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.processors.standard.util.UDPStreamConsumer;
-import org.apache.nifi.util.Tuple;
+import org.apache.nifi.processor.util.listen.AbstractListenEventBatchingProcessor;
+import org.apache.nifi.processor.util.listen.dispatcher.ChannelDispatcher;
+import org.apache.nifi.processor.util.listen.dispatcher.DatagramChannelDispatcher;
+import org.apache.nifi.processor.util.listen.event.EventFactory;
+import org.apache.nifi.processor.util.listen.event.StandardEvent;
+import org.apache.nifi.processor.util.listen.event.StandardEventFactory;
 
-/**
- * <p>
- * This processor listens for Datagram Packets on a given port and concatenates the contents of those packets together generating flow files roughly as often as the internal buffer fills up or until
- * no more data is currently available.
- * </p>
- *
- * <p>
- * This processor has the following required properties:
- * <ul>
- * <li><b>Port</b> - The port to listen on for data packets. Must be known by senders of Datagrams.</li>
- * <li><b>Receive Timeout</b> - The time out period when waiting to receive data from the socket. Specify units. Default is 5 secs.</li>
- * <li><b>Max Buffer Size</b> - Determines the size each receive buffer may be. Specify units. Default is 1 MB.</li>
- * <li><b>FlowFile Size Trigger</b> - Determines the (almost) upper bound size at which a flow file would be generated. A flow file will get made even if this value isn't reached if there is no more
- * data streaming in and this value may be exceeded by the size of a single packet. Specify units. Default is 1 MB.</li>
- * <li><b>Max size of UDP Buffer</b> - The maximum UDP buffer size that should be used. This is a suggestion to the Operating System to indicate how big the udp socket buffer should be. Specify units.
- * Default is 1 MB.")</li>
- * <li><b>Receive Buffer Count</b> - Number of receiving buffers to be used to accept data from the socket. Higher numbers means more ram is allocated but can allow better throughput. Default is
- * 4.</li>
- * <li><b>Channel Reader Interval</b> - Scheduling interval for each read channel. Specify units. Default is 50 millisecs.</li>
- * <li><b>FlowFiles Per Session</b> - The number of flow files per session. Higher number is more efficient, but will lose more data if a problem occurs that causes a rollback of a session. Default is
- * 10</li>
- * </ul>
- * </p>
- *
- * This processor has the following optional properties:
- * <ul>
- * <li><b>Sending Host</b> - IP, or name, of a remote host. Only Datagrams from the specified Sending Host Port and this host will be accepted. Improves Performance. May be a system property or an
- * environment variable.</li>
- * <li><b>Sending Host Port</b> - Port being used by remote host to send Datagrams. Only Datagrams from the specified Sending Host and this port will be accepted. Improves Performance. May be a system
- * property or an environment variable.</li>
- * </ul>
- *
- * <p>
- * The following relationships are required:
- * <ul>
- * <li><b>success</b> - Where to route newly created flow files.</li>
- * </ul>
- * </p>
- *
- */
-@TriggerWhenEmpty
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+@SupportsBatching
 @Tags({"ingest", "udp", "listen", "source"})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
-@CapabilityDescription("Listens for Datagram Packets on a given port and concatenates the contents of those packets "
-        + "together generating flow files")
-public class ListenUDP extends AbstractSessionFactoryProcessor {
+@CapabilityDescription("Listens for Datagram Packets on a given port. The default behavior produces a FlowFile " +
+        "per datagram, however for higher throughput the Max Batch Size property may be increased to specify the number of " +
+        "datagrams to batch together in a single FlowFile. This processor can be restricted to listening for datagrams from  a " +
+        "specific remote host and port by specifying the Sending Host and Sending Host Port properties, otherwise it will listen " +
+        "for datagrams from all hosts and ports.")
+@WritesAttributes({
+        @WritesAttribute(attribute="udp.sender", description="The sending host of the messages."),
+        @WritesAttribute(attribute="udp.port", description="The sending port the messages were received.")
+})
+public class ListenUDP extends AbstractListenEventBatchingProcessor<StandardEvent> {
 
-    private static final Set<Relationship> relationships;
-    private static final List<PropertyDescriptor> properties;
-
-    // relationships.
-    public static final Relationship RELATIONSHIP_SUCCESS = new Relationship.Builder()
-            .name("success")
-            .description("Connection which contains concatenated Datagram Packets")
-            .build();
-
-    static {
-        final Set<Relationship> rels = new HashSet<>();
-        rels.add(RELATIONSHIP_SUCCESS);
-        relationships = Collections.unmodifiableSet(rels);
-    }
-    // required properties.
-    public static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
-            .name("Port")
-            .description("Port to listen on. Must be known by senders of Datagrams.")
-            .addValidator(StandardValidators.PORT_VALIDATOR)
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor RECV_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("Receive Timeout")
-            .description("The time out period when waiting to receive data from the socket. Specify units.")
-            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-            .defaultValue("5 secs")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor FLOW_FILE_PER_DATAGRAM = new PropertyDescriptor.Builder()
-            .name("FlowFile Per Datagram")
-            .description("Determines if this processor emits each datagram as a FlowFile, or if multiple datagrams can be placed in a single FlowFile.")
-            .allowableValues("true", "false")
-            .defaultValue("false")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor MAX_BUFFER_SIZE = new PropertyDescriptor.Builder()
-            .name("Max Buffer Size")
-            .description("Determines the size each receive buffer may be")
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
-            .defaultValue("1 MB")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor FLOW_FILE_SIZE_TRIGGER = new PropertyDescriptor.Builder()
-            .name("FlowFile Size Trigger")
-            .description("Determines the (almost) upper bound size at which a flow file would be generated.")
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
-            .defaultValue("1 MB")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor MAX_UDP_BUFFER = new PropertyDescriptor.Builder()
-            .name("Max size of UDP Buffer")
-            .description("The maximum UDP buffer size that should be used. This is a suggestion to the Operating System "
-                    + "to indicate how big the udp socket buffer should be.")
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
-            .defaultValue("1 MB")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor RECV_BUFFER_COUNT = new PropertyDescriptor.Builder()
-            .name("Receive Buffer Count")
-            .description("Number of receiving buffers to be used to accept data from the socket. Higher numbers "
-                    + "means more ram is allocated but can allow better throughput.")
-            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .defaultValue("4")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor CHANNEL_READER_PERIOD = new PropertyDescriptor.Builder()
-            .name("Channel Reader Interval")
-            .description("Scheduling interval for each read channel.")
-            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-            .defaultValue("50 ms")
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor FLOW_FILES_PER_SESSION = new PropertyDescriptor.Builder()
-            .name("FlowFiles Per Session")
-            .description("The number of flow files per session.")
-            .required(true)
-            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .defaultValue("10")
-            .build();
-
-    // optional properties.
     public static final PropertyDescriptor SENDING_HOST = new PropertyDescriptor.Builder()
             .name("Sending Host")
             .description("IP, or name, of a remote host. Only Datagrams from the specified Sending Host Port and this host will "
@@ -224,359 +80,70 @@ public class ListenUDP extends AbstractSessionFactoryProcessor {
             .expressionLanguageSupported(true)
             .build();
 
-    private static final Set<String> interfaceSet = new HashSet<>();
-
-    static {
-        try {
-            final Enumeration<NetworkInterface> interfaceEnum = NetworkInterface.getNetworkInterfaces();
-            while (interfaceEnum.hasMoreElements()) {
-                final NetworkInterface ifc = interfaceEnum.nextElement();
-                interfaceSet.add(ifc.getName());
-            }
-        } catch (SocketException e) {
-        }
-    }
-    public static final PropertyDescriptor NETWORK_INTF_NAME = new PropertyDescriptor.Builder()
-            .name("Local Network Interface")
-            .description("The name of a local network interface to be used to restrict listening for UDP Datagrams to a specific LAN."
-                    + "May be a system property or an environment variable.")
-            .addValidator(new Validator() {
-                @Override
-                public ValidationResult validate(String subject, String input, ValidationContext context) {
-                    ValidationResult result = new ValidationResult.Builder()
-                    .subject("Local Network Interface").valid(true).input(input).build();
-                    if (interfaceSet.contains(input.toLowerCase())) {
-                        return result;
-                    }
-
-                    String message;
-                    try {
-                        AttributeExpression ae = context.newExpressionLanguageCompiler().compile(input);
-                        String realValue = ae.evaluate();
-                        if (interfaceSet.contains(realValue.toLowerCase())) {
-                            return result;
-                        }
-
-                        message = realValue + " is not a valid network name. Valid names are " + interfaceSet.toString();
-
-                    } catch (IllegalArgumentException e) {
-                        message = "Not a valid AttributeExpression: " + e.getMessage();
-                    }
-                    result = new ValidationResult.Builder().subject("Local Network Interface")
-                    .valid(false).input(input).explanation(message).build();
-
-                    return result;
-                }
-            })
-            .expressionLanguageSupported(true).build();
-
-    static {
-        List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(SENDING_HOST);
-        props.add(SENDING_HOST_PORT);
-        props.add(NETWORK_INTF_NAME);
-        props.add(CHANNEL_READER_PERIOD);
-        props.add(FLOW_FILE_SIZE_TRIGGER);
-        props.add(MAX_BUFFER_SIZE);
-        props.add(MAX_UDP_BUFFER);
-        props.add(PORT);
-        props.add(RECV_BUFFER_COUNT);
-        props.add(FLOW_FILES_PER_SESSION);
-        props.add(RECV_TIMEOUT);
-        props.add(FLOW_FILE_PER_DATAGRAM);
-        properties = Collections.unmodifiableList(props);
-    }
-    // defaults
-    public static final int DEFAULT_LISTENING_THREADS = 2;
-    // lock used to protect channelListener
-    private final Lock lock = new ReentrantLock();
-    private volatile ChannelListener channelListener = null;
-    private final BlockingQueue<Tuple<ProcessSession, List<FlowFile>>> flowFilesPerSessionQueue = new LinkedBlockingQueue<>();
-    private final List<FlowFile> newFlowFiles = new ArrayList<>();
-    private final AtomicReference<UDPStreamConsumer> consumerRef = new AtomicReference<>();
-    private final AtomicBoolean stopping = new AtomicBoolean(false);
-    private final AtomicReference<ProcessSessionFactory> sessionFactoryRef = new AtomicReference<>();
-    private final ExecutorService consumerExecutorService = Executors.newSingleThreadExecutor();
-    private final AtomicReference<Future<Tuple<ProcessSession, List<FlowFile>>>> consumerFutureRef = new AtomicReference<>();
-    private final AtomicBoolean resetChannelListener = new AtomicBoolean(false);
-    // instance attribute for provenance receive event generation
-    private volatile String sendingHost;
+    public static final String UDP_PORT_ATTR = "udp.port";
+    public static final String UDP_SENDER_ATTR = "udp.sender";
 
     @Override
-    public Set<Relationship> getRelationships() {
-        return relationships;
-    }
-
-    @Override
-    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
-    }
-
-    /**
-     * Create the ChannelListener and a thread that causes the Consumer to create flow files.
-     *
-     * @param context context
-     * @throws IOException ex
-     */
-    @OnScheduled
-    public void initializeChannelListenerAndConsumerProcessing(final ProcessContext context) throws IOException {
-        getChannelListener(context);
-        stopping.set(false);
-        Future<Tuple<ProcessSession, List<FlowFile>>> consumerFuture = consumerExecutorService.submit(new Callable<Tuple<ProcessSession, List<FlowFile>>>() {
-
-            @Override
-            public Tuple<ProcessSession, List<FlowFile>> call() {
-                final int maxFlowFilesPerSession = context.getProperty(FLOW_FILES_PER_SESSION).asInteger();
-                final long channelReaderIntervalMSecs = context.getProperty(CHANNEL_READER_PERIOD).asTimePeriod(TimeUnit.MILLISECONDS);
-                // number of waits in 5 secs, or 1
-                final int maxWaits = (int) (channelReaderIntervalMSecs <= 1000 ? 5000 / channelReaderIntervalMSecs : 1);
-                final ProcessorLog logger = getLogger();
-                int flowFileCount = maxFlowFilesPerSession;
-                ProcessSession session = null;
-                int numWaits = 0;
-                while (!stopping.get()) {
-                    UDPStreamConsumer consumer = consumerRef.get();
-                    if (consumer == null || sessionFactoryRef.get() == null) {
-                        try {
-                            Thread.sleep(100L);
-                        } catch (InterruptedException swallow) {
-                        }
-                    } else {
-                        try {
-                                    // first time through, flowFileCount is maxFlowFilesPerSession so that a session
-                            // is created and the consumer is updated with it.
-                            if (flowFileCount == maxFlowFilesPerSession || numWaits == maxWaits) {
-                                logger.debug("Have waited {} times", new Object[]{numWaits});
-                                numWaits = 0;
-                                if (session != null) {
-                                    Tuple<ProcessSession, List<FlowFile>> flowFilesPerSession = new Tuple<ProcessSession, List<FlowFile>>(session, new ArrayList<>(newFlowFiles));
-                                    newFlowFiles.clear();
-                                    flowFilesPerSessionQueue.add(flowFilesPerSession);
-                                }
-                                session = sessionFactoryRef.get().createSession();
-                                consumer.setSession(session);
-                                flowFileCount = 0;
-                            }
-                                    // this will throttle the processing of the received datagrams. If there are no more
-                            // buffers to read into because none have been returned to the pool via consumer.process(),
-                            // then the desired back pressure on the channel is created.
-                            if (context.getAvailableRelationships().size() > 0) {
-                                consumer.process();
-                                if (flowFileCount == newFlowFiles.size()) {
-                                            // no new datagrams received, need to throttle this thread back so it does
-                                    // not consume all cpu...but don't want to cause back pressure on the channel
-                                    // so the sleep time is same as the reader interval
-                                    // If have done this for approx. 5 secs, assume datagram sender is down. So, push
-                                    // out the remaining flow files (see numWaits == maxWaits above)
-                                    Thread.sleep(channelReaderIntervalMSecs);
-                                    if (flowFileCount > 0) {
-                                        numWaits++;
-                                    }
-                                } else {
-                                    flowFileCount = newFlowFiles.size();
-                                }
-                            } else {
-                                logger.debug("Creating back pressure...no available destinations");
-                                Thread.sleep(1000L);
-                            }
-                        } catch (final IOException ioe) {
-                            logger.error("Unable to fully process consumer {}", new Object[]{consumer}, ioe);
-                        } catch (InterruptedException e) {
-                            // don't care
-                        } finally {
-                            if (consumer.isConsumerFinished()) {
-                                logger.info("Consumer {} was closed and is finished", new Object[]{consumer});
-                                consumerRef.set(null);
-                                disconnect();
-                                if (!stopping.get()) {
-                                    resetChannelListener.set(true);
-                                }
-                            }
-                        }
-                    }
-                }
-                        // when shutting down, need consumer to drain rest of cached buffers and clean up.
-                // prior to getting here, the channelListener was shutdown
-                UDPStreamConsumer consumer;
-                while ((consumer = consumerRef.get()) != null && !consumer.isConsumerFinished()) {
-                    try {
-                        consumer.process();
-                    } catch (IOException swallow) {
-                        // if this is blown...consumer.isConsumerFinished will be true
-                    }
-                }
-                Tuple<ProcessSession, List<FlowFile>> flowFilesPerSession = new Tuple<ProcessSession, List<FlowFile>>(session, new ArrayList<>(newFlowFiles));
-                return flowFilesPerSession;
-            }
-        });
-        consumerFutureRef.set(consumerFuture);
-    }
-
-    private void disconnect() {
-        if (lock.tryLock()) {
-            try {
-                if (channelListener != null) {
-                    getLogger().debug("Shutting down channel listener {}", new Object[]{channelListener});
-                    channelListener.shutdown(500L, TimeUnit.MILLISECONDS);
-                    channelListener = null;
-                }
-            } finally {
-                lock.unlock();
-            }
-        }
-    }
-
-    private void getChannelListener(final ProcessContext context) throws IOException {
-        if (lock.tryLock()) {
-            try {
-                ProcessorLog logger = getLogger();
-                logger.debug("Instantiating a new channel listener");
-                final int port = context.getProperty(PORT).asInteger();
-                final int bufferCount = context.getProperty(RECV_BUFFER_COUNT).asInteger();
-                final Double bufferSize = context.getProperty(MAX_BUFFER_SIZE).asDataSize(DataUnit.B);
-                final Double rcvBufferSize = context.getProperty(MAX_UDP_BUFFER).asDataSize(DataUnit.B);
-                sendingHost = context.getProperty(SENDING_HOST).evaluateAttributeExpressions().getValue();
-                final Integer sendingHostPort = context.getProperty(SENDING_HOST_PORT).evaluateAttributeExpressions().asInteger();
-                final String nicIPAddressStr = context.getProperty(NETWORK_INTF_NAME).evaluateAttributeExpressions().getValue();
-                final Double flowFileSizeTrigger = context.getProperty(FLOW_FILE_SIZE_TRIGGER).asDataSize(DataUnit.B);
-                final int recvTimeoutMS = context.getProperty(RECV_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
-                final boolean flowFilePerDatagram = context.getProperty(FLOW_FILE_PER_DATAGRAM).asBoolean();
-                final StreamConsumerFactory consumerFactory = new StreamConsumerFactory() {
-
-                    @Override
-                    public StreamConsumer newInstance(final String streamId) {
-                        final UDPStreamConsumer consumer = new UDPStreamConsumer(streamId, newFlowFiles, flowFileSizeTrigger.intValue(), getLogger(), flowFilePerDatagram);
-                        consumerRef.set(consumer);
-                        return consumer;
-                    }
-                };
-                final int readerMilliseconds = context.getProperty(CHANNEL_READER_PERIOD).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
-                final BufferPool bufferPool = new BufferPool(bufferCount, bufferSize.intValue(), false, Integer.MAX_VALUE);
-                channelListener = new ChannelListener(DEFAULT_LISTENING_THREADS, consumerFactory, bufferPool, recvTimeoutMS, TimeUnit.MILLISECONDS, flowFilePerDatagram);
-                // specifying a sufficiently low number for each stream to be fast enough though very efficient
-                channelListener.setChannelReaderSchedulingPeriod(readerMilliseconds, TimeUnit.MILLISECONDS);
-                InetAddress nicIPAddress = null;
-                if (null != nicIPAddressStr) {
-                    NetworkInterface netIF = NetworkInterface.getByName(nicIPAddressStr);
-                    nicIPAddress = netIF.getInetAddresses().nextElement();
-                }
-                channelListener.addDatagramChannel(nicIPAddress, port, rcvBufferSize.intValue(), sendingHost, sendingHostPort);
-                logger.info("Registered service and initialized UDP socket listener. Now listening on port " + port + "...");
-            } finally {
-                lock.unlock();
-            }
-        }
+    protected List<PropertyDescriptor> getAdditionalProperties() {
+        return Arrays.asList(
+                SENDING_HOST,
+                SENDING_HOST_PORT
+        );
     }
 
     @Override
     protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
-        Collection<ValidationResult> result = new ArrayList<>();
-        String sendingHost = validationContext.getProperty(SENDING_HOST).getValue();
-        String sendingPort = validationContext.getProperty(SENDING_HOST_PORT).getValue();
+        final Collection<ValidationResult> result = new ArrayList<>();
+
+        final String sendingHost = validationContext.getProperty(SENDING_HOST).getValue();
+        final String sendingPort = validationContext.getProperty(SENDING_HOST_PORT).getValue();
+
         if (StringUtils.isBlank(sendingHost) && StringUtils.isNotBlank(sendingPort)) {
-            result.add(new ValidationResult.Builder().subject(SENDING_HOST.getName()).valid(false)
-                    .explanation("Must specify Sending Host when specifying Sending Host Port").build());
+            result.add(
+                    new ValidationResult.Builder()
+                            .subject(SENDING_HOST.getName())
+                            .valid(false)
+                            .explanation("Must specify Sending Host when specifying Sending Host Port")
+                            .build());
         } else if (StringUtils.isBlank(sendingPort) && StringUtils.isNotBlank(sendingHost)) {
             result.add(
-                    new ValidationResult.Builder().subject(SENDING_HOST_PORT.getName()).valid(false).explanation("Must specify Sending Host Port when specifying Sending Host").build());
+                    new ValidationResult.Builder()
+                            .subject(SENDING_HOST_PORT.getName())
+                            .valid(false)
+                            .explanation("Must specify Sending Host Port when specifying Sending Host")
+                            .build());
         }
+
         return result;
     }
 
     @Override
-    public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
-        final ProcessorLog logger = getLogger();
-        sessionFactoryRef.compareAndSet(null, sessionFactory);
-        if (resetChannelListener.getAndSet(false) && !stopping.get()) {
-            try {
-                getChannelListener(context);
-            } catch (IOException e) {
-                logger.error("Tried to reset Channel Listener and failed due to:", e);
-                resetChannelListener.set(true);
-            }
-        }
-
-        transferFlowFiles();
+    protected ChannelDispatcher createDispatcher(final ProcessContext context, final BlockingQueue<StandardEvent> events)
+            throws IOException {
+        final String sendingHost = context.getProperty(SENDING_HOST).evaluateAttributeExpressions().getValue();
+        final Integer sendingHostPort = context.getProperty(SENDING_HOST_PORT).evaluateAttributeExpressions().asInteger();
+        final Integer bufferSize = context.getProperty(RECV_BUFFER_SIZE).asDataSize(DataUnit.B).intValue();
+        final BlockingQueue<ByteBuffer> bufferPool = createBufferPool(context.getMaxConcurrentTasks(), bufferSize);
+        final EventFactory<StandardEvent> eventFactory = new StandardEventFactory();
+        return new DatagramChannelDispatcher<>(eventFactory, bufferPool, events, getLogger(), sendingHost, sendingHostPort);
     }
 
-    private boolean transferFlowFiles() {
-        final ProcessorLog logger = getLogger();
-        ProcessSession session;
-        Tuple<ProcessSession, List<FlowFile>> flowFilesPerSession = null;
-        boolean transferred = false;
-        try {
-            flowFilesPerSession = flowFilesPerSessionQueue.poll(100L, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-        }
-        if (flowFilesPerSession != null) {
-            session = flowFilesPerSession.getKey();
-            List<FlowFile> flowFiles = flowFilesPerSession.getValue();
-            String sourceSystem = sendingHost == null ? "Unknown" : sendingHost;
-            try {
-                for (FlowFile flowFile : flowFiles) {
-                    session.getProvenanceReporter().receive(flowFile, sourceSystem);
-                    session.transfer(flowFile, RELATIONSHIP_SUCCESS);
-                }
-                logger.info("Transferred flow files {} to success", new Object[]{flowFiles});
-                transferred = true;
-
-                // need to check for erroneous flow files in input queue
-                List<FlowFile> existingFlowFiles = session.get(10);
-                for (FlowFile existingFlowFile : existingFlowFiles) {
-                    if (existingFlowFile != null && existingFlowFile.getSize() > 0) {
-                        session.transfer(existingFlowFile, RELATIONSHIP_SUCCESS);
-                        logger.warn("Found flow file in input queue (shouldn't have). Transferred flow file {} to success",
-                                new Object[]{existingFlowFile});
-                    } else if (existingFlowFile != null) {
-                        session.remove(existingFlowFile);
-                        logger.warn("Found empty flow file in input queue (shouldn't have). Removed flow file {}",
-                                new Object[]{existingFlowFile});
-                    }
-                }
-                session.commit();
-            } catch (Throwable t) {
-                session.rollback();
-                logger.error("Failed to transfer flow files or commit session...rolled back", t);
-                throw t;
-            }
-        }
-        return transferred;
+    @Override
+    protected Map<String, String> getAttributes(final FlowFileEventBatch batch) {
+        final String sender = batch.getEvents().get(0).getSender();
+        final Map<String,String> attributes = new HashMap<>(3);
+        attributes.put(UDP_SENDER_ATTR, sender);
+        attributes.put(UDP_PORT_ATTR, String.valueOf(port));
+        return attributes;
     }
 
-    @OnUnscheduled
-    public void stopping() {
-        getLogger().debug("Stopping Processor");
-        disconnect();
-        stopping.set(true);
-        Future<Tuple<ProcessSession, List<FlowFile>>> future;
-        Tuple<ProcessSession, List<FlowFile>> flowFilesPerSession;
-        if ((future = consumerFutureRef.getAndSet(null)) != null) {
-            try {
-                flowFilesPerSession = future.get();
-                if (flowFilesPerSession.getValue().size() > 0) {
-                    getLogger().debug("Draining remaining flow Files when stopping");
-                    flowFilesPerSessionQueue.add(flowFilesPerSession);
-                } else {
-                    // need to close out the session that has no flow files
-                    flowFilesPerSession.getKey().commit();
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                getLogger().error("Failure in cleaning up!", e);
-            }
-            boolean moreFiles = true;
-            while (moreFiles) {
-                try {
-                    moreFiles = transferFlowFiles();
-                } catch (Throwable t) {
-                    getLogger().error("Problem transferring cached flowfiles", t);
-                }
-            }
-        }
-    }
-
-    @OnStopped
-    public void stopped() {
-        sessionFactoryRef.set(null);
+    @Override
+    protected String getTransitUri(FlowFileEventBatch batch) {
+        final String sender = batch.getEvents().get(0).getSender();
+        final String senderHost = sender.startsWith("/") && sender.length() > 1 ? sender.substring(1) : sender;
+        final String transitUri = new StringBuilder().append("udp").append("://").append(senderHost).append(":")
+                .append(port).toString();
+        return transitUri;
     }
 
     public static class HostValidator implements Validator {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/relp/handler/RELPSSLSocketChannelHandler.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/relp/handler/RELPSSLSocketChannelHandler.java
@@ -50,7 +50,7 @@ public class RELPSSLSocketChannelHandler<E extends Event<SocketChannel>> extends
                                        final ProcessorLog logger) {
         super(key, dispatcher, charset, eventFactory, events, logger);
         this.decoder = new RELPDecoder(charset);
-        this.frameHandler = new RELPFrameHandler<>(key, charset, eventFactory, events, dispatcher);
+        this.frameHandler = new RELPFrameHandler<>(key, charset, eventFactory, events, dispatcher, logger);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/relp/handler/RELPSocketChannelHandler.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/relp/handler/RELPSocketChannelHandler.java
@@ -50,7 +50,7 @@ public class RELPSocketChannelHandler<E extends Event<SocketChannel>> extends St
                                     final ProcessorLog logger) {
         super(key, dispatcher, charset, eventFactory, events, logger);
         this.decoder = new RELPDecoder(charset);
-        this.frameHandler = new RELPFrameHandler<>(key, charset, eventFactory, events, dispatcher);
+        this.frameHandler = new RELPFrameHandler<>(key, charset, eventFactory, events, dispatcher, logger);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenRELP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenRELP.java
@@ -18,8 +18,11 @@ package org.apache.nifi.processors.standard;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSessionFactory;
+import org.apache.nifi.processor.util.listen.dispatcher.ChannelDispatcher;
+import org.apache.nifi.processor.util.listen.response.ChannelResponder;
 import org.apache.nifi.processors.standard.relp.event.RELPEvent;
 import org.apache.nifi.processors.standard.relp.frame.RELPEncoder;
 import org.apache.nifi.processors.standard.relp.frame.RELPFrame;
@@ -35,13 +38,16 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 
 public class TestListenRELP {
 
@@ -78,7 +84,7 @@ public class TestListenRELP {
         encoder = new RELPEncoder(StandardCharsets.UTF_8);
         proc = new ResponseCapturingListenRELP();
         runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(ListenSyslog.PORT, "0");
+        runner.setProperty(ListenRELP.PORT, "0");
     }
 
     @Test
@@ -169,6 +175,38 @@ public class TestListenRELP {
         run(frames, 5, 5, sslContextService);
     }
 
+    @Test
+    public void testNoEventsAvailable() throws IOException, InterruptedException {
+        MockListenRELP mockListenRELP = new MockListenRELP(new ArrayList<RELPEvent>());
+        runner = TestRunners.newTestRunner(mockListenRELP);
+        runner.setProperty(ListenRELP.PORT, "1");
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(ListenRELP.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testBatchingWithDifferentSenders() throws IOException, InterruptedException {
+        final String sender1 = "sender1";
+        final String sender2 = "sender2";
+        final ChannelResponder<SocketChannel> responder = Mockito.mock(ChannelResponder.class);
+
+        final List<RELPEvent> mockEvents = new ArrayList<>();
+        mockEvents.add(new RELPEvent(sender1, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+        mockEvents.add(new RELPEvent(sender1, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+        mockEvents.add(new RELPEvent(sender2, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+        mockEvents.add(new RELPEvent(sender2, SYSLOG_FRAME.getData(), responder, SYSLOG_FRAME.getTxnr(), SYSLOG_FRAME.getCommand()));
+
+        MockListenRELP mockListenRELP = new MockListenRELP(mockEvents);
+        runner = TestRunners.newTestRunner(mockListenRELP);
+        runner.setProperty(ListenRELP.PORT, "1");
+        runner.setProperty(ListenRELP.MAX_BATCH_SIZE, "10");
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(ListenRELP.REL_SUCCESS, 2);
+    }
+
+
     protected void run(final List<RELPFrame> frames, final int expectedTransferred, final int expectedResponses, final SSLContextService sslContextService)
             throws IOException, InterruptedException {
 
@@ -248,6 +286,29 @@ public class TestListenRELP {
             this.responses.add(relpResponse);
             super.respond(event, relpResponse);
         }
+    }
+
+    // Extend ListenRELP to mock the ChannelDispatcher and allow us to return staged events
+    private static class MockListenRELP extends ListenRELP {
+
+        private List<RELPEvent> mockEvents;
+
+        public MockListenRELP(List<RELPEvent> mockEvents) {
+            this.mockEvents = mockEvents;
+        }
+
+        @OnScheduled
+        @Override
+        public void onScheduled(ProcessContext context) throws IOException {
+            super.onScheduled(context);
+            events.addAll(mockEvents);
+        }
+
+        @Override
+        protected ChannelDispatcher createDispatcher(ProcessContext context, BlockingQueue<RELPEvent> events) throws IOException {
+            return Mockito.mock(ChannelDispatcher.class);
+        }
+
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
@@ -95,7 +95,7 @@ public class TestListenSyslog {
             while (numTransfered < numMessages && System.currentTimeMillis() < timeout) {
                 Thread.sleep(10);
                 proc.onTrigger(context, processSessionFactory);
-                numTransfered = runner.getFlowFilesForRelationship(ListenUDP.RELATIONSHIP_SUCCESS).size();
+                numTransfered = runner.getFlowFilesForRelationship(ListenSyslog.REL_SUCCESS).size();
             }
             Assert.assertEquals("Did not process all the datagrams", numMessages, numTransfered);
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/handler/TestRELPFrameHandler.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/handler/TestRELPFrameHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.standard.relp.handler;
 
+import org.apache.nifi.logging.ProcessorLog;
 import org.apache.nifi.processor.util.listen.dispatcher.AsyncChannelDispatcher;
 import org.apache.nifi.processor.util.listen.event.EventFactory;
 import org.apache.nifi.processor.util.listen.response.ChannelResponder;
@@ -45,6 +46,7 @@ public class TestRELPFrameHandler {
     private BlockingQueue<RELPEvent> events;
     private SelectionKey key;
     private AsyncChannelDispatcher dispatcher;
+    private ProcessorLog logger;
 
     private RELPFrameHandler<RELPEvent> frameHandler;
 
@@ -55,8 +57,9 @@ public class TestRELPFrameHandler {
         this.events = new LinkedBlockingQueue<>();
         this.key = Mockito.mock(SelectionKey.class);
         this.dispatcher = Mockito.mock(AsyncChannelDispatcher.class);
+        this.logger = Mockito.mock(ProcessorLog.class);
 
-        this.frameHandler = new RELPFrameHandler<>(key, charset, eventFactory, events, dispatcher);
+        this.frameHandler = new RELPFrameHandler<>(key, charset, eventFactory, events, dispatcher, logger);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/handler/TestRELPSocketChannelHandler.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/relp/handler/TestRELPSocketChannelHandler.java
@@ -127,7 +127,7 @@ public class TestRELPSocketChannelHandler {
         final ByteBuffer buffer = ByteBuffer.allocate(1024);
         try {
             // starts the dispatcher listening on port 0 so it selects a random port
-            dispatcher.open(0, 4096);
+            dispatcher.open(null, 0, 4096);
 
             // starts a thread to run the dispatcher which will accept/read connections
             Thread dispatcherThread = new Thread(dispatcher);


### PR DESCRIPTION
… the following changes:

- Adding Network Interface property to AbstractListenEventProcessor and ListenSyslog
- Adding sending host and sending port to DatagramChannelDispatcher
- Creation of common base class AbstractListenEventBatchingProcessor
- Refactor of ListenUDP, ListenTCP, and ListenRELP to all extend from AbstractListenEventBatchingProcessor