### PR TITLE
NIFI-1619: Fix Elasticsearch processor bug when flow file missing ID attribute

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearch.java
@@ -188,6 +188,26 @@ public class TestPutElasticsearch {
         runner.assertTransferCount(PutElasticsearch.REL_FAILURE, 1);
     }
 
+    @Test
+    public void testPutElasticsearchOnTriggerWithNoIdAttribute() throws IOException {
+        runner = TestRunners.newTestRunner(new PutElasticsearchTestProcessor(true)); // simulate failures
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(AbstractElasticsearchProcessor.CLUSTER_NAME, "elasticsearch");
+        runner.setProperty(AbstractElasticsearchProcessor.HOSTS, "127.0.0.1:9300");
+        runner.setProperty(AbstractElasticsearchProcessor.PING_TIMEOUT, "5s");
+        runner.setProperty(AbstractElasticsearchProcessor.SAMPLER_INTERVAL, "5s");
+        runner.setProperty(PutElasticsearch.INDEX, "doc");
+        runner.setProperty(PutElasticsearch.TYPE, "status");
+        runner.setProperty(PutElasticsearch.BATCH_SIZE, "1");
+        runner.setProperty(PutElasticsearch.ID_ATTRIBUTE, "doc_id");
+
+        runner.enqueue(docExample);
+        runner.run(1, true, true);
+
+        runner.assertAllFlowFilesTransferred(PutElasticsearch.REL_FAILURE, 1);
+        final MockFlowFile out = runner.getFlowFilesForRelationship(PutElasticsearch.REL_FAILURE).get(0);
+        assertNotNull(out);
+    }
 
     /**
      * A Test class that extends the processor in order to inject/mock behavior


### PR DESCRIPTION
When the flow file was missing the attribute specified in the processor config, there was still an attempt to insert it into Elasticsearch. This was a simple missing "else" clause. However the flow files that had already been transferred to failure due to this condition caused other problems of multiple transfers. The fix is to keep track of the flow files that remain to be transferred, starting with the original list and removing them as they are transferred.