### PR TITLE
NIFI-1629 downgraded Kafka back to 0.8

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
@@ -37,12 +37,12 @@
         <dependency>
 		    <groupId>org.apache.kafka</groupId>
 		    <artifactId>kafka-clients</artifactId>
-		    <version>0.9.0.0</version>
+		    <version>0.8.2.2</version>
 		</dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
-            <version>0.9.0.0</version>
+            <version>0.8.2.2</version>
             <exclusions>
                 <!-- Transitive dependencies excluded because they are located 
                 in a legacy Maven repository, which Maven 3 doesn't support. -->

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/processors/kafka/KafkaUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/processors/kafka/KafkaUtils.java
@@ -25,7 +25,6 @@ import org.I0Itec.zkclient.serialize.ZkSerializer;
 import kafka.admin.AdminUtils;
 import kafka.api.TopicMetadata;
 import kafka.utils.ZKStringSerializer;
-import kafka.utils.ZkUtils;
 import scala.collection.JavaConversions;
 
 /**
@@ -52,7 +51,7 @@ class KafkaUtils {
             }
         });
         scala.collection.Set<TopicMetadata> topicMetadatas = AdminUtils
-                .fetchTopicMetadataFromZk(JavaConversions.asScalaSet(Collections.singleton(topicName)), ZkUtils.apply(zkClient, false));
+                .fetchTopicMetadataFromZk(JavaConversions.asScalaSet(Collections.singleton(topicName)), zkClient);
         return topicMetadatas.size();
     }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/processors/kafka/TestGetKafka.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/processors/kafka/TestGetKafka.java
@@ -16,12 +16,11 @@
  */
 package org.apache.nifi.processors.kafka;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import kafka.consumer.ConsumerIterator;
-import kafka.message.MessageAndMetadata;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.log4j.BasicConfigurator;
 import org.apache.nifi.processor.ProcessContext;
@@ -34,6 +33,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import kafka.consumer.ConsumerIterator;
+import kafka.message.MessageAndMetadata;
 
 public class TestGetKafka {
 
@@ -119,6 +121,13 @@ public class TestGetKafka {
 
         @Override
         public void createConsumers(ProcessContext context) {
+            try {
+                Field f = GetKafka.class.getDeclaredField("consumerStreamsReady");
+                f.setAccessible(true);
+                ((AtomicBoolean) f.get(this)).set(true);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/processors/kafka/TestPutKafka.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/processors/kafka/TestPutKafka.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.producer.BufferExhaustedException;
 import org.apache.kafka.clients.producer.Callback;
@@ -475,16 +474,5 @@ public class TestPutKafka {
         @Override
         public void close() {
         }
-
-        @Override
-        public void close(long arg0, TimeUnit arg1) {
-            // ignore, not used in test
-        }
-
-        @Override
-        public void flush() {
-            // ignore, not used in test
-        }
     }
-
 }


### PR DESCRIPTION
- added context.yield to PutKafka
- added lifecycle hooks to defend from Kafka deadlocks