### PR TITLE
NIFI-1464 removed e.printStackTrace() from onTrigger in StandarProces…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -1055,8 +1055,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
     public void onTrigger(final ProcessContext context, final ProcessSessionFactory sessionFactory) {
         try (final NarCloseable narCloseable = NarCloseable.withNarLoader()) {
             processor.onTrigger(context, sessionFactory);
-        } catch (Exception ex) {
-            ex.printStackTrace();
         }
     }
 


### PR DESCRIPTION
…sScheduler