### PR TITLE
NIFI-1613 Initial version, try to improve conversion for different SQ…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java
@@ -425,10 +425,7 @@ public class ConvertJSONToSQL extends AbstractProcessor {
                 final Integer colSize = desc.getColumnSize();
                 final JsonNode fieldNode = rootNode.get(fieldName);
                 if (!fieldNode.isNull()) {
-                    String fieldValue = fieldNode.asText();
-                    if (colSize != null && fieldValue.length() > colSize) {
-                        fieldValue = fieldValue.substring(0, colSize);
-                    }
+                    String fieldValue = createSqlStringValue(fieldNode, colSize, sqlType);
                     attributes.put("sql.args." + fieldCount + ".value", fieldValue);
                 }
             }
@@ -450,6 +447,18 @@ public class ConvertJSONToSQL extends AbstractProcessor {
         }
 
         return sqlBuilder.toString();
+    }
+
+    /**
+     *  Try to create correct SQL String representation of value.
+     *
+     */
+    protected static String createSqlStringValue(final JsonNode fieldNode, final Integer colSize, final int sqlType) {
+        String fieldValue = fieldNode.asText();
+        if (colSize != null && fieldValue.length() > colSize) {
+            fieldValue = fieldValue.substring(0, colSize);
+        }
+        return fieldValue;
     }
 
     private String generateUpdate(final JsonNode rootNode, final Map<String, String> attributes, final String tableName, final String updateKeys,
@@ -529,10 +538,7 @@ public class ConvertJSONToSQL extends AbstractProcessor {
 
             final JsonNode fieldNode = rootNode.get(fieldName);
             if (!fieldNode.isNull()) {
-                String fieldValue = rootNode.get(fieldName).asText();
-                if (colSize != null && fieldValue.length() > colSize) {
-                    fieldValue = fieldValue.substring(0, colSize);
-                }
+                String fieldValue = createSqlStringValue(fieldNode, colSize, sqlType);
                 attributes.put("sql.args." + fieldCount + ".value", fieldValue);
             }
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestConvertJSONToSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestConvertJSONToSQL.java
@@ -21,9 +21,13 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.dbcp.DBCPService;
@@ -32,37 +36,47 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class TestConvertJSONToSQL {
     static String createPersons = "CREATE TABLE PERSONS (id integer primary key, name varchar(100), code integer)";
+    static String createDifferentTypes = "CREATE TABLE DIFTYPES (id integer primary key, b boolean, f float, dbl double, dcml decimal, d date)";
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Setting up Connection pooling is expensive operation.
+     * So let's do this only once and reuse MockDBCPService in each test.
+     */
+    static protected DBCPService service;
 
     @BeforeClass
-    public static void setup() {
+    public static void setupClass() throws ProcessException, SQLException {
         System.setProperty("derby.stream.error.file", "target/derby.log");
-    }
-
-    @Test
-    public void testInsert() throws InitializationException, ProcessException, SQLException, IOException {
-        final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
         final File tempDir = folder.getRoot();
         final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
-        runner.addControllerService("dbcp", service);
-        runner.enableControllerService(service);
-
+        service = new MockDBCPService(dbDir.getAbsolutePath());
         try (final Connection conn = service.getConnection()) {
             try (final Statement stmt = conn.createStatement()) {
                 stmt.executeUpdate(createPersons);
             }
         }
+    }
 
+    @Test
+    public void testInsert() throws InitializationException, ProcessException, SQLException, IOException {
+        final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
+
+        runner.addControllerService("dbcp", service);
+        runner.enableControllerService(service);
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
@@ -85,18 +99,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testInsertWithNullValue() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
@@ -120,18 +125,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateWithNullValue() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -155,18 +151,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testMultipleInserts() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
@@ -189,18 +176,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateBasedOnPrimaryKey() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -223,18 +201,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUnmappedFieldBehavior() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
@@ -258,18 +227,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateBasedOnUpdateKey() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -293,18 +253,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateBasedOnCompoundUpdateKey() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -328,18 +279,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateWithMissingFieldBasedOnCompoundUpdateKey() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -353,18 +295,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateWithMalformedJson() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -378,18 +311,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testInsertWithMissingField() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
@@ -403,20 +327,17 @@ public class TestConvertJSONToSQL {
     @Test
     public void testInsertWithMissingColumnFail() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
-        runner.addControllerService("dbcp", service);
-        runner.enableControllerService(service);
 
         try (final Connection conn = service.getConnection()) {
             try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate("CREATE TABLE PERSONS (id integer, name varchar(100), code integer, generated_key integer primary key)");
+                stmt.executeUpdate("CREATE TABLE PERSONS3 (id integer, name varchar(100), code integer, generated_key integer primary key)");
             }
         }
 
+        runner.addControllerService("dbcp", service);
+        runner.enableControllerService(service);
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
-        runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
+        runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS3");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
         runner.setProperty(ConvertJSONToSQL.UNMATCHED_COLUMN_BEHAVIOR, ConvertJSONToSQL.FAIL_UNMATCHED_COLUMN);
         runner.enqueue(Paths.get("src/test/resources/TestConvertJSONToSQL/person-1.json"));
@@ -428,20 +349,17 @@ public class TestConvertJSONToSQL {
     @Test
     public void testInsertWithMissingColumnWarning() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
-        runner.addControllerService("dbcp", service);
-        runner.enableControllerService(service);
 
         try (final Connection conn = service.getConnection()) {
             try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate("CREATE TABLE PERSONS (id integer, name varchar(100), code integer, generated_key integer primary key)");
+                stmt.executeUpdate("CREATE TABLE PERSONS2 (id integer, name varchar(100), code integer, generated_key integer primary key)");
             }
         }
 
+        runner.addControllerService("dbcp", service);
+        runner.enableControllerService(service);
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
-        runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
+        runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS2");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
         runner.setProperty(ConvertJSONToSQL.UNMATCHED_COLUMN_BEHAVIOR, ConvertJSONToSQL.WARNING_UNMATCHED_COLUMN);
         runner.enqueue(Paths.get("src/test/resources/TestConvertJSONToSQL/person-1.json"));
@@ -457,24 +375,15 @@ public class TestConvertJSONToSQL {
         out.assertAttributeEquals("sql.args.3.type", String.valueOf(java.sql.Types.INTEGER));
         out.assertAttributeEquals("sql.args.3.value", "48");
 
-        out.assertContentEquals("INSERT INTO PERSONS (ID, NAME, CODE) VALUES (?, ?, ?)");
+        out.assertContentEquals("INSERT INTO PERSONS2 (ID, NAME, CODE) VALUES (?, ?, ?)");
     } // End testInsertWithMissingColumnWarning()
 
     @Test
     public void testInsertWithMissingColumnIgnore() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate("CREATE TABLE PERSONS (id integer, name varchar(100), code integer, generated_key integer primary key)");
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "INSERT");
@@ -498,18 +407,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateWithMissingColumnFail() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -524,18 +424,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateWithMissingColumnWarning() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -561,18 +452,9 @@ public class TestConvertJSONToSQL {
     @Test
     public void testUpdateWithMissingColumnIgnore() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(ConvertJSONToSQL.class);
-        final File tempDir = folder.getRoot();
-        final File dbDir = new File(tempDir, "db");
-        final DBCPService service = new MockDBCPService(dbDir.getAbsolutePath());
+
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
-
-        try (final Connection conn = service.getConnection()) {
-            try (final Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate(createPersons);
-            }
-        }
-
         runner.setProperty(ConvertJSONToSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(ConvertJSONToSQL.TABLE_NAME, "PERSONS");
         runner.setProperty(ConvertJSONToSQL.STATEMENT_TYPE, "UPDATE");
@@ -595,6 +477,58 @@ public class TestConvertJSONToSQL {
 
     } // End testUpdateWithMissingColumnIgnore()
 
+    /**
+     *  Test create correct SQL String representation of value.
+     *  Use PutSQL processor to verify converted value can be used and don't fail.
+     */
+    @Test
+    public void testCreateSqlStringValue() throws ProcessException, SQLException, JsonGenerationException, JsonMappingException, IOException, InitializationException {
+        final TestRunner putSqlRunner = TestRunners.newTestRunner(PutSQL.class);
+
+        putSqlRunner.addControllerService("dbcp", service);
+        putSqlRunner.enableControllerService(service);
+        putSqlRunner.setProperty(PutSQL.OBTAIN_GENERATED_KEYS, "false");
+        putSqlRunner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
+
+        String tableName = "DIFTYPES";
+        ObjectMapper mapper = new ObjectMapper();
+        ResultSet colrs = null;
+        try (final Connection conn = service.getConnection()) {
+            try (final Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate(createDifferentTypes);
+            }
+            colrs = conn.getMetaData().getColumns(null, null, tableName, "%");
+            while (colrs.next()) {
+                final int sqlType = colrs.getInt("DATA_TYPE");
+                final int colSize = colrs.getInt("COLUMN_SIZE");
+                switch (sqlType) {
+                case Types.BOOLEAN:
+                    String json = mapper.writeValueAsString("true");
+                    final JsonNode fieldNode = mapper.readTree(json);
+                    String booleanString = ConvertJSONToSQL.createSqlStringValue(fieldNode, colSize, sqlType);
+         //           assertEquals("true",booleanString);
+
+                    final Map<String, String> attributes = new HashMap<>();
+                    attributes.put("sql.args.1.type", String.valueOf(sqlType));
+                    attributes.put("sql.args.1.value", booleanString);
+
+                    final byte[] data = "INSERT INTO DIFTYPES (ID, B) VALUES (007, ?)".getBytes();
+                    putSqlRunner.enqueue(data, attributes);
+                    putSqlRunner.run();
+                    List<MockFlowFile> failed = putSqlRunner.getFlowFilesForRelationship(PutSQL.REL_FAILURE);
+                    putSqlRunner.assertTransferCount(PutSQL.REL_SUCCESS, 1);
+
+                    break;
+
+                default:
+                    break;
+                }
+
+            }
+
+        }
+
+    }
 
     /**
      * Simple implementation only for testing purposes


### PR DESCRIPTION
Initial version.
1. New method createSqlStringValue(), placeholder for future logic
2. New test testCreateSqlStringValue()
3. Refactored TestConvertJSONToSQL. 
  Setting up Connection pooling is expensive operation.
  So let's do this only once and reuse MockDBCPService in each test.
