### PR TITLE
NIFI-1676: Do not allow Processor to be started if state is STOPPING

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -1117,8 +1117,9 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
     @Override
     public void verifyCanStart(final Set<ControllerServiceNode> ignoredReferences) {
-        if (this.getScheduledState() == ScheduledState.RUNNING) {
-            throw new IllegalStateException(this + " cannot be started because it is already running");
+        final ScheduledState currentState = getPhysicalScheduledState();
+        if (currentState != ScheduledState.STOPPED && currentState != ScheduledState.DISABLED) {
+            throw new IllegalStateException(this + " cannot be started because it is not stopped. Current state is " + currentState.name());
         }
 
         verifyNoActiveThreads();


### PR DESCRIPTION
Need to ensure that processor state is STOPPED, not STOPPING