### PR TITLE
NIFI-1686 - NiFi is unable to populate over 1/4 of AMQP properties from flow properties

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -18,9 +18,11 @@ package org.apache.nifi.amqp.processors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +53,20 @@ public class PublishAMQPTest {
         Map<String, String> attributes = new HashMap<>();
         attributes.put("foo", "bar");
         attributes.put("amqp$contentType", "foo/bar");
+        attributes.put("amqp$contentEncoding", "foobar123");
+        attributes.put("amqp$headers", "foo=bar,foo2=bar2,foo3");
+        attributes.put("amqp$deliveryMode", "1");
+        attributes.put("amqp$priority", "2");
+        attributes.put("amqp$correlationId", "correlationId123");
+        attributes.put("amqp$replyTo", "replyTo123");
+        attributes.put("amqp$expiration", "expiration123");
+        attributes.put("amqp$messageId", "messageId123");
+        attributes.put("amqp$timestamp", "123456789");
+        attributes.put("amqp$type", "type123");
+        attributes.put("amqp$userId", "userId123");
+        attributes.put("amqp$appId", "appId123");
+        attributes.put("amqp$clusterId", "clusterId123");
+
         runner.enqueue("Hello Joe".getBytes(), attributes);
 
         runner.run();
@@ -60,6 +76,31 @@ public class PublishAMQPTest {
         GetResponse msg1 = channel.basicGet("queue1", true);
         assertNotNull(msg1);
         assertEquals("foo/bar", msg1.getProps().getContentType());
+
+        assertEquals("foobar123", msg1.getProps().getContentEncoding());
+
+        Map<String, Object> headerMap = msg1.getProps().getHeaders();
+
+        Object foo = headerMap.get("foo");
+        Object foo2 = headerMap.get("foo2");
+        Object foo3 = headerMap.get("foo3");
+
+        assertEquals("bar", foo.toString());
+        assertEquals("bar2", foo2.toString());
+        assertNull(foo3);
+
+        assertEquals((Integer) 1, msg1.getProps().getDeliveryMode());
+        assertEquals((Integer) 2, msg1.getProps().getPriority());
+        assertEquals("correlationId123", msg1.getProps().getCorrelationId());
+        assertEquals("replyTo123", msg1.getProps().getReplyTo());
+        assertEquals("expiration123", msg1.getProps().getExpiration());
+        assertEquals("messageId123", msg1.getProps().getMessageId());
+        assertEquals(new Date(123456789L), msg1.getProps().getTimestamp());
+        assertEquals("type123", msg1.getProps().getType());
+        assertEquals("userId123", msg1.getProps().getUserId());
+        assertEquals("appId123", msg1.getProps().getAppId());
+        assertEquals("clusterId123", msg1.getProps().getClusterId());
+
         assertNotNull(channel.basicGet("queue2", true));
     }
 


### PR DESCRIPTION
I've changed propertyNames into an enum so that we can refer to their values multiple times properly instead of hard-coding string values all over the place. The enum includes a lookup map that is built by a static block so we can get the enum "by value" efficiently.

I've removed the reflective calls and so am using a setter for each property type - along with fixes for the 4 properties that had issues in the bug. Multiple headers can be passed in as follows: amqp$headers=foo$bar$foo2$bar2$foo3$bar3 etc. and the code will build the Map parameter that the Builder requires.

Removed the now unnecessary variable amqpPropertyNames, and getter getAmqpPropertyNames.

Fixed some spelling mistakes, amended doc comments, removed unused imports, made the test more robust by testing all of the properties instead of just contentType.