### PR TITLE
NIFI-1711 Client-side JS for proxy-friendly URLs

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -56,7 +56,6 @@
                     }
                 });
 
-                var url = $$('#requestUrl').text();
                 var ref = $$('#ref').text();
                 
                 // create the parameters
@@ -129,6 +128,7 @@
                                     contentParameter['access_token'] = uiExtensionToken;
                                 }
 
+                                var url = window.location.origin + window.location.pathname;
                                 window.location.href = url + '?' + $$.param($$.extend(contentParameter, params));
                             });
                         }
@@ -141,7 +141,6 @@
         <span id="ref" class="hidden"><%= org.apache.nifi.util.EscapeUtils.escapeHtml(request.getParameter("ref")) %></span>
         <span id="clusterNodeId" class="hidden"><%= request.getParameter("clusterNodeId") == null ? "" : org.apache.nifi.util.EscapeUtils.escapeHtml(request.getParameter("clusterNodeId")) %></span>
         <span id="mode" class="hidden"><%= request.getParameter("mode") == null ? "" : org.apache.nifi.util.EscapeUtils.escapeHtml(request.getParameter("mode")) %></span>
-        <span id="requestUrl" class="hidden"><%= org.apache.nifi.util.EscapeUtils.escapeHtml(request.getRequestURL().toString()) %></span>
         <div id="content-viewer-message-dialog">
             <div class="dialog-content" style="margin-top: -20px;">
                 <div id="content-viewer-message"></div>


### PR DESCRIPTION
This is a possible fix for generating proxy-friendly URLs in the content viewer using client-side Javascript rather than calculating the URLs server-side using the proxy headers.