### PR TITLE
NIFI-1690 Changed MonitorMemory to use allowable values for pool names

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/CapturingLogger.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/CapturingLogger.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
+import org.slf4j.helpers.MessageFormatter;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -215,25 +216,23 @@ public class CapturingLogger implements Logger {
 
     @Override
     public void info(String msg) {
-        infoMessages.add(new LogMessage(null, msg, null));
-        logger.info(msg);
+        this.info(msg, (Object) null);
     }
 
     @Override
     public void info(String format, Object arg) {
-        infoMessages.add(new LogMessage(null, format, null, arg));
-        logger.info(format, arg);
+        this.info(format, arg, null);
     }
 
     @Override
     public void info(String format, Object arg1, Object arg2) {
-        infoMessages.add(new LogMessage(null, format, null, arg1, arg2));
-        logger.info(format, arg1, arg2);
+        this.info(format, new Object[] { arg1, arg2 });
     }
 
     @Override
     public void info(String format, Object... arguments) {
-        infoMessages.add(new LogMessage(null, format, null, arguments));
+        String message = MessageFormatter.arrayFormat(format, arguments).getMessage();
+        infoMessages.add(new LogMessage(null, message, null, arguments));
         logger.info(format, arguments);
     }
 
@@ -287,25 +286,23 @@ public class CapturingLogger implements Logger {
 
     @Override
     public void warn(String msg) {
-        warnMessages.add(new LogMessage(null, msg, null));
-        logger.warn(msg);
+        this.warn(msg, (Object) null);
     }
 
     @Override
     public void warn(String format, Object arg) {
-        warnMessages.add(new LogMessage(null, format, null, arg));
-        logger.warn(format, arg);
+        this.warn(format, arg, null);
     }
 
     @Override
     public void warn(String format, Object arg1, Object arg2) {
-        warnMessages.add(new LogMessage(null, format, null, arg1, arg2));
-        logger.warn(format, arg1, arg2);
+        this.warn(format, new Object[] { arg1, arg2 });
     }
 
     @Override
     public void warn(String format, Object... arguments) {
-        warnMessages.add(new LogMessage(null, format, null, arguments));
+        String message = MessageFormatter.arrayFormat(format, arguments).getMessage();
+        warnMessages.add(new LogMessage(null, message, null, arguments));
         logger.warn(format, arguments);
     }
 

--- a/nifi-mock/src/main/java/org/apache/nifi/util/LogMessage.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/LogMessage.java
@@ -42,4 +42,9 @@ public class LogMessage {
     public Object[] getArgs() {
         return args;
     }
+
+    @Override
+    public String toString() {
+        return this.msg;
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -203,7 +203,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                             }
 
                             try (final NarCloseable x = NarCloseable.withNarLoader()) {
-                                ReflectionUtils.invokeMethodsWithAnnotations(OnScheduled.class, OnConfigured.class, reportingTask, taskNode.getConfigurationContext());
+                                ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, reportingTask, taskNode.getConfigurationContext());
                             }
 
                             agent.schedule(taskNode, scheduleState);
@@ -254,7 +254,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
 
                     try {
                         try (final NarCloseable x = NarCloseable.withNarLoader()) {
-                            ReflectionUtils.invokeMethodsWithAnnotations(OnUnscheduled.class, org.apache.nifi.processor.annotation.OnUnscheduled.class, reportingTask, configurationContext);
+                            ReflectionUtils.invokeMethodsWithAnnotation(OnUnscheduled.class, reportingTask, configurationContext);
                         }
                     } catch (final Exception e) {
                         final Throwable cause = e instanceof InvocationTargetException ? e.getCause() : e;
@@ -274,7 +274,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                     agent.unschedule(taskNode, scheduleState);
 
                     if (scheduleState.getActiveThreadCount() == 0 && scheduleState.mustCallOnStoppedMethods()) {
-                        ReflectionUtils.quietlyInvokeMethodsWithAnnotations(OnStopped.class, org.apache.nifi.processor.annotation.OnStopped.class, reportingTask, configurationContext);
+                        ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, reportingTask, configurationContext);
                     }
                 }
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/pom.xml
@@ -56,5 +56,16 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-nar-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/MonitorMemoryTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/MonitorMemoryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.nifi.admin.service.AuditService;
+import org.apache.nifi.admin.service.KeyService;
+import org.apache.nifi.controller.repository.FlowFileEventRepository;
+import org.apache.nifi.provenance.MockProvenanceEventRepository;
+import org.apache.nifi.util.CapturingLogger;
+import org.apache.nifi.util.NiFiProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public class MonitorMemoryTest {
+
+    private FlowController fc;
+
+    @Before
+    public void before() throws Exception {
+        System.setProperty("nifi.properties.file.path", "src/test/resources/nifi.properties");
+        NiFiProperties.getInstance().setProperty(NiFiProperties.ADMINISTRATIVE_YIELD_DURATION, "1 sec");
+        NiFiProperties.getInstance().setProperty(NiFiProperties.STATE_MANAGEMENT_CONFIG_FILE, "target/test-classes/state-management.xml");
+        NiFiProperties.getInstance().setProperty(NiFiProperties.STATE_MANAGEMENT_LOCAL_PROVIDER_ID, "local-provider");
+        fc = this.buildFlowControllerForTest();
+    }
+
+    @After
+    public void after() throws Exception {
+        FileUtils.deleteDirectory(new File("./target/test-repo"));
+        FileUtils.deleteDirectory(new File("./target/content_repository"));
+        fc.shutdown(true);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void validatevalidationKicksInOnWrongPoolNames() throws Exception {
+        ReportingTaskNode reportingTask = fc.createReportingTask(MonitorMemory.class.getName());
+        reportingTask.setProperty(MonitorMemory.MEMORY_POOL_PROPERTY.getName(), "foo");
+        ProcessScheduler ps = fc.getProcessScheduler();
+        ps.schedule(reportingTask);
+    }
+
+    @Test
+    public void validateWarnWhenPercentThresholdReached() throws Exception {
+        this.doValidate("10%");
+    }
+
+    /*
+     * We're ignoring this tests as it is practically impossible to run it
+     * reliably together with automated Maven build since we can't control the
+     * state of the JVM on each machine during the build. However, you can run
+     * it selectively for further validation
+     */
+    @Test
+    @Ignore
+    public void validateWarnWhenSizeThresholdReached() throws Exception {
+        this.doValidate("10 MB");
+    }
+
+    public void doValidate(String threshold) throws Exception {
+        CapturingLogger capturingLogger = this.wrapAndReturnCapturingLogger();
+        ReportingTaskNode reportingTask = fc.createReportingTask(MonitorMemory.class.getName());
+        reportingTask.setScheduldingPeriod("1 sec");
+        reportingTask.setProperty(MonitorMemory.MEMORY_POOL_PROPERTY.getName(), "PS Old Gen");
+        reportingTask.setProperty(MonitorMemory.REPORTING_INTERVAL.getName(), "100 millis");
+        reportingTask.setProperty(MonitorMemory.THRESHOLD_PROPERTY.getName(), threshold);
+
+        ProcessScheduler ps = fc.getProcessScheduler();
+        ps.schedule(reportingTask);
+
+        Thread.sleep(2000);
+        // ensure no memory warning were issued
+        assertTrue(capturingLogger.getWarnMessages().size() == 0);
+
+        // throw something on the heap
+        @SuppressWarnings("unused")
+        byte[] b = new byte[Integer.MAX_VALUE / 3];
+        Thread.sleep(200);
+        assertTrue(capturingLogger.getWarnMessages().size() > 0);
+        assertTrue(capturingLogger.getWarnMessages().get(0).getMsg()
+                .startsWith("Memory Pool 'PS Old Gen' has exceeded the configured Threshold of " + threshold));
+
+        // now try to clear the heap and see memory being reclaimed
+        b = null;
+        System.gc();
+        Thread.sleep(1000);
+        assertTrue(capturingLogger.getInfoMessages().get(0).getMsg().startsWith(
+                "Memory Pool 'PS Old Gen' is no longer exceeding the configured Threshold of " + threshold));
+    }
+
+    private CapturingLogger wrapAndReturnCapturingLogger() throws Exception {
+        Field loggerField = MonitorMemory.class.getDeclaredField("logger");
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(loggerField, loggerField.getModifiers() & ~Modifier.FINAL);
+
+        loggerField.setAccessible(true);
+        CapturingLogger capturingLogger = new CapturingLogger((Logger) loggerField.get(null));
+        loggerField.set(null, capturingLogger);
+        return capturingLogger;
+    }
+
+    private FlowController buildFlowControllerForTest() throws Exception {
+        NiFiProperties properties = NiFiProperties.getInstance();
+
+        properties.setProperty(NiFiProperties.PROVENANCE_REPO_IMPLEMENTATION_CLASS,
+                MockProvenanceEventRepository.class.getName());
+        properties.setProperty("nifi.remote.input.socket.port", "");
+        properties.setProperty("nifi.remote.input.secure", "");
+
+        return FlowController.createStandaloneInstance(mock(FlowFileEventRepository.class), properties,
+                mock(KeyService.class), mock(AuditService.class), null, null);
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/resources/nifi.properties
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/resources/nifi.properties
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Core Properties #
+nifi.version=nifi-test 0.*
+nifi.flow.configuration.file=./target/flow.xml.gz
+nifi.flow.configuration.archive.dir=./target/archive/
+
+nifi.reporting.task.configuration.file=./target/reporting-tasks.xml
+nifi.controller.service.configuration.file=./target/controller-services.xml
+nifi.templates.directory=./target/templates
+nifi.nar.library.directory=./target/lib
+nifi.nar.working.directory=./target/work/nar/
+
+# FlowFile Repository
+nifi.flowfile.repository.directory=./target/test-repo
+
+# Content Repository
+nifi.content.repository.directory.default=./target/content_repository

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/resources/state-management.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/resources/state-management.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+    This file lists the authority providers to use when running securely. In order
+    to use a specific provider it must be configured here and it's identifier
+    must be specified in the nifi.properties file.
+-->
+<stateManagement>
+    <!--
+      This file provides a mechanism for defining and configuring the State Providers
+      that should be used for storing state locally and across a NiFi cluster.
+    -->
+    
+    <!--
+        State Provider that stores state locally in a configurable directory. This Provider requires the following properties:
+        
+        Directory - the directory to store components' state in. If the directory being used is a sub-directory of the NiFi installation, it
+                    is important that the directory be copied over to the new version when upgrading NiFi.
+     -->
+    <local-provider>
+        <id>local-provider</id>
+        <class>org.apache.nifi.controller.state.providers.local.WriteAheadLocalStateProvider</class>
+        <property name="Directory">target/test-classes/access-control/state-management</property>
+    </local-provider>
+</stateManagement>


### PR DESCRIPTION
- removed dead code from MonitorMemory
- added MonitorMemoryTest
- minor refactoring in MonitorMemory
- initial fix for NIFI-1731 (WARN/INFO logging) that was required by MonitorMemoryTest