### PR TITLE
NIFI-1180 Adding more IT tests.

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITFetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITFetchS3Object.java
@@ -55,6 +55,10 @@ public class ITFetchS3Object extends AbstractS3IT {
         runner.run(1);
 
         runner.assertAllFlowFilesTransferred(FetchS3Object.REL_SUCCESS, 1);
+        final List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(FetchS3Object.REL_SUCCESS);
+        MockFlowFile ff = ffs.get(0);
+        ff.assertAttributeNotExists(PutS3Object.S3_SSE_ALGORITHM);
+        ff.assertContentEquals(getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME));
     }
 
     @Test
@@ -75,7 +79,9 @@ public class ITFetchS3Object extends AbstractS3IT {
 
         runner.assertAllFlowFilesTransferred(FetchS3Object.REL_SUCCESS, 1);
         final List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(FetchS3Object.REL_SUCCESS);
-        ffs.get(0).assertAttributeEquals(PutS3Object.S3_SSE_ALGORITHM, ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        MockFlowFile ff = ffs.get(0);
+        ff.assertAttributeEquals(PutS3Object.S3_SSE_ALGORITHM, ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        ff.assertContentEquals(getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME));
     }
 
     @Test


### PR DESCRIPTION
I've checkout the latest master, built and played with it, it works without any issue!
The Integration Tests worked fine with my AWS environment.
By doing that, I thought it'd be helpful to add more IT test to illustrate how ServerSideEncryption works.

The idea is using PutS3Object and FetchS3Object consecutively then assert FlowFile's attribute is set or empty based on the specified SSE algorithm.

Also I've added ITFetchS3Object to check if the downloaded content matches with expected one.

Would you review the test case? I hope it'll make IT a little bit more robust.