### PR TITLE
NIFI-1762: Use Lambda Expressions in StandardNiFIServiceFacade to simplify codebase

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-optimistic-locking/src/main/java/org/apache/nifi/web/StandardConfigurationResult.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-optimistic-locking/src/main/java/org/apache/nifi/web/StandardConfigurationResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.web;
+
+public class StandardConfigurationResult<T> implements ConfigurationResult<T> {
+    private final boolean isNew;
+    private final T configuration;
+
+    public StandardConfigurationResult(final boolean isNew, final T configuration) {
+        this.isNew = isNew;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @Override
+    public T getConfiguration() {
+        return configuration;
+    }
+}

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderTest.java
@@ -69,9 +69,9 @@ public class JMSConnectionFactoryProviderTest {
         assertNotNull(cf);
         assertEquals("org.apache.nifi.jms.testcflib.TestConnectionFactory", cf.getClass().getName());
         assertEquals("myhost", this.get("getHost", cf));
-        assertEquals(1234, this.get("getPort", cf));
+        assertEquals(1234, ((Integer) this.get("getPort", cf)).intValue());
         assertEquals("foo", this.get("getFoo", cf));
-        assertEquals(3, this.get("getBar", cf));
+        assertEquals(3, ((Integer) this.get("getBar", cf)).intValue());
     }
 
     @Test(expected = AssertionError.class)

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@ language governing permissions and limitations under the License. -->
         <url>https://issues.apache.org/jira/browse/NIFI</url>
     </issueManagement>
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <maven.min-version>3.1.0</maven.min-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1313,7 +1313,7 @@ language governing permissions and limitations under the License. -->
                         <show>private</show>
                         <encoding>UTF-8</encoding>
                         <quiet>true</quiet>
-                        <javadocVersion>1.7</javadocVersion>
+                        <javadocVersion>1.8</javadocVersion>
                         <additionalJOption>-J-Xmx512m</additionalJOption>
                     </configuration>
                 </plugin>
@@ -1383,8 +1383,8 @@ language governing permissions and limitations under the License. -->
                     </execution>
                 </executions>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
 Changed Java dependency to 1.8 instead of 1.7 and refactored StandardNiFiServiceFacade to make use of Lambda expressions to simplify code base. Also had to address a unit test because changing to Java 8 results in calls to assertEquals to become ambiguous