### PR TITLE
NIFI-361 - Create Processors to mutate JSON data

### DIFF
--- a/nifi-docs/src/main/asciidoc/getting-started.adoc
+++ b/nifi-docs/src/main/asciidoc/getting-started.adoc
@@ -285,6 +285,7 @@ categorizing them by their functions.
 - *EncryptContent*: Encrypt or Decrypt Content
 - *ReplaceText*: Use Regular Expressions to modify textual Content
 - *TransformXml*: Apply an XSLT transform to XML Content
+- *TransformJSON: Apply a JOLT specification to transform JSON Content
 
 === Routing and Mediation
 - *ControlRate*: Throttle the rate at which data can flow through one part of the flow

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/src/main/resources/META-INF/NOTICE
@@ -92,6 +92,10 @@ The following binary components are provided under the Apache Software License v
     The following NOTICE information applies:
       Copyright 2011 JsonPath authors
 
+  (ASLv2) Jolt
+    The following NOTICE information applies:
+      Copyright 2013-2014 Jolt authors
+
   (ASLv2) Apache Commons Codec
     The following NOTICE information applies:
       Apache Commons Codec

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -225,6 +225,16 @@ language governing permissions and limitations under the License. -->
             <version>1.4.187</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.jolt</groupId>
+            <artifactId>jolt-core</artifactId>
+            <version>0.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.jolt</groupId>
+            <artifactId>json-utils</artifactId>
+            <version>0.0.20</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -299,6 +309,17 @@ language governing permissions and limitations under the License. -->
                         <exclude>src/test/resources/TestSplitText/4.txt</exclude>
                         <exclude>src/test/resources/TestSplitText/5.txt</exclude>
                         <exclude>src/test/resources/TestSplitText/6.txt</exclude>
+                        <exclude>src/test/resources/TestTransformJson/input.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/chainrSpec.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/chainrOutput.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/defaultrSpec.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/defaultrOutput.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/shiftrSpec.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/shiftrOutput.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/removrSpec.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/removrOutput.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/defaultrSpec.json</exclude>
+                        <exclude>src/test/resources/TestTransformJson/defaultrOutput.json</exclude>
                         <exclude>src/test/resources/TestSplitText/original.txt</exclude>
                         <exclude>src/test/resources/TestTransformXml/math.html</exclude>
                         <exclude>src/test/resources/TestTransformXml/tokens.csv</exclude>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformJSON.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ProcessorLog;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.StreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.stream.io.BufferedInputStream;
+import org.apache.nifi.util.StopWatch;
+
+import com.bazaarvoice.jolt.Shiftr;
+import com.bazaarvoice.jolt.Removr;
+import com.bazaarvoice.jolt.Chainr;
+import com.bazaarvoice.jolt.Defaultr;
+import com.bazaarvoice.jolt.Transform;
+import com.bazaarvoice.jolt.JsonUtils;
+
+@EventDriven
+@SideEffectFree
+@SupportsBatching
+@Tags({"json", "jolt", "transform", "shiftr", "chainr", "defaultr", "removr"})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@CapabilityDescription("Applies a list of JOLT specifications to the flowfile JSON payload. A new FlowFile is created "
+        + "with transformed content and is routed to the 'success' relationship. If the JSON transform "
+        + "fails, the original FlowFile is routed to the 'failure' relationship")
+public class TransformJSON extends AbstractProcessor {
+
+    public static final AllowableValue SHIFTR = new AllowableValue("Shift", "Shift Transform DSL", "This JOLT transformation will shift input JSON/data to create the output JSON/data.");
+    public static final AllowableValue CHAINR = new AllowableValue("Chain", "Chain Transform DSL", "Execute list of JOLT transformations.");
+    public static final AllowableValue DEFAULTR = new AllowableValue("Default", "Default Transform DSL", " This JOLT transformation will apply default values to the output JSON/data.");
+    public static final AllowableValue REMOVR = new AllowableValue("Remove", "Remove Transform DSL", " This JOLT transformation will apply default values to the output JSON/data.");
+
+    public static final PropertyDescriptor JOLT_SPEC = new PropertyDescriptor.Builder()
+            .name("Jolt Specification")
+            .description("Jolt Specification for transform of JSON data.")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(new JOLTSpecValidator())
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor JOLT_TRANSFORM = new PropertyDescriptor.Builder()
+            .name("Jolt Transformation")
+            .description("Specifies the Jolt Transformation that should be used with the provided specification.")
+            .required(true)
+            .allowableValues(SHIFTR, CHAINR, DEFAULTR, REMOVR)
+            .defaultValue(CHAINR.getValue())
+            .build();
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("The FlowFile with transformed content will be routed to this relationship")
+            .build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid JSON), it will be routed to this relationship")
+            .build();
+
+    private List<PropertyDescriptor> properties;
+    private Set<Relationship> relationships;
+    private Transform transform;
+
+
+    @Override
+    protected void init(ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(JOLT_TRANSFORM);
+        properties.add(JOLT_SPEC);
+        this.properties = Collections.unmodifiableList(properties);
+
+        final Set<Relationship> relationships = new HashSet<>();
+        relationships.add(REL_SUCCESS);
+        relationships.add(REL_FAILURE);
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, ProcessSession session) throws ProcessException {
+
+        final FlowFile original = session.get();
+        if (original == null) {
+            return;
+        }
+
+        final ProcessorLog logger = getLogger();
+        final StopWatch stopWatch = new StopWatch(true);
+
+        try {
+
+            FlowFile transformed = session.write(original, new StreamCallback() {
+                @Override
+                public void process(final InputStream rawIn, final OutputStream out) throws IOException {
+
+                    try (final InputStream in = new BufferedInputStream(rawIn)) {
+                        Object inputJson = JsonUtils.jsonToObject(in);
+                        Object transformedJson = transform.transform(inputJson);
+                        out.write(JsonUtils.toJsonString(transformedJson).getBytes());
+                    } catch (final Exception e) {
+                        throw new IOException(e);
+                    }
+
+                }
+            });
+
+            session.transfer(transformed, REL_SUCCESS);
+            session.getProvenanceReporter().modifyContent(transformed, stopWatch.getElapsed(TimeUnit.MILLISECONDS));
+            logger.info("Transformed {}", new Object[]{original});
+
+        } catch (ProcessException e) {
+            logger.error("Unable to transform {} due to {}", new Object[]{original, e});
+            session.transfer(original, REL_FAILURE);
+        }
+
+    }
+
+    @OnScheduled
+    public void setup(final ProcessContext context) {
+        Object specJson = JsonUtils.jsonToObject(context.getProperty(JOLT_SPEC).getValue());
+        transform = TransformationFactory.getTransform(context.getProperty(JOLT_TRANSFORM).getValue(), specJson);
+    }
+
+    private static class TransformationFactory {
+
+        static Transform getTransform(String transform, Object specJson) {
+
+            if (transform.equals(DEFAULTR.getValue())) {
+                return new Defaultr(specJson);
+            } else if (transform.equals(SHIFTR.getValue())) {
+                return new Shiftr(specJson);
+            } else if (transform.equals(REMOVR.getValue())) {
+                return new Removr(specJson);
+            } else {
+                return Chainr.fromSpec(specJson);
+            }
+        }
+    }
+
+    private static class JOLTSpecValidator implements Validator {
+        @Override
+        public ValidationResult validate(String subject, String input, ValidationContext context) {
+
+            try {
+                Object specJson = JsonUtils.jsonToObject(input);
+                TransformationFactory.getTransform(context.getProperty(JOLT_TRANSFORM).getValue(), specJson);
+            } catch (final Exception e) {
+                String message = "Input is not a valid JOLT specification - " + e.getMessage();
+
+                return new ValidationResult.Builder()
+                        .input(input).subject(subject).valid(false)
+                        .explanation(message)
+                        .build();
+            }
+            return new ValidationResult.Builder().subject(subject).input(input).valid(true).build();
+        }
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -79,6 +79,7 @@ org.apache.nifi.processors.standard.SplitJson
 org.apache.nifi.processors.standard.SplitText
 org.apache.nifi.processors.standard.SplitXml
 org.apache.nifi.processors.standard.TailFile
+org.apache.nifi.processors.standard.TransformJSON
 org.apache.nifi.processors.standard.TransformXml
 org.apache.nifi.processors.standard.UnpackContent
 org.apache.nifi.processors.standard.ValidateXml

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformJSON.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import com.bazaarvoice.jolt.Diffy;
+import com.bazaarvoice.jolt.JsonUtils;
+import org.apache.nifi.stream.io.ByteArrayInputStream;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class TestTransformJSON {
+
+    final static Path JSON_INPUT = Paths.get("src/test/resources/TestTransformJSON/input.json");
+    final static Diffy DIFFY = new Diffy();
+
+    @Test
+    public void testInvalidJOLTSpec() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String spec = "[{}]";
+        runner.setProperty(TransformJSON.JOLT_SPEC, spec);
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testIncorrectJOLTSpec() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String chainrSpec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformJSON/chainrSpec.json")));
+        runner.setProperty(TransformJSON.JOLT_SPEC, chainrSpec);
+        runner.setProperty(TransformJSON.JOLT_TRANSFORM, TransformJSON.SHIFTR);
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testInvalidFlowFileContent() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformJSON/chainrSpec.json")));
+        runner.setProperty(TransformJSON.JOLT_SPEC, spec);
+        runner.enqueue("invalid json");
+        runner.run();
+        runner.assertAllFlowFilesTransferred(TransformJSON.REL_FAILURE);
+    }
+
+    @Test
+    public void testTransformInputWithChainr() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformJSON/chainrSpec.json")));
+        runner.setProperty(TransformJSON.JOLT_SPEC, spec);
+        runner.enqueue(JSON_INPUT);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(TransformJSON.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformJSON.REL_SUCCESS).get(0);
+        Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
+        Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestTransformJSON/chainrOutput.json")));
+        assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
+    }
+
+    @Test
+    public void testTransformInputWithShiftr() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformJSON/shiftrSpec.json")));
+        runner.setProperty(TransformJSON.JOLT_SPEC, spec);
+        runner.setProperty(TransformJSON.JOLT_TRANSFORM, TransformJSON.SHIFTR);
+        runner.enqueue(JSON_INPUT);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(TransformJSON.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformJSON.REL_SUCCESS).get(0);
+        Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
+        Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestTransformJSON/shiftrOutput.json")));
+        assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
+    }
+
+    @Test
+    public void testTransformInputWithDefaultr() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformJSON/defaultrSpec.json")));
+        runner.setProperty(TransformJSON.JOLT_SPEC, spec);
+        runner.setProperty(TransformJSON.JOLT_TRANSFORM, TransformJSON.DEFAULTR);
+        runner.enqueue(JSON_INPUT);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(TransformJSON.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformJSON.REL_SUCCESS).get(0);
+        Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
+        Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestTransformJSON/defaultrOutput.json")));
+        assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
+    }
+
+    @Test
+    public void testTransformInputWithRemovr() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformJSON());
+        final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformJSON/removrSpec.json")));
+        runner.setProperty(TransformJSON.JOLT_SPEC, spec);
+        runner.setProperty(TransformJSON.JOLT_TRANSFORM, TransformJSON.REMOVR);
+        runner.enqueue(JSON_INPUT);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(TransformJSON.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformJSON.REL_SUCCESS).get(0);
+        Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
+        Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestTransformJSON/removrOutput.json")));
+        assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/chainrOutput.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/chainrOutput.json
@@ -1,0 +1,11 @@
+{
+  "Range" : 5,
+  "Rating" : 3,
+  "SecondaryRatings" : {
+    "quality" : {
+      "Id" : "quality",
+      "Range" : 5,
+      "Value" : 3
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/chainrSpec.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/chainrSpec.json
@@ -1,0 +1,29 @@
+[
+  {
+    "operation": "shift",
+    "spec": {
+      "rating": {
+        "primary": {
+          "value": "Rating",
+          "max": "RatingRange"
+        },
+        "*": {
+          "max": "SecondaryRatings.&1.Range",
+          "value": "SecondaryRatings.&1.Value",
+          "$": "SecondaryRatings.&1.Id"
+        }
+      }
+    }
+  },
+  {
+    "operation": "default",
+    "spec": {
+      "Range": 5,
+      "SecondaryRatings": {
+        "*": {
+          "Range": 5
+        }
+      }
+    }
+  }
+]

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/defaultrOutput.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/defaultrOutput.json
@@ -1,0 +1,17 @@
+{
+  "RatingRange" : 5,
+  "rating": {
+    "primary": {
+      "value": 3,
+      "MaxLabel": "High",
+      "MinLabel": "Low",
+      "DisplayType": "NORMAL"
+    },
+    "quality": {
+      "value": 3,
+      "MaxLabel": "High",
+      "MinLabel": "Low",
+      "DisplayType": "NORMAL"
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/defaultrSpec.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/defaultrSpec.json
@@ -1,0 +1,10 @@
+ {
+   "RatingRange" : 5,
+   "rating": {
+     "*": {
+        "MaxLabel": "High",
+        "MinLabel": "Low",
+        "DisplayType": "NORMAL"
+     }
+   }
+ }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/input.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/input.json
@@ -1,0 +1,10 @@
+{
+  "rating": {
+    "primary": {
+      "value": 3
+    },
+    "quality": {
+      "value": 3
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/removrOutput.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/removrOutput.json
@@ -1,0 +1,7 @@
+{
+  "rating": {
+    "primary": {
+      "value": 3
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/removrSpec.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/removrSpec.json
@@ -1,0 +1,5 @@
+{
+  "rating": {
+    "quality": ""
+  }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/shiftrOutput.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/shiftrOutput.json
@@ -1,0 +1,8 @@
+{
+   "SecondaryRatings" : {
+     "quality" : {
+       "Value" : 3,
+       "RatingRange" : 3
+     }
+   }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/shiftrSpec.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformJson/shiftrSpec.json
@@ -1,0 +1,10 @@
+{
+     "rating": {
+       "primary": {
+         "value": "SecondaryRatings.quality.RatingRange"
+       },
+       "quality": {
+         "value": "SecondaryRatings.quality.Value"
+       }
+     }
+}


### PR DESCRIPTION
This is an initial implementation of the TransformJSON processor using the Jolt library. TransformJSON supports Jolt specifications for the following transformations:  Chain, Shift, Remove, and Default. Users will be able to add the TransformJSON processor, select the transformation they wish to apply and enter the specification for the given transformation. 

Details for creating Jolt specifications can be found [here](https://github.com/bazaarvoice/jolt)