### PR TITLE
NIFI-1654 Creating an initial appveyor.yml file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+version: '0.7.0-SNAPSHOT-{build}'
+os: Windows Server 2012
+environment:
+  JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+install:
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\maven" )) {
+        (new-object System.Net.WebClient).DownloadFile(
+          'http://www.us.apache.org/dist/maven/maven-3/3.1.1/binaries/apache-maven-3.1.1-bin.zip',
+          'C:\maven-bin.zip'
+        )
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
+      }
+  - cmd: SET PATH=C:\maven\apache-maven-3.1.1\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+build_script:
+  - mvn clean package --batch-mode -DskipTests
+test_script:
+  - mvn clean install --batch-mode -Pcontrib-check
+cache:
+  - C:\maven\
+  - C:\Users\appveyor\.m2

--- a/pom.xml
+++ b/pom.xml
@@ -1523,6 +1523,7 @@ language governing permissions and limitations under the License. -->
                         <exclude>nbactions.xml</exclude> <!-- courtesy excludes for netbeans users -->
                         <exclude>DEPENDENCIES</exclude> <!-- auto generated file by apache's maven config while building sources.zip -->
                         <exclude>.travis.yml</exclude> <!-- Travis CI Build Descriptor File -->
+                        <exclude>appveyor.yml</exclude> <!-- AppVeyor CI Build Descriptor File -->
                     </excludes>
                 </configuration>
                 <dependencies>


### PR DESCRIPTION
Adding appveyor.yml to the list of excluded items for RAT check.  This patch successfully integrates our repository with Appveyor and performs a build, however, there are test failures in the Windows environment  (Windows Server 2k12) when executed.  Would prefer to get this incorporated and running and then track down the associated test issues.