### PR TITLE
NIFI-1814 Extended caught exceptions

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -155,9 +154,9 @@ public class HandleHttpResponse extends AbstractProcessor {
         try {
             session.exportTo(flowFile, response.getOutputStream());
             response.flushBuffer();
-        } catch (final IOException ioe) {
+        } catch (final Exception e) {
             session.transfer(flowFile, REL_FAILURE);
-            getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, ioe});
+            getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, e});
             return;
         }
 


### PR DESCRIPTION
In some cases, when trying to
session.exportTo(flowFile, response.getOutputStream());
It seems that response.getOutputStream() has been somehow modified by
Jetty resulting to a FlowFileAccessException encapsulating the
EofException of Jetty.

Extended the exceptions caught and added a unit test to reproduce this
case.