### PR TITLE
NIFI-1806 Set file encoding to UTF-8 when running unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,6 +1269,7 @@ language governing permissions and limitations under the License. -->
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <argLine combine.children="append">-Xmx1G -Djava.net.preferIPv4Stack=true</argLine>
+                        <argLine combine.children="append">-Dfile.encoding=UTF-8</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Full build is OK.
Tested with Windows 10 / Java 8.