### PR TITLE
NIFI-1832 Allowing expression language in properties with a set of allowable values

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
@@ -533,6 +533,7 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
     private static final class ConstrainedSetValidator implements Validator {
 
         private static final String POSITIVE_EXPLANATION = "Given value found in allowed set";
+        private static final String EL_EXPLANATION = "Expression language supported for this set";
         private static final String NEGATIVE_EXPLANATION = "Given value not found in allowed set '%1$s'";
         private static final String VALUE_DEMARCATOR = ", ";
         private final String validStrings;
@@ -570,6 +571,9 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
             if (validValues.contains(input)) {
                 builder.valid(true);
                 builder.explanation(POSITIVE_EXPLANATION);
+            } else if (context.isExpressionLanguageSupported(subject)) {
+                builder.valid(true);
+                builder.explanation(EL_EXPLANATION);
             } else {
                 builder.valid(false);
                 builder.explanation(String.format(NEGATIVE_EXPLANATION, validStrings));


### PR DESCRIPTION
At the moment, if a property is defined with a set of allowable values AND is supporting expression language, then validation will always fail when the expression language value is not matching an allowable value. There are two options:

- In the processor, add in the allowable values the expression language value that is authorized and let the user knows that the expected value MUST BE in this specific attribute.

Example: .allowableValues("A", "B", "C", "${myProcessor.type}")
Then the incoming flow files must have this attribute (using UpdateAttribute before).

- Authorize any input value when expression language is supported for this kind of properties.

This PR is a proposition for the second option.