### PR TITLE
NIFI-1560 - Fixing a copy and paste error

### DIFF
--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/LdapProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/LdapProvider.java
@@ -191,7 +191,7 @@ public class LdapProvider implements LoginIdentityProvider {
             referralStrategy = ReferralStrategy.valueOf(rawReferralStrategy);
         } catch (final IllegalArgumentException iae) {
             throw new ProviderCreationException(String.format("Unrecgonized authentication strategy '%s'. Possible values are [%s]",
-                    rawAuthenticationStrategy, StringUtils.join(ReferralStrategy.values(), ", ")));
+                    rawReferralStrategy, StringUtils.join(ReferralStrategy.values(), ", ")));
         }
 
         context.setReferral(referralStrategy.toString());


### PR DESCRIPTION
Looks like when the original coder copied code from AuthenticationStrategy for the ReferralStrategy and did not change this reference for the error case.