### PR TITLE
NIFI-1773 Removed unused import statement.

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/AbstractControllerService.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/AbstractControllerService.java
@@ -18,7 +18,6 @@ package org.apache.nifi.controller;
 
 import java.util.Map;
 
-import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.AbstractConfigurableComponent;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;


### PR DESCRIPTION
This commit removes the unused import statement which is added at [this commit](https://github.com/apache/nifi/commit/46f8693bc6e906d66326e48233e139924648b904), in order to make build process succeed.

I was not sure if this is the right action to fix the problem since original JIRA issue [NIFI-1773](https://issues.apache.org/jira/browse/NIFI-1773) is already marked as resolved. Please let me know if there's a better way to do. I hope this helps.