### PR TITLE
NIFI-1799 Implements auto-scaling flow layout

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Connectable.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Connectable.java
@@ -32,7 +32,7 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 /**
  * Represents a connectable component to which or from which data can flow.
  */
-public interface Connectable extends Triggerable, Authorizable {
+public interface Connectable extends Triggerable, Authorizable, Positionable {
 
     /**
      * @return the unique identifier for this <code>Connectable</code>
@@ -105,18 +105,6 @@ public interface Connectable extends Triggerable, Authorizable {
      * source
      */
     Set<Connection> getConnections(Relationship relationship);
-
-    /**
-     * @return the position on the graph where this Connectable is located
-     */
-    Position getPosition();
-
-    /**
-     * Updates this component's position on the graph
-     *
-     * @param position new position
-     */
-    void setPosition(Position position);
 
     /**
      * @return the name of this Connectable

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Positionable.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Positionable.java
@@ -14,32 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.controller.label;
+package org.apache.nifi.connectable;
 
-import org.apache.nifi.authorization.resource.Authorizable;
-import org.apache.nifi.connectable.Positionable;
-import org.apache.nifi.connectable.Size;
-import org.apache.nifi.groups.ProcessGroup;
+/**
+ * Represents a component that can be positioned with X,Y coordinates on the canvas.
+ */
+public interface Positionable {
 
-import java.util.Map;
+    /**
+     * @return the position on the graph where this Connectable is located
+     */
+    Position getPosition();
 
-public interface Label extends Authorizable, Positionable {
-
-    String getIdentifier();
-
-    Map<String, String> getStyle();
-
-    void setStyle(Map<String, String> style);
-
-    Size getSize();
-
-    void setSize(Size size);
-
-    ProcessGroup getProcessGroup();
-
-    void setProcessGroup(ProcessGroup group);
-
-    String getValue();
-
-    void setValue(String value);
+    /**
+     * Updates this component's position on the graph
+     *
+     * @param position new position
+     */
+    void setPosition(Position position);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
@@ -21,7 +21,7 @@ import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.connectable.Funnel;
 import org.apache.nifi.connectable.Port;
-import org.apache.nifi.connectable.Position;
+import org.apache.nifi.connectable.Positionable;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.Snippet;
@@ -45,7 +45,7 @@ import java.util.function.Predicate;
  * <p>
  * MUST BE THREAD-SAFE</p>
  */
-public interface ProcessGroup extends Authorizable {
+public interface ProcessGroup extends Authorizable, Positionable {
 
     /**
      * Predicate for filtering schedulable Processors.
@@ -96,17 +96,6 @@ public interface ProcessGroup extends Authorizable {
      * @param name new name
      */
     void setName(String name);
-
-    /**
-     * Updates the position of where this ProcessGroup is located in the graph
-     * @param position new position
-     */
-    void setPosition(Position position);
-
-    /**
-     * @return the position of where this ProcessGroup is located in the graph
-     */
-    Position getPosition();
 
     /**
      * @return the user-set comments about this ProcessGroup, or
@@ -738,6 +727,12 @@ public interface ProcessGroup extends Authorizable {
      * input ports, output ports, funnels, processors, and remote process groups
      */
     Connectable findConnectable(String identifier);
+
+    /**
+     * @return a Set of all {@link org.apache.nifi.connectable.Positionable}s contained within this
+     * {@link ProcessGroup} and any child {@link ProcessGroup}s
+     */
+    Set<Positionable> findAllPositionables();
 
     /**
      * Moves all of the components whose ID's are specified within the given

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/RemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/RemoteProcessGroup.java
@@ -16,18 +16,18 @@
  */
 package org.apache.nifi.groups;
 
+import org.apache.nifi.authorization.resource.Authorizable;
+import org.apache.nifi.connectable.Positionable;
+import org.apache.nifi.controller.exception.CommunicationsException;
+import org.apache.nifi.events.EventReporter;
+import org.apache.nifi.remote.RemoteGroupPort;
+
 import java.net.URI;
 import java.util.Date;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.nifi.authorization.resource.Authorizable;
-import org.apache.nifi.connectable.Position;
-import org.apache.nifi.controller.exception.CommunicationsException;
-import org.apache.nifi.events.EventReporter;
-import org.apache.nifi.remote.RemoteGroupPort;
-
-public interface RemoteProcessGroup extends Authorizable {
+public interface RemoteProcessGroup extends Authorizable, Positionable {
 
     String getIdentifier();
 
@@ -36,10 +36,6 @@ public interface RemoteProcessGroup extends Authorizable {
     ProcessGroup getProcessGroup();
 
     void setProcessGroup(ProcessGroup group);
-
-    void setPosition(Position position);
-
-    Position getPosition();
 
     String getComments();
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -13,7 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.nifi</groupId>
@@ -156,6 +157,17 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/PositionScaler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/PositionScaler.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller;
+
+import org.apache.nifi.connectable.Connection;
+import org.apache.nifi.connectable.Position;
+import org.apache.nifi.connectable.Positionable;
+import org.apache.nifi.groups.ProcessGroup;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Provides utility to scale the positions of {@link Positionable}s and bend points of {@link Connection}s
+ * by a given factor.
+ */
+class PositionScaler {
+
+    /**
+     * Scales the positions of all {@link Position}s in the given {@link ProcessGroup} by
+     * the provided factor.  This method replaces all {@link Position}s in each {@link Positionable}
+     * in the {@link ProcessGroup} with a new scaled {@link Position}.
+     *
+     * @param processGroup containing the {@link Positionable}s to be scaled
+     * @param factorX      used to scale a {@link Positionable}'s X-coordinate position
+     * @param factorY      used to scale a {@link Positionable}'s Y-coordinate position
+     */
+    public static void scale(ProcessGroup processGroup, double factorX, double factorY) {
+        processGroup.findAllPositionables().stream().forEach(p -> scale(p, factorX, factorY));
+        Map<Connection, List<Position>> bendPointsByConnection =
+                processGroup.findAllConnections().stream().collect(Collectors.toMap(connection -> connection, Connection::getBendPoints));
+        bendPointsByConnection.entrySet().stream()
+                .forEach(connectionListEntry -> connectionListEntry.getKey().setBendPoints(connectionListEntry.getValue().stream()
+                        .map(p -> scalePosition(p, factorX, factorY)).collect(Collectors.toList())));
+
+    }
+
+    /**
+     * Scales the {@link Position} of the given {@link Positionable} by the provided factor.  This method
+     * replaces the {@link Position} in the {@link Positionable} with a new scaled {@link Position}.
+     *
+     * @param positionable containing a {@link Position} to scale
+     * @param factorX      used to scale a {@link Positionable}'s X-coordinate position
+     * @param factorY      used to scale a {@link Positionable}'s Y-coordinate position
+     */
+    public static void scale(Positionable positionable, double factorX, double factorY) {
+        final Position startingPosition = positionable.getPosition();
+        final Position scaledPosition = scalePosition(startingPosition, factorX, factorY);
+        positionable.setPosition(scaledPosition);
+    }
+
+    private static Position scalePosition(Position position, double factorX, double factorY) {
+        return new Position(position.getX() * factorX,
+                position.getY() * factorY);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
@@ -277,6 +277,8 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
                         }
                     }
 
+                    scaleRootGroup(rootGroup, encodingVersion);
+
                     final Element reportingTasksElement = DomUtils.getChild(rootElement, "reportingTasks");
                     if (reportingTasksElement != null) {
                         final List<Element> taskElements = DomUtils.getChildElementsByTagName(reportingTasksElement, "reportingTask");
@@ -308,6 +310,13 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
             logger.debug("Finished synching flows");
         } catch (final Exception ex) {
             throw new FlowSynchronizationException(ex);
+        }
+    }
+
+    void scaleRootGroup(ProcessGroup rootGroup, FlowEncodingVersion encodingVersion) {
+        if (encodingVersion == null || encodingVersion.getMajorVersion() < 1) {
+            // Calculate new Positions if the encoding version of the flow is older than 1.0.
+            PositionScaler.scale(rootGroup, 1.5, 1.34);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/FlowConfiguration.xsd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/FlowConfiguration.xsd
@@ -15,7 +15,7 @@
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
     <xs:element name="flowController" type="FlowControllerType" />
-	
+
     <xs:complexType name="FlowControllerType">
         <xs:sequence>
             <xs:choice>
@@ -35,6 +35,7 @@
             
             <xs:element name="reportingTasks" type="ReportingTasksType" minOccurs="0" maxOccurs="1" />
         </xs:sequence>
+        <xs:attribute name="encoding-version" type="xs:string"/>
     </xs:complexType>
 	
     <!-- the processor "id" is a key that should be valid within each flowController-->

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/PositionScalerSpec.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/PositionScalerSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller
+
+import org.apache.nifi.connectable.Connectable
+import org.apache.nifi.connectable.Position
+import org.apache.nifi.connectable.Positionable
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PositionScalerSpec extends Specification {
+
+    @Unroll
+    def "scale #positionableType.getSimpleName()"() {
+        given:
+        def positionable = Mock positionableType
+
+        when:
+        PositionScaler.scale positionable, factorX, factorY
+
+        then:
+        1 * positionable.position >> new Position(originalX, originalY)
+        1 * positionable.setPosition(_) >> { Position p ->
+            assert p.x == newX
+            assert p.y == newY
+        }
+
+        where:
+        positionableType | originalX | originalY | factorX | factorY | newX | newY
+        Connectable      | 10        | 10        | 1.5     | 1.5     | 15   | 15
+        Positionable     | -10       | -10       | 1.5     | 1.5     | -15  | -15
+    }
+
+    //TODO Test scaling of a ProcessGroup
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/StandardFlowSynchronizerSpec.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/StandardFlowSynchronizerSpec.groovy
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller
+
+import groovy.xml.XmlUtil
+import org.apache.nifi.cluster.protocol.DataFlow
+import org.apache.nifi.connectable.*
+import org.apache.nifi.controller.label.Label
+import org.apache.nifi.controller.queue.FlowFileQueue
+import org.apache.nifi.groups.ProcessGroup
+import org.apache.nifi.groups.RemoteProcessGroup
+import org.apache.nifi.processor.Relationship
+import org.apache.nifi.reporting.BulletinRepository
+import org.apache.nifi.util.NiFiProperties
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class StandardFlowSynchronizerSpec extends Specification {
+
+    def setupSpec() {
+        System.setProperty NiFiProperties.PROPERTIES_FILE_PATH, "src/test/resources/nifi.properties"
+    }
+
+    def teardownSpec() {
+        System.clearProperty NiFiProperties.PROPERTIES_FILE_PATH
+    }
+
+    @Unroll
+    def "scaling of #filename with encoding version \"#flowEncodingVersion\""() {
+        given: "a StandardFlowSynchronizer with mocked collaborators"
+        def controller = Mock FlowController
+        def proposedFlow = Mock DataFlow
+        def snippetManager = Mock SnippetManager
+        def bulletinRepository = Mock BulletinRepository
+        def flowFileQueue = Mock FlowFileQueue
+        def flowFile = new File(StandardFlowSynchronizerSpec.getResource(filename).toURI())
+        def flowControllerXml = new XmlSlurper().parse(flowFile)
+        def Map<String, Position> originalPositionablePositionsById = flowControllerXml.rootGroup.'**'
+                .findAll { !it.name().equals('connection') && it.id.size() == 1 && it.position.size() == 1 }
+                .collectEntries { [it.id.text(), new Position(it.position.@x.toDouble(), it.position.@y.toDouble())] }
+        def Map<String, List<Position>> originalBendPointsByConnectionId = flowControllerXml.rootGroup.'**'
+                .findAll { it.name().equals('connection') && it.bendPoints.size() > 0 }
+                .collectEntries { [it.id.text(), it.bendPoints.children().collect { new Position(it.@x.toDouble(), it.@y.toDouble()) }] }
+        flowControllerXml.@'encoding-version' = flowEncodingVersion
+        def testFlowBytes = XmlUtil.serialize(flowControllerXml).bytes
+        def Map<String, Position> positionablePositionsById = [:]
+        def Map<String, Positionable> positionableMocksById = [:]
+        def Map<String, Connection> connectionMocksById = [:]
+        def Map<String, List<Position>> bendPointPositionsByConnectionId = [:]
+        // the unit under test
+        def flowSynchronizer = new StandardFlowSynchronizer(null)
+
+        when: "the flow is synchronized with the current state of the controller"
+        flowSynchronizer.sync controller, proposedFlow, null
+
+        then: "establish interactions for the mocked collaborators of StandardFlowSynchronizer to store the ending positions of components"
+        1 * controller.isInitialized() >> false
+        _ * controller.rootGroupId >> flowControllerXml.rootGroup.id.text()
+        _ * controller.getGroup(_) >> { String id -> positionableMocksById.get(id) }
+        _ * controller.snippetManager >> snippetManager
+        _ * controller.bulletinRepository >> bulletinRepository
+        _ * controller./set.*/(*_)
+        _ * controller.createProcessGroup(_) >> { String pgId ->
+            def processGroup = Mock(ProcessGroup)
+            _ * processGroup.getIdentifier() >> pgId
+            _ * processGroup.getPosition() >> { positionablePositionsById.get(pgId) }
+            _ * processGroup.setPosition(_) >> { Position pos ->
+                positionablePositionsById.put pgId, pos
+            }
+            _ * processGroup./(add|set).*/(*_)
+            _ * processGroup.isEmpty() >> true
+            _ * processGroup.isRootGroup() >> { pgId == flowControllerXml.rootGroup.id }
+            _ * processGroup.getConnectable(_) >> { String connId -> positionableMocksById.get(connId) }
+            _ * processGroup.findAllPositionables() >> {
+                def foundProcessGroup = flowControllerXml.rootGroup.'**'.find { it.id == pgId }
+                def idsUnderPg = foundProcessGroup.'**'.findAll { it.name() == 'id' }.collect { it.text() }
+                positionableMocksById.entrySet().collect {
+                    if (idsUnderPg.contains(it.key)) {
+                        it.value
+                    }
+                }
+            }
+            _ * processGroup.findAllConnections() >> {
+                def foundProcessGroup = flowControllerXml.rootGroup.'**'.find { it.id == pgId }
+                def foundConnections = foundProcessGroup.'**'.findAll { it.name() == 'connection' }.collect { it.id.text() }
+                connectionMocksById.entrySet().collect {
+                    if (foundConnections.contains(it.key)) {
+                        it.value
+                    }
+                }
+            }
+            positionableMocksById.put(pgId, processGroup)
+            return processGroup
+        }
+
+        _ * controller.createProcessor(_, _, _) >> { String type, String id, boolean firstTimeAdded ->
+            def processor = Mock(ProcessorNode)
+            _ * processor.getPosition() >> { positionablePositionsById.get(id) }
+            _ * processor.setPosition(_) >> { Position pos ->
+                positionablePositionsById.put id, pos
+            }
+            _ * processor./(add|set).*/(*_)
+            _ * processor.getIdentifier() >> id
+            _ * processor.getRelationship(_) >> { String n -> new Relationship.Builder().name(n).build() }
+            positionableMocksById.put(id, processor)
+            return processor
+        }
+        _ * controller.createFunnel(_) >> { String id ->
+            def funnel = Mock(Funnel)
+            _ * funnel.getPosition() >> { positionablePositionsById.get(id) }
+            _ * funnel.setPosition(_) >> { Position pos ->
+                positionablePositionsById.put id, pos
+            }
+            _ * funnel./(add|set).*/(*_)
+            positionableMocksById.put id, funnel
+            return funnel
+        }
+        _ * controller.createLabel(_, _) >> { String id, String text ->
+            def l = Mock(Label)
+            _ * l.getPosition() >> { positionablePositionsById.get(id) }
+            _ * l.setPosition(_) >> { Position pos ->
+                positionablePositionsById.put id, pos
+            }
+            _ * l./(add|set).*/(*_)
+            positionableMocksById.put(id, l)
+            return l
+        }
+        _ * controller./create.*Port/(_, _) >> { String id, String text ->
+            def port = Mock(Port)
+            _ * port.getPosition() >> { positionablePositionsById.get(id) }
+            _ * port.setPosition(_) >> { Position pos ->
+                positionablePositionsById.put id, pos
+            }
+            _ * port./(add|set).*/(*_)
+            positionableMocksById.put(id, port)
+            return port
+        }
+        _ * controller.createRemoteProcessGroup(_, _) >> { String id, String uri ->
+            def rpg = Mock(RemoteProcessGroup)
+            _ * rpg.getPosition() >> { positionablePositionsById.get(id) }
+            _ * rpg.setPosition(_) >> { Position pos ->
+                positionablePositionsById.put id, pos
+            }
+            _ * rpg./(add|set).*/(*_)
+            _ * rpg.getOutputPort(_) >> { String rpgId -> positionableMocksById.get(rpgId) }
+            _ * rpg.getIdentifier() >> id
+            positionableMocksById.put(id, rpg)
+            return rpg
+        }
+        _ * controller.createConnection(_, _, _, _, _) >> { String id, String name, Connectable source, Connectable destination, Collection<String> relationshipNames ->
+            def connection = Mock(Connection)
+            _ * connection.getIdentifier() >> id
+            _ * connection.getBendPoints() >> {
+                def bendpoints = bendPointPositionsByConnectionId.get(id)
+                return bendpoints
+            }
+            _ * connection.setBendPoints(_) >> {
+                // There seems to be a bug in Spock method matching where a list of arguments to a method
+                // is being coerced into an Arrays$ArrayList with the actual list of bend points as an
+                // ArrayList in the 0th element.
+                // Need to keep an eye on this...
+                bendPointPositionsByConnectionId.put id, it[0]
+            }
+            _ * connection./set.*/(*_)
+            _ * connection.flowFileQueue >> flowFileQueue
+            connectionMocksById.put(id, connection)
+            return connection
+        }
+        _ * controller.startProcessor(*_)
+        _ * controller.startConnectable(_)
+        _ * controller.enableControllerServices(_)
+        _ * snippetManager.export() >> {
+            [] as byte[]
+        }
+        _ * snippetManager.clear()
+        1 * proposedFlow.flow >> testFlowBytes
+        _ * proposedFlow.snippets >> {
+            [] as byte[]
+        }
+        _ * flowFileQueue./set.*/(*_)
+        _ * _.hashCode() >> 1
+        0 * _ // no other mock calls allowed
+
+        then: "verify that the flow was scaled properly"
+        originalPositionablePositionsById.entrySet().forEach { entry ->
+            assert positionablePositionsById.containsKey(entry.key)
+            def originalPosition = entry.value
+            def position = positionablePositionsById.get(entry.key)
+            compareOriginalPointToScaledPoint(originalPosition, position, isSyncedPositionGreater)
+        }
+        originalBendPointsByConnectionId.entrySet().forEach { entry ->
+            assert bendPointPositionsByConnectionId.containsKey(entry.key)
+            def originalBendPoints = entry.value
+            def sortedBendPoints = bendPointPositionsByConnectionId.get(entry.key).sort { it.x }
+            def sortedOriginalBendPoints = originalBendPoints.sort { it.x }
+            assert sortedOriginalBendPoints.size() == sortedBendPoints.size()
+            [sortedOriginalBendPoints, sortedBendPoints].transpose().forEach { Position originalPosition, Position position ->
+                compareOriginalPointToScaledPoint(originalPosition, position, isSyncedPositionGreater)
+            }
+        }
+
+        where: "the each flowfile and flow encoding version is run through the StandardFlowSynchronizer"
+        filename                               | flowEncodingVersion | isSyncedPositionGreater
+        '/conf/scale-positions-flow-0.7.0.xml' | null                | true
+        '/conf/scale-positions-flow-0.7.0.xml' | '0.7'               | true
+        '/conf/scale-positions-flow-0.7.0.xml' | '1.0'               | false
+        '/conf/scale-positions-flow-0.7.0.xml' | '99.0'              | false
+    }
+
+    private void compareOriginalPointToScaledPoint(Position originalPosition, Position position, boolean isSyncedPositionGreater) {
+        if (originalPosition.x == 0) {
+            assert position.x == 0
+        }
+        if (originalPosition.y == 0) {
+            assert position.y == 0
+        }
+        if (originalPosition.x > 0) {
+            assert isSyncedPositionGreater == position.x > originalPosition.x
+        }
+        if (originalPosition.y > 0) {
+            assert isSyncedPositionGreater == position.y > originalPosition.y
+        }
+        if (originalPosition.x < 0) {
+            assert isSyncedPositionGreater == position.x < originalPosition.x
+        }
+        if (originalPosition.y < 0) {
+            assert isSyncedPositionGreater == position.y < originalPosition.y
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/MockProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/MockProcessGroup.java
@@ -17,12 +17,6 @@
 
 package org.apache.nifi.controller.service.mock;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.nifi.authorization.Resource;
 import org.apache.nifi.authorization.resource.Authorizable;
 import org.apache.nifi.connectable.Connectable;
@@ -30,6 +24,7 @@ import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.connectable.Funnel;
 import org.apache.nifi.connectable.Port;
 import org.apache.nifi.connectable.Position;
+import org.apache.nifi.connectable.Positionable;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.Snippet;
 import org.apache.nifi.controller.Template;
@@ -38,6 +33,12 @@ import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.ProcessGroupCounts;
 import org.apache.nifi.groups.RemoteProcessGroup;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class MockProcessGroup implements ProcessGroup {
     private Map<String, ControllerServiceNode> serviceMap = new HashMap<>();
@@ -264,6 +265,11 @@ public class MockProcessGroup implements ProcessGroup {
 
     @Override
     public ProcessorNode getProcessor(String id) {
+        return null;
+    }
+
+    @Override
+    public Set<Positionable> findAllPositionables() {
         return null;
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/conf/scale-positions-flow-0.7.0.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/conf/scale-positions-flow-0.7.0.xml
@@ -1,0 +1,1533 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<flowController>
+  <maxTimerDrivenThreadCount>10</maxTimerDrivenThreadCount>
+  <maxEventDrivenThreadCount>5</maxEventDrivenThreadCount>
+  <rootGroup>
+    <id>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</id>
+    <name>NiFi Flow</name>
+    <position x="0.0" y="0.0"/>
+    <comment/>
+    <processor>
+      <id>a05b4e5f-059f-4105-af89-a551098d2779</id>
+      <name>ExtractText</name>
+      <position x="686.0" y="542.0"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ExtractText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Maximum Capture Group Length</name>
+        <value>1024</value>
+      </property>
+      <property>
+        <name>Enable Canonical Equivalence</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Case-insensitive Matching</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Permit Whitespace and Comments in Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable DOTALL Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Literal Parsing of the Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Multiline Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode-aware Case Folding</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode Predefined Character Classes</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unix Lines Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Include Capture Group 0</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>data</name>
+        <value>((?s:^.*$))</value>
+      </property>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>74af00f4-5b4a-4236-bae0-ebc6bef5ae1f</id>
+      <name>ReplaceText</name>
+      <position x="1122.363037109375" y="895.7132568359375"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ReplaceText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Regular Expression</name>
+        <value>(?s:^.*$)</value>
+      </property>
+      <property>
+        <name>Replacement Value</name>
+        <value>${nextInt()}</value>
+      </property>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Replacement Strategy</name>
+        <value>Regex Replace</value>
+      </property>
+      <property>
+        <name>Evaluation Mode</name>
+        <value>Entire text</value>
+      </property>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>b4369bf2-e5d5-4df8-b397-4d63c1a11d29</id>
+      <name>RouteOnAttribute</name>
+      <position x="690.0" y="676.0"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Routing Strategy</name>
+        <value>Route to Property name</value>
+      </property>
+      <property>
+        <name>data is even</name>
+        <value>${data:mod(2):equals(0)}</value>
+      </property>
+    </processor>
+    <processor>
+      <id>b1f6cb42-dbce-49a3-be9f-cfc6c889bb8b</id>
+      <name>RouteOnAttribute</name>
+      <position x="1058.489013671875" y="545.9861450195312"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Routing Strategy</name>
+        <value>Route to Property name</value>
+      </property>
+      <property>
+        <name>content is even</name>
+        <value>${data:mod(2):equals(0)}</value>
+      </property>
+      <autoTerminatedRelationship>content is even</autoTerminatedRelationship>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>0e49512d-67f4-4b74-9880-ea2e2fb3436b</id>
+      <name>ExtractText</name>
+      <position x="224.6471710205078" y="1028.7507019042969"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ExtractText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Maximum Capture Group Length</name>
+        <value>1024</value>
+      </property>
+      <property>
+        <name>Enable Canonical Equivalence</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Case-insensitive Matching</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Permit Whitespace and Comments in Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable DOTALL Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Literal Parsing of the Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Multiline Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode-aware Case Folding</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode Predefined Character Classes</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unix Lines Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Include Capture Group 0</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>data</name>
+        <value>((?s:^.*$))</value>
+      </property>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>c697e51f-aa4f-4cbf-a4e7-25156970a360</id>
+      <name>RouteOnAttribute</name>
+      <position x="1129.363037109375" y="1164.7132568359375"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Routing Strategy</name>
+        <value>Route to Property name</value>
+      </property>
+      <property>
+        <name>content is even</name>
+        <value>${data:mod(2):equals(0)}</value>
+      </property>
+    </processor>
+    <processor>
+      <id>2a1e8019-5264-48e7-bc61-8d71c4ecaa82</id>
+      <name>ExtractText</name>
+      <position x="1125.363037109375" y="1030.7132568359375"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ExtractText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Maximum Capture Group Length</name>
+        <value>1024</value>
+      </property>
+      <property>
+        <name>Enable Canonical Equivalence</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Case-insensitive Matching</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Permit Whitespace and Comments in Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable DOTALL Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Literal Parsing of the Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Multiline Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode-aware Case Folding</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode Predefined Character Classes</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unix Lines Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Include Capture Group 0</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>data</name>
+        <value>((?s:^.*$))</value>
+      </property>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>ab9e02ee-511f-48de-ac07-da46481c1a70</id>
+      <name>ReplaceText</name>
+      <position x="1051.489013671875" y="276.98614501953125"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ReplaceText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Regular Expression</name>
+        <value>(?s:^.*$)</value>
+      </property>
+      <property>
+        <name>Replacement Value</name>
+        <value>${nextInt()}</value>
+      </property>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Replacement Strategy</name>
+        <value>Regex Replace</value>
+      </property>
+      <property>
+        <name>Evaluation Mode</name>
+        <value>Entire text</value>
+      </property>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>a4b100b5-f3da-41ed-8ed9-a198d3f4aba3</id>
+      <name>ExtractText</name>
+      <position x="1740.591796875" y="1481.1141967773438"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ExtractText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Maximum Capture Group Length</name>
+        <value>1024</value>
+      </property>
+      <property>
+        <name>Enable Canonical Equivalence</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Case-insensitive Matching</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Permit Whitespace and Comments in Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable DOTALL Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Literal Parsing of the Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Multiline Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode-aware Case Folding</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode Predefined Character Classes</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unix Lines Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Include Capture Group 0</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>data</name>
+        <value>((?s:^.*$))</value>
+      </property>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>4b771af6-af32-443f-b807-6b9f7c476e39</id>
+      <name>ReplaceText</name>
+      <position x="297.56959533691406" y="276.02215576171875"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ReplaceText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Regular Expression</name>
+        <value>(?s:^.*$)</value>
+      </property>
+      <property>
+        <name>Replacement Value</name>
+        <value>${nextInt()}</value>
+      </property>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Replacement Strategy</name>
+        <value>Regex Replace</value>
+      </property>
+      <property>
+        <name>Evaluation Mode</name>
+        <value>Entire text</value>
+      </property>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>f3063c47-c8ae-4b25-bd71-98dffdf33e0a</id>
+      <name>GenerateFlowFile</name>
+      <position x="682.0" y="271.0"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.GenerateFlowFile</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>1 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>File Size</name>
+        <value>0b</value>
+      </property>
+      <property>
+        <name>Batch Size</name>
+        <value>1</value>
+      </property>
+      <property>
+        <name>Data Format</name>
+        <value>Binary</value>
+      </property>
+      <property>
+        <name>Unique FlowFiles</name>
+        <value>false</value>
+      </property>
+    </processor>
+    <processor>
+      <id>3dae3e31-ab40-49ca-bb86-21e91f24ee97</id>
+      <name>RouteOnAttribute</name>
+      <position x="228.6471710205078" y="1162.7507019042969"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Routing Strategy</name>
+        <value>Route to Property name</value>
+      </property>
+      <property>
+        <name>content is even</name>
+        <value>${data:mod(2):equals(0)}</value>
+      </property>
+      <autoTerminatedRelationship>content is even</autoTerminatedRelationship>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>de1f9362-f8a5-44a0-bef7-9a6f608e6e66</id>
+      <name>ExtractText</name>
+      <position x="300.56959533691406" y="411.02215576171875"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ExtractText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Maximum Capture Group Length</name>
+        <value>1024</value>
+      </property>
+      <property>
+        <name>Enable Canonical Equivalence</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Case-insensitive Matching</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Permit Whitespace and Comments in Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable DOTALL Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Literal Parsing of the Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Multiline Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode-aware Case Folding</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode Predefined Character Classes</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unix Lines Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Include Capture Group 0</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>data</name>
+        <value>((?s:^.*$))</value>
+      </property>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>92fd75c1-7d4c-4adc-bd2e-e3c33075dfb6</id>
+      <name>ReplaceText</name>
+      <position x="1740.0157470703125" y="1346.1141967773438"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ReplaceText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Regular Expression</name>
+        <value>(?s:^.*$)</value>
+      </property>
+      <property>
+        <name>Replacement Value</name>
+        <value>${nextInt()}</value>
+      </property>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Replacement Strategy</name>
+        <value>Regex Replace</value>
+      </property>
+      <property>
+        <name>Evaluation Mode</name>
+        <value>Entire text</value>
+      </property>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>d908041d-3f7a-4d07-bf76-cdee0c2e2c28</id>
+      <name>ExtractText</name>
+      <position x="1054.489013671875" y="411.98614501953125"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ExtractText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Maximum Capture Group Length</name>
+        <value>1024</value>
+      </property>
+      <property>
+        <name>Enable Canonical Equivalence</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Case-insensitive Matching</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Permit Whitespace and Comments in Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable DOTALL Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Literal Parsing of the Pattern</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Multiline Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode-aware Case Folding</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unicode Predefined Character Classes</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Enable Unix Lines Mode</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>Include Capture Group 0</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>data</name>
+        <value>((?s:^.*$))</value>
+      </property>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>dd6046fa-f346-461d-93a3-c65bcc38e3d8</id>
+      <name>RouteOnAttribute</name>
+      <position x="304.56959533691406" y="545.0221557617188"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Routing Strategy</name>
+        <value>Route to Property name</value>
+      </property>
+      <property>
+        <name>content is even</name>
+        <value>${data:mod(2):equals(0)}</value>
+      </property>
+      <autoTerminatedRelationship>content is even</autoTerminatedRelationship>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>6461ece1-db83-481f-88ba-534cd3a67b1b</id>
+      <name>RouteOnAttribute</name>
+      <position x="1740.9559326171875" y="1615.1141967773438"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Routing Strategy</name>
+        <value>Route to Property name</value>
+      </property>
+      <property>
+        <name>content is even</name>
+        <value>${data:mod(2):equals(0)}</value>
+      </property>
+      <autoTerminatedRelationship>content is even</autoTerminatedRelationship>
+      <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>65140227-fe60-42ad-beb9-69c36bc75acb</id>
+      <name>ReplaceText</name>
+      <position x="683.0" y="407.0"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ReplaceText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Regular Expression</name>
+        <value>(?s:^.*$)</value>
+      </property>
+      <property>
+        <name>Replacement Value</name>
+        <value>${nextInt()}</value>
+      </property>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Replacement Strategy</name>
+        <value>Regex Replace</value>
+      </property>
+      <property>
+        <name>Evaluation Mode</name>
+        <value>Entire text</value>
+      </property>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <processor>
+      <id>3d47cfae-2ada-4992-8597-e7e814490749</id>
+      <name>ReplaceText</name>
+      <position x="221.6471710205078" y="893.7507019042969"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.ReplaceText</class>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Regular Expression</name>
+        <value>(?s:^.*$)</value>
+      </property>
+      <property>
+        <name>Replacement Value</name>
+        <value>${nextInt()}</value>
+      </property>
+      <property>
+        <name>Character Set</name>
+        <value>UTF-8</value>
+      </property>
+      <property>
+        <name>Maximum Buffer Size</name>
+        <value>1 MB</value>
+      </property>
+      <property>
+        <name>Replacement Strategy</name>
+        <value>Regex Replace</value>
+      </property>
+      <property>
+        <name>Evaluation Mode</name>
+        <value>Entire text</value>
+      </property>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <label>
+      <id>4b34ece6-21eb-4191-8284-6d478cc6548b</id>
+      <position x="696.0520892861283" y="193.75377880056814"/>
+      <size height="33.134117126464844" width="268.2286682128906"/>
+      <styles>
+        <style name="font-size">20px</style>
+      </styles>
+      <value>Position Scaling Test Flow</value>
+    </label>
+    <funnel>
+      <id>a008d0fa-ab77-48ff-bc46-09a92344b4a5</id>
+      <position x="617.7619729219375" y="816.7007985295049"/>
+    </funnel>
+    <funnel>
+      <id>2c272f59-c00b-44cb-a6b6-b4a6510ac3db</id>
+      <position x="995.2340698242188" y="818.6952514648438"/>
+    </funnel>
+    <processGroup>
+      <id>e7e03999-bbb8-491f-bba0-dbf772ec1966</id>
+      <name>Process Group</name>
+      <position x="1712.4232974441734" y="1129.179978284284"/>
+      <comment/>
+      <processor>
+        <id>aea93188-0832-4876-9bb8-38901a773922</id>
+        <name>ExtractText</name>
+        <position x="-699.489013671875" y="-244.98614501953125"/>
+        <styles/>
+        <comment/>
+        <class>org.apache.nifi.processors.standard.ExtractText</class>
+        <maxConcurrentTasks>1</maxConcurrentTasks>
+        <schedulingPeriod>0 sec</schedulingPeriod>
+        <penalizationPeriod>30 sec</penalizationPeriod>
+        <yieldPeriod>1 sec</yieldPeriod>
+        <bulletinLevel>WARN</bulletinLevel>
+        <lossTolerant>false</lossTolerant>
+        <scheduledState>RUNNING</scheduledState>
+        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+        <runDurationNanos>0</runDurationNanos>
+        <property>
+          <name>Character Set</name>
+          <value>UTF-8</value>
+        </property>
+        <property>
+          <name>Maximum Buffer Size</name>
+          <value>1 MB</value>
+        </property>
+        <property>
+          <name>Maximum Capture Group Length</name>
+          <value>1024</value>
+        </property>
+        <property>
+          <name>Enable Canonical Equivalence</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable Case-insensitive Matching</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Permit Whitespace and Comments in Pattern</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable DOTALL Mode</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable Literal Parsing of the Pattern</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable Multiline Mode</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable Unicode-aware Case Folding</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable Unicode Predefined Character Classes</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Enable Unix Lines Mode</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>Include Capture Group 0</name>
+          <value>false</value>
+        </property>
+        <property>
+          <name>data</name>
+          <value>((?s:^.*$))</value>
+        </property>
+        <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+      </processor>
+      <processor>
+        <id>3b3957f9-91ff-4817-9a7f-fa80f78c2b72</id>
+        <name>ReplaceText</name>
+        <position x="493.489013671875" y="81.98614501953125"/>
+        <styles/>
+        <comment/>
+        <class>org.apache.nifi.processors.standard.ReplaceText</class>
+        <maxConcurrentTasks>1</maxConcurrentTasks>
+        <schedulingPeriod>0 sec</schedulingPeriod>
+        <penalizationPeriod>30 sec</penalizationPeriod>
+        <yieldPeriod>1 sec</yieldPeriod>
+        <bulletinLevel>WARN</bulletinLevel>
+        <lossTolerant>false</lossTolerant>
+        <scheduledState>RUNNING</scheduledState>
+        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+        <runDurationNanos>0</runDurationNanos>
+        <property>
+          <name>Regular Expression</name>
+          <value>(?s:^.*$)</value>
+        </property>
+        <property>
+          <name>Replacement Value</name>
+          <value>${nextInt()}</value>
+        </property>
+        <property>
+          <name>Character Set</name>
+          <value>UTF-8</value>
+        </property>
+        <property>
+          <name>Maximum Buffer Size</name>
+          <value>1 MB</value>
+        </property>
+        <property>
+          <name>Replacement Strategy</name>
+          <value>Regex Replace</value>
+        </property>
+        <property>
+          <name>Evaluation Mode</name>
+          <value>Entire text</value>
+        </property>
+        <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+      </processor>
+      <processor>
+        <id>79d49fec-3b95-4e7b-a949-0d414594e7fa</id>
+        <name>RouteOnAttribute</name>
+        <position x="878.489013671875" y="408.98614501953125"/>
+        <styles/>
+        <comment/>
+        <class>org.apache.nifi.processors.standard.RouteOnAttribute</class>
+        <maxConcurrentTasks>1</maxConcurrentTasks>
+        <schedulingPeriod>0 sec</schedulingPeriod>
+        <penalizationPeriod>30 sec</penalizationPeriod>
+        <yieldPeriod>1 sec</yieldPeriod>
+        <bulletinLevel>WARN</bulletinLevel>
+        <lossTolerant>false</lossTolerant>
+        <scheduledState>RUNNING</scheduledState>
+        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+        <runDurationNanos>0</runDurationNanos>
+        <property>
+          <name>Routing Strategy</name>
+          <value>Route to Property name</value>
+        </property>
+        <property>
+          <name>content is even</name>
+          <value>${data:mod(2):equals(0)}</value>
+        </property>
+        <autoTerminatedRelationship>unmatched</autoTerminatedRelationship>
+      </processor>
+      <inputPort>
+        <id>5f2c8c29-4cea-4da9-9a48-23abe40bd08d</id>
+        <name>Input</name>
+        <position x="153.7276087194923" y="-40.93787518813599"/>
+        <comments/>
+        <scheduledState>RUNNING</scheduledState>
+      </inputPort>
+      <outputPort>
+        <id>b6e55392-154f-46d6-ba5a-4d1311659094</id>
+        <name>Output</name>
+        <position x="1331.9999908843054" y="686.9999981428347"/>
+        <comments/>
+        <scheduledState>RUNNING</scheduledState>
+      </outputPort>
+      <connection>
+        <id>7b7f871b-8f4b-4ce7-a9d4-2f810bf2b55f</id>
+        <name/>
+        <bendPoints/>
+        <labelIndex>1</labelIndex>
+        <zIndex>0</zIndex>
+        <sourceId>aea93188-0832-4876-9bb8-38901a773922</sourceId>
+        <sourceGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</sourceGroupId>
+        <sourceType>PROCESSOR</sourceType>
+        <destinationId>79d49fec-3b95-4e7b-a949-0d414594e7fa</destinationId>
+        <destinationGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</destinationGroupId>
+        <destinationType>PROCESSOR</destinationType>
+        <relationship>matched</relationship>
+        <maxWorkQueueSize>0</maxWorkQueueSize>
+        <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+        <flowFileExpiration>0 sec</flowFileExpiration>
+      </connection>
+      <connection>
+        <id>8bf960ca-ba33-4b5b-9830-1a808dd2db0e</id>
+        <name/>
+        <bendPoints/>
+        <labelIndex>1</labelIndex>
+        <zIndex>0</zIndex>
+        <sourceId>79d49fec-3b95-4e7b-a949-0d414594e7fa</sourceId>
+        <sourceGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</sourceGroupId>
+        <sourceType>PROCESSOR</sourceType>
+        <destinationId>b6e55392-154f-46d6-ba5a-4d1311659094</destinationId>
+        <destinationGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</destinationGroupId>
+        <destinationType>OUTPUT_PORT</destinationType>
+        <relationship>content is even</relationship>
+        <maxWorkQueueSize>0</maxWorkQueueSize>
+        <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+        <flowFileExpiration>0 sec</flowFileExpiration>
+      </connection>
+      <connection>
+        <id>a82d78cb-de24-40e3-8fb9-d2117919cb31</id>
+        <name/>
+        <bendPoints/>
+        <labelIndex>1</labelIndex>
+        <zIndex>0</zIndex>
+        <sourceId>3b3957f9-91ff-4817-9a7f-fa80f78c2b72</sourceId>
+        <sourceGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</sourceGroupId>
+        <sourceType>PROCESSOR</sourceType>
+        <destinationId>aea93188-0832-4876-9bb8-38901a773922</destinationId>
+        <destinationGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</destinationGroupId>
+        <destinationType>PROCESSOR</destinationType>
+        <relationship>success</relationship>
+        <maxWorkQueueSize>0</maxWorkQueueSize>
+        <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+        <flowFileExpiration>0 sec</flowFileExpiration>
+      </connection>
+      <connection>
+        <id>197ffc73-76d3-4e83-84ca-a431fef50a8f</id>
+        <name/>
+        <bendPoints/>
+        <labelIndex>1</labelIndex>
+        <zIndex>0</zIndex>
+        <sourceId>5f2c8c29-4cea-4da9-9a48-23abe40bd08d</sourceId>
+        <sourceGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</sourceGroupId>
+        <sourceType>INPUT_PORT</sourceType>
+        <destinationId>3b3957f9-91ff-4817-9a7f-fa80f78c2b72</destinationId>
+        <destinationGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</destinationGroupId>
+        <destinationType>PROCESSOR</destinationType>
+        <relationship/>
+        <maxWorkQueueSize>0</maxWorkQueueSize>
+        <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+        <flowFileExpiration>0 sec</flowFileExpiration>
+      </connection>
+    </processGroup>
+    <remoteProcessGroup>
+      <id>b1ebe9d0-56db-4f2e-8448-b78ec9daab66</id>
+      <name>https://localhost:8080/nifi</name>
+      <position x="1099.124343746611" y="690.4645198499999"/>
+      <comment/>
+      <url>https://localhost:8080/nifi</url>
+      <timeout>30 sec</timeout>
+      <yieldPeriod>10 sec</yieldPeriod>
+      <transmitting>false</transmitting>
+    </remoteProcessGroup>
+    <connection>
+      <id>c08639c3-fdf4-465d-9f17-361fc2b8717f</id>
+      <name/>
+      <bendPoints>
+        <bendPoint x="1002.2285766601562" y="248.48902893066406"/>
+      </bendPoints>
+      <labelIndex>0</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>2c272f59-c00b-44cb-a6b6-b4a6510ac3db</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>FUNNEL</sourceType>
+      <destinationId>ab9e02ee-511f-48de-ac07-da46481c1a70</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship/>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>d7b307c3-9a81-4764-ac47-86f1b34e3789</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>65140227-fe60-42ad-beb9-69c36bc75acb</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>a05b4e5f-059f-4105-af89-a551098d2779</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>2559c168-06e9-456c-9de7-72220127c35a</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>2c272f59-c00b-44cb-a6b6-b4a6510ac3db</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>FUNNEL</sourceType>
+      <destinationId>74af00f4-5b4a-4236-bae0-ebc6bef5ae1f</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship/>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>805d91a6-aa21-4cd4-a14f-28063fd7da52</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>a4b100b5-f3da-41ed-8ed9-a198d3f4aba3</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>6461ece1-db83-481f-88ba-534cd3a67b1b</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>matched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>e2f12e55-8b85-4e04-99c7-c33718b96495</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>92fd75c1-7d4c-4adc-bd2e-e3c33075dfb6</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>a4b100b5-f3da-41ed-8ed9-a198d3f4aba3</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>9a53fe17-7b7b-4a29-b993-b19fc7ba3e9b</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>b6e55392-154f-46d6-ba5a-4d1311659094</sourceId>
+      <sourceGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</sourceGroupId>
+      <sourceType>OUTPUT_PORT</sourceType>
+      <destinationId>92fd75c1-7d4c-4adc-bd2e-e3c33075dfb6</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship/>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>657c6894-2e76-4dd1-bcfe-94e8beeb82ff</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>74af00f4-5b4a-4236-bae0-ebc6bef5ae1f</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>2a1e8019-5264-48e7-bc61-8d71c4ecaa82</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>be5e2f01-7a6f-49d2-80b0-2dbb7b4efea5</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>0e49512d-67f4-4b74-9880-ea2e2fb3436b</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>3dae3e31-ab40-49ca-bb86-21e91f24ee97</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>matched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>c9f12359-99bb-47c4-bac7-9fc9e1f8779f</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>2a1e8019-5264-48e7-bc61-8d71c4ecaa82</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>c697e51f-aa4f-4cbf-a4e7-25156970a360</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>matched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>2087d4da-e40c-4674-ac98-e11e8f0f1851</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>f3063c47-c8ae-4b25-bd71-98dffdf33e0a</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>65140227-fe60-42ad-beb9-69c36bc75acb</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>8a6298e5-2b79-4099-8b21-ab35c2c663c4</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>d908041d-3f7a-4d07-bf76-cdee0c2e2c28</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>b1f6cb42-dbce-49a3-be9f-cfc6c889bb8b</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>matched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>69888bdf-518b-467c-b4aa-70dc97c5d5dc</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>de1f9362-f8a5-44a0-bef7-9a6f608e6e66</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>dd6046fa-f346-461d-93a3-c65bcc38e3d8</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>matched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>e2fef810-29c7-4c7c-a127-9fcf01b27634</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>3d47cfae-2ada-4992-8597-e7e814490749</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>0e49512d-67f4-4b74-9880-ea2e2fb3436b</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>69ab1907-f0b7-490a-9630-95f886b4f49f</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>4b771af6-af32-443f-b807-6b9f7c476e39</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>de1f9362-f8a5-44a0-bef7-9a6f608e6e66</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>fb2d7868-d1f6-4f9a-83f2-2431acd4cf41</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>b4369bf2-e5d5-4df8-b397-4d63c1a11d29</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>2c272f59-c00b-44cb-a6b6-b4a6510ac3db</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>FUNNEL</destinationType>
+      <relationship>data is even</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>2c06978d-8cc0-46f2-84c0-bf448029cdd9</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>a05b4e5f-059f-4105-af89-a551098d2779</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>b4369bf2-e5d5-4df8-b397-4d63c1a11d29</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>matched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>a50b2dc1-baa9-402a-abf7-20e39b0dba0c</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>c697e51f-aa4f-4cbf-a4e7-25156970a360</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>5f2c8c29-4cea-4da9-9a48-23abe40bd08d</destinationId>
+      <destinationGroupId>e7e03999-bbb8-491f-bba0-dbf772ec1966</destinationGroupId>
+      <destinationType>INPUT_PORT</destinationType>
+      <relationship>content is even</relationship>
+      <relationship>unmatched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>a1cf21e6-2cf3-4cb6-b969-e3521035e5af</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>a008d0fa-ab77-48ff-bc46-09a92344b4a5</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>FUNNEL</sourceType>
+      <destinationId>3d47cfae-2ada-4992-8597-e7e814490749</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship/>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>a08466d6-8c3e-43d7-9d36-0f5019845342</id>
+      <name/>
+      <bendPoints>
+        <bendPoint x="668.6912841796875" y="250.4862518310547"/>
+      </bendPoints>
+      <labelIndex>0</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>a008d0fa-ab77-48ff-bc46-09a92344b4a5</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>FUNNEL</sourceType>
+      <destinationId>4b771af6-af32-443f-b807-6b9f7c476e39</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship/>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>988349d3-faf0-4ffb-8403-dd9db2376958</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>ab9e02ee-511f-48de-ac07-da46481c1a70</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>d908041d-3f7a-4d07-bf76-cdee0c2e2c28</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+    <connection>
+      <id>3a1725d4-4e55-448f-8f52-453d9dbfc40b</id>
+      <name>data is odd</name>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>b4369bf2-e5d5-4df8-b397-4d63c1a11d29</sourceId>
+      <sourceGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>a008d0fa-ab77-48ff-bc46-09a92344b4a5</destinationId>
+      <destinationGroupId>32b64df5-b2f5-4c47-9880-3d0bd5c8ff15</destinationGroupId>
+      <destinationType>FUNNEL</destinationType>
+      <relationship>unmatched</relationship>
+      <maxWorkQueueSize>0</maxWorkQueueSize>
+      <maxWorkQueueDataSize>0 MB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+  </rootGroup>
+  <controllerServices/>
+  <reportingTasks/>
+</flowController>

--- a/pom.xml
+++ b/pom.xml
@@ -1217,6 +1217,12 @@ language governing permissions and limitations under the License. -->
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.spockframework</groupId>
+                <artifactId>spock-core</artifactId>
+                <version>1.0-groovy-2.4</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>1.3</version>
@@ -1285,9 +1291,22 @@ language governing permissions and limitations under the License. -->
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.18</version>
                     <configuration>
+                        <includes>
+                            <include>**/*Test.class</include>
+                            <include>**/Test*.class</include>
+                            <include>**/*Spec.class</include>
+                        </includes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <argLine combine.children="append">-Xmx1G -Djava.net.preferIPv4Stack=true</argLine>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <!-- Force surefire to use JUnit -->
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit4</artifactId>
+                            <version>2.18</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
added utility class to scale positions of components on the canvas,
extracted get/setPosition methods from ProcesGroup, RemoteProcessGroup, Label, and Connectable into new interface Positionable
added interface method for finding all Positionables in a ProcessGroup to the ProcessGroup interface and added implementation to StandardProcessGroup
added test flow for position rescaling
added Spock config to POM and a spec for testing the scaling of Positionables
forced Surefire to use JUnit (TestNG was on classpath and Surefire seems to prioritize that over JUnit),
added check in StandardFlowSynchronizer to scale positions only when flow encoding version is less than 1.0