### PR TITLE
NIFI-1881 Added surefire-junit4 dependency to the surefire build plug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,6 +1269,13 @@ language governing permissions and limitations under the License. -->
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <argLine combine.children="append">-Xmx1G -Djava.net.preferIPv4Stack=true</argLine>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit4</artifactId>
+                            <version>2.18</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…in configuration to force Surefire to run tests with JUnit.  This specifically addresses the issue as it relates to version 0.x.  For 1.0.0, the PR for NIFI-1799 includes this same POM update.