### PR TITLE
NIFI-1829 - Create new DebugFlow processor.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DebugFlow.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DebugFlow.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.logging.ProcessorLog;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@EventDriven()
+@Tags({"test", "debug", "processor", "utility", "flow", "flowfile"})
+@CapabilityDescription("This processor aids in the testing and debugging of the flowfile framework by allowing "
+        + "a developer or flow manager to force various responses to a flowfile.  In response to a receiving a flowfile "
+        + "it can route to the success or failure relationships, rollback, rollback and yield, rollback with penalty, "
+        + "or throw an exception.  In addition, if using a timer based scheduling strategy, upon being triggered without "
+        + "a flowfile, it can be configured to throw an exception,  when triggered without a flowfile.\n"
+        + "\n"
+        + "The 'iterations' properties, such as \"Success iterations\", configure how many times each response should occur "
+        + "in succession before moving on to the next response within the group of flowfile responses or no flowfile"
+        + "responses.\n"
+        + "\n"
+        + "The order of responses when a flow file is received are:"
+        + "  1. transfer flowfile to success relationship.\n"
+        + "  2. transfer flowfile to failure relationship.\n"
+        + "  3. rollback the flowfile without penalty.\n"
+        + "  4. rollback the flowfile and yield the context.\n"
+        + "  5. rollback the flowfile with penalty.\n"
+        + "  6. throw an exception.\n"
+        + "\n"
+        + "The order of responses when no flow file is received are:"
+        + "  1. yield the context.\n"
+        + "  2. throw an exception.\n"
+        + "  3. do nothing and return.\n"
+        + "\n"
+        + "By default, the processor is configured to perform each response one time.  After processing the list of "
+        + "responses it will resume from the top of the list.\n"
+        + "\n"
+        + "To suppress any response, it's value can be set to zero (0) and no responses of that type will occur during "
+        + "processing.")
+public class DebugFlow extends AbstractProcessor {
+
+    private Set<Relationship> relationships = null;
+
+    static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Flowfiles processed successfully.")
+            .build();
+    static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("Flowfiles that failed to process.")
+            .build();
+
+    private List<PropertyDescriptor> propertyDescriptors = null;
+
+    static final PropertyDescriptor FF_SUCCESS_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("Success Iterations")
+            .description("Number of flowfiles to forward to success relationship.")
+            .required(true)
+            .defaultValue("1")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor FF_FAILURE_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("Failure Iterations")
+            .description("Number of flowfiles to forward to failure relationship.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor FF_ROLLBACK_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("Rollback Iterations")
+            .description("Number of flowfiles to roll back (without penalty).")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor FF_ROLLBACK_YIELD_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("Rollback Yield Iterations")
+            .description("Number of flowfiles to roll back and yield.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor FF_ROLLBACK_PENALTY_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("Rollback Penalty Iterations")
+            .description("Number of flowfiles to roll back with penalty.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor FF_EXCEPTION_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("Exception Iterations")
+            .description("Number of flowfiles to throw NPE exception.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    static final PropertyDescriptor NO_FF_EXCEPTION_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("No Flowfile Exception Iterations")
+            .description("Number of times to throw NPE exception if no flowfile.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor NO_FF_YIELD_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("No Flowfile Yield Iterations")
+            .description("Number of times to yield if no flowfile.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+    static final PropertyDescriptor NO_FF_SKIP_ITERATIONS = new PropertyDescriptor.Builder()
+            .name("No Flowfile Skip Iterations")
+            .description("Number of times to skip onTrigger if no flowfile.")
+            .required(true)
+            .defaultValue("1")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    Integer FF_SUCCESS_MAX = 0;
+    private Integer FF_FAILURE_MAX = 0;
+    private Integer FF_ROLLBACK_MAX = 0;
+    private Integer FF_YIELD_MAX = 0;
+    private Integer FF_PENALTY_MAX = 0;
+    private Integer FF_EXCEPTION_MAX = 0;
+
+    private Integer NO_FF_EXCEPTION_MAX = 0;
+    private Integer NO_FF_YIELD_MAX = 0;
+    private Integer NO_FF_SKIP_MAX = 0;
+
+    private Integer FF_SUCCESS_CURR = 0;
+    private Integer FF_FAILURE_CURR = 0;
+    private Integer FF_ROLLBACK_CURR = 0;
+    private Integer FF_YIELD_CURR = 0;
+    private Integer FF_PENALTY_CURR = 0;
+    private Integer FF_EXCEPTION_CURR = 0;
+
+    private Integer NO_FF_EXCEPTION_CURR = 0;
+    private Integer NO_FF_YIELD_CURR = 0;
+    private Integer NO_FF_SKIP_CURR = 0;
+
+    private FlowfileResponse curr_ff_resp;
+    private NoFlowfileResponse curr_noff_resp;
+
+    private enum FlowfileResponse {
+        FF_SUCCESS_RESPONSE(0, 1),
+        FF_FAILURE_RESPONSE(1, 2),
+        FF_ROLLBACK_RESPONSE(2, 3),
+        FF_YIELD_RESPONSE(3, 4),
+        FF_PENALTY_RESPONSE(4, 5),
+        FF_EXCEPTION_RESPONSE(5, 0);
+
+        private Integer id;
+        private Integer nextId;
+        private FlowfileResponse next;
+
+        private static final Map<Integer, FlowfileResponse> byId = new HashMap<>();
+        static {
+            for (FlowfileResponse rc : FlowfileResponse.values()) {
+                if (byId.put(rc.id, rc) != null) {
+                    throw new IllegalArgumentException("duplicate id: " + rc.id);
+                }
+            }
+            for (FlowfileResponse rc : FlowfileResponse.values()) {
+                rc.next = byId.get(rc.nextId);
+            }
+        }
+        FlowfileResponse(Integer pId, Integer pNext) {
+            id = pId;
+            nextId = pNext;
+        }
+        FlowfileResponse getNextCycle() {
+            return next;
+        }
+    }
+
+    private enum NoFlowfileResponse {
+        NO_FF_EXCEPTION_RESPONSE(0, 1),
+        NO_FF_YIELD_RESPONSE(1, 2),
+        NO_FF_SKIP_RESPONSE(2, 0);
+
+        private Integer id;
+        private Integer nextId;
+        private NoFlowfileResponse next;
+
+        private static final Map<Integer, NoFlowfileResponse> byId = new HashMap<>();
+        static {
+            for (NoFlowfileResponse rc : NoFlowfileResponse.values()) {
+                if (byId.put(rc.id, rc) != null) {
+                    throw new IllegalArgumentException("duplicate id: " + rc.id);
+                }
+            }
+            for (NoFlowfileResponse rc : NoFlowfileResponse.values()) {
+                rc.next = byId.get(rc.nextId);
+            }
+        }
+        NoFlowfileResponse(Integer pId, Integer pNext) {
+            id = pId;
+            nextId = pNext;
+        }
+        NoFlowfileResponse getNextCycle() {
+            return next;
+        }
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        if (relationships == null) {
+            HashSet<Relationship> relSet = new HashSet<>();
+            relSet.add(REL_SUCCESS);
+            relSet.add(REL_FAILURE);
+            relationships = Collections.unmodifiableSet(relSet);
+        }
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        if (propertyDescriptors == null) {
+            ArrayList<PropertyDescriptor> propList = new ArrayList<>();
+            propList.add(FF_SUCCESS_ITERATIONS);
+            propList.add(FF_FAILURE_ITERATIONS);
+            propList.add(FF_ROLLBACK_ITERATIONS);
+            propList.add(FF_ROLLBACK_YIELD_ITERATIONS);
+            propList.add(FF_ROLLBACK_PENALTY_ITERATIONS);
+            propList.add(FF_EXCEPTION_ITERATIONS);
+            propList.add(NO_FF_EXCEPTION_ITERATIONS);
+            propList.add(NO_FF_YIELD_ITERATIONS);
+            propList.add(NO_FF_SKIP_ITERATIONS);
+            propertyDescriptors = Collections.unmodifiableList(propList);
+        }
+        return propertyDescriptors;
+    }
+
+    @SuppressWarnings("unused")
+    @OnScheduled
+    public void onScheduled(ProcessContext context) {
+        FF_SUCCESS_MAX = context.getProperty(FF_SUCCESS_ITERATIONS).asInteger();
+        FF_FAILURE_MAX = context.getProperty(FF_FAILURE_ITERATIONS).asInteger();
+        FF_YIELD_MAX = context.getProperty(FF_ROLLBACK_YIELD_ITERATIONS).asInteger();
+        FF_ROLLBACK_MAX = context.getProperty(FF_ROLLBACK_ITERATIONS).asInteger();
+        FF_PENALTY_MAX = context.getProperty(FF_ROLLBACK_PENALTY_ITERATIONS).asInteger();
+        FF_EXCEPTION_MAX = context.getProperty(FF_EXCEPTION_ITERATIONS).asInteger();
+        NO_FF_EXCEPTION_MAX = context.getProperty(NO_FF_EXCEPTION_ITERATIONS).asInteger();
+        NO_FF_YIELD_MAX = context.getProperty(NO_FF_YIELD_ITERATIONS).asInteger();
+        NO_FF_SKIP_MAX = context.getProperty(NO_FF_SKIP_ITERATIONS).asInteger();
+        curr_ff_resp = FlowfileResponse.FF_SUCCESS_RESPONSE;
+        curr_noff_resp = NoFlowfileResponse.NO_FF_EXCEPTION_RESPONSE;
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        final ProcessorLog logger = getLogger();
+
+        FlowFile ff = session.get();
+
+        // Make up to 2 passes to allow rollover from last cycle to first.
+        // (This could be "while(true)" since responses should break out  if selected, but this
+        //  prevents endless loops in the event of unexpected errors or future changes.)
+        int pass = 2;
+        while (pass > 0) {
+            pass -= 1;
+            if (ff == null) {
+                if (curr_noff_resp == NoFlowfileResponse.NO_FF_EXCEPTION_RESPONSE) {
+                    if (NO_FF_EXCEPTION_CURR < NO_FF_EXCEPTION_MAX) {
+                        NO_FF_EXCEPTION_CURR += 1;
+                        logger.info("DebugFlow throwing NPE with no flow file");
+                        throw new NullPointerException("forced by " + this.getClass().getName());
+                    } else {
+                        NO_FF_EXCEPTION_CURR = 0;
+                        curr_noff_resp = curr_noff_resp.getNextCycle();
+                    }
+                }
+                if (curr_noff_resp == NoFlowfileResponse.NO_FF_YIELD_RESPONSE) {
+                    if (NO_FF_YIELD_CURR < NO_FF_YIELD_MAX) {
+                        NO_FF_YIELD_CURR += 1;
+                        logger.info("DebugFlow yielding with no flow file");
+                        context.yield();
+                        break;
+                    } else {
+                        NO_FF_YIELD_CURR = 0;
+                        curr_noff_resp = curr_noff_resp.getNextCycle();
+                    }
+                }
+                if (curr_noff_resp == NoFlowfileResponse.NO_FF_SKIP_RESPONSE) {
+                    if (NO_FF_SKIP_CURR < NO_FF_SKIP_MAX) {
+                        NO_FF_SKIP_CURR += 1;
+                        logger.info("DebugFlow skipping with no flow file");
+                        return;
+                    } else {
+                        NO_FF_SKIP_CURR = 0;
+                        curr_noff_resp = curr_noff_resp.getNextCycle();
+                    }
+                }
+                return;
+            } else {
+                if (curr_ff_resp == FlowfileResponse.FF_SUCCESS_RESPONSE) {
+                    if (FF_SUCCESS_CURR < FF_SUCCESS_MAX) {
+                        FF_SUCCESS_CURR += 1;
+                        logger.info("DebugFlow transferring to success file={} UUID={}",
+                                new Object[]{ff.getAttribute(CoreAttributes.FILENAME.key()),
+                                        ff.getAttribute(CoreAttributes.UUID.key())});
+                        session.transfer(ff, REL_SUCCESS);
+                        session.commit();
+                        break;
+                    } else {
+                        FF_SUCCESS_CURR = 0;
+                        curr_ff_resp = curr_ff_resp.getNextCycle();
+                    }
+                }
+                if (curr_ff_resp == FlowfileResponse.FF_FAILURE_RESPONSE) {
+                    if (FF_FAILURE_CURR < FF_FAILURE_MAX) {
+                        FF_FAILURE_CURR += 1;
+                        logger.info("DebugFlow transferring to failure file={} UUID={}",
+                                new Object[]{ff.getAttribute(CoreAttributes.FILENAME.key()),
+                                        ff.getAttribute(CoreAttributes.UUID.key())});
+                        session.transfer(ff, REL_FAILURE);
+                        session.commit();
+                        break;
+                    } else {
+                        FF_FAILURE_CURR = 0;
+                        curr_ff_resp = curr_ff_resp.getNextCycle();
+                    }
+                }
+                if (curr_ff_resp == FlowfileResponse.FF_ROLLBACK_RESPONSE) {
+                    if (FF_ROLLBACK_CURR < FF_ROLLBACK_MAX) {
+                        FF_ROLLBACK_CURR += 1;
+                        logger.info("DebugFlow rolling back (no penalty) file={} UUID={}",
+                                new Object[]{ff.getAttribute(CoreAttributes.FILENAME.key()),
+                                        ff.getAttribute(CoreAttributes.UUID.key())});
+                        session.rollback();
+                        session.commit();
+                        break;
+                    } else {
+                        FF_ROLLBACK_CURR = 0;
+                        curr_ff_resp = curr_ff_resp.getNextCycle();
+                    }
+                }
+                if (curr_ff_resp == FlowfileResponse.FF_YIELD_RESPONSE) {
+                    if (FF_YIELD_CURR < FF_YIELD_MAX) {
+                        FF_YIELD_CURR += 1;
+                        logger.info("DebugFlow yielding file={} UUID={}",
+                                new Object[]{ff.getAttribute(CoreAttributes.FILENAME.key()),
+                                        ff.getAttribute(CoreAttributes.UUID.key())});
+                        session.rollback();
+                        context.yield();
+                        return;
+                    } else {
+                        FF_YIELD_CURR = 0;
+                        curr_ff_resp = curr_ff_resp.getNextCycle();
+                    }
+                }
+                if (curr_ff_resp == FlowfileResponse.FF_PENALTY_RESPONSE) {
+                    if (FF_PENALTY_CURR < FF_PENALTY_MAX) {
+                        FF_PENALTY_CURR += 1;
+                        logger.info("DebugFlow rolling back (with penalty) file={} UUID={}",
+                                new Object[]{ff.getAttribute(CoreAttributes.FILENAME.key()),
+                                        ff.getAttribute(CoreAttributes.UUID.key())});
+                        session.rollback(true);
+                        session.commit();
+                        break;
+                    } else {
+                        FF_PENALTY_CURR = 0;
+                        curr_ff_resp = curr_ff_resp.getNextCycle();
+                    }
+                }
+                if (curr_ff_resp == FlowfileResponse.FF_EXCEPTION_RESPONSE) {
+                    if (FF_EXCEPTION_CURR < FF_EXCEPTION_MAX) {
+                        FF_EXCEPTION_CURR += 1;
+                        logger.info("DebugFlow throwing NPE file={} UUID={}",
+                                new Object[]{ff.getAttribute(CoreAttributes.FILENAME.key()),
+                                        ff.getAttribute(CoreAttributes.UUID.key())});
+                        throw new NullPointerException("forced by " + this.getClass().getName());
+                    } else {
+                        FF_EXCEPTION_CURR = 0;
+                        curr_ff_resp = curr_ff_resp.getNextCycle();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DebugFlow.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DebugFlow.java
@@ -167,7 +167,7 @@ public class DebugFlow extends AbstractProcessor {
             .build();
     static final PropertyDescriptor NO_FF_EXCEPTION_CLASS = new PropertyDescriptor.Builder()
             .name("No FlowFile Exception Class")
-            .description("Exception class to be thrown if no FlowFile (must extend java.lang.Exception).")
+            .description("Exception class to be thrown if no FlowFile (must extend java.lang.RuntimeException).")
             .required(true)
             .defaultValue("java.lang.Exception")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -179,7 +179,7 @@ public class DebugFlow extends AbstractProcessor {
                             .subject(subject)
                             .input(input)
                             .valid(klass != null && (RuntimeException.class.isAssignableFrom(klass)))
-                            .explanation(subject + " class must exist and extend java.lang.Exception")
+                            .explanation(subject + " class must exist and extend java.lang.RuntimeException")
                             .build();
                 }
             })
@@ -252,9 +252,11 @@ public class DebugFlow extends AbstractProcessor {
                 propList.add(FF_ROLLBACK_YIELD_ITERATIONS);
                 propList.add(FF_ROLLBACK_PENALTY_ITERATIONS);
                 propList.add(FF_EXCEPTION_ITERATIONS);
+                propList.add(FF_EXCEPTION_CLASS);
                 propList.add(NO_FF_EXCEPTION_ITERATIONS);
                 propList.add(NO_FF_YIELD_ITERATIONS);
                 propList.add(NO_FF_SKIP_ITERATIONS);
+                propList.add(NO_FF_EXCEPTION_CLASS);
                 propertyDescriptors.compareAndSet(null, Collections.unmodifiableList(propList));
             }
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -18,6 +18,7 @@ org.apache.nifi.processors.standard.CompressContent
 org.apache.nifi.processors.standard.ControlRate
 org.apache.nifi.processors.standard.ConvertCharacterSet
 org.apache.nifi.processors.standard.ConvertJSONToSQL
+org.apache.nifi.processors.standard.DebugFlow
 org.apache.nifi.processors.standard.DetectDuplicate
 org.apache.nifi.processors.standard.DistributeLoad
 org.apache.nifi.processors.standard.DuplicateFlowFile

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.DebugFlow/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.DebugFlow/additionalDetails.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+    <!--
+      Licensed to the Apache Software Foundation (ASF) under one or more
+      contributor license agreements.  See the NOTICE file distributed with
+      this work for additional information regarding copyright ownership.
+      The ASF licenses this file to You under the Apache License, Version 2.0
+      (the "License"); you may not use this file except in compliance with
+      the License.  You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    -->
+    <head>
+        <meta charset="utf-8"/>
+        <title>DebugFlow</title>
+        <link rel="stylesheet" href="../../css/component-usage.css" type="text/css"/>
+    </head>
+
+    <body>
+        <!-- Processor Documentation ================================================== -->
+        <p>
+            When triggered, the processor loops through the appropriate response list (based on whether or not it
+            received a FlowFile).  A response is produced the configured number of times for each pass through its
+            response list, as long as the processor is running.
+        </p><p>
+            Triggered by a FlowFile, the processor can produce the following responses.
+            <ol>
+                <li>transfer FlowFile to success relationship.</li>
+                <li>transfer FlowFile to failure relationship.</li>
+                <li>rollback the FlowFile without penalty.</li>
+                <li>rollback the FlowFile and yield the context.</li>
+                <li>rollback the FlowFile with penalty.</li>
+                <li>throw an exception.</li>
+            </ol>
+        </p><p>
+            Triggered without a FlowFile, the processor can produce the following responses.
+            <ol>
+                <li>do nothing and return.</li>
+                <li>throw an exception.</li>
+                <li>yield the context.</li>
+            </ol>
+        </p>
+    </body>
+</html>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDebugFlow.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDebugFlow.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TestDebugFlow {
+
+    private DebugFlowInspectable debugFlow;
+    private TestRunner runner;
+    private ProcessContext context;
+    private ProcessSession session;
+
+    final String content1 = "Hello, World 1!";
+    final String filename1 = "testFile1.txt";
+    final String content2 = "Hello, World 2!";
+    final String filename2 = "testFile2.txt";
+    final String content3 = "Hello, World 3!";
+    final String filename3 = "testFile3.txt";
+
+    Map<String, String> attribs1 = new HashMap<>();
+    Map<String, String> attribs2 = new HashMap<>();
+    Map<String, String> attribs3 = new HashMap<>();
+    Map<String, String> namesToContent = new HashMap<>();
+
+    @Before
+    public void setup() throws IOException {
+        debugFlow = new DebugFlowInspectable();
+        runner = TestRunners.newTestRunner(debugFlow);
+        context = runner.getProcessContext();
+        session = runner.getProcessSessionFactory().createSession();
+
+        attribs1.put(CoreAttributes.FILENAME.key(), filename1);
+        attribs1.put(CoreAttributes.UUID.key(), "TESTING-1234-TESTING");
+
+        attribs2.put(CoreAttributes.FILENAME.key(), filename2);
+        attribs2.put(CoreAttributes.UUID.key(), "TESTING-2345-TESTING");
+
+        attribs1.put(CoreAttributes.FILENAME.key(), filename3);
+        attribs3.put(CoreAttributes.UUID.key(), "TESTING-3456-TESTING");
+
+        namesToContent.put(filename1, content1);
+        namesToContent.put(filename2, content2);
+        namesToContent.put(filename3, content3);
+
+        // by default flowfiles go to success
+        runner.setProperty(DebugFlow.FF_SUCCESS_ITERATIONS, "1");
+        runner.setProperty(DebugFlow.FF_FAILURE_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_YIELD_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_PENALTY_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_EXCEPTION_ITERATIONS, "0");
+
+        // by default if triggered without flowfile nothing happens
+        runner.setProperty(DebugFlow.NO_FF_EXCEPTION_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.NO_FF_YIELD_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.NO_FF_SKIP_ITERATIONS, "1");
+    }
+
+    @Test
+    public void testGetSupportedPropertyDescriptors() throws Exception {
+        assertEquals(9, debugFlow.getPropertyDescriptors().size());
+    }
+
+    @Test
+    public void testGetRelationships() throws Exception {
+        assertEquals(2, debugFlow.getRelationships().size());
+    }
+
+    @Test
+    public void testSuccessMaxIsZeroUntilOnScheduled() throws Exception {
+        assertEquals(0L, debugFlow.getSuccessMax());
+        runner.assertValid();
+        runner.run();
+        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(),
+                debugFlow.getSuccessMax());
+    }
+
+    @Test
+    public void testSuccess() {
+        runner.assertValid();
+
+        runner.enqueue(content1.getBytes(), attribs1);
+        runner.enqueue(content2.getBytes(), attribs2);
+        runner.enqueue(content3.getBytes(), attribs3);
+
+        runner.run(4);
+        runner.assertTransferCount(DebugFlow.REL_SUCCESS, 3);
+        runner.assertTransferCount(DebugFlow.REL_FAILURE, 0);
+
+        runner.getFlowFilesForRelationship(DebugFlow.REL_SUCCESS).get(0).assertContentEquals(content1);
+        runner.getFlowFilesForRelationship(DebugFlow.REL_SUCCESS).get(1).assertContentEquals(content2);
+        runner.getFlowFilesForRelationship(DebugFlow.REL_SUCCESS).get(2).assertContentEquals(content3);
+    }
+
+    @Test
+    public void testFailure() {
+        runner.setProperty(DebugFlow.FF_SUCCESS_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_FAILURE_ITERATIONS, "1");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_YIELD_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_PENALTY_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_EXCEPTION_ITERATIONS, "0");
+        runner.assertValid();
+
+        runner.enqueue(content1.getBytes(), attribs1);
+        runner.enqueue(content2.getBytes(), attribs2);
+        runner.enqueue(content3.getBytes(), attribs3);
+
+        runner.run(4);
+        runner.assertTransferCount(DebugFlow.REL_SUCCESS, 0);
+        runner.assertTransferCount(DebugFlow.REL_FAILURE, 3);
+
+        runner.getFlowFilesForRelationship(DebugFlow.REL_FAILURE).get(0).assertContentEquals(content1);
+        runner.getFlowFilesForRelationship(DebugFlow.REL_FAILURE).get(1).assertContentEquals(content2);
+        runner.getFlowFilesForRelationship(DebugFlow.REL_FAILURE).get(2).assertContentEquals(content3);
+    }
+
+    @Test
+    public void testSuccessAndFailure() {
+        runner.setProperty(DebugFlow.FF_SUCCESS_ITERATIONS, "1");
+        runner.setProperty(DebugFlow.FF_FAILURE_ITERATIONS, "1");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_YIELD_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_PENALTY_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_EXCEPTION_ITERATIONS, "0");
+        runner.assertValid();
+
+        runner.enqueue(content1.getBytes(), attribs1);
+        runner.enqueue(content2.getBytes(), attribs2);
+        runner.enqueue(content3.getBytes(), attribs3);
+
+        runner.run(4);
+        runner.assertTransferCount(DebugFlow.REL_SUCCESS, 2);
+        runner.assertTransferCount(DebugFlow.REL_FAILURE, 1);
+
+        runner.getFlowFilesForRelationship(DebugFlow.REL_SUCCESS).get(0).assertContentEquals(content1);
+        runner.getFlowFilesForRelationship(DebugFlow.REL_SUCCESS).get(1).assertContentEquals(content3);
+        runner.getFlowFilesForRelationship(DebugFlow.REL_FAILURE).get(0).assertContentEquals(content2);
+    }
+
+    @Test
+    public void testYield() {
+        runner.setProperty(DebugFlow.FF_SUCCESS_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_FAILURE_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_YIELD_ITERATIONS, "1");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_PENALTY_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_EXCEPTION_ITERATIONS, "0");
+        runner.assertValid();
+
+        runner.enqueue(content1.getBytes(), attribs1);
+        runner.enqueue(content2.getBytes(), attribs2);
+        runner.enqueue(content3.getBytes(), attribs3);
+
+        runner.run(4);
+        runner.assertTransferCount(DebugFlow.REL_SUCCESS, 0);
+        runner.assertTransferCount(DebugFlow.REL_FAILURE, 0);
+
+        runner.assertQueueNotEmpty();
+        assertEquals(3, runner.getQueueSize().getObjectCount());
+    }
+
+    @Test
+    public void testRollback() throws IOException {
+        runner.setProperty(DebugFlow.FF_SUCCESS_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_FAILURE_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_ITERATIONS, "1");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_YIELD_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_ROLLBACK_PENALTY_ITERATIONS, "0");
+        runner.setProperty(DebugFlow.FF_EXCEPTION_ITERATIONS, "0");
+        runner.assertValid();
+
+        runner.enqueue(content1.getBytes(), attribs1);
+        runner.enqueue(content2.getBytes(), attribs2);
+        runner.enqueue(content3.getBytes(), attribs3);
+
+        runner.run(4);
+        runner.assertTransferCount(DebugFlow.REL_SUCCESS, 0);
+        runner.assertTransferCount(DebugFlow.REL_FAILURE, 0);
+
+        runner.assertQueueNotEmpty();
+        assertEquals(3, runner.getQueueSize().getObjectCount());
+
+        MockFlowFile ff1 = (MockFlowFile) session.get();
+        assertNotNull(ff1);
+        assertEquals(namesToContent.get(ff1.getAttribute(CoreAttributes.FILENAME.key())), new String(ff1.toByteArray()));
+        session.rollback();
+    }
+
+    private class DebugFlowInspectable extends DebugFlow {
+        public int getSuccessMax() {
+            return this.FF_SUCCESS_MAX;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDebugFlow.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDebugFlow.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertNotNull;
 
 public class TestDebugFlow {
 
-//    private DebugFlowInspectable debugFlow;
     private DebugFlow debugFlow;
     private TestRunner runner;
     private ProcessContext context;
@@ -51,7 +50,6 @@ public class TestDebugFlow {
 
     @Before
     public void setup() throws IOException {
-//        debugFlow = new DebugFlowInspectable();
         debugFlow = new DebugFlow();
         runner = TestRunners.newTestRunner(debugFlow);
         context = runner.getProcessContext();
@@ -98,13 +96,19 @@ public class TestDebugFlow {
     }
 
     @Test
-    public void testSuccessMaxIsZeroUntilOnScheduled() throws Exception {
-//        assertEquals(0L, debugFlow.getSuccessMax());
-        assertEquals(0L, debugFlow.FF_SUCCESS_MAX.longValue());
+    public void testFlowFileMaxSuccessIsZeroUntilOnScheduled() throws Exception {
+        assertEquals(0, debugFlow.flowFileMaxSuccess.intValue());
         runner.assertValid();
         runner.run();
-//        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(), debugFlow.getSuccessMax());
-        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(), debugFlow.FF_SUCCESS_MAX.longValue());
+        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(), debugFlow.flowFileMaxSuccess.intValue());
+    }
+
+    @Test
+    public void testNoFlowFileMaxSkipIsZeroUntilOnScheduled() throws Exception {
+        assertEquals(0, debugFlow.noFlowFileMaxSkip.intValue());
+        runner.assertValid();
+        runner.run();
+        assertEquals(context.getProperty(DebugFlow.NO_FF_SKIP_ITERATIONS).asInteger().intValue(), debugFlow.noFlowFileMaxSkip.intValue());
     }
 
     @Test
@@ -218,10 +222,4 @@ public class TestDebugFlow {
         assertEquals(namesToContent.get(ff1.getAttribute(CoreAttributes.FILENAME.key())), new String(ff1.toByteArray()));
         session.rollback();
     }
-
-//    private class DebugFlowInspectable extends DebugFlow {
-//        public int getSuccessMax() {
-//            return this.FF_SUCCESS_MAX;
-//        }
-//    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDebugFlow.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDebugFlow.java
@@ -34,36 +34,38 @@ import static org.junit.Assert.assertNotNull;
 
 public class TestDebugFlow {
 
-    private DebugFlowInspectable debugFlow;
+//    private DebugFlowInspectable debugFlow;
+    private DebugFlow debugFlow;
     private TestRunner runner;
     private ProcessContext context;
     private ProcessSession session;
 
-    final String content1 = "Hello, World 1!";
-    final String filename1 = "testFile1.txt";
-    final String content2 = "Hello, World 2!";
-    final String filename2 = "testFile2.txt";
-    final String content3 = "Hello, World 3!";
-    final String filename3 = "testFile3.txt";
+    private final String content1 = "Hello, World 1!";
+    private final String content2 = "Hello, World 2!";
+    private final String content3 = "Hello, World 3!";
 
-    Map<String, String> attribs1 = new HashMap<>();
-    Map<String, String> attribs2 = new HashMap<>();
-    Map<String, String> attribs3 = new HashMap<>();
-    Map<String, String> namesToContent = new HashMap<>();
+    private Map<String, String> attribs1 = new HashMap<>();
+    private Map<String, String> attribs2 = new HashMap<>();
+    private Map<String, String> attribs3 = new HashMap<>();
+    private Map<String, String> namesToContent = new HashMap<>();
 
     @Before
     public void setup() throws IOException {
-        debugFlow = new DebugFlowInspectable();
+//        debugFlow = new DebugFlowInspectable();
+        debugFlow = new DebugFlow();
         runner = TestRunners.newTestRunner(debugFlow);
         context = runner.getProcessContext();
         session = runner.getProcessSessionFactory().createSession();
 
+        String filename1 = "testFile1.txt";
         attribs1.put(CoreAttributes.FILENAME.key(), filename1);
         attribs1.put(CoreAttributes.UUID.key(), "TESTING-1234-TESTING");
 
+        String filename2 = "testFile2.txt";
         attribs2.put(CoreAttributes.FILENAME.key(), filename2);
         attribs2.put(CoreAttributes.UUID.key(), "TESTING-2345-TESTING");
 
+        String filename3 = "testFile3.txt";
         attribs1.put(CoreAttributes.FILENAME.key(), filename3);
         attribs3.put(CoreAttributes.UUID.key(), "TESTING-3456-TESTING");
 
@@ -97,11 +99,12 @@ public class TestDebugFlow {
 
     @Test
     public void testSuccessMaxIsZeroUntilOnScheduled() throws Exception {
-        assertEquals(0L, debugFlow.getSuccessMax());
+//        assertEquals(0L, debugFlow.getSuccessMax());
+        assertEquals(0L, debugFlow.FF_SUCCESS_MAX.longValue());
         runner.assertValid();
         runner.run();
-        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(),
-                debugFlow.getSuccessMax());
+//        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(), debugFlow.getSuccessMax());
+        assertEquals(context.getProperty(DebugFlow.FF_SUCCESS_ITERATIONS).asInteger().intValue(), debugFlow.FF_SUCCESS_MAX.longValue());
     }
 
     @Test
@@ -216,9 +219,9 @@ public class TestDebugFlow {
         session.rollback();
     }
 
-    private class DebugFlowInspectable extends DebugFlow {
-        public int getSuccessMax() {
-            return this.FF_SUCCESS_MAX;
-        }
-    }
+//    private class DebugFlowInspectable extends DebugFlow {
+//        public int getSuccessMax() {
+//            return this.FF_SUCCESS_MAX;
+//        }
+//    }
 }


### PR DESCRIPTION
* Create DebugFlow processor for use in testing and troubleshooting the processor framework.

* 0.x - commits as is.
* 1.x - in o.a.n.p.s.DebugFlow.java replace ProcessorLog references with ComponentLog.