### PR TITLE
NIFI-1918 Ignored failing test because timing is not deterministic an…

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
@@ -22,6 +22,7 @@ import org.apache.nifi.util.TestRunners
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -149,6 +150,7 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         }
     }
 
+    @Ignore("This test fails intermittently when the serial execution happens faster than pooled")
     @Test
     public void testPooledExecutionShouldBeFaster() throws Exception {
         // Arrange


### PR DESCRIPTION
…d should not be used in unit test.

I did not delete the test because it is still illustrative in most cases of the relative differences in execution time, but in some scenarios (thread-starved hardware?) the serial execution can finish faster than pooled. 