### PR TITLE
NIFI-1265: Upgrading to Jetty 9.3

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
@@ -51,27 +51,22 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jsp</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
@@ -77,24 +77,8 @@
             <version>1.7</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/pom.xml
@@ -43,24 +43,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/src/main/java/org/apache/nifi/web/docs/DocumentationController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/src/main/java/org/apache/nifi/web/docs/DocumentationController.java
@@ -16,27 +16,24 @@
  */
 package org.apache.nifi.web.docs;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.nar.ExtensionMapping;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.Collator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.nifi.nar.ExtensionMapping;
-import org.apache.commons.lang3.StringUtils;
-
 /**
  *
  */
-@WebServlet(name = "DocumenationController", urlPatterns = {"/*"})
 public class DocumentationController extends HttpServlet {
 
     private static final int GENERAL_LINK_COUNT = 4;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/pom.xml
@@ -30,22 +30,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
@@ -72,18 +72,16 @@
                 must exclude them here.
             -->
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-jspc-maven-plugin</artifactId>
-                <version>8.1.10.v20130312</version>
+                <version>${jetty.version}</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>jspc</goal>
                         </goals>
                         <configuration>
-                            <packageRoot>org.apache.nifi.web.jsp</packageRoot>
                             <keepSources>true</keepSources>
-                            <verbose>true</verbose>
                             <useProvidedScope>true</useProvidedScope>
                             <excludes>
                                 **/message-page.jsp,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
@@ -761,22 +761,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>            
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/java/org/apache/nifi/web/servlet/DownloadSvg.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/java/org/apache/nifi/web/servlet/DownloadSvg.java
@@ -16,20 +16,19 @@
  */
 package org.apache.nifi.web.servlet;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 /**
  *
  */
-@WebServlet(name = "DownloadSvg", urlPatterns = {"/download-svg"})
 public class DownloadSvg extends HttpServlet {
 
     private static final Logger logger = LoggerFactory.getLogger(DownloadSvg.class);

--- a/nifi-nar-bundles/nifi-image-bundle/nifi-image-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-image-bundle/nifi-image-viewer/pom.xml
@@ -33,18 +33,6 @@
             <artifactId>nifi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-image-bundle/nifi-image-viewer/src/main/java/org/apache/nifi/web/ImageViewerController.java
+++ b/nifi-nar-bundles/nifi-image-bundle/nifi-image-viewer/src/main/java/org/apache/nifi/web/ImageViewerController.java
@@ -16,16 +16,13 @@
  */
 package org.apache.nifi.web;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-
 import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
 
-@WebServlet(name = "ImageViewer", urlPatterns = {"/view-content"})
 public class ImageViewerController extends HttpServlet {
 
     /**

--- a/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
@@ -49,32 +49,22 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jsp</artifactId>
+            <artifactId>jetty-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>apache-jsp</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>apache-jstl</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-jsp-jdt</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
@@ -56,24 +56,8 @@
             <artifactId>nifi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
@@ -17,12 +17,9 @@
 package org.apache.nifi.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import org.apache.nifi.web.ViewableContent.DisplayMode;
 
 import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -33,9 +30,10 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import org.apache.nifi.web.ViewableContent.DisplayMode;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
-@WebServlet(name = "StandardContentViewer", urlPatterns = {"/view-content"})
 public class StandardContentViewerController extends HttpServlet {
 
     /**

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
@@ -124,7 +124,7 @@ public class TestInvokeHTTP extends TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     // Currently InvokeHttp does not support Proxy via Https
@@ -171,7 +171,7 @@ public class TestInvokeHTTP extends TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     public static class MyProxyHandler extends AbstractHandler {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
@@ -16,16 +16,6 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.nifi.processors.standard.util.TestInvokeHttpCommon;
 import org.apache.nifi.ssl.StandardSSLContextService;
 import org.apache.nifi.util.MockFlowFile;
@@ -38,6 +28,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class TestInvokeHTTP extends TestInvokeHttpCommon {
@@ -183,7 +182,7 @@ public class TestInvokeHTTP extends TestInvokeHttpCommon {
 
             if ("Get".equalsIgnoreCase(request.getMethod())) {
                 response.setStatus(200);
-                String proxyPath = baseRequest.getUri().toString();
+                String proxyPath = baseRequest.getHttpURI().toString();
                 response.setContentLength(proxyPath.length());
                 response.setContentType("text/plain");
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestInvokeHttpCommon.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestInvokeHttpCommon.java
@@ -132,7 +132,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
 
         final List<ProvenanceEventRecord> provEvents = runner.getProvenanceEvents();
         assertEquals(2, provEvents.size());
@@ -185,7 +185,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "404");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "Not Found");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -225,7 +225,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "404");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "Not Found");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -266,8 +266,8 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
-        bundle1.assertAttributeEquals("mime.type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
+        bundle1.assertAttributeEquals("mime.type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -311,7 +311,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "404");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "Not Found");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
 
@@ -349,7 +349,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
         bundle1.assertAttributeEquals("double", "1, 2");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -378,7 +378,7 @@ public abstract class TestInvokeHttpCommon {
         bundle.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle.assertAttributeEquals("Foo", "Bar");
         bundle.assertAttributeEquals("double", "1, 2");
-        bundle.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
 
         // expected in response
         // status code, status message, all headers from server response --> ff attributes
@@ -389,7 +389,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
         bundle1.assertAttributeEquals("double", "1, 2");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -445,7 +445,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertContentEquals("/status/200".getBytes("UTF-8"));
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -547,7 +547,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
 
         final List<ProvenanceEventRecord> provEvents = runner.getProvenanceEvents();
         assertEquals(2, provEvents.size());
@@ -641,7 +641,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -683,7 +683,7 @@ public abstract class TestInvokeHttpCommon {
                 "<h2>HTTP ERROR: 401</h2>\n" +
                 "<p>Problem accessing /status/200. Reason:\n" +
                 "<pre>    Unauthorized</pre></p>\n" +
-                "<hr /><i><small>Powered by Jetty://</small></i>\n" +
+                "<hr /><a href=\"http://eclipse.org/jetty\">Powered by Jetty:// 9.3.9.v20160517</a><hr/>\n" +
                 "</body>\n" +
                 "</html>\n", response);
     }
@@ -752,6 +752,7 @@ public abstract class TestInvokeHttpCommon {
 
         createFlowFiles(runner);
 
+        //assertTrue(server.jetty.isRunning());
         runner.run();
         runner.assertTransferCount(InvokeHTTP.REL_SUCCESS_REQ, 0);
         runner.assertTransferCount(InvokeHTTP.REL_RESPONSE, 0);
@@ -885,7 +886,6 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain");
         final String actual1 = new String(bundle1.toByteArray(), StandardCharsets.UTF_8);
         final String expected1 = "";
         Assert.assertEquals(expected1, actual1);
@@ -1164,7 +1164,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("dynamicHeader","yes!");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
     @Test
@@ -1279,7 +1279,7 @@ public abstract class TestInvokeHttpCommon {
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_CODE, "200");
         bundle1.assertAttributeEquals(InvokeHTTP.STATUS_MESSAGE, "OK");
         bundle1.assertAttributeEquals("Foo", "Bar");
-        bundle1.assertAttributeEquals("Content-Type", "text/plain; charset=ISO-8859-1");
+        bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
         final String actual1 = new String(bundle1.toByteArray(), StandardCharsets.UTF_8);
         final String expected1 = "/status/200";
         Assert.assertEquals(expected1, actual1);
@@ -1408,10 +1408,15 @@ public abstract class TestInvokeHttpCommon {
             final int status = Integer.valueOf(target.substring("/status".length() + 1));
             response.setStatus(status);
 
-            response.setContentType("text/plain");
-            response.setContentLength(target.length());
-
             if ("GET".equalsIgnoreCase(request.getMethod())) {
+                if (status == 304){
+                    // Status code 304 ("Not Modified") must not contain a message body
+                    return;
+                }
+
+                response.setContentType("text/plain");
+                response.setContentLength(target.length());
+
                 try (PrintWriter writer = response.getWriter()) {
                     writer.print(target);
                     writer.flush();

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/pom.xml
@@ -56,24 +56,8 @@
             <artifactId>nifi-expression-language</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@ language governing permissions and limitations under the License. -->
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <org.slf4j.version>1.7.12</org.slf4j.version>
-        <jetty.version>9.2.11.v20150529</jetty.version>
+        <jetty.version>9.3.9.v20160517</jetty.version>
         <lucene.version>4.10.4</lucene.version>
         <spring.version>4.2.4.RELEASE</spring.version>
         <spring.security.version>4.0.3.RELEASE</spring.security.version>
@@ -696,38 +696,26 @@ language governing permissions and limitations under the License. -->
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jsp</artifactId>
+                <artifactId>jetty-annotations</artifactId>
                 <version>${jetty.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>javax.servlet.jsp-api</artifactId>
-                <version>2.3.1</version>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>apache-jsp</artifactId>
+                <version>${jetty.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-                <version>3.0.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet.jsp.jstl</groupId>
-                <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-                <version>1.2.1</version>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>apache-jstl</artifactId>
+                <version>${jetty.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.toolchain</groupId>
-                <artifactId>jetty-jsp-jdt</artifactId>
-                <version>2.3.3</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR should only be applied to master as Jetty 9.3 requires Java 8. 