### PR TITLE
NIFI-1754 Rollback log messages should include the flowfile filename …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -861,6 +861,11 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
     }
 
     private void rollback(final boolean penalize, final boolean rollbackCheckpoint) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} session rollback called, FlowFile records are {} {}",
+                    this, loggableFlowfileInfo(), new Throwable("Stack Trace on rollback"));
+        }
+
         deleteOnCommit.clear();
 
         final Set<StandardRepositoryRecord> recordsToHandle = new HashSet<>();
@@ -949,6 +954,45 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
         acknowledgeRecords();
         resetState();
     }
+
+    private String loggableFlowfileInfo() {
+        final StringBuilder details = new StringBuilder(1024).append("[");
+        final int initLen = details.length();
+        int filesListed = 0;
+        int maxRollbackFlowfilesToLog = 5;
+        for (Map.Entry<FlowFileRecord, StandardRepositoryRecord> entry : records.entrySet()) {
+            final FlowFileRecord entryKey = entry.getKey();
+            final StandardRepositoryRecord entryValue = entry.getValue();
+            if (details.length() > initLen) {
+                details.append(", ");
+            }
+            if (entryValue.getOriginalQueue() != null && entryValue.getOriginalQueue().getIdentifier() != null) {
+                details.append("queue=")
+                        .append(entryValue.getOriginalQueue().getIdentifier())
+                        .append("/");
+            }
+            details.append("filename=")
+                    .append(entryKey.getAttribute(CoreAttributes.FILENAME.key()))
+                    .append("/uuid=")
+                    .append(entryKey.getAttribute(CoreAttributes.UUID.key()));
+            filesListed++;
+            if (filesListed > maxRollbackFlowfilesToLog) {
+                break;
+            }
+        }
+        if (filesListed > maxRollbackFlowfilesToLog) {
+            if (details.length() > initLen) {
+                details.append(", ");
+            }
+            details.append(records.entrySet().size() - maxRollbackFlowfilesToLog)
+                    .append(" additional Flowfiles not listed");
+        } else if (filesListed == 0) {
+            details.append("none");
+        }
+        details.append("]");
+        return details.toString();
+    }
+
 
     private void removeContent(final ContentClaim claim) {
         if (claim == null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -136,7 +136,7 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
     // so that we are able to aggregate many into a single Fork Event.
     private final Map<FlowFile, ProvenanceEventBuilder> forkEventBuilders = new HashMap<>();
 
-    private int maxRollbackFlowfilesToLog = 5;
+    private final int MAX_ROLLBACK_FLOWFILES_TO_LOG = 5;
 
     private Checkpoint checkpoint = new Checkpoint();
 
@@ -962,7 +962,7 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
         final int initLen = details.length();
         int filesListed = 0;
         for (Map.Entry<FlowFileRecord, StandardRepositoryRecord> entry : records.entrySet()) {
-            if (filesListed >= maxRollbackFlowfilesToLog) {
+            if (filesListed >= MAX_ROLLBACK_FLOWFILES_TO_LOG) {
                 break;
             }
             filesListed++;
@@ -981,11 +981,11 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
                     .append("/uuid=")
                     .append(entryKey.getAttribute(CoreAttributes.UUID.key()));
         }
-        if (records.entrySet().size() > maxRollbackFlowfilesToLog) {
+        if (records.entrySet().size() > MAX_ROLLBACK_FLOWFILES_TO_LOG) {
             if (details.length() > initLen) {
                 details.append(", ");
             }
-            details.append(records.entrySet().size() - maxRollbackFlowfilesToLog)
+            details.append(records.entrySet().size() - MAX_ROLLBACK_FLOWFILES_TO_LOG)
                     .append(" additional Flowfiles not listed");
         } else if (filesListed == 0) {
             details.append("none");


### PR DESCRIPTION
…and UUID to assist in flow management.  Incorporates debug logging into StandardProcessSession.rollback() to list Flowfile records retreived from the session.