### PR TITLE
NiFi 1945 - Corrects minor issue in HashContent "<Hash Attribute Name>" description

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HashContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HashContent.java
@@ -57,7 +57,7 @@ import org.apache.nifi.util.ObjectHolder;
 @CapabilityDescription("Calculates a hash value for the Content of a FlowFile and puts that hash value on the FlowFile as an attribute whose name "
         + "is determined by the <Hash Attribute Name> property")
 @WritesAttribute(attribute = "<Hash Attribute Name>", description = "This Processor adds an attribute whose value is the result of Hashing the "
-        + "existing FlowFile attributes. The name of this attribute is specified by the <Hash Attribute Name> property")
+        + "existing FlowFile content. The name of this attribute is specified by the <Hash Attribute Name> property")
 public class HashContent extends AbstractProcessor {
 
     public static final PropertyDescriptor ATTRIBUTE_NAME = new PropertyDescriptor.Builder()


### PR DESCRIPTION
Fixes typo identified in NIFI-1945