### PR TITLE
NIFI-1978: Restore RPG yield duration.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowFromDOMFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowFromDOMFactory.java
@@ -253,6 +253,7 @@ public class FlowFromDOMFactory {
         dto.setTransmitting(getBoolean(element, "transmitting"));
         dto.setPosition(getPosition(DomUtils.getChild(element, "position")));
         dto.setCommunicationsTimeout(getString(element, "timeout"));
+        dto.setYieldDuration(getString(element, "yieldPeriod"));
         dto.setComments(getString(element, "comment"));
 
         return dto;


### PR DESCRIPTION
The persisted configuration value was not restored properly, and it will be reset to default value 10 sec after restarting NiFi.

I found this issue while I'm working on HTTP Site-to-Site, for master branch, PR #497 has the same fix in it. So, this PR is only meant for 0.x branch.