### PR TITLE
NIFI-1981 Cluster communication without client certificate

### DIFF
--- a/nifi-commons/nifi-security-utils/pom.xml
+++ b/nifi-commons/nifi-security-utils/pom.xml
@@ -30,6 +30,16 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 


### PR DESCRIPTION
This PR resolves an issue where cluster communications were failing when the node sent a heartbeat without a client certificate chain because `nifi.security.needClientAuth` was set to false on the NCM. Even though the TLS negotiation did not require or expect a client certificate and the handshake was successful, the NiFi code in `SocketProtocolListener` immediately attempted to determine the incoming node's DN from the certificate, which was missing, and thus `SSLSocketImpl` threw an `SSLPeerNotVerifiedException` saying "peer not authenticated". 

With this patch, the NCM will now respect the `needClientAuth` setting when attempting to extract the node DN. 

This PR is targeted to the `0.x` branch as this is where the issue was discovered and does not merge cleanly with the `master` branch. These changes will need to be selectively merged to the `master` branch. 