### PR TITLE
NIFI-1982: Use Compressed check box value.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -131,6 +131,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
             .url(remoteGroup.getTargetUri().toString())
             .portIdentifier(getIdentifier())
             .sslContext(sslContext)
+            .useCompression(isUseCompression())
             .eventReporter(remoteGroup.getEventReporter())
             .peerPersistenceFile(getPeerPersistenceFile(getIdentifier()))
             .nodePenalizationPeriod(penalizationMillis, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
- The Compressed check box UI input was not used
- This commit enables Site-to-Site compression configuration from UI