### PR TITLE
fixes NIFI-1989

### DIFF
--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- External dependencies -->
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>1.3.2</version>
         </dependency>


### PR DESCRIPTION
Fixes : https://issues.sonatype.org/browse/MVNCENTRAL-244

> Taking a look at the POM at http://repo1.maven.org/maven2/org/apache/commons/commons-io/1.3.2/commons-io-1.3.2.pom, the groupId and artifactId are different from the deploy path and it seems the identical artifacts are available at http://repo1.maven.org/maven2/commons-io/commons-io/1.3.2/
Having the same classes available under two different GAV coordinates may lead to a lot of problems should one decide to update the component to a new version. I see a lot of old builds could break when we delete from the old coordinates, but what about a (correct) relocation POM? Builds would continue to work and the mishap would appear on the screen.