### PR TITLE
NIFI-1997: Use the 'autoResumeState' property defined in nifi.properties on each node instead of inheriting the property from the Cluster Coordinator

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/StandardDataFlow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/StandardDataFlow.java
@@ -34,8 +34,6 @@ public class StandardDataFlow implements Serializable, DataFlow {
     private final byte[] flow;
     private final byte[] snippetBytes;
 
-    private boolean autoStartProcessors;
-
     /**
      * Constructs an instance.
      *
@@ -55,7 +53,6 @@ public class StandardDataFlow implements Serializable, DataFlow {
     public StandardDataFlow(final DataFlow toCopy) {
         this.flow = copy(toCopy.getFlow());
         this.snippetBytes = copy(toCopy.getSnippets());
-        this.autoStartProcessors = toCopy.isAutoStartProcessors();
     }
 
     private static byte[] copy(final byte[] bytes) {
@@ -71,21 +68,5 @@ public class StandardDataFlow implements Serializable, DataFlow {
     @Override
     public byte[] getSnippets() {
         return snippetBytes;
-    }
-
-    @Override
-    public boolean isAutoStartProcessors() {
-        return autoStartProcessors;
-    }
-
-    /**
-     *
-     * Sets the flag to automatically start processors at application startup.
-     *
-     * @param autoStartProcessors true if processors should be automatically
-     * started at application startup; false otherwise
-     */
-    public void setAutoStartProcessors(final boolean autoStartProcessors) {
-        this.autoStartProcessors = autoStartProcessors;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/message/AdaptedDataFlow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/message/AdaptedDataFlow.java
@@ -23,11 +23,6 @@ public class AdaptedDataFlow {
     private byte[] flow;
     private byte[] snippets;
 
-    private boolean autoStartProcessors;
-
-    public AdaptedDataFlow() {
-    }
-
     public byte[] getFlow() {
         return flow;
     }
@@ -43,13 +38,4 @@ public class AdaptedDataFlow {
     public void setSnippets(byte[] snippets) {
         this.snippets = snippets;
     }
-
-    public boolean isAutoStartProcessors() {
-        return autoStartProcessors;
-    }
-
-    public void setAutoStartProcessors(boolean runningAllProcessors) {
-        this.autoStartProcessors = runningAllProcessors;
-    }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/message/DataFlowAdapter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/message/DataFlowAdapter.java
@@ -32,7 +32,6 @@ public class DataFlowAdapter extends XmlAdapter<AdaptedDataFlow, DataFlow> {
         if (df != null) {
             aDf.setFlow(df.getFlow());
             aDf.setSnippets(df.getSnippets());
-            aDf.setAutoStartProcessors(df.isAutoStartProcessors());
         }
 
         return aDf;
@@ -41,7 +40,6 @@ public class DataFlowAdapter extends XmlAdapter<AdaptedDataFlow, DataFlow> {
     @Override
     public DataFlow unmarshal(final AdaptedDataFlow aDf) {
         final StandardDataFlow dataFlow = new StandardDataFlow(aDf.getFlow(), aDf.getSnippets());
-        dataFlow.setAutoStartProcessors(aDf.isAutoStartProcessors());
         return dataFlow;
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/cluster/protocol/DataFlow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/cluster/protocol/DataFlow.java
@@ -28,9 +28,4 @@ public interface DataFlow {
      */
     public byte[] getSnippets();
 
-    /**
-     * @return true if processors should be automatically started at application
-     * startup; false otherwise
-     */
-    public boolean isAutoStartProcessors();
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -855,7 +855,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
             controller.setConnectionStatus(new NodeConnectionStatus(nodeId, NodeConnectionState.CONNECTED));
 
             // start the processors as indicated by the dataflow
-            controller.onFlowInitialized(dataFlow.isAutoStartProcessors());
+            controller.onFlowInitialized(autoResumeState);
 
             loadSnippets(dataFlow.getSnippets());
 


### PR DESCRIPTION
Use the 'autoResumeState' property defined in nifi.properties on each node instead of inheriting the property from the Cluster Coordinator