### PR TITLE
NIFI-1955: Deprecate IntegerHolder, LongHolder, BooleanHolder

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/BooleanHolder.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/BooleanHolder.java
@@ -16,6 +16,18 @@
  */
 package org.apache.nifi.util;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @deprecated As of release 1.0.1. Please use {@link AtomicBoolean}
+ *
+ * Wraps an Boolean value so that it can be declared <code>final</code> and still be accessed from inner classes;
+ * the functionality is similar to that of an AtomicBoolean, but operations on this class
+ * are not atomic. This results in greater performance when the atomicity is not needed.
+ *
+ */
+
+@Deprecated
 public class BooleanHolder extends ObjectHolder<Boolean> {
 
     public BooleanHolder(final boolean initialValue) {

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/IntegerHolder.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/IntegerHolder.java
@@ -16,6 +16,18 @@
  */
 package org.apache.nifi.util;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @deprecated As of release 1.0.1. Please use {@link AtomicInteger}
+ *
+ * Wraps an Integer value so that it can be declared <code>final</code> and still be accessed from inner classes;
+ * the functionality is similar to that of an AtomicInteger, but operations on this class
+ * are not atomic. This results in greater performance when the atomicity is not needed.
+ *
+ */
+
+@Deprecated
 public class IntegerHolder extends ObjectHolder<Integer> {
 
     public IntegerHolder(final int initialValue) {
@@ -48,7 +60,4 @@ public class IntegerHolder extends ObjectHolder<Integer> {
         return addAndGet(-1);
     }
 
-    public int getAndDecrement() {
-        return getAndAdd(-1);
-    }
 }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/LongHolder.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/LongHolder.java
@@ -16,10 +16,17 @@
  */
 package org.apache.nifi.util;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
- * Wraps a Long value so that it can be declared <code>final</code> and still be accessed from which inner classes; the functionality is similar to that of an AtomicLong, but operations on this class
+ * @deprecated As of release 1.0.1. Please use {@link AtomicLong}
+ *
+ * Wraps a Long value so that it can be declared <code>final</code> and still be accessed from inner classes;
+ * the functionality is similar to that of an AtomicLong, but operations on this class
  * are not atomic. This results in greater performance when the atomicity is not needed.
  */
+
+@Deprecated
 public class LongHolder extends ObjectHolder<Long> {
 
     public LongHolder(final long initialValue) {


### PR DESCRIPTION
NIFI-1955: Deprecate IntegerHolder, LongHolder, BooleanHolder