### PR TITLE
NIFI-1895 for 0.x

### DIFF
--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/AbstractPutHBase.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/AbstractPutHBase.java
@@ -17,7 +17,14 @@
 package org.apache.nifi.hbase;
 
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.hbase.put.PutFlowFile;
@@ -27,12 +34,6 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Base class for processors that put data to HBase.
@@ -179,5 +180,12 @@ public abstract class AbstractPutHBase extends AbstractProcessor {
      * @return a PutFlowFile instance for the given FlowFile
      */
     protected abstract PutFlowFile createPut(final ProcessSession session, final ProcessContext context, final FlowFile flowFile);
+
+    protected HBaseClientService cliSvc;
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        cliSvc = context.getProperty(HBASE_CLIENT_SERVICE).asControllerService(HBaseClientService.class);
+    }
 
 }

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseJSON.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseJSON.java
@@ -89,6 +89,25 @@ public class PutHBaseJSON extends AbstractPutHBase {
             .defaultValue(COMPLEX_FIELD_TEXT.getValue())
             .build();
 
+    protected static final String STRING_ENCODING_VALUE = "String";
+    protected static final String BYTES_ENCODING_VALUE = "Bytes";
+
+    protected static final AllowableValue FIELD_ENCODING_STRING = new AllowableValue(STRING_ENCODING_VALUE, STRING_ENCODING_VALUE,
+            "Stores the value of each field as a UTF-8 String.");
+    protected static final AllowableValue FIELD_ENCODING_BYTES = new AllowableValue(BYTES_ENCODING_VALUE, BYTES_ENCODING_VALUE,
+            "Stores the value of each field as the byte representation of the type derived from the JSON.");
+
+    protected static final PropertyDescriptor FIELD_ENCODING_STRATEGY = new PropertyDescriptor.Builder()
+            .name("Field Encoding Strategy")
+            .description(("Indicates how to store the value of each field in HBase. The default behavior is to convert each value from the " +
+                    "JSON to a String, and store the UTF-8 bytes. Choosing Bytes will interpret the type of each field from " +
+                    "the JSON, and convert the value to the byte representation of that type, meaning an integer will be stored as the " +
+                    "byte representation of that integer."))
+            .required(true)
+            .allowableValues(FIELD_ENCODING_STRING, FIELD_ENCODING_BYTES)
+            .defaultValue(FIELD_ENCODING_STRING.getValue())
+            .build();
+
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         final List<PropertyDescriptor> properties = new ArrayList<>();
@@ -99,6 +118,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
         properties.add(COLUMN_FAMILY);
         properties.add(BATCH_SIZE);
         properties.add(COMPLEX_FIELD_STRATEGY);
+        properties.add(FIELD_ENCODING_STRATEGY);
         return properties;
     }
 
@@ -142,6 +162,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
         final String columnFamily = context.getProperty(COLUMN_FAMILY).evaluateAttributeExpressions(flowFile).getValue();
         final boolean extractRowId = !StringUtils.isBlank(rowFieldName);
         final String complexFieldStrategy = context.getProperty(COMPLEX_FIELD_STRATEGY).getValue();
+        final String fieldEncodingStrategy = context.getProperty(FIELD_ENCODING_STRATEGY).getValue();
 
         // Parse the JSON document
         final ObjectMapper mapper = new ObjectMapper();
@@ -180,7 +201,13 @@ public class PutHBaseJSON extends AbstractPutHBase {
             if (fieldNode.isNull()) {
                 getLogger().debug("Skipping {} because value was null", new Object[]{fieldName});
             } else if (fieldNode.isValueNode()) {
-                fieldValueHolder.set(extractJNodeValue(fieldNode));
+                // for a value node we need to determine if we are storing the bytes of a string, or the bytes of actual types
+                if (STRING_ENCODING_VALUE.equals(fieldEncodingStrategy)) {
+                    final byte[] valueBytes = clientService.toBytes(fieldNode.asText());
+                    fieldValueHolder.set(valueBytes);
+                } else {
+                    fieldValueHolder.set(extractJNodeValue(fieldNode));
+                }
             } else {
                 // for non-null, non-value nodes, determine what to do based on the handling strategy
                 switch (complexFieldStrategy) {
@@ -193,7 +220,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
                     case TEXT_VALUE:
                         // use toString() here because asText() is only guaranteed to be supported on value nodes
                         // some other types of nodes, like ArrayNode, provide toString implementations
-                        fieldValueHolder.set(cliSvc.toBytes(fieldNode.toString()));
+                        fieldValueHolder.set(clientService.toBytes(fieldNode.toString()));
                         break;
                     case IGNORE_VALUE:
                         // silently skip
@@ -229,21 +256,21 @@ public class PutHBaseJSON extends AbstractPutHBase {
     /*
      *Handles the conversion of the JsonNode value into it correct underlying data type in the form of a byte array as expected by the columns.add function
      */
-    private byte[] extractJNodeValue(JsonNode n){
+    private byte[] extractJNodeValue(final JsonNode n){
         if (n.isBoolean()){
             //boolean
-            return cliSvc.toBytes(n.asBoolean());
+            return clientService.toBytes(n.asBoolean());
         }else if(n.isNumber()){
             if(n.isIntegralNumber()){
                 //interpret as Long
-                return cliSvc.toBytes(n.asLong());
+                return clientService.toBytes(n.asLong());
             }else{
                 //interpret as Double
-                return cliSvc.toBytes(n.asDouble());
+                return clientService.toBytes(n.asDouble());
             }
         }else{
             //if all else fails, interpret as String
-            return cliSvc.toBytes(n.asText());
+            return clientService.toBytes(n.asText());
         }
     }
 

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/HBaseTestUtil.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/HBaseTestUtil.java
@@ -17,20 +17,20 @@
  */
 package org.apache.nifi.hbase;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.nifi.hbase.put.PutColumn;
 import org.apache.nifi.hbase.put.PutFlowFile;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
-
 public class HBaseTestUtil {
 
-    public static void verifyPut(final String row, final String columnFamily, final Map<String,String> columns, final List<PutFlowFile> puts) {
+    public static void verifyPut(final String row, final String columnFamily, final Map<String,byte[]> columns, final List<PutFlowFile> puts) {
         boolean foundPut = false;
 
         for (final PutFlowFile put : puts) {
@@ -45,13 +45,12 @@ public class HBaseTestUtil {
             // start off assuming we have all the columns
             boolean foundAllColumns = true;
 
-            for (Map.Entry<String, String> entry : columns.entrySet()) {
+            for (Map.Entry<String, byte[]> entry : columns.entrySet()) {
                 // determine if we have the current expected column
                 boolean foundColumn = false;
                 for (PutColumn putColumn : put.getColumns()) {
-                    final String colVal = new String(putColumn.getBuffer(), StandardCharsets.UTF_8);
                     if (columnFamily.equals(putColumn.getColumnFamily()) && entry.getKey().equals(putColumn.getColumnQualifier())
-                            && entry.getValue().equals(colVal)) {
+                            && Arrays.equals(entry.getValue(), putColumn.getBuffer())) {
                         foundColumn = true;
                         break;
                     }

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/MockHBaseClientService.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/MockHBaseClientService.java
@@ -105,4 +105,30 @@ public class MockHBaseClientService extends AbstractControllerService implements
     public void setThrowException(boolean throwException) {
         this.throwException = throwException;
     }
+
+    @Override
+    public byte[] toBytes(final boolean b) {
+        return new byte[] { b ? (byte) -1 : (byte) 0 };
+    }
+
+    @Override
+    public byte[] toBytes(long l) {
+        byte [] b = new byte[8];
+        for (int i = 7; i > 0; i--) {
+          b[i] = (byte) l;
+          l >>>= 8;
+        }
+        b[0] = (byte) l;
+        return b;
+    }
+
+    @Override
+    public byte[] toBytes(final double d) {
+        return toBytes(Double.doubleToRawLongBits(d));
+    }
+
+    @Override
+    public byte[] toBytes(final String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
 }

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/TestPutHBaseJSON.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/TestPutHBaseJSON.java
@@ -102,6 +102,8 @@ public class TestPutHBaseJSON {
     @Test
     public void testSingleJsonDocAndProvidedRowIdwithNonString() throws IOException, InitializationException {
         final TestRunner runner = getTestRunner(DEFAULT_TABLE_NAME, DEFAULT_COLUMN_FAMILY, "1");
+        runner.setProperty(PutHBaseJSON.FIELD_ENCODING_STRATEGY, PutHBaseJSON.BYTES_ENCODING_VALUE);
+
         final MockHBaseClientService hBaseClient = getHBaseClientService(runner);
         runner.setProperty(PutHBaseJSON.ROW_ID, DEFAULT_ROW);
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
@@ -98,4 +98,8 @@ public interface HBaseClientService extends ControllerService {
      */
     void scan(String tableName, Collection<Column> columns, String filterExpression, long minTime, ResultHandler handler) throws IOException;
 
+    byte[] toBytes(boolean b);
+    byte[] toBytes(long l);
+    byte[] toBytes(double d);
+    byte[] toBytes(String s);
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
@@ -98,8 +98,36 @@ public interface HBaseClientService extends ControllerService {
      */
     void scan(String tableName, Collection<Column> columns, String filterExpression, long minTime, ResultHandler handler) throws IOException;
 
+    /**
+     * Converts the given boolean to it's byte representation.
+     *
+     * @param b a boolean
+     * @return the boolean represented as bytes
+     */
     byte[] toBytes(boolean b);
+
+    /**
+     * Converts the given long to it's byte representation.
+     *
+     * @param l a long
+     * @return the long represented as bytes
+     */
     byte[] toBytes(long l);
+
+    /**
+     * Converts the given double to it's byte representation.
+     *
+     * @param d a double
+     * @return the double represented as bytes
+     */
     byte[] toBytes(double d);
+
+    /**
+     * Converts the given string to it's byte representation.
+     *
+     * @param s a string
+     * @return the string represented as bytes
+     */
     byte[] toBytes(String s);
+
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.ParseFilter;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
@@ -403,6 +404,26 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
         public Configuration getConfiguration() {
             return configuration;
         }
+    }
+
+    @Override
+    public byte[] toBytes(boolean b) {
+        return Bytes.toBytes(b);
+    }
+
+    @Override
+    public byte[] toBytes(long l) {
+        return Bytes.toBytes(l);
+    }
+
+    @Override
+    public byte[] toBytes(double d) {
+        return Bytes.toBytes(d);
+    }
+
+    @Override
+    public byte[] toBytes(String s) {
+        return Bytes.toBytes(s);
     }
 
 }


### PR DESCRIPTION
This pull request contains @rtempleton 's work from PR 513, but rebased for the 0.x branch.

In addition, there is another commit by me which adds a new property to PutHBaseJSON allowing the user to specify how to store the values. The reason for this is that we can't change the behavior for existing users who may want the processor to continue working how it was. This change makes the default behavior the same as previous versions, but allows the user to enable the change Ryan made. 