### PR TITLE
NIFI-2060 - fixed unit tests to be compatible with 2.7.x

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/inotify/util/EventTestUtils.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/inotify/util/EventTestUtils.java
@@ -47,14 +47,6 @@ public class EventTestUtils {
         return new Event.CloseEvent("/some/path/close", 1L, 2L);
     }
 
-    public static Event.AppendEvent createAppendEvent() {
-        return new Event.AppendEvent("/some/path/append");
-    }
-
-    public static Event.RenameEvent createRenameEvent() {
-        return new Event.RenameEvent("/some/path/rename/src", "/some/path/rename/dest", 200L);
-    }
-
     public static Event.MetadataUpdateEvent createMetadataUpdateEvent() {
         return new Event.MetadataUpdateEvent.Builder()
                 .replication(0)
@@ -69,9 +61,5 @@ public class EventTestUtils {
                 .xAttrs(Collections.singletonList(new XAttr.Builder().setName("name").setNameSpace(XAttr.NameSpace.USER).setValue(new byte[0]).build()))
                 .xAttrsRemoved(false)
                 .build();
-    }
-
-    public static Event.UnlinkEvent createUnlinkEvent() {
-        return new Event.UnlinkEvent("/some/path/unlink", 300L);
     }
 }


### PR DESCRIPTION
It’s a shame to limit what is tested here (in terms of event types) but it seems to be the only way to have both 2.6 and 2.7 lines working.