### PR TITLE
Removed duplicate dependency declaration from nifi-standard-processor…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -240,11 +240,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-standard-utils</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-utils</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
…s/pom.xml.

Simple PR for duplicated dependency declaration (probably a copy/paste error). Did not open Jira for this. 