### PR TITLE
NIFI-2063 - Install Script Relative Path Mismatch from Init Dir

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
@@ -26,3 +26,4 @@ export NIFI_PID_DIR="${NIFI_HOME}/run"
 
 #The directory for NiFi log files
 export NIFI_LOG_DIR="${NIFI_HOME}/logs"
+

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
@@ -20,12 +20,12 @@
 #
 
 # Script structure inspired from Apache Karaf and other Apache projects with similar startup approaches
-
+ENV_FILE=nifi-env.sh
 SCRIPT_DIR=$(dirname "$0")
 SCRIPT_NAME=$(basename "$0")
 PROGNAME=$(basename "$0")
 
-. "$SCRIPT_DIR"/nifi-env.sh
+. "$SCRIPT_DIR"/"$ENV_FILE"
 
 warn() {
     echo "${PROGNAME}: $*"
@@ -148,7 +148,10 @@ install() {
         fi
 
         SVC_FILE="/etc/init.d/${SVC_NAME}"
-        cp "$0" "${SVC_FILE}"
+        cat "${SCRIPT_DIR}/${ENV_FILE}" "$0" > "${SVC_FILE}"
+        chmod 755 "${SVC_FILE}"
+        sed -i '/ENV_FILE=/d' "${SVC_FILE}"
+        sed -i '/\$ENV_FILE/d' "${SVC_FILE}"
         sed -i s:NIFI_HOME=.*:NIFI_HOME="${NIFI_HOME}": "${SVC_FILE}"
         sed -i s:PROGNAME=.*:PROGNAME="${SCRIPT_NAME}": "${SVC_FILE}"
         rm -f "/etc/rc2.d/S65${SVC_NAME}"


### PR DESCRIPTION
Made changes to ensure proper execution of nifi.sh install:

1) added cp command of nifi_env.sh to /etc/init.d so it can be executed by /etc/init.d/nifi
2) Ensured the NIFI_HOME is properly corrected in /etc/init.d/nifi_env.sh

Test of service install, manual start and stop, was done on vagrant vm with centos7.0. Reboot startup was checked using chkconfig command (**chckconfig nifi on**) and then restarting the vm.  With the service installation correction the issue noted on reboot was not observed so further testing may be required.