### PR TITLE
NIFI-2067 ignored intermittently failing MemoryTest

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/MonitorMemoryTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/MonitorMemoryTest.java
@@ -65,6 +65,9 @@ public class MonitorMemoryTest {
     }
 
     @Test
+    @Ignore // temporarily ignoring it since it fails intermittently due to
+            // unpredictability during full build
+            // still keeping it for local testing
     public void validateWarnWhenPercentThresholdReached() throws Exception {
         this.doValidate("10%");
     }


### PR DESCRIPTION
left comment with the explanation as to why it was not removed