### PR TITLE
NIFI-2078, 2363, 2364, 2442: External state management. CLUSTER scope behavior in cluster. Clear state error handling.

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/Stateful.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/Stateful.java
@@ -26,11 +26,16 @@ import java.lang.annotation.Target;
 
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateManager;
+import org.apache.nifi.components.state.ExternalStateManager;
 
 /**
  * <p>
  * Annotation that a Processor, ReportingTask, or Controller Service can use to indicate
- * that the component makes use of the {@link StateManager}. This annotation provides the
+ * that the component makes use of the {@link StateManager} or implements
+ * {@link ExternalStateManager}.
+ * </p>
+ * <p>
+ * This annotation provides the
  * user with a description of what information is being stored so that the user is able to
  * understand what is shown to them and know what they are clearing should they choose to
  * clear the state. Additionally, the UI will not show any state information to users if
@@ -43,7 +48,7 @@ import org.apache.nifi.components.state.StateManager;
 @Inherited
 public @interface Stateful {
     /**
-     * Provides a description of what information is being stored in the {@link StateManager}
+     * Provides a description of what information is being stored in the {@link StateManager} or {@link ExternalStateManager}
      */
     String description();
 

--- a/nifi-api/src/main/java/org/apache/nifi/components/state/ExternalStateManager.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/state/ExternalStateManager.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.state;
+
+import org.apache.nifi.annotation.behavior.Stateful;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * The ExternalStateManager is responsible for providing NiFi a mechanism for retrieving
+ * and clearing state stored in an external system a NiFi component interact with.
+ * </p>
+ *
+ * <p>
+ * This mechanism is designed to allow Data Flow Managers to easily view and clear
+ * component state stored externally.
+ * It is advisable to implement this interface for components those have such state.
+ * </p>
+ *
+ * <p>
+ * When calling methods in this class, the state is always retrieved/cleared from external system
+ * regardless NiFi instance is a part of a cluster or standalone.
+ * </p>
+ *
+ * <p>
+ * Any component that wishes to implement ExternalStateManager should also use the {@link Stateful} annotation
+ * with {@link Scope#EXTERNAL} to provide a description of what state is being stored.
+ * If this annotation is not present, the UI will not expose such information or allow DFMs to clear the state.
+ * </p>
+ *
+ */
+public interface ExternalStateManager {
+
+    /**
+     * Returns the current state for the component. This return value may be <code>null</code>.
+     *
+     * @return the current state for the component or null if there is no state is retrieved
+     * @throws IOException if unable to communicate with the underlying storage mechanism
+     */
+    StateMap getExternalState() throws IOException;
+
+    /**
+     * Clears all keys and values from the component's state
+     *
+     * @throws IOException if unable to communicate with the underlying storage mechanism
+     */
+    void clearExternalState() throws IOException;
+
+    /**
+     * <p>
+     * In a clustered environment, implementations of {@link ExternalStateManager} interface is called based on the
+     * {@link ExternalStateScope} value returned by its {@link #getExternalStateScope()} method.
+     * </p>
+     */
+    enum ExternalStateScope {
+        /**
+         * State is to be treated as "global" across the cluster. I.e., the same component on all nodes will
+         * have access to the same state.
+         */
+        CLUSTER,
+
+        /**
+         * State is to be treated per node. I.e., the same component will have different state in the external system for
+         * each node in the cluster.
+         */
+        NODE
+    }
+
+    /**
+     * @return An external state scope defining how this state manager should behave.
+     */
+    ExternalStateScope getExternalStateScope();
+
+}

--- a/nifi-api/src/main/java/org/apache/nifi/components/state/ExternalStateManager.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/state/ExternalStateManager.java
@@ -18,8 +18,11 @@
 package org.apache.nifi.components.state;
 
 import org.apache.nifi.annotation.behavior.Stateful;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * <p>
@@ -46,6 +49,18 @@ import java.io.IOException;
  *
  */
 public interface ExternalStateManager {
+
+    /**
+     * To access an external system from those method implementations, configured property values of the component will be needed,
+     * such as Database connection URL or Kafka broker address.
+     * NiFi framework will call {@link #validateExternalStateAccess} method, to determine if required properties are set
+     * to access an external system, before {@link #getExternalState} or {@link #clearExternalState} is called.
+     * In this method, implementations has to validate configured properties,
+     * and also capture configured property values to use at getExternalState and clearExternalState.
+     * @param context validation context
+     * @return validation error result
+     */
+    Collection<ValidationResult> validateExternalStateAccess(final ValidationContext context);
 
     /**
      * Returns the current state for the component. This return value may be <code>null</code>.

--- a/nifi-api/src/main/java/org/apache/nifi/components/state/Scope.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/state/Scope.java
@@ -32,7 +32,16 @@ public enum Scope {
      * State is to be treated local to the node. I.e., the same component will have different state on each
      * node in the cluster.
      */
-    LOCAL;
+    LOCAL,
+
+    /**
+     * <p>
+     * State is to be treated local to the node but managed by external system.
+     * It can also be treated as "global" across the cluster.
+     * See {@link ExternalStateManager#getExternalStateScope()} for detail.
+     * </p>
+     */
+    EXTERNAL;
 
     @Override
     public String toString() {

--- a/nifi-api/src/main/java/org/apache/nifi/components/state/StandardStateMap.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/state/StandardStateMap.java
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.controller.state;
+package org.apache.nifi.components.state;
 
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.nifi.components.state.StateMap;
 
 public class StandardStateMap implements StateMap {
     private final Map<String, String> stateValues;

--- a/nifi-api/src/main/java/org/apache/nifi/components/state/StateManager.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/state/StateManager.java
@@ -52,6 +52,14 @@ import org.apache.nifi.components.state.exception.StateTooLargeException;
  * a description of what state is being stored and what Scope is used. If this annotation is not present, the UI
  * will not expose such information or allow DFMs to clear the state.
  * </p>
+ *
+ * <p>
+ * Some external systems may store NiFi component state when NiFi components interact with those,
+ * and those state are scoped as {@link Scope#EXTERNAL}.
+ * A component that wishes to provide Data Flow Managers access to external state, should implement {@link ExternalStateManager}.
+ * Since StateManager doesn't manage external states, implementation of StateManager class
+ * should throw {@link IllegalArgumentException} when {@link Scope#EXTERNAL} is passed as the scope argument of each method.
+ * </p>
  */
 public interface StateManager {
 

--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -645,12 +645,14 @@ External State Manager is a mechanism to provide DFMs such interactions with ext
 If a Processor, Controller Service or Reporting Task interact with an external system that manages NiFi component state,
 it's advisable for those components to implement `ExternalStateManager` interface, and annotate the class with `@Stateful` using `Scope.EXTERNAL`.
 
-By doing so, NiFi UI lets a DFM to access component states by calling corresponding `getExternalState` or `clearExternalState` method.
+By doing so, NiFi UI lets a DFM access component states by calling corresponding `getExternalState` or `clearExternalState` method.
 
-To access an external system from those method implementations, you will need configured property values of the component,
+To access an external system from those method implementations, configured property values of the component will be needed,
 such as Database connection URL or Kafka broker address.
-Since `ExternalStateManager` methods can be called before component is fully configured or scheduled,
-it's important to use `onPropertyModified` to capture those required configuration values for an external system connection.
+NiFi framework will call `validateExternalStateAccess` method, to determine if required properties are set to access an external system,
+before `getExternalState` or `clearExternalState` is called.
+At `valiadteExternalStateAccess` method, implementations has to validate configured properties,
+and also capture configured property values to use at `getExternalState` and `clearExternalState`.
 
 `ExternalStateManager` also has the `getExternalStateScope` method which return either `ExternalStateScope.NODE` or `ExternalStateScope.CLUSTER`
 to indicate how a NiFi cluster should access the target external system.

--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -579,32 +579,35 @@ replaced. Moreover, the only implementation that is currently supported for stor
 backed by ZooKeeper. As such, the entire State Map must be less than 1 MB in size, after being serialized.
 Attempting to store more than this will result in an Exception being thrown. If the interactions required
 by the Processor for managing state are more complex than this (e.g., large amounts of data must be stored
-and retrieved, or individual keys must be stored and fetched individually) than a different mechanism should
+and retrieved, or individual keys must be stored and fetched individually) then a different mechanism should
 be used (e.g., communicating with an external database). 
 
 
 [[state_scope]]
 ==== Scope
 When communicating with the State Manager, all method calls require that a Scope be provided. This Scope will
-either be `Scope.NODE` or `Scope.CLUSTER`. If NiFi is run in a cluster, this Scope provides important information
+either be `Scope.LOCAL` or `Scope.CLUSTER`. If NiFi is run in a cluster, this Scope provides important information
 to the framework about how the operation should occur.
 
 If state as stored using `Scope.CLUSTER`, then all nodes in the cluster will be communicating with the same
-state storage mechanism. If state is stored and retrieved using `Scope.NODE`, then each node will see a different
+state storage mechanism. If state is stored and retrieved using `Scope.LOCAL`, then each node will see a different
 representation of the state.
 
 It is also worth noting that if NiFi is configured to run as a standalone instance, rather than running in a cluster,
-a scope of `Scope.NODE` is always used. This is done in order to allow the developer of a NiFi component to write the code
+a scope of `Scope.LOCAL` is always used. This is done in order to allow the developer of a NiFi component to write the code
 in one consistent way, without worrying about whether or not the NiFi instance is clustered. The developer should instead assume
 that the instance is clustered and write the code accordingly.
 
+There is also `Scope.EXTERNAL`, that is conceptually different than `Scope.LOCAL` or `Scope.CLUSTER`.
+`Scope.EXTERNAL` represents that the state is managed by external system, not by NiFi State Manager.
+See the <<external_state_manager>> for detail.
 
 ==== Storing and Retrieving State
 
 State is stored using the StateManager's `getState`, `setState`, `replace`, and `clear` methods. All of these methods
 require that a Scope be provided. It should be noted that the state that is stored with the Local scope is entirely different
 than state stored with a Cluster scope. If a Processor stores a value with the key of _My Key_ using the `Scope.CLUSTER` scope,
-and then attempts to retrieve the value using the `Scope.NODE` scope, the value retrieved will be `null` (unless a value was
+and then attempts to retrieve the value using the `Scope.LOCAL` scope, the value retrieved will be `null` (unless a value was
 also stored with the same key using the `Scope.CLUSTER` scope). Each Processor's state, is stored in isolation from other
 Processors' state.
 
@@ -612,6 +615,11 @@ It follows, then, that two Processors cannot share the same state. There are, ho
 necessary to share state between two Processors of different types, or two Processors of the same type. This can be accomplished
 by using a Controller Service. By storing and retrieving state from a Controller Service, multiple Processors can use the same
 Controller Service and the state can be exposed via the Controller Service's API.
+
+==== Accessing state from NiFi UI
+
+When a DFM view or clear state from NiFi UI, all of the `Scope.LOCAL`, `Scope.CLUSTER`, and `Scope.EXTERNAL` state are retrieved or cleared at the same time.
+To avoid accessing underlying data storage unnecessarily frequently, those operations for `Scope.CLUSTER` and `Scope.EXTERNAL` with `ExternalStateScope.CLUSTER` are executed only from a primary node in a NiFi cluster.
 
 
 ==== Unit Tests
@@ -625,8 +633,30 @@ Additionally, the `MockStateManager` exposes a handful of `assert*` methods to p
 The `MockStateManager` also provides the ability to indicate that the unit test should immediately fail if state is updated for a particular
 `Scope`.
 
+[[external_state_manager]]
+==== External State Manager
 
+Some external system stores client state in it, so that multiple clients can share workloads or for any other reasons.
+For example, Apache Kafka stores consumer group's offset per partition, to provide a mechanism for consumers to resume where they left off.
+If a DFM wants NiFi ConsumeKafka processor to replay messages from beginning of a topic, the offset information stored at Kafka server needs to be cleared.
+Also if a DFM can view the offset information from NiFi UI, it's useful to understand how far a consumer has processed.
 
+External State Manager is a mechanism to provide DFMs such interactions with external systems.
+If a Processor, Controller Service or Reporting Task interact with an external system that manages NiFi component state,
+it's advisable for those components to implement `ExternalStateManager` interface, and annotate the class with `@Stateful` using `Scope.EXTERNAL`.
+
+By doing so, NiFi UI lets a DFM to access component states by calling corresponding `getExternalState` or `clearExternalState` method.
+
+To access an external system from those method implementations, you will need configured property values of the component,
+such as Database connection URL or Kafka broker address.
+Since `ExternalStateManager` methods can be called before component is fully configured or scheduled,
+it's important to use `onPropertyModified` to capture those required configuration values for an external system connection.
+
+`ExternalStateManager` also has the `getExternalStateScope` method which return either `ExternalStateScope.NODE` or `ExternalStateScope.CLUSTER`
+to indicate how a NiFi cluster should access the target external system.
+With `ExternalStateScope.NODE`, each node in a NiFi cluster attempts to retrieve or clear state from an external system
+then individual responses will be merged into the final single response,
+while those operations are executed only on a Primary Node with `ExternalStateScope.CLUSTER`.
 
 === Reporting Processor Activity
 

--- a/nifi-mock/src/main/java/org/apache/nifi/state/MockStateManager.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/state/MockStateManager.java
@@ -138,6 +138,10 @@ public class MockStateManager implements StateManager {
     }
 
     private void verifyAnnotation(final Scope scope) {
+        if (scope == Scope.EXTERNAL) {
+            Assert.fail("EXTERNAL scope is not managed by StateManager." +
+                    " A component should implement ExternalStateManager by itself to support EXTERNAL scope state.");
+        }
         // ensure that the @Stateful annotation is present with the appropriate Scope
         if ((scope == Scope.LOCAL && !usesLocalState) || (scope == Scope.CLUSTER && !usesClusterState)) {
             Assert.fail("Component is attempting to set or retrieve state with a scope of " + scope + " but does not declare that it will use "

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessContext.java
@@ -32,6 +32,7 @@ import org.apache.nifi.attribute.expression.language.Query.Range;
 import org.apache.nifi.components.ConfigurableComponent;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ControllerService;
@@ -393,5 +394,9 @@ public class MockProcessContext extends MockControllerServiceLookup implements S
             throw new IllegalArgumentException("Primary node is only available in cluster. Use setClustered(true) first.");
         }
         isPrimaryNode = primaryNode;
+    }
+
+    public ValidationContext newValidationContext() {
+        return new MockValidationContext(this, stateManager, variableRegistry);
     }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -606,7 +606,7 @@ public class StandardProcessorTestRunner implements TestRunner {
             throw new IllegalStateException("Controller Service has not been added to this TestRunner via the #addControllerService method");
         }
 
-        final ValidationContext validationContext = new MockValidationContext(context, serviceStateManager, variableRegistry).getControllerServiceValidationContext(service);
+        final ValidationContext validationContext = newValidationContext().getControllerServiceValidationContext(service);
         final Collection<ValidationResult> results = context.getControllerService(service.getIdentifier()).validate(validationContext);
 
         for (final ValidationResult result : results) {
@@ -625,7 +625,7 @@ public class StandardProcessorTestRunner implements TestRunner {
             throw new IllegalStateException("Controller Service has not been added to this TestRunner via the #addControllerService method");
         }
 
-        final ValidationContext validationContext = new MockValidationContext(context, serviceStateManager, variableRegistry).getControllerServiceValidationContext(service);
+        final ValidationContext validationContext = newValidationContext().getControllerServiceValidationContext(service);
         final Collection<ValidationResult> results = context.getControllerService(service.getIdentifier()).validate(validationContext);
 
         for (final ValidationResult result : results) {
@@ -740,7 +740,7 @@ public class StandardProcessorTestRunner implements TestRunner {
         final Map<PropertyDescriptor, String> curProps = configuration.getProperties();
         final Map<PropertyDescriptor, String> updatedProps = new HashMap<>(curProps);
 
-        final ValidationContext validationContext = new MockValidationContext(context, serviceStateManager, variableRegistry).getControllerServiceValidationContext(service);
+        final ValidationContext validationContext = newValidationContext().getControllerServiceValidationContext(service);
         final ValidationResult validationResult = property.validate(value, validationContext);
 
         updatedProps.put(property, value);
@@ -823,5 +823,10 @@ public class StandardProcessorTestRunner implements TestRunner {
     @Override
     public void setPrimaryNode(boolean primaryNode) {
         context.setPrimaryNode(primaryNode);
+    }
+
+    @Override
+    public ValidationContext newValidationContext() {
+        return context.newValidationContext();
     }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.queue.QueueSize;
@@ -901,4 +902,10 @@ public interface TestRunner {
      * @param primaryNode Specify if this test emulates running as a primary node
      */
     void setPrimaryNode(boolean primaryNode);
+
+    /**
+     * Returns the {@link MockValidationContext} instance that enables custom validation test cases.
+     * @return newly created validation context
+     */
+    ValidationContext newValidationContext();
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ComponentStateDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ComponentStateDTO.java
@@ -30,6 +30,7 @@ public class ComponentStateDTO {
     private String stateDescription;
     private StateMapDTO clusterState;
     private StateMapDTO localState;
+    private StateMapDTO externalState;
 
     /**
      * @return The component identifier
@@ -85,5 +86,19 @@ public class ComponentStateDTO {
 
     public void setLocalState(StateMapDTO localState) {
         this.localState = localState;
+    }
+
+    /**
+     * @return The external state for this component
+     */
+    @ApiModelProperty(
+            value = "The external state for this component."
+    )
+    public StateMapDTO getExternalState() {
+        return externalState;
+    }
+
+    public void setExternalState(StateMapDTO externalState) {
+        this.externalState = externalState;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ClearComponentStateResultEntity.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ClearComponentStateResultEntity.java
@@ -14,29 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.web.dao;
+package org.apache.nifi.web.api.entity;
 
-import org.apache.nifi.components.ConfigurableComponent;
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
+import javax.xml.bind.annotation.XmlRootElement;
 
-public interface ComponentStateDAO {
+/**
+ * A serialized representation of this class can be placed in the entity body of a request or response to or from the API.
+ * This particular entity holds a result of clear state operation.
+ */
+@XmlRootElement(name = "result")
+public class ClearComponentStateResultEntity extends Entity {
 
-    /**
-     * Gets the state for the specified component.
-     *
-     * @param component component
-     * @param scope     scope
-     * @return state map
-     */
-    StateMap getState(ConfigurableComponent component, Scope scope);
+    private boolean cleared = true;
+    private String message = null;
 
-    /**
-     * Clears the state for the specified component.
-     *
-     * @param component component
-     * @param scope     scope
-     */
-    void clearState(ConfigurableComponent component, Scope scope);
+    public boolean isCleared() {
+        return cleared;
+    }
 
+    public void setCleared(boolean cleared) {
+        this.cleared = cleared;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMerger.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.cluster.coordination.http;
 
 import org.apache.nifi.cluster.coordination.http.endpoints.BulletinBoardEndpointMerger;
+import org.apache.nifi.cluster.coordination.http.endpoints.ClearComponentStateEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ComponentStateEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ConnectionEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ConnectionStatusEndpiontMerger;
@@ -102,6 +103,7 @@ public class StandardHttpResponseMerger implements HttpResponseMerger {
         endpointMergers.add(new DropRequestEndpiontMerger());
         endpointMergers.add(new ListFlowFilesEndpointMerger());
         endpointMergers.add(new ComponentStateEndpointMerger());
+        endpointMergers.add(new ClearComponentStateEndpointMerger());
         endpointMergers.add(new BulletinBoardEndpointMerger());
         endpointMergers.add(new StatusHistoryEndpointMerger());
         endpointMergers.add(new SystemDiagnosticsEndpointMerger());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ClearComponentStateEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ClearComponentStateEndpointMerger.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.apache.nifi.cluster.manager.NodeResponse;
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.web.api.entity.ClearComponentStateResultEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class ClearComponentStateEndpointMerger extends AbstractSingleEntityEndpoint<ClearComponentStateResultEntity> {
+    public static final Pattern PROCESSOR_STATE_URI_PATTERN = Pattern.compile("/nifi-api/processors/[a-f0-9\\-]{36}/state/clear-requests");
+    public static final Pattern CONTROLLER_SERVICE_STATE_URI_PATTERN = Pattern.compile("/nifi-api/controller-services/[a-f0-9\\-]{36}/state/clear-requests");
+    public static final Pattern REPORTING_TASK_STATE_URI_PATTERN = Pattern.compile("/nifi-api/reporting-tasks/[a-f0-9\\-]{36}/state/clear-requests");
+
+    private static final Logger logger = LoggerFactory.getLogger(ClearComponentStateEndpointMerger.class);
+
+    @Override
+    public boolean canHandle(URI uri, String method) {
+        if (!"POST".equalsIgnoreCase(method)) {
+            return false;
+        }
+
+        return PROCESSOR_STATE_URI_PATTERN.matcher(uri.getPath()).matches()
+            || CONTROLLER_SERVICE_STATE_URI_PATTERN.matcher(uri.getPath()).matches()
+            || REPORTING_TASK_STATE_URI_PATTERN.matcher(uri.getPath()).matches();
+    }
+
+    @Override
+    protected Class<ClearComponentStateResultEntity> getEntityClass() {
+        return ClearComponentStateResultEntity.class;
+    }
+
+    @Override
+    protected void mergeResponses(ClearComponentStateResultEntity clientEntity, Map<NodeIdentifier,
+            ClearComponentStateResultEntity> entityMap, Set<NodeResponse> successfulResponses, Set<NodeResponse> problematicResponses) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("entityMap={}, successfulResponse={}, problematicResponse={}", entityMap, successfulResponses, problematicResponses);
+            entityMap.forEach((id, res) -> logger.debug("nodeId={}, res.isCleared={}", id, res.isCleared()));
+        }
+
+        // If there's a uncleared response, use that.
+        final ClearComponentStateResultEntity unclearedRes = entityMap.values().stream().filter(res -> !res.isCleared()).findFirst().orElse(null);
+        if (unclearedRes != null) {
+            clientEntity.setCleared(unclearedRes.isCleared());
+            clientEntity.setMessage(unclearedRes.getMessage());
+        }
+
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ComponentStateEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ComponentStateEndpointMerger.java
@@ -19,6 +19,7 @@ package org.apache.nifi.cluster.coordination.http.endpoints;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ import java.util.regex.Pattern;
 
 import org.apache.nifi.cluster.manager.NodeResponse;
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.controller.state.SortedStateUtils;
 import org.apache.nifi.web.api.dto.ComponentStateDTO;
 import org.apache.nifi.web.api.dto.StateEntryDTO;
@@ -60,41 +62,91 @@ public class ComponentStateEndpointMerger extends AbstractSingleDTOEndpoint<Comp
     }
 
     @Override
-    protected void mergeResponses(ComponentStateDTO clientDto, Map<NodeIdentifier, ComponentStateDTO> dtoMap, Set<NodeResponse> successfulResponses, Set<NodeResponse> problematicResponses) {
-        List<StateEntryDTO> localStateEntries = new ArrayList<>();
+    public void mergeResponses(ComponentStateDTO clientDto, Map<NodeIdentifier, ComponentStateDTO> dtoMap,
+                               Set<NodeResponse> successfulResponses, Set<NodeResponse> problematicResponses) {
 
-        int totalStateEntries = 0;
+        // If there're more than 1 node returning external state, then it's a per node external state.
+        final boolean externalPerNode = dtoMap.values().stream()
+                .filter(component -> (component.getExternalState() != null && component.getExternalState().getState() != null))
+                .count() > 1;
+
+        final StateMapDTOMerger[] mergers = {
+                new StateMapDTOMerger(Scope.LOCAL, node -> node.getLocalState(), (merged, state) -> merged.setLocalState(state), true),
+                new StateMapDTOMerger(Scope.CLUSTER, node -> node.getClusterState(), (merged, state) -> merged.setClusterState(state), false),
+                new StateMapDTOMerger(Scope.EXTERNAL, node -> node.getExternalState(), (merged, state) -> merged.setExternalState(state), externalPerNode)
+        };
+
+        // Loop through nodes
         for (final Map.Entry<NodeIdentifier, ComponentStateDTO> nodeEntry : dtoMap.entrySet()) {
             final ComponentStateDTO nodeComponentState = nodeEntry.getValue();
             final NodeIdentifier nodeId = nodeEntry.getKey();
             final String nodeAddress = nodeId.getApiAddress() + ":" + nodeId.getApiPort();
 
-            final StateMapDTO nodeLocalStateMap = nodeComponentState.getLocalState();
-            if (nodeLocalStateMap.getState() != null) {
-                totalStateEntries += nodeLocalStateMap.getTotalEntryCount();
+            for (final StateMapDTOMerger merger : mergers) {
+                final StateMapDTO nodeStateMapDTO = merger.stateGetter.apply(nodeComponentState);
+                if (nodeStateMapDTO != null && nodeStateMapDTO.getState() != null) {
+                    final StateMapDTO mergedStateMapDTO = merger.getMergedStateMapDTO();
+                    final List<StateEntryDTO> stateEntries = mergedStateMapDTO.getState();
+                    mergedStateMapDTO.setTotalEntryCount(mergedStateMapDTO.getTotalEntryCount() + nodeStateMapDTO.getTotalEntryCount());
 
-                for (final StateEntryDTO nodeStateEntry : nodeLocalStateMap.getState()) {
-                    if (nodeStateEntry.getClusterNodeId() == null || nodeStateEntry.getClusterNodeAddress() == null) {
-                        nodeStateEntry.setClusterNodeId(nodeId.getId());
-                        nodeStateEntry.setClusterNodeAddress(nodeAddress);
+                    for (final StateEntryDTO nodeStateEntry : nodeStateMapDTO.getState()) {
+                        if (merger.perNode
+                                && (nodeStateEntry.getClusterNodeId() == null || nodeStateEntry.getClusterNodeAddress() == null)) {
+                            nodeStateEntry.setClusterNodeId(nodeId.getId());
+                            nodeStateEntry.setClusterNodeAddress(nodeAddress);
+                        }
+
+                        stateEntries.add(nodeStateEntry);
                     }
-
-                    localStateEntries.add(nodeStateEntry);
                 }
             }
         }
 
-        // ensure appropriate sort
-        Collections.sort(localStateEntries, SortedStateUtils.getEntryDtoComparator());
+        Arrays.stream(mergers).filter(m -> m.mergedStateMapDTO != null).forEach(m -> {
+            // ensure appropriate sort
+            final List<StateEntryDTO> stateEntries = m.mergedStateMapDTO.getState();
+            Collections.sort(stateEntries, SortedStateUtils.getEntryDtoComparator());
 
-        // sublist if necessary
-        if (localStateEntries.size() > SortedStateUtils.MAX_COMPONENT_STATE_ENTRIES) {
-            localStateEntries = localStateEntries.subList(0, SortedStateUtils.MAX_COMPONENT_STATE_ENTRIES);
+            // sublist if necessary
+            if (stateEntries.size() > SortedStateUtils.MAX_COMPONENT_STATE_ENTRIES) {
+                m.mergedStateMapDTO.setState(stateEntries.subList(0, SortedStateUtils.MAX_COMPONENT_STATE_ENTRIES));
+            }
+
+            m.stateSetter.apply(clientDto, m.mergedStateMapDTO);
+        });
+
+    }
+
+    private interface StateGetter {
+        StateMapDTO apply(ComponentStateDTO node);
+    }
+    private interface StateSetter {
+        void apply(ComponentStateDTO merged, StateMapDTO state);
+    }
+
+    private static class StateMapDTOMerger {
+        private final StateGetter stateGetter;
+        private final StateSetter stateSetter;
+        private final Scope scope;
+        private final boolean perNode;
+        private StateMapDTO mergedStateMapDTO;
+
+        public StateMapDTOMerger(final Scope scope, final StateGetter stateGetter, final StateSetter stateSetter, final boolean perNode) {
+            this.scope = scope;
+            this.stateGetter = stateGetter;
+            this.stateSetter = stateSetter;
+            this.perNode = perNode;
         }
 
-        // add all the local state entries
-        clientDto.getLocalState().setTotalEntryCount(totalStateEntries);
-        clientDto.getLocalState().setState(localStateEntries);
+        public StateMapDTO getMergedStateMapDTO() {
+            if (mergedStateMapDTO == null) {
+                mergedStateMapDTO = new StateMapDTO();
+                mergedStateMapDTO.setScope(scope.toString());
+                mergedStateMapDTO.setTotalEntryCount(0);
+                mergedStateMapDTO.setState(new ArrayList<>());
+            }
+            return mergedStateMapDTO;
+        }
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/TestComponentStateEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/TestComponentStateEndpointMerger.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.web.api.dto.ComponentStateDTO;
+import org.apache.nifi.web.api.dto.StateEntryDTO;
+import org.apache.nifi.web.api.dto.StateMapDTO;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class TestComponentStateEndpointMerger {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestComponentStateEndpointMerger.class);
+
+    private static final NodeIdentifier NODE_1 = new NodeIdentifier("1", "localhost", 9101, "localhost", 9102, "localhost", 9103, 9104, false);
+    private static final NodeIdentifier NODE_2 = new NodeIdentifier("2", "localhost", 9201, "localhost", 9202, "localhost", 9203, 9204, false);
+    private static final NodeIdentifier NODE_3 = new NodeIdentifier("3", "localhost", 9301, "localhost", 9302, "localhost", 9303, 9304, false);
+
+    private static class StateMapDTOBuilder {
+        private final StateMapDTO stateMap;
+        private final List<StateEntryDTO> stateEntries;
+
+        public StateMapDTOBuilder(Scope scope) {
+            stateEntries = new ArrayList<>();
+            stateMap = new StateMapDTO();
+            stateMap.setScope(scope.toString());
+            stateMap.setState(stateEntries);
+        }
+
+        public StateMapDTOBuilder addState(String key, String value) {
+            final StateEntryDTO stateEntryDTO = new StateEntryDTO();
+            stateEntryDTO.setKey(key);
+            stateEntryDTO.setValue(value);
+            stateEntries.add(stateEntryDTO);
+            stateMap.setTotalEntryCount(stateEntries.size());
+            return this;
+        }
+
+    }
+
+    private static class ComponentStateDTOBuilder {
+        private final ComponentStateDTO state;
+
+        public ComponentStateDTOBuilder() {
+            this.state = new ComponentStateDTO();
+        }
+
+        public StateMapDTOBuilder buildState(Scope scope) {
+            final StateMapDTOBuilder builder = new StateMapDTOBuilder(scope);
+            switch (scope) {
+                case LOCAL:
+                    state.setLocalState(builder.stateMap);
+                    break;
+                case CLUSTER:
+                    state.setClusterState(builder.stateMap);
+                    break;
+                case EXTERNAL:
+                    state.setExternalState(builder.stateMap);
+                    break;
+            }
+            return builder;
+        }
+
+    }
+
+    private void printDTO(ComponentStateDTO clientDto) throws IOException {
+        try (final StringWriter writer = new StringWriter();) {
+            new ObjectMapper().writeValue(writer, clientDto);
+            logger.info("clientDto={}", writer);
+        }
+    }
+
+    private ComponentStateEndpointMerger merger = new ComponentStateEndpointMerger();
+
+    private ComponentStateDTOBuilder builder1;
+    private ComponentStateDTOBuilder builder2;
+    private ComponentStateDTOBuilder builder3;
+    private Map<NodeIdentifier, ComponentStateDTO> dtoMap;
+    private ComponentStateDTO clientDto;
+
+    @Before
+    public void before() {
+        builder1 = new ComponentStateDTOBuilder();
+        builder2 = new ComponentStateDTOBuilder();
+        builder3 = new ComponentStateDTOBuilder();
+        dtoMap = new HashMap<>();
+        clientDto = builder1.state;
+        dtoMap.put(NODE_1, builder1.state);
+        dtoMap.put(NODE_2, builder2.state);
+        dtoMap.put(NODE_3, builder3.state);
+
+        // Local scope state is always set.
+        builder1.buildState(Scope.LOCAL);
+        builder2.buildState(Scope.LOCAL);
+        builder3.buildState(Scope.LOCAL);
+
+    }
+
+    @Test
+    public void testMergeNothing() throws Exception {
+
+        merger.mergeResponses(clientDto, dtoMap, null, null);
+
+        printDTO(clientDto);
+
+        assertNotNull(clientDto.getLocalState());
+        assertEquals(0, clientDto.getLocalState().getTotalEntryCount());
+        assertEquals(0, clientDto.getLocalState().getState().size());
+        assertNull(clientDto.getClusterState());
+        assertNull(clientDto.getExternalState());
+    }
+
+    @Test
+    public void testMergeLocal() throws Exception {
+
+        builder1.buildState(Scope.LOCAL)
+                .addState("k1-1", "v1-1");
+        builder2.buildState(Scope.LOCAL)
+                .addState("k2-1", "v2-1")
+                .addState("k2-2", "v2-2");
+        builder3.buildState(Scope.LOCAL)
+                .addState("k3-1", "v3-1")
+                .addState("k3-2", "v3-2")
+                .addState("k3-3", "v3-3");
+
+        merger.mergeResponses(clientDto, dtoMap, null, null);
+
+        printDTO(clientDto);
+
+        // Local
+        final StateMapDTO localStateMap = clientDto.getLocalState();
+        assertNotNull(localStateMap);
+        assertEquals(6, localStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> localState = localStateMap.getState();
+        assertEquals(6, localState.size());
+        assertEquals("k1-1", localState.get(0).getKey());
+        assertEquals("v1-1", localState.get(0).getValue());
+        assertEquals("k2-1", localState.get(1).getKey());
+        assertEquals("v2-1", localState.get(1).getValue());
+        assertEquals("k2-2", localState.get(2).getKey());
+        assertEquals("v2-2", localState.get(2).getValue());
+        assertEquals("k3-1", localState.get(3).getKey());
+        assertEquals("v3-1", localState.get(3).getValue());
+        assertEquals("k3-2", localState.get(4).getKey());
+        assertEquals("v3-2", localState.get(4).getValue());
+        assertEquals("k3-3", localState.get(5).getKey());
+        assertEquals("v3-3", localState.get(5).getValue());
+
+        assertEquals("1", localState.get(0).getClusterNodeId());
+        assertEquals("2", localState.get(1).getClusterNodeId());
+        assertEquals("2", localState.get(2).getClusterNodeId());
+        assertEquals("3", localState.get(3).getClusterNodeId());
+        assertEquals("3", localState.get(4).getClusterNodeId());
+        assertEquals("3", localState.get(5).getClusterNodeId());
+
+        assertEquals("localhost:9101", localState.get(0).getClusterNodeAddress());
+        assertEquals("localhost:9201", localState.get(1).getClusterNodeAddress());
+        assertEquals("localhost:9201", localState.get(2).getClusterNodeAddress());
+        assertEquals("localhost:9301", localState.get(3).getClusterNodeAddress());
+        assertEquals("localhost:9301", localState.get(4).getClusterNodeAddress());
+        assertEquals("localhost:9301", localState.get(5).getClusterNodeAddress());
+
+        // Cluster
+        assertNull(clientDto.getClusterState());
+
+        // External
+        assertNull(clientDto.getExternalState());
+    }
+
+    @Test
+    public void testMergeCluster() throws Exception {
+
+        // Node2 is the primary node.
+        builder2.buildState(Scope.CLUSTER)
+                .addState("c-k1", "c-v1")
+                .addState("c-k2", "c-v2");
+
+        merger.mergeResponses(clientDto, dtoMap, null, null);
+
+        printDTO(clientDto);
+
+        // Local
+        assertNotNull(clientDto.getLocalState());
+        assertEquals(0, clientDto.getLocalState().getTotalEntryCount());
+        assertEquals(0, clientDto.getLocalState().getState().size());
+
+        // Cluster
+        final StateMapDTO clusterStateMap = clientDto.getClusterState();
+        assertNotNull(clusterStateMap);
+        assertEquals(2, clusterStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> clusterState = clusterStateMap.getState();
+        assertEquals(2, clusterState.size());
+
+        assertEquals("c-k1", clusterState.get(0).getKey());
+        assertEquals("c-v1", clusterState.get(0).getValue());
+        assertEquals("c-k2", clusterState.get(1).getKey());
+        assertEquals("c-v2", clusterState.get(1).getValue());
+
+        assertNull(clusterState.get(0).getClusterNodeId());
+        assertNull(clusterState.get(1).getClusterNodeId());
+        assertNull(clusterState.get(0).getClusterNodeAddress());
+        assertNull(clusterState.get(1).getClusterNodeAddress());
+
+        // External
+        assertNull(clientDto.getExternalState());
+
+    }
+
+    @Test
+    public void testMergeExternal() throws Exception {
+
+        // Node2 is the primary node.
+        builder2.buildState(Scope.EXTERNAL)
+                .addState("e-k1", "e-v1")
+                .addState("e-k2", "e-v2");
+
+        merger.mergeResponses(clientDto, dtoMap, null, null);
+
+        printDTO(clientDto);
+
+        // Local
+        assertNotNull(clientDto.getLocalState());
+        assertEquals(0, clientDto.getLocalState().getTotalEntryCount());
+        assertEquals(0, clientDto.getLocalState().getState().size());
+
+        // Cluster
+        assertNull(clientDto.getClusterState());
+
+        // External
+        final StateMapDTO externalStateMap = clientDto.getExternalState();
+        assertNotNull(externalStateMap);
+        assertEquals(2, externalStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> externalState = externalStateMap.getState();
+        assertEquals(2, externalState.size());
+
+        assertEquals("e-k1", externalState.get(0).getKey());
+        assertEquals("e-v1", externalState.get(0).getValue());
+        assertEquals("e-k2", externalState.get(1).getKey());
+        assertEquals("e-v2", externalState.get(1).getValue());
+
+        assertNull(externalState.get(0).getClusterNodeId());
+        assertNull(externalState.get(1).getClusterNodeId());
+        assertNull(externalState.get(0).getClusterNodeAddress());
+        assertNull(externalState.get(1).getClusterNodeAddress());
+
+    }
+
+    @Test
+    public void testMergeExternalPerNode() throws Exception {
+
+        builder1.buildState(Scope.EXTERNAL)
+                .addState("e-k11", "e-v11")
+                .addState("e-k12", "e-v12");
+
+        builder2.buildState(Scope.EXTERNAL)
+                .addState("e-k21", "e-v21")
+                .addState("e-k22", "e-v22");
+
+        builder3.buildState(Scope.EXTERNAL)
+                .addState("e-k31", "e-v31")
+                .addState("e-k32", "e-v32");
+
+
+        merger.mergeResponses(clientDto, dtoMap, null, null);
+
+        printDTO(clientDto);
+
+        // Local
+        assertNotNull(clientDto.getLocalState());
+        assertEquals(0, clientDto.getLocalState().getTotalEntryCount());
+        assertEquals(0, clientDto.getLocalState().getState().size());
+
+        // Cluster
+        assertNull(clientDto.getClusterState());
+
+        // External
+        final StateMapDTO externalStateMap = clientDto.getExternalState();
+        assertNotNull(externalStateMap);
+        assertEquals(6, externalStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> externalState = externalStateMap.getState();
+        assertEquals(6, externalState.size());
+
+        assertEquals("e-k11", externalState.get(0).getKey());
+        assertEquals("e-v11", externalState.get(0).getValue());
+        assertEquals("e-k12", externalState.get(1).getKey());
+        assertEquals("e-v12", externalState.get(1).getValue());
+
+        assertEquals("e-k21", externalState.get(2).getKey());
+        assertEquals("e-v21", externalState.get(2).getValue());
+        assertEquals("e-k22", externalState.get(3).getKey());
+        assertEquals("e-v22", externalState.get(3).getValue());
+
+        assertEquals("e-k31", externalState.get(4).getKey());
+        assertEquals("e-v31", externalState.get(4).getValue());
+        assertEquals("e-k32", externalState.get(5).getKey());
+        assertEquals("e-v32", externalState.get(5).getValue());
+
+        assertEquals("1", externalState.get(0).getClusterNodeId());
+        assertEquals("1", externalState.get(1).getClusterNodeId());
+        assertEquals("2", externalState.get(2).getClusterNodeId());
+        assertEquals("2", externalState.get(3).getClusterNodeId());
+        assertEquals("3", externalState.get(4).getClusterNodeId());
+        assertEquals("3", externalState.get(5).getClusterNodeId());
+        assertEquals("localhost:9101", externalState.get(0).getClusterNodeAddress());
+        assertEquals("localhost:9101", externalState.get(1).getClusterNodeAddress());
+        assertEquals("localhost:9201", externalState.get(2).getClusterNodeAddress());
+        assertEquals("localhost:9201", externalState.get(3).getClusterNodeAddress());
+        assertEquals("localhost:9301", externalState.get(4).getClusterNodeAddress());
+        assertEquals("localhost:9301", externalState.get(5).getClusterNodeAddress());
+
+    }
+
+    @Test
+    public void testMergeAll() throws Exception {
+
+        builder1.buildState(Scope.LOCAL)
+                .addState("k1-1", "v1-1");
+        builder2.buildState(Scope.LOCAL)
+                .addState("k2-1", "v2-1")
+                .addState("k2-2", "v2-2");
+        builder3.buildState(Scope.LOCAL)
+                .addState("k3-1", "v3-1")
+                .addState("k3-2", "v3-2")
+                .addState("k3-3", "v3-3");
+
+        // Node2 is the primary node.
+        builder2.buildState(Scope.CLUSTER)
+                .addState("c-k1", "c-v1")
+                .addState("c-k2", "c-v2");
+        builder2.buildState(Scope.EXTERNAL)
+                .addState("e-k1", "e-v1")
+                .addState("e-k2", "e-v2");
+
+        merger.mergeResponses(clientDto, dtoMap, null, null);
+
+        printDTO(clientDto);
+
+        // Local
+        final StateMapDTO localStateMap = clientDto.getLocalState();
+        assertNotNull(localStateMap);
+        assertEquals(6, localStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> localState = localStateMap.getState();
+        assertEquals(6, localState.size());
+        assertEquals("k1-1", localState.get(0).getKey());
+        assertEquals("v1-1", localState.get(0).getValue());
+        assertEquals("k2-1", localState.get(1).getKey());
+        assertEquals("v2-1", localState.get(1).getValue());
+        assertEquals("k2-2", localState.get(2).getKey());
+        assertEquals("v2-2", localState.get(2).getValue());
+        assertEquals("k3-1", localState.get(3).getKey());
+        assertEquals("v3-1", localState.get(3).getValue());
+        assertEquals("k3-2", localState.get(4).getKey());
+        assertEquals("v3-2", localState.get(4).getValue());
+        assertEquals("k3-3", localState.get(5).getKey());
+        assertEquals("v3-3", localState.get(5).getValue());
+
+        assertEquals("1", localState.get(0).getClusterNodeId());
+        assertEquals("2", localState.get(1).getClusterNodeId());
+        assertEquals("2", localState.get(2).getClusterNodeId());
+        assertEquals("3", localState.get(3).getClusterNodeId());
+        assertEquals("3", localState.get(4).getClusterNodeId());
+        assertEquals("3", localState.get(5).getClusterNodeId());
+
+        assertEquals("localhost:9101", localState.get(0).getClusterNodeAddress());
+        assertEquals("localhost:9201", localState.get(1).getClusterNodeAddress());
+        assertEquals("localhost:9201", localState.get(2).getClusterNodeAddress());
+        assertEquals("localhost:9301", localState.get(3).getClusterNodeAddress());
+        assertEquals("localhost:9301", localState.get(4).getClusterNodeAddress());
+        assertEquals("localhost:9301", localState.get(5).getClusterNodeAddress());
+
+        // Cluster
+        final StateMapDTO clusterStateMap = clientDto.getClusterState();
+        assertNotNull(clusterStateMap);
+        assertEquals(2, clusterStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> clusterState = clusterStateMap.getState();
+        assertEquals(2, clusterState.size());
+
+        assertEquals("c-k1", clusterState.get(0).getKey());
+        assertEquals("c-v1", clusterState.get(0).getValue());
+        assertEquals("c-k2", clusterState.get(1).getKey());
+        assertEquals("c-v2", clusterState.get(1).getValue());
+
+        assertNull(clusterState.get(0).getClusterNodeId());
+        assertNull(clusterState.get(1).getClusterNodeId());
+        assertNull(clusterState.get(0).getClusterNodeAddress());
+        assertNull(clusterState.get(1).getClusterNodeAddress());
+
+        // External
+        final StateMapDTO externalStateMap = clientDto.getExternalState();
+        assertNotNull(externalStateMap);
+        assertEquals(2, externalStateMap.getTotalEntryCount());
+        final List<StateEntryDTO> externalState = externalStateMap.getState();
+        assertEquals(2, externalState.size());
+
+        assertEquals("e-k1", externalState.get(0).getKey());
+        assertEquals("e-v1", externalState.get(0).getValue());
+        assertEquals("e-k2", externalState.get(1).getKey());
+        assertEquals("e-v2", externalState.get(1).getValue());
+
+        assertNull(externalState.get(0).getClusterNodeId());
+        assertNull(externalState.get(1).getClusterNodeId());
+        assertNull(externalState.get(0).getClusterNodeAddress());
+        assertNull(externalState.get(1).getClusterNodeAddress());
+
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/StandardStateManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/StandardStateManager.java
@@ -41,6 +41,10 @@ public class StandardStateManager implements StateManager {
     }
 
     private StateProvider getProvider(final Scope scope) {
+        if (scope == Scope.EXTERNAL) {
+            throw new IllegalArgumentException("EXTERNAL scope is not managed by StateManager." +
+                    " A component should implement ExternalStateManager by itself to support EXTERNAL scope state.");
+        }
         if (scope == Scope.LOCAL || clusterProvider == null || !clusterProvider.isEnabled()) {
             return localProvider;
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/StateMapSerDe.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/StateMapSerDe.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.nifi.components.state.StandardStateMap;
 import org.apache.nifi.components.state.StateMap;
 import org.wali.SerDe;
 import org.wali.UpdateType;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
@@ -37,7 +37,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProviderInitializationContext;
-import org.apache.nifi.controller.state.StandardStateMap;
+import org.apache.nifi.components.state.StandardStateMap;
 import org.apache.nifi.controller.state.StateMapSerDe;
 import org.apache.nifi.controller.state.StateMapUpdate;
 import org.apache.nifi.controller.state.providers.AbstractStateProvider;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/ZooKeeperStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/ZooKeeperStateProvider.java
@@ -39,7 +39,7 @@ import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProviderInitializationContext;
 import org.apache.nifi.components.state.exception.StateTooLargeException;
-import org.apache.nifi.controller.state.StandardStateMap;
+import org.apache.nifi.components.state.StandardStateMap;
 import org.apache.nifi.controller.state.providers.AbstractStateProvider;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.zookeeper.CreateMode;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/TestStateMapSerDe.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/TestStateMapSerDe.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.nifi.components.state.StandardStateMap;
 import org.apache.nifi.components.state.StateMap;
 import org.junit.Test;
 import org.wali.UpdateType;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -71,6 +71,7 @@ import org.apache.nifi.web.api.dto.status.ProcessorStatusDTO;
 import org.apache.nifi.web.api.dto.status.RemoteProcessGroupStatusDTO;
 import org.apache.nifi.web.api.dto.status.StatusHistoryDTO;
 import org.apache.nifi.web.api.entity.AccessPolicyEntity;
+import org.apache.nifi.web.api.entity.ClearComponentStateResultEntity;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ControllerBulletinsEntity;
 import org.apache.nifi.web.api.entity.ControllerConfigurationEntity;
@@ -1092,8 +1093,9 @@ public interface NiFiServiceFacade {
      * Clears the state for the specified processor.
      *
      * @param processorId the processor id
+     * @return the result of clear operation
      */
-    void clearProcessorState(String processorId);
+    ClearComponentStateResultEntity clearProcessorState(String processorId);
 
     /**
      * Gets the state for the specified controller service.
@@ -1114,8 +1116,9 @@ public interface NiFiServiceFacade {
      * Clears the state for the specified controller service.
      *
      * @param controllerServiceId the controller service id
+     * @return the result of clear operation
      */
-    void clearControllerServiceState(String controllerServiceId);
+    ClearComponentStateResultEntity clearControllerServiceState(String controllerServiceId);
 
     /**
      * Gets the state for the specified reporting task.
@@ -1136,8 +1139,9 @@ public interface NiFiServiceFacade {
      * Clears the state for the specified reporting task.
      *
      * @param reportingTaskId the reporting task id
+     * @return the result of clear operation
      */
-    void clearReportingTaskState(String reportingTaskId);
+    ClearComponentStateResultEntity clearReportingTaskState(String reportingTaskId);
 
     // ----------------------------------------
     // Label methods

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
@@ -38,6 +38,7 @@ import org.apache.nifi.web.api.dto.ComponentStateDTO;
 import org.apache.nifi.web.api.dto.ControllerServiceDTO;
 import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.api.dto.RevisionDTO;
+import org.apache.nifi.web.api.entity.ClearComponentStateResultEntity;
 import org.apache.nifi.web.api.entity.ComponentStateEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceReferencingComponentsEntity;
@@ -319,7 +320,7 @@ public class ControllerServiceResource extends ApplicationResource {
      *
      * @param httpServletRequest servlet request
      * @param id The id of the controller service
-     * @return a componentStateEntity
+     * @return a clearComponentStateEntity
      */
     @POST
     @Consumes(MediaType.WILDCARD)
@@ -328,7 +329,7 @@ public class ControllerServiceResource extends ApplicationResource {
     // TODO - @PreAuthorize("hasAnyRole('ROLE_DFM')")
     @ApiOperation(
         value = "Clears the state for a controller service",
-        response = ComponentStateDTO.class,
+        response = ClearComponentStateResultEntity.class,
         authorizations = {
             @Authorization(value = "Data Flow Manager", type = "ROLE_DFM")
         }
@@ -367,11 +368,7 @@ public class ControllerServiceResource extends ApplicationResource {
             return generateContinueResponse().build();
         }
 
-        // get the component state
-        serviceFacade.clearControllerServiceState(id);
-
-        // generate the response entity
-        final ComponentStateEntity entity = new ComponentStateEntity();
+        ClearComponentStateResultEntity entity = serviceFacade.clearControllerServiceState(id);
 
         // generate the response
         return clusterContext(generateOkResponse(entity)).build();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
@@ -36,6 +36,7 @@ import org.apache.nifi.web.api.dto.ComponentStateDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
+import org.apache.nifi.web.api.entity.ClearComponentStateResultEntity;
 import org.apache.nifi.web.api.entity.ComponentStateEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
@@ -276,7 +277,7 @@ public class ProcessorResource extends ApplicationResource {
     // TODO - @PreAuthorize("hasAnyRole('ROLE_DFM')")
     @ApiOperation(
         value = "Gets the state for a processor",
-        response = ComponentStateDTO.class,
+        response = ComponentStateEntity.class,
         authorizations = {
             @Authorization(value = "Data Flow Manager", type = "ROLE_DFM")
         }
@@ -323,7 +324,7 @@ public class ProcessorResource extends ApplicationResource {
      *
      * @param httpServletRequest servlet request
      * @param id The id of the processor
-     * @return a componentStateEntity
+     * @return a clearComponentStateEntity
      * @throws InterruptedException if interrupted
      */
     @POST
@@ -333,7 +334,7 @@ public class ProcessorResource extends ApplicationResource {
     // TODO - @PreAuthorize("hasAnyRole('ROLE_DFM')")
     @ApiOperation(
         value = "Clears the state for a processor",
-        response = ComponentStateDTO.class,
+        response = ClearComponentStateResultEntity.class,
         authorizations = {
             @Authorization(value = "Data Flow Manager", type = "ROLE_DFM")
         }
@@ -372,11 +373,7 @@ public class ProcessorResource extends ApplicationResource {
             return generateContinueResponse().build();
         }
 
-        // get the component state
-        serviceFacade.clearProcessorState(id);
-
-        // generate the response entity
-        final ComponentStateEntity entity = new ComponentStateEntity();
+        final ClearComponentStateResultEntity entity = serviceFacade.clearProcessorState(id);
 
         // generate the response
         return clusterContext(generateOkResponse(entity)).build();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
@@ -35,6 +35,7 @@ import org.apache.nifi.web.UiExtensionType;
 import org.apache.nifi.web.api.dto.ComponentStateDTO;
 import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
+import org.apache.nifi.web.api.entity.ClearComponentStateResultEntity;
 import org.apache.nifi.web.api.entity.ComponentStateEntity;
 import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskEntity;
@@ -306,7 +307,7 @@ public class ReportingTaskResource extends ApplicationResource {
      *
      * @param httpServletRequest servlet request
      * @param id The id of the reporting task
-     * @return a componentStateEntity
+     * @return a clearComponentStateEntity
      */
     @POST
     @Consumes(MediaType.WILDCARD)
@@ -315,7 +316,7 @@ public class ReportingTaskResource extends ApplicationResource {
     // TODO - @PreAuthorize("hasAnyRole('ROLE_DFM')")
     @ApiOperation(
         value = "Clears the state for a reporting task",
-        response = ComponentStateDTO.class,
+        response = ClearComponentStateResultEntity.class,
         authorizations = {
             @Authorization(value = "Data Flow Manager", type = "ROLE_DFM")
         }
@@ -354,11 +355,7 @@ public class ReportingTaskResource extends ApplicationResource {
             return generateContinueResponse().build();
         }
 
-        // get the component state
-        serviceFacade.clearReportingTaskState(id);
-
-        // generate the response entity
-        final ComponentStateEntity entity = new ComponentStateEntity();
+        final ClearComponentStateResultEntity entity = serviceFacade.clearReportingTaskState(id);
 
         // generate the response
         return clusterContext(generateOkResponse(entity)).build();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -49,6 +49,7 @@ import org.apache.nifi.cluster.event.NodeEvent;
 import org.apache.nifi.cluster.manager.StatusMerger;
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.ConfigurableComponent;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.state.Scope;
@@ -313,17 +314,21 @@ public final class DtoFactory {
     /**
      * Creates a ComponentStateDTO for the given component and state's.
      *
-     * @param componentId component id
+     * @param component component
      * @param localState local state
      * @param clusterState cluster state
+     * @param externalState external state
      * @return dto
      */
-    public ComponentStateDTO createComponentStateDTO(final String componentId, final Class<?> componentClass, final StateMap localState, final StateMap clusterState) {
+    public ComponentStateDTO createComponentStateDTO(final ConfigurableComponent component, final StateMap localState,
+                                                     final StateMap clusterState, final StateMap externalState) {
         final ComponentStateDTO dto = new ComponentStateDTO();
-        dto.setComponentId(componentId);
-        dto.setStateDescription(getStateDescription(componentClass));
+        dto.setComponentId(component.getIdentifier());
+        dto.setStateDescription(getStateDescription(component.getClass()));
         dto.setLocalState(createStateMapDTO(Scope.LOCAL, localState));
         dto.setClusterState(createStateMapDTO(Scope.CLUSTER, clusterState));
+        dto.setExternalState(createStateMapDTO(Scope.EXTERNAL, externalState));
+
         return dto;
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -41,6 +41,7 @@ import org.apache.nifi.controller.ContentAvailability;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.Counter;
 import org.apache.nifi.controller.FlowController;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.ScheduledState;
@@ -134,7 +135,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.nifi.controller.FlowController.ROOT_GROUP_ID_ALIAS;
 
-public class ControllerFacade implements Authorizable {
+public class ControllerFacade implements Authorizable, NodeTypeProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(ControllerFacade.class);
 
@@ -367,11 +368,14 @@ public class ControllerFacade implements Authorizable {
         return flowController.getNodeId();
     }
 
-    /**
-     * @return true if is clustered
-     */
+    @Override
     public boolean isClustered() {
         return flowController.isClustered();
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return flowController.isPrimary();
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -33,10 +33,13 @@ import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.state.ExternalStateManager;
 import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.connectable.Funnel;
 import org.apache.nifi.connectable.Port;
+import org.apache.nifi.controller.ConfiguredComponent;
 import org.apache.nifi.controller.ContentAvailability;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.Counter;
@@ -69,6 +72,7 @@ import org.apache.nifi.nar.NarCloseable;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.StandardValidationContext;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceRepository;
 import org.apache.nifi.provenance.SearchableFields;
@@ -1757,6 +1761,12 @@ public class ControllerFacade implements Authorizable, NodeTypeProvider {
         }
     }
 
+    public Collection<ValidationResult> validateExternalStateAccess(final ConfiguredComponent configuredComponent, final ExternalStateManager stateManager) {
+        final StandardValidationContext validationContext = new StandardValidationContext(flowController, configuredComponent.getProperties(),
+                configuredComponent.getAnnotationData(), null, configuredComponent.getIdentifier(), variableRegistry);
+        return stateManager.validateExternalStateAccess(validationContext);
+    }
+
     /*
      * setters
      */
@@ -1791,4 +1801,5 @@ public class ControllerFacade implements Authorizable, NodeTypeProvider {
     public void setVariableRegistry(VariableRegistry variableRegistry) {
         this.variableRegistry = variableRegistry;
     }
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ComponentStateDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ComponentStateDAO.java
@@ -20,6 +20,8 @@ import org.apache.nifi.components.ConfigurableComponent;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 
+import java.io.IOException;
+
 public interface ComponentStateDAO {
 
     /**
@@ -29,7 +31,7 @@ public interface ComponentStateDAO {
      * @param scope     scope
      * @return state map
      */
-    StateMap getState(ConfigurableComponent component, Scope scope);
+    StateMap getState(ConfigurableComponent component, Scope scope) throws IOException;
 
     /**
      * Clears the state for the specified component.
@@ -37,6 +39,6 @@ public interface ComponentStateDAO {
      * @param component component
      * @param scope     scope
      */
-    void clearState(ConfigurableComponent component, Scope scope);
+    void clearState(ConfigurableComponent component, Scope scope) throws IOException;
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ControllerServiceDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ControllerServiceDAO.java
@@ -18,8 +18,6 @@ package org.apache.nifi.web.dao;
 
 import java.util.Set;
 
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.controller.ConfiguredComponent;
 import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.service.ControllerServiceNode;
@@ -107,24 +105,9 @@ public interface ControllerServiceDAO {
     void deleteControllerService(String controllerServiceId);
 
     /**
-     * Gets the specified controller service.
-     *
-     * @param controllerServiceId controller service id
-     * @return state map
-     */
-    StateMap getState(String controllerServiceId, Scope scope);
-
-    /**
      * Verifies the controller service can clear state.
      *
      * @param controllerServiceId controller service id
      */
     void verifyClearState(String controllerServiceId);
-
-    /**
-     * Clears the state of the specified controller service.
-     *
-     * @param controllerServiceId controller service id
-     */
-    void clearState(String controllerServiceId);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ProcessorDAO.java
@@ -16,8 +16,6 @@
  */
 package org.apache.nifi.web.dao;
 
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
 
@@ -86,24 +84,9 @@ public interface ProcessorDAO {
     void deleteProcessor(String processorId);
 
     /**
-     * Gets the specified processor.
-     *
-     * @param processorId processor id
-     * @return state map
-     */
-    StateMap getState(String processorId, Scope scope);
-
-    /**
      * Verifies the processor can clear state.
      *
      * @param processorId processor id
      */
     void verifyClearState(String processorId);
-
-    /**
-     * Clears the state of the specified processor.
-     *
-     * @param processorId processor id
-     */
-    void clearState(String processorId);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ReportingTaskDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ReportingTaskDAO.java
@@ -18,8 +18,6 @@ package org.apache.nifi.web.dao;
 
 import java.util.Set;
 
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.controller.ReportingTaskNode;
 
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
@@ -87,24 +85,9 @@ public interface ReportingTaskDAO {
     void deleteReportingTask(String reportingTaskId);
 
     /**
-     * Gets the specified reporting task.
-     *
-     * @param reportingTaskId reporting task id
-     * @return state map
-     */
-    StateMap getState(String reportingTaskId, Scope scope);
-
-    /**
      * Verifies the reporting task can clear state.
      *
      * @param reportingTaskId reporting task id
      */
     void verifyClearState(String reportingTaskId);
-
-    /**
-     * Clears the state of the specified reporting task.
-     *
-     * @param reportingTaskId reporting task id
-     */
-    void clearState(String reportingTaskId);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardComponentStateDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardComponentStateDAO.java
@@ -16,13 +16,12 @@
  */
 package org.apache.nifi.web.dao.impl;
 
+import org.apache.nifi.components.ConfigurableComponent;
+import org.apache.nifi.components.state.ExternalStateManager;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.components.state.StateManagerProvider;
 import org.apache.nifi.components.state.StateMap;
-import org.apache.nifi.controller.ProcessorNode;
-import org.apache.nifi.controller.ReportingTaskNode;
-import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.dao.ComponentStateDAO;
 
@@ -31,6 +30,16 @@ import java.io.IOException;
 public class StandardComponentStateDAO implements ComponentStateDAO {
 
     private StateManagerProvider stateManagerProvider;
+
+    @Override
+    public StateMap getState(final ConfigurableComponent component, final Scope scope) {
+        switch (scope) {
+            case EXTERNAL:
+                return getExternalState(component);
+            default:
+                return getState(component.getIdentifier(), scope);
+        }
+    }
 
     private StateMap getState(final String componentId, final Scope scope) {
         try {
@@ -45,49 +54,52 @@ public class StandardComponentStateDAO implements ComponentStateDAO {
         }
     }
 
-    private void clearState(final String componentId) {
+    private StateMap getExternalState(final ConfigurableComponent component) {
+        if (component instanceof ExternalStateManager) {
+            try {
+                return ((ExternalStateManager)component).getExternalState();
+            } catch (final IOException ioe) {
+                throw new IllegalStateException(String.format("Unable to get the external state for the specified component %s: %s",
+                        component.getIdentifier(), ioe), ioe);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void clearState(final ConfigurableComponent component, final Scope scope) {
+        switch (scope) {
+            case EXTERNAL:
+                clearExternalState(component);
+                break;
+            default:
+                clearState(component.getIdentifier(), scope);
+                break;
+        }
+    }
+
+    private void clearState(final String componentId, final Scope scope) {
         try {
             final StateManager manager = stateManagerProvider.getStateManager(componentId);
             if (manager == null) {
                 throw new ResourceNotFoundException(String.format("State for the specified component %s could not be found.", componentId));
             }
+            manager.clear(scope);
 
-            // clear both state's at the same time
-            manager.clear(Scope.CLUSTER);
-            manager.clear(Scope.LOCAL);
         } catch (final IOException ioe) {
             throw new IllegalStateException(String.format("Unable to clear the state for the specified component %s: %s", componentId, ioe), ioe);
         }
     }
 
-    @Override
-    public StateMap getState(ProcessorNode processor, Scope scope) {
-        return getState(processor.getIdentifier(), scope);
-    }
-
-    @Override
-    public void clearState(ProcessorNode processor) {
-        clearState(processor.getIdentifier());
-    }
-
-    @Override
-    public StateMap getState(ControllerServiceNode controllerService, Scope scope) {
-        return getState(controllerService.getIdentifier(), scope);
-    }
-
-    @Override
-    public void clearState(ControllerServiceNode controllerService) {
-        clearState(controllerService.getIdentifier());
-    }
-
-    @Override
-    public StateMap getState(ReportingTaskNode reportingTask, Scope scope) {
-        return getState(reportingTask.getIdentifier(), scope);
-    }
-
-    @Override
-    public void clearState(ReportingTaskNode reportingTask) {
-        clearState(reportingTask.getIdentifier());
+    private void clearExternalState(final ConfigurableComponent component) {
+        if (component instanceof ExternalStateManager) {
+            try {
+                ((ExternalStateManager)component).clearExternalState();
+            } catch (final IOException ioe) {
+                throw new IllegalStateException(String.format("Unable to clear the external state for the specified component %s: %s",
+                        component.getIdentifier(), ioe), ioe);
+            }
+        }
     }
 
     /* setters */

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardComponentStateDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardComponentStateDAO.java
@@ -32,7 +32,7 @@ public class StandardComponentStateDAO implements ComponentStateDAO {
     private StateManagerProvider stateManagerProvider;
 
     @Override
-    public StateMap getState(final ConfigurableComponent component, final Scope scope) {
+    public StateMap getState(final ConfigurableComponent component, final Scope scope) throws IOException {
         switch (scope) {
             case EXTERNAL:
                 return getExternalState(component);
@@ -54,20 +54,15 @@ public class StandardComponentStateDAO implements ComponentStateDAO {
         }
     }
 
-    private StateMap getExternalState(final ConfigurableComponent component) {
+    private StateMap getExternalState(final ConfigurableComponent component) throws IOException {
         if (component instanceof ExternalStateManager) {
-            try {
-                return ((ExternalStateManager)component).getExternalState();
-            } catch (final IOException ioe) {
-                throw new IllegalStateException(String.format("Unable to get the external state for the specified component %s: %s",
-                        component.getIdentifier(), ioe), ioe);
-            }
+            return ((ExternalStateManager)component).getExternalState();
         }
         return null;
     }
 
     @Override
-    public void clearState(final ConfigurableComponent component, final Scope scope) {
+    public void clearState(final ConfigurableComponent component, final Scope scope) throws IOException {
         switch (scope) {
             case EXTERNAL:
                 clearExternalState(component);
@@ -78,27 +73,17 @@ public class StandardComponentStateDAO implements ComponentStateDAO {
         }
     }
 
-    private void clearState(final String componentId, final Scope scope) {
-        try {
-            final StateManager manager = stateManagerProvider.getStateManager(componentId);
-            if (manager == null) {
-                throw new ResourceNotFoundException(String.format("State for the specified component %s could not be found.", componentId));
-            }
-            manager.clear(scope);
-
-        } catch (final IOException ioe) {
-            throw new IllegalStateException(String.format("Unable to clear the state for the specified component %s: %s", componentId, ioe), ioe);
+    private void clearState(final String componentId, final Scope scope) throws IOException {
+        final StateManager manager = stateManagerProvider.getStateManager(componentId);
+        if (manager == null) {
+            throw new ResourceNotFoundException(String.format("State for the specified component %s could not be found.", componentId));
         }
+        manager.clear(scope);
     }
 
-    private void clearExternalState(final ConfigurableComponent component) {
+    private void clearExternalState(final ConfigurableComponent component) throws IOException {
         if (component instanceof ExternalStateManager) {
-            try {
-                ((ExternalStateManager)component).clearExternalState();
-            } catch (final IOException ioe) {
-                throw new IllegalStateException(String.format("Unable to clear the external state for the specified component %s: %s",
-                        component.getIdentifier(), ioe), ioe);
-            }
+            ((ExternalStateManager)component).clearExternalState();
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
@@ -16,8 +16,6 @@
  */
 package org.apache.nifi.web.dao.impl;
 
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.controller.ConfiguredComponent;
 import org.apache.nifi.controller.FlowController;
 import org.apache.nifi.controller.ScheduledState;
@@ -30,7 +28,6 @@ import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.web.NiFiCoreException;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.api.dto.ControllerServiceDTO;
-import org.apache.nifi.web.dao.ComponentStateDAO;
 import org.apache.nifi.web.dao.ControllerServiceDAO;
 
 import java.util.ArrayList;
@@ -44,7 +41,6 @@ import static org.apache.nifi.controller.FlowController.ROOT_GROUP_ID_ALIAS;
 public class StandardControllerServiceDAO extends ComponentDAO implements ControllerServiceDAO {
 
     private ControllerServiceProvider serviceProvider;
-    private ComponentStateDAO componentStateDAO;
     private FlowController flowController;
 
     private ControllerServiceNode locateControllerService(final String controllerServiceId) {
@@ -294,30 +290,14 @@ public class StandardControllerServiceDAO extends ComponentDAO implements Contro
     }
 
     @Override
-    public StateMap getState(final String controllerServiceId, final Scope scope) {
-        final ControllerServiceNode controllerService = locateControllerService(controllerServiceId);
-        return componentStateDAO.getState(controllerService, scope);
-    }
-
-    @Override
     public void verifyClearState(final String controllerServiceId) {
         final ControllerServiceNode controllerService = locateControllerService(controllerServiceId);
         controllerService.verifyCanClearState();
     }
 
-    @Override
-    public void clearState(final String controllerServiceId) {
-        final ControllerServiceNode controllerService = locateControllerService(controllerServiceId);
-        componentStateDAO.clearState(controllerService);
-    }
-
     /* setters */
     public void setServiceProvider(final ControllerServiceProvider serviceProvider) {
         this.serviceProvider = serviceProvider;
-    }
-
-    public void setComponentStateDAO(final ComponentStateDAO componentStateDAO) {
-        this.componentStateDAO = componentStateDAO;
     }
 
     public void setFlowController(final FlowController flowController) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -17,8 +17,6 @@
 package org.apache.nifi.web.dao.impl;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.connectable.Position;
 import org.apache.nifi.controller.FlowController;
@@ -36,7 +34,6 @@ import org.apache.nifi.web.NiFiCoreException;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
-import org.apache.nifi.web.dao.ComponentStateDAO;
 import org.apache.nifi.web.dao.ProcessorDAO;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
@@ -56,7 +53,6 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
 
     private static final Logger logger = LoggerFactory.getLogger(StandardProcessorDAO.class);
     private FlowController flowController;
-    private ComponentStateDAO componentStateDAO;
 
     private ProcessorNode locateProcessor(final String processorId) {
         final ProcessGroup rootGroup = flowController.getGroup(flowController.getRootGroupId());
@@ -444,21 +440,9 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
     }
 
     @Override
-    public StateMap getState(String processorId, final Scope scope) {
-        final ProcessorNode processor = locateProcessor(processorId);
-        return componentStateDAO.getState(processor, scope);
-    }
-
-    @Override
-    public void verifyClearState(String processorId) {
+    public void verifyClearState(final String processorId) {
         final ProcessorNode processor = locateProcessor(processorId);
         processor.verifyCanClearState();
-    }
-
-    @Override
-    public void clearState(String processorId) {
-        final ProcessorNode processor = locateProcessor(processorId);
-        componentStateDAO.clearState(processor);
     }
 
     /* setters */
@@ -466,7 +450,4 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
         this.flowController = flowController;
     }
 
-    public void setComponentStateDAO(ComponentStateDAO componentStateDAO) {
-        this.componentStateDAO = componentStateDAO;
-    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.regex.Matcher;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.nifi.components.state.Scope;
-import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.exception.ComponentLifeCycleException;
@@ -38,14 +36,12 @@ import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.web.NiFiCoreException;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
-import org.apache.nifi.web.dao.ComponentStateDAO;
 import org.apache.nifi.web.dao.ReportingTaskDAO;
 import org.quartz.CronExpression;
 
 public class StandardReportingTaskDAO extends ComponentDAO implements ReportingTaskDAO {
 
     private ReportingTaskProvider reportingTaskProvider;
-    private ComponentStateDAO componentStateDAO;
 
     private ReportingTaskNode locateReportingTask(final String reportingTaskId) {
         // get the reporting task
@@ -304,21 +300,9 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
     }
 
     @Override
-    public StateMap getState(String reportingTaskId, Scope scope) {
-        final ReportingTaskNode reportingTask = locateReportingTask(reportingTaskId);
-        return componentStateDAO.getState(reportingTask, scope);
-    }
-
-    @Override
     public void verifyClearState(String reportingTaskId) {
         final ReportingTaskNode reportingTask = locateReportingTask(reportingTaskId);
         reportingTask.verifyCanClearState();
-    }
-
-    @Override
-    public void clearState(String reportingTaskId) {
-        final ReportingTaskNode reportingTask = locateReportingTask(reportingTaskId);
-        componentStateDAO.clearState(reportingTask);
     }
 
     /* setters */
@@ -326,7 +310,4 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
         this.reportingTaskProvider = reportingTaskProvider;
     }
 
-    public void setComponentStateDAO(ComponentStateDAO componentStateDAO) {
-        this.componentStateDAO = componentStateDAO;
-    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/resources/nifi-web-api-context.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/resources/nifi-web-api-context.xml
@@ -86,16 +86,13 @@
     </bean>
     <bean id="processorDAO" class="org.apache.nifi.web.dao.impl.StandardProcessorDAO">
         <property name="flowController" ref="flowController"/>
-        <property name="componentStateDAO" ref="componentStateDAO"/>
     </bean>
     <bean id="controllerServiceDAO" class="org.apache.nifi.web.dao.impl.StandardControllerServiceDAO">
         <property name="serviceProvider" ref="controllerServiceProvider"/>
-        <property name="componentStateDAO" ref="componentStateDAO"/>
         <property name="flowController" ref="flowController" />
     </bean>
     <bean id="reportingTaskDAO" class="org.apache.nifi.web.dao.impl.StandardReportingTaskDAO">
         <property name="reportingTaskProvider" ref="reportingTaskProvider"/>
-        <property name="componentStateDAO" ref="componentStateDAO"/>
     </bean>
     <bean id="componentStateDAO" class="org.apache.nifi.web.dao.impl.StandardComponentStateDAO">
         <property name="stateManagerProvider" ref="stateManagerProvider"/>
@@ -165,6 +162,7 @@
         <property name="clusterCoordinator" ref="clusterCoordinator"/>
         <property name="heartbeatMonitor" ref="heartbeatMonitor" />
         <property name="bulletinRepository" ref="bulletinRepository"/>
+        <property name="componentStateDAO" ref="componentStateDAO"/>
     </bean>
     
     <!-- component ui extension configuration context -->

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/java/org/apache/nifi/web/ContentViewerController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/java/org/apache/nifi/web/ContentViewerController.java
@@ -108,7 +108,7 @@ public class ContentViewerController extends HttpServlet {
             viewerContext.getRequestDispatcher("/message").forward(request, response);
             return;
         } catch (final AccessDeniedException ade) {
-            request.setAttribute("title", "Acess Denied");
+            request.setAttribute("title", "Access Denied");
             request.setAttribute("messages", "Unable to approve access to the specified content: " + ade.getMessage());
 
             // forward to the error page

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-state.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-state.js
@@ -90,20 +90,9 @@ nf.ComponentState = (function () {
     var sort = function (sortDetails, data) {
         // defines a function for sorting
         var comparer = function (a, b) {
-            if(a.permissions.canRead && b.permissions.canRead) {
-                var aString = nf.Common.isDefinedAndNotNull(a.component[sortDetails.columnId]) ? a.component[sortDetails.columnId] : '';
-                var bString = nf.Common.isDefinedAndNotNull(b.component[sortDetails.columnId]) ? b.component[sortDetails.columnId] : '';
-                return aString === bString ? 0 : aString > bString ? 1 : -1;
-            } else {
-                if (!a.permissions.canRead && !b.permissions.canRead){
-                    return 0;
-                }
-                if(a.permissions.canRead){
-                    return 1;
-                } else {
-                    return -1;
-                }
-            }
+            var aString = nf.Common.isDefinedAndNotNull(a[sortDetails.columnId]) ? a[sortDetails.columnId] : '';
+            var bString = nf.Common.isDefinedAndNotNull(b[sortDetails.columnId]) ? b[sortDetails.columnId] : '';
+            return aString === bString ? 0 : aString > bString ? 1 : -1;
         };
 
         // perform the sort

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-state.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-state.js
@@ -145,7 +145,7 @@ nf.ComponentState = (function () {
      *
      * @param {object} componentState
      */
-    var loadComponentState = function (localState, clusterState) {
+    var loadComponentState = function (localState, clusterState, externalState) {
         var count = 0;
         var totalEntries = 0;
         var showPartialDetails = false;
@@ -156,34 +156,35 @@ nf.ComponentState = (function () {
         // begin the update
         componentStateData.beginUpdate();
 
-        // local state
-        if (nf.Common.isDefinedAndNotNull(localState)) {
-            $.each(localState.state, function (i, stateEntry) {
-                componentStateData.addItem($.extend({
-                    id: count++,
-                    scope: stateEntry.clusterNodeAddress
-                }, stateEntry));
-            });
-            totalEntries += localState.totalEntryCount;
+        var addComponentStateData = function (componentState, getScope) {
+            if (nf.Common.isDefinedAndNotNull(componentState)
+                && nf.Common.isDefinedAndNotNull(componentState.state)) {
 
-            if (nf.Common.isDefinedAndNotNull(localState.state) && localState.totalEntryCount !== localState.state.length) {
-                showPartialDetails = true;
+                $.each(componentState.state, function (i, stateEntry) {
+                    componentStateData.addItem($.extend({
+                        id: count++,
+                        scope: getScope(stateEntry),
+                    }, stateEntry));
+                });
+                totalEntries += componentState.totalEntryCount;
+
+                if (componentState.totalEntryCount !== componentState.state.length) {
+                    showPartialDetails = true;
+                }
             }
         }
 
-        if (nf.Common.isDefinedAndNotNull(clusterState)) {
-            $.each(clusterState.state, function (i, stateEntry) {
-                componentStateData.addItem($.extend({
-                    id: count++,
-                    scope: 'Cluster'
-                }, stateEntry));
-            });
-            totalEntries += clusterState.totalEntryCount;
+        addComponentStateData(localState, function(stateEntry) {
+            return stateEntry.clusterNodeAddress;
+        });
 
-            if (nf.Common.isDefinedAndNotNull(clusterState.state) && clusterState.totalEntryCount !== clusterState.state.length) {
-                showPartialDetails = true;
-            }
-        }
+        addComponentStateData(clusterState, function(stateEntry) {
+            return 'Cluster';
+        });
+
+        addComponentStateData(externalState, function(stateEntry) {
+            return 'External' + (stateEntry.clusterNodeAddress ? ' - ' + stateEntry.clusterNodeAddress : '');
+        });
 
         // complete the update
         componentStateData.endUpdate();
@@ -273,11 +274,19 @@ nf.ComponentState = (function () {
                             url: componentEntity.uri + '/state/clear-requests',
                             dataType: 'json'
                         }).done(function (response) {
-                            // clear the table
-                            clearTable();
+                            if (response.cleared) {
+                                // clear the table
+                                clearTable();
 
-                            // reload the table with no state
-                            loadComponentState()
+                                // reload the table with no state
+                                loadComponentState()
+                            } else {
+                                nf.Dialog.showOkDialog({
+                                    headerText: 'Failed to clear state',
+                                    dialogContent: response.message
+                                });
+                            }
+
                         }).fail(nf.Common.handleAjaxError);
                     } else {
                         nf.Dialog.showOkDialog({
@@ -293,17 +302,6 @@ nf.ComponentState = (function () {
                 {id: 'key', field: 'key', name: 'Key', sortable: true, resizable: true},
                 {id: 'value', field: 'value', name: 'Value', sortable: true, resizable: true}
             ];
-
-            // conditionally show the cluster node identifier
-            if (nf.Canvas.isClustered()) {
-                componentStateColumns.push({
-                    id: 'scope',
-                    field: 'scope',
-                    name: 'Scope',
-                    sortable: true,
-                    resizable: true
-                });
-            }
 
             var componentStateOptions = {
                 forceFitColumns: true,
@@ -379,8 +377,25 @@ nf.ComponentState = (function () {
                 var componentState = response.componentState;
                 var componentStateTable = $('#component-state-table');
 
+                // conditionally show the cluster node identifier
+                var gridInstance = componentStateTable.data().gridInstance;
+                var componentStateColumns = gridInstance.getColumns();
+                if (nf.Canvas.isClustered() || nf.Common.isDefinedAndNotNull(componentState.externalState)) {
+                    if (componentStateColumns.length === 2) {
+                        // Show scope column
+                        componentStateColumns.push({id: 'scope', field: 'scope', name: 'Scope', sortable: true, resizable: true});
+                        gridInstance.setColumns(componentStateColumns);
+                    }
+                } else {
+                    if (componentStateColumns.length === 3) {
+                        // Hide scope columns
+                        componentStateColumns.pop();
+                        gridInstance.setColumns(componentStateColumns);
+                    }
+                }
+
                 // load the table
-                loadComponentState(componentState.localState, componentState.clusterState);
+                loadComponentState(componentState.localState, componentState.clusterState, componentState.externalState);
 
                 // populate the name/description
                 $('#component-state-name').text(componentEntity.component.name);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/processors/kafka/GetKafka.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/processors/kafka/GetKafka.java
@@ -205,10 +205,14 @@ public class GetKafka extends AbstractProcessor implements ExternalStateManager 
                 .fromPropertyDescriptor(CLIENT_NAME)
                 .defaultValue("NiFi-" + getIdentifier())
                 .build();
+        final String defaultGroupId = getIdentifier();
         final PropertyDescriptor groupIdWithDefault = new PropertyDescriptor.Builder()
                 .fromPropertyDescriptor(GROUP_ID)
-                .defaultValue(getIdentifier())
+                .defaultValue(defaultGroupId)
                 .build();
+        if (StringUtils.isBlank(groupId)) {
+            groupId = defaultGroupId;
+        }
 
         final List<PropertyDescriptor> props = new ArrayList<>();
         props.add(ZOOKEEPER_CONNECTION_STRING);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/processors/kafka/KafkaUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/processors/kafka/KafkaUtils.java
@@ -1,7 +1,20 @@
 package org.apache.nifi.processors.kafka;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import kafka.client.ClientUtils;
+import kafka.common.OffsetAndMetadata;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.OffsetFetchRequest;
+import kafka.javaapi.OffsetFetchResponse;
+import kafka.javaapi.OffsetCommitRequest;
+import kafka.javaapi.OffsetCommitResponse;
+import kafka.network.BlockingChannel;
+import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkMarshallingError;
 /*
@@ -26,13 +39,34 @@ import kafka.admin.AdminUtils;
 import kafka.api.TopicMetadata;
 import kafka.utils.ZKStringSerializer;
 import scala.collection.JavaConversions;
+import scala.collection.Seq;
+import scala.collection.mutable.Buffer;
+
+import static scala.collection.JavaConversions.asJavaList;
+import static scala.collection.JavaConversions.asScalaBuffer;
 
 /**
- * Utility class to support interruction with Kafka internals.
+ * Utility class to support interaction with Kafka internals.
  *
  */
 class KafkaUtils {
 
+    private static final int ZK_CONNECTION_TIMEOUT_MS = 30_000;
+    private static final int SOCKET_TIMEOUT_MS = 30_000;
+    private static final int RETRY_BACK_OFF_MS = 30_000;
+    private static final String DEFAULT_CLIENT_ID = "";
+
+    private static class StingSerializer implements ZkSerializer {
+        @Override
+        public byte[] serialize(Object o) throws ZkMarshallingError {
+            return ZKStringSerializer.serialize(o);
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) throws ZkMarshallingError {
+            return ZKStringSerializer.deserialize(bytes);
+        }
+    }
 
     /**
      * Will retrieve the amount of partitions for a given Kafka topic.
@@ -41,18 +75,8 @@ class KafkaUtils {
         ZkClient zkClient = null;
 
         try {
-            zkClient = new ZkClient(zookeeperConnectionString);
-            zkClient.setZkSerializer(new ZkSerializer() {
-                @Override
-                public byte[] serialize(Object o) throws ZkMarshallingError {
-                    return ZKStringSerializer.serialize(o);
-                }
-
-                @Override
-                public Object deserialize(byte[] bytes) throws ZkMarshallingError {
-                    return ZKStringSerializer.deserialize(bytes);
-                }
-            });
+            zkClient = new ZkClient(zookeeperConnectionString, ZK_CONNECTION_TIMEOUT_MS);
+            zkClient.setZkSerializer(new StingSerializer());
             scala.collection.Set<TopicMetadata> topicMetadatas = AdminUtils
                     .fetchTopicMetadataFromZk(JavaConversions.asScalaSet(Collections.singleton(topicName)), zkClient);
             if (topicMetadatas != null && topicMetadatas.size() > 0) {
@@ -70,5 +94,78 @@ class KafkaUtils {
             }
         }
     }
+
+    static Map<String, String> retrievePartitionOffsets(final String zookeeperConnectionString, final String topicName,
+                                                        final String groupName) throws IOException {
+        return executeConsumerGroupCommand(zookeeperConnectionString, topicName, groupName, "retrievePartitionOffsets", (channel, topicPartitions) -> {
+            // Use version 0 to retrieve offsets from Zookeeper. version 1 will get from Kafka.
+            channel.send(new OffsetFetchRequest(groupName, topicPartitions, (short)0, 0, DEFAULT_CLIENT_ID).underlying());
+            final OffsetFetchResponse offsetFetchResponse = OffsetFetchResponse.readFrom(channel.receive().buffer());
+            final Map<String, String> state = offsetFetchResponse.offsets().entrySet().stream()
+                    .filter(entry -> entry.getValue().offset() > -1)
+                    .collect(Collectors.toMap(entry -> "partition:" + entry.getKey().partition(), entry -> String.valueOf(entry.getValue().offset())));
+            return state;
+        });
+    }
+
+    static void clearPartitionOffsets(final String zookeeperConnectionString, final String topicName, final String groupName) throws IOException {
+        executeConsumerGroupCommand(zookeeperConnectionString, topicName, groupName, "clearPartitionOffsets", (channel, topicPartitions) -> {
+            final Map<TopicAndPartition, OffsetAndMetadata> offsets = topicPartitions.stream()
+                    .collect(Collectors.toMap(tp -> tp, tp -> new OffsetAndMetadata(-1, OffsetAndMetadata.NoMetadata(), -1L)));
+
+            // Use version 0 to clear offsets from Zookeeper. version 1 will get from Kafka.
+            final OffsetCommitRequest request = new OffsetCommitRequest(groupName, offsets, 0, DEFAULT_CLIENT_ID, (short) 0);
+            channel.send(request.underlying());
+            final OffsetCommitResponse response = OffsetCommitResponse.readFrom(channel.receive().buffer());
+            if (response.hasError()) {
+                throw new IOException("Failed to clear offsets due to " + response.errors());
+            }
+
+            return true;
+        });
+    }
+
+    static <T> T executeConsumerGroupCommand(final String zookeeperConnectionString, final String topicName, final String groupId,
+                                             final String commandName, final ConsumerGroupCommand<T> command) throws IOException {
+        ZkClient zkClient = null;
+        BlockingChannel channel = null;
+
+        try {
+            zkClient = new ZkClient(zookeeperConnectionString, ZK_CONNECTION_TIMEOUT_MS);
+            zkClient.setZkSerializer(new StingSerializer());
+
+            final Buffer<String> topics = asScalaBuffer(Collections.singletonList(topicName));
+            final scala.collection.mutable.Map<String, Seq<Object>> topicMap = ZkUtils.getPartitionsForTopics(zkClient, topics);
+
+            final List<TopicAndPartition> topicPartitions = asJavaList(topicMap.get(topicName).get()).stream()
+                    .map(p -> new TopicAndPartition(topicName, (Integer) p))
+                    .collect(Collectors.toList());
+
+            // Use version 0 to retrieve offsets from Zookeeper. version 1 will get from Kafka.
+            channel = ClientUtils.channelToOffsetManager(groupId, zkClient, SOCKET_TIMEOUT_MS, RETRY_BACK_OFF_MS);
+
+            return command.execute(channel, topicPartitions);
+
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to " + commandName + " for topic: " + topicName + " consumer group:" + groupId, e);
+        } finally {
+            try {
+                if (channel != null) {
+                    channel.disconnect();
+                }
+            } finally {
+                if (zkClient != null) {
+                    zkClient.close();
+                }
+            }
+        }
+    }
+
+    private interface ConsumerGroupCommand<T> {
+        T execute(final BlockingChannel channel, final List<TopicAndPartition> topicPartitions) throws IOException;
+    }
+
 
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/processors/kafka/TestGetKafka.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/processors/kafka/TestGetKafka.java
@@ -178,11 +178,11 @@ public class TestGetKafka {
         assertNull("State should be null when required properties are not specified.", processor.getExternalState());
 
         runner.setProperty(GetKafka.ZOOKEEPER_CONNECTION_STRING, "0.0.0.0:invalid-port");
-        runner.setProperty(GetKafka.TOPIC, "testX");
+        runner.setProperty(GetKafka.GROUP_ID, "consumer-group-id");
 
         assertNull("State should be null when required properties are not specified.", processor.getExternalState());
 
-        runner.setProperty(GetKafka.GROUP_ID, "consumer-group-id");
+        runner.setProperty(GetKafka.TOPIC, "testX");
 
         try {
             processor.getExternalState();

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/pom.xml
@@ -35,10 +35,6 @@
             <artifactId>nifi-utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-expression-language</artifactId>
-        </dependency>
-        <dependency>
 		    <groupId>org.apache.kafka</groupId>
 		    <artifactId>kafka-clients</artifactId>
 		    <version>0.9.0.1</version>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>nifi-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-expression-language</artifactId>
+        </dependency>
+        <dependency>
 		    <groupId>org.apache.kafka</groupId>
 		    <artifactId>kafka-clients</artifactId>
 		    <version>0.9.0.1</version>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/AbstractKafkaProcessor.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/AbstractKafkaProcessor.java
@@ -69,6 +69,7 @@ abstract class AbstractKafkaProcessor<T extends Closeable> extends AbstractSessi
     static final AllowableValue SEC_SASL_PLAINTEXT = new AllowableValue("SASL_PLAINTEXT", "SASL_PLAINTEXT", "SASL_PLAINTEXT");
     static final AllowableValue SEC_SASL_SSL = new AllowableValue("SASL_SSL", "SASL_SSL", "SASL_SSL");
 
+    protected static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
     static final PropertyDescriptor BOOTSTRAP_SERVERS = new PropertyDescriptor.Builder()
             .name(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
             .displayName("Kafka Brokers")
@@ -77,7 +78,7 @@ abstract class AbstractKafkaProcessor<T extends Closeable> extends AbstractSessi
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .addValidator(StandardValidators.createRegexMatchingValidator(Pattern.compile(BROKER_REGEX)))
             .expressionLanguageSupported(true)
-            .defaultValue("localhost:9092")
+            .defaultValue(DEFAULT_BOOTSTRAP_SERVERS)
             .build();
     static final PropertyDescriptor CLIENT_ID = new PropertyDescriptor.Builder()
             .name(ProducerConfig.CLIENT_ID_CONFIG)

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-pubsub-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka.java
@@ -121,7 +121,7 @@ public class ConsumeKafka extends AbstractKafkaProcessor<Consumer<byte[], byte[]
 
     private volatile String topic;
 
-    private volatile String brokers;
+    private volatile String brokers = DEFAULT_BOOTSTRAP_SERVERS;
 
     private volatile Properties kafkaProperties;
 
@@ -491,7 +491,7 @@ public class ConsumeKafka extends AbstractKafkaProcessor<Consumer<byte[], byte[]
         if (kafkaProperties == null) {
             kafkaProperties = getDefaultKafkaProperties();
         }
-        setKafkaProperty(kafkaProperties, descriptor, new StandardPropertyValue(newValue, null));
+        setKafkaProperty(kafkaProperties, descriptor, new StandardPropertyValue(newValue, null, null));
 
         if (TOPIC.equals(descriptor)) {
             topic = kafkaProperties.getProperty(TOPIC.getName());


### PR DESCRIPTION
- Added ExternalStateManager to handle components' state managed
  externally
- Added UI codes to display external state
- Added view/clear functionality to ConsumeKafka
- Added view/clear functionality to GetKafka
- Capture property value change, so that external state can be accessed
  before onTrigger is called
- Fixed Component State UI clear link NIFI-2078
- Added Expression Language support at onPropertyModified.
- Tested with Kerberized Zookeeper and Kafka
