### PR TITLE
NIFI-2089: Ensure streams are closed before attempting to remove files

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -628,6 +628,16 @@ public class FileSystemRepository implements ContentRepository {
         } catch (final ContentNotFoundException cnfe) {
         }
 
+        // Ensure that we have no writable claim streams for this resource claim
+        final ByteCountingOutputStream bcos = writableClaimStreams.remove(claim);
+        if (bcos != null) {
+            try {
+                bcos.close();
+            } catch (final IOException e) {
+                LOG.warn("Failed to close Output Stream for {} due to {}", claim, e);
+            }
+        }
+
         final File file = path.toFile();
         if (!file.delete() && file.exists()) {
             LOG.warn("Unable to delete {} at path {}", new Object[] {claim, path});

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
@@ -329,10 +329,11 @@ public class TestFileSystemRepository {
     @Test
     public void testExportToOutputStream() throws IOException {
         final ContentClaim claim = repository.create(true);
-        final Path path = getPath(claim);
 
-        Files.createDirectories(path.getParent());
-        Files.copy(helloWorldFile.toPath(), path, StandardCopyOption.REPLACE_EXISTING);
+        try (final OutputStream out = repository.write(claim)) {
+            Files.copy(helloWorldFile.toPath(), out);
+        }
+
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         repository.exportTo(claim, baos);
         final byte[] data = baos.toByteArray();
@@ -342,10 +343,10 @@ public class TestFileSystemRepository {
     @Test
     public void testExportToFile() throws IOException {
         final ContentClaim claim = repository.create(true);
-        final Path path = getPath(claim);
+        try (final OutputStream out = repository.write(claim)) {
+            Files.copy(helloWorldFile.toPath(), out);
+        }
 
-        Files.createDirectories(path.getParent());
-        Files.copy(helloWorldFile.toPath(), path, StandardCopyOption.REPLACE_EXISTING);
         final File outFile = new File("target/testExportToFile");
         final Path outPath = outFile.toPath();
         Files.deleteIfExists(outPath);


### PR DESCRIPTION
Also fixed buggy unit tests that did not properly utilize the Content Repository API but instead attempted to write to files directly