### PR TITLE
NIFI-1733 Adding a Ranger implementation of NiFi's Authorizer API

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -44,6 +44,21 @@ The following binary components are provided under the Apache Software License v
     The following NOTICE information applies:
          Copyright 2006 Envoi Solutions LLC
 
+  (ASLv2) Jets3t
+    The following NOTICE information applies:
+
+         This product includes software developed by:
+
+         The Apache Software Foundation (http://www.apache.org/).
+
+         The ExoLab Project (http://www.exolab.org/)
+
+         Sun Microsystems (http://www.sun.com/)
+
+         Codehaus (http://castor.codehaus.org)
+
+         Tatu Saloranta (http://wiki.fasterxml.com/TatuSaloranta)
+
   (ASLv2) Jasypt
     The following NOTICE information applies:    
 	  Copyright (c) 2007-2010, The JASYPT team (http://www.jasypt.org)
@@ -585,6 +600,11 @@ The following binary components are provided under the Apache Software License v
       from and not be held liable to the user for any such damages as noted
       above as far as the program is concerned.
 
+  (ASLv2) Apache Solr
+    The following NOTICE information applies:
+      Apache Solrj
+      Copyright 2006-2014 The Apache Software Foundation
+
   (ASLv2) Joda Time
     The following NOTICE information applies:
       This product includes software developed by
@@ -920,6 +940,9 @@ The following binary components are provided under the Eclipse Public License 1.
         The following NOTICE information applies:
             Copyright (c) 2007-2015 The JRuby project
     (EPL 1.0) Eclipse Paho MQTT Client (org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2 - https://github.com/eclipse/paho.mqtt.java)
+    (EPL 1.0) Eclipse Link (org.eclipse.persistence:eclipselink:2.5.2 - http://www.eclipse.org/eclipselink/)
+    (EPL 1.0) Common Service Data Objects (org.eclipse.persistence:commonj.sdo:2.1.1 - http://www.eclipse.org/eclipselink/)
+    (EPL 1.0) Java Persistence API (org.eclipse.persistence:javax.persistence:2.1.0 - http://www.eclipse.org/eclipselink/)
 
 *****************
 Mozilla Public License v2.0

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -344,8 +344,8 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mqtt-nar</artifactId>
-            <type>nar</type>
-      	</dependency>
+	        <type>nar</type>
+	    </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-snmp-nar</artifactId>
@@ -688,6 +688,58 @@ language governing permissions and limitations under the License. -->
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>include-ranger</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <finalName>nifi-${project.version}</finalName>
+                            <attach>false</attach>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make shared resource</id>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <archiverConfig>
+                                        <defaultDirectoryMode>0775</defaultDirectoryMode>
+                                        <directoryMode>0775</directoryMode>
+                                        <fileMode>0664</fileMode>
+                                    </archiverConfig>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/ranger.xml</descriptor>
+                                    </descriptors>
+                                    <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-ranger-nar</artifactId>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.ranger</groupId>
+                    <artifactId>credentialbuilder</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-ranger-resources</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/nifi-assembly/src/main/assembly/common.xml
+++ b/nifi-assembly/src/main/assembly/common.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<component>
+    <dependencySets>
+        <!-- Write out the bootstrap lib component to its own dir -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib/bootstrap</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>nifi-bootstrap</include>
+                <include>slf4j-api</include>
+                <include>logback-classic</include>
+                <include>nifi-api</include>
+            </includes>
+        </dependencySet>
+
+        <!-- Write out the conf directory contents -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>./</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0664</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>nifi-resources</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>true</filtered>
+                <includes>
+                    <include>conf/*</include>
+                </includes>
+            </unpackOptions>
+        </dependencySet>
+
+        <!-- Write out the bin directory contents -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>./</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0770</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>nifi-resources</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>true</filtered>
+                <includes>
+                    <include>bin/*</include>
+                </includes>
+            </unpackOptions>
+        </dependencySet>
+
+        <!-- Writes out the docs directory contents -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>docs/</outputDirectory>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>nifi-docs</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>false</filtered>
+                <excludes>
+                    <!-- LICENSE and NOTICE both covered by top-level -->
+                    <exclude>LICENSE</exclude>
+                    <exclude>NOTICE</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet>
+    </dependencySets>
+    <files>
+        <file>
+            <source>./README.md</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>README</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>./LICENSE</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>LICENSE</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>./NOTICE</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>NOTICE</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+    </files>
+</component>

--- a/nifi-assembly/src/main/assembly/ranger.xml
+++ b/nifi-assembly/src/main/assembly/ranger.xml
@@ -28,7 +28,7 @@
     </componentDescriptors>
 
     <dependencySets>
-        <!-- Write out all dependency artifacts to lib directory -->
+        <!-- Write out all dependency artifacts to lib directory, exclude Ranger dependencies -->
         <dependencySet>
             <scope>runtime</scope>
             <useProjectArtifact>false</useProjectArtifact>
@@ -40,7 +40,41 @@
                 <exclude>nifi-bootstrap</exclude>
                 <exclude>nifi-resources</exclude>
                 <exclude>nifi-docs</exclude>
+                <exclude>org.apache.ranger:credentialbuilder:jar</exclude>
+                <exclude>org.apache.nifi:nifi-ranger-resources:jar</exclude>
             </excludes>
+        </dependencySet>
+        <!-- Write out dependencies for Ranger's credentialbuilder to ext/ranger/install/lib -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>ext/ranger/install/lib/</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>org.apache.ranger:credentialbuilder:jar</include>
+                <include>org.slf4j:slf4j-api</include>
+            </includes>
+        </dependencySet>
+        <!-- Write out scripts from nifi-ranger-resources to ext/ranger/scripts -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>ext/ranger/</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0770</fileMode>
+            <useTransitiveFiltering>false</useTransitiveFiltering>
+            <includes>
+                <include>org.apache.nifi:nifi-ranger-resources:jar</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>true</filtered>
+                <includes>
+                    <include>scripts/</include>
+                </includes>
+            </unpackOptions>
         </dependencySet>
     </dependencySets>
 

--- a/nifi-nar-bundles/nifi-geo-bundle/nifi-geo-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-geo-bundle/nifi-geo-processors/pom.xml
@@ -38,6 +38,17 @@
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
             <version>2.1.0</version>
-        </dependency>        
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -37,6 +37,12 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hadoop-utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
@@ -30,10 +30,21 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/pom.xml
@@ -133,6 +133,10 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -154,6 +158,11 @@
                     <artifactId>hadoop-common</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-ranger-bundle</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-ranger-nar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-ranger-plugin</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,389 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.
+
+  The binary distribution of this product bundles 'Scala Library' under a BSD
+  style license.
+
+    Copyright (c) 2002-2015 EPFL
+    Copyright (c) 2011-2015 Typesafe, Inc.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+	  are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of
+    conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, this list of
+    conditions and the following disclaimer in the documentation and/or other materials
+    provided with the distribution.
+
+    Neither the name of the EPFL nor the names of its contributors may be used to endorse
+    or promote products derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+    IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  The binary distribution of this product bundles 'JOpt Simple' under an MIT
+  style license.
+
+    Copyright (c) 2009 Paul R. Holser, Jr.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+  The binary distribution of this product bundles 'JCraft Jsch' which is available
+  under a BSD style license.
+
+    Copyright (c) 2002-2015 Atsuhiko Yamanaka, JCraft,Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in
+         the documentation and/or other materials provided with the distribution.
+
+      3. The names of the authors may not be used to endorse or promote products
+         derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+    INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+    OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+    EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  The binary distribution of this product bundles 'ParaNamer' and 'Paranamer Core'
+  which is available under a BSD style license.
+
+    Copyright (c) 2006 Paul Hammant & ThoughtWorks Inc
+     All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions
+     are met:
+     1. Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+     3. Neither the name of the copyright holders nor the names of its
+        contributors may be used to endorse or promote products derived from
+        this software without specific prior written permission.
+
+     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+     LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+     INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+     CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+     THE POSSIBILITY OF SUCH DAMAGE.
+
+  The binary distribution of this product bundles 'Protocol Buffers - Google's data interchange format'
+  which is available under a BSD style license.
+
+    Copyright 2008 Google Inc.  All rights reserved.
+    http://code.google.com/p/protobuf/
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  The binary distribution of this product bundles 'Woodstox StAX 2 API' which is
+     "licensed under standard BSD license"
+
+  The binary distribution of this product bundles 'XMLENC' which is available
+  under a BSD license.  More details found here: http://xmlenc.sourceforge.net.
+
+    Copyright 2003-2005, Ernst de Haan <wfe.dehaan@gmail.com>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,378 @@
+nifi-ranger-nar
+Copyright 2014-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+******************
+Apache Software License v2
+******************
+
+  (ASLv2) Apache Avro
+    The following NOTICE information applies:
+      Apache Avro
+      Copyright 2009-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Collections
+    The following NOTICE information applies:
+      Apache Commons Collections
+      Copyright 2001-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Compress
+    The following NOTICE information applies:
+      Apache Commons Compress
+      Copyright 2002-2014 The Apache Software Foundation
+
+      The files in the package org.apache.commons.compress.archivers.sevenz
+      were derived from the LZMA SDK, version 9.20 (C/ and CPP/7zip/),
+      which has been placed in the public domain:
+
+      "LZMA SDK is placed in the public domain." (http://www.7-zip.org/sdk.html)
+
+  (ASLv2) Apache Commons Codec
+    The following NOTICE information applies:
+      Apache Commons Codec
+      Copyright 2002-2014 The Apache Software Foundation
+
+      src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+      contains test data from http://aspell.net/test/orig/batch0.tab.
+      Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+
+      ===============================================================================
+
+      The content of package org.apache.commons.codec.language.bm has been translated
+      from the original php source code available at http://stevemorse.org/phoneticinfo.htm
+      with permission from the original authors.
+      Original source copyright:
+      Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+
+  (ASLv2) Apache Commons CLI
+    The following NOTICE information applies:
+      Apache Commons CLI
+      Copyright 2001-2009 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Configuration
+    The following NOTICE information applies:
+      Apache Commons Configuration
+      Copyright 2001-2008 The Apache Software Foundation
+
+  (ASLv2) Apache Commons EL
+    The following NOTICE information applies:
+      Apache Commons EL
+      Copyright 1999-2007 The Apache Software Foundation
+
+      EL-8 patch - Copyright 2004-2007 Jamie Taylor
+      http://issues.apache.org/jira/browse/EL-8
+
+  (ASLv2) Apache Directory Server
+    The following NOTICE information applies:
+      ApacheDS Protocol Kerberos Codec
+      Copyright 2003-2013 The Apache Software Foundation
+
+      ApacheDS I18n
+      Copyright 2003-2013 The Apache Software Foundation
+
+      Apache Directory API ASN.1 API
+      Copyright 2003-2013 The Apache Software Foundation
+
+      Apache Directory LDAP API Utilities
+      Copyright 2003-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Jakarta HttpClient
+    The following NOTICE information applies:
+      Apache Jakarta HttpClient
+      Copyright 1999-2007 The Apache Software Foundation
+
+  (ASLv2) Apache Commons IO
+    The following NOTICE information applies:
+      Apache Commons IO
+      Copyright 2002-2012 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Lang
+    The following NOTICE information applies:
+      Apache Commons Lang
+      Copyright 2001-2015 The Apache Software Foundation
+
+      This product includes software from the Spring Framework,
+      under the Apache License 2.0 (see: StringUtils.containsWhitespace())
+
+  (ASLv2) Apache Commons Logging
+    The following NOTICE information applies:
+      Apache Commons Logging
+      Copyright 2003-2014 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Math
+    The following NOTICE information applies:
+      Apache Commons Math
+      Copyright 2001-2012 The Apache Software Foundation
+
+      This product includes software developed by
+      The Apache Software Foundation (http://www.apache.org/).
+
+      ===============================================================================
+
+      The BracketFinder (package org.apache.commons.math3.optimization.univariate)
+      and PowellOptimizer (package org.apache.commons.math3.optimization.general)
+      classes are based on the Python code in module "optimize.py" (version 0.5)
+      developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
+      Copyright © 2003-2009 SciPy Developers.
+      ===============================================================================
+
+      The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
+      RelationShip, SimplexSolver and SimplexTableau classes in package
+      org.apache.commons.math3.optimization.linear include software developed by
+      Benjamin McCann (http://www.benmccann.com) and distributed with
+      the following copyright: Copyright 2009 Google Inc.
+      ===============================================================================
+
+      This product includes software developed by the
+      University of Chicago, as Operator of Argonne National
+      Laboratory.
+      The LevenbergMarquardtOptimizer class in package
+      org.apache.commons.math3.optimization.general includes software
+      translated from the lmder, lmpar and qrsolv Fortran routines
+      from the Minpack package
+      Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
+      ===============================================================================
+
+      The GraggBulirschStoerIntegrator class in package
+      org.apache.commons.math3.ode.nonstiff includes software translated
+      from the odex Fortran routine developed by E. Hairer and G. Wanner.
+      Original source copyright:
+      Copyright (c) 2004, Ernst Hairer
+      ===============================================================================
+
+      The EigenDecompositionImpl class in package
+      org.apache.commons.math3.linear includes software translated
+      from some LAPACK Fortran routines.  Original source copyright:
+      Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
+      ===============================================================================
+
+      The MersenneTwister class in package org.apache.commons.math3.random
+      includes software translated from the 2002-01-26 version of
+      the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
+      Nishimura. Original source copyright:
+      Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+      All rights reserved
+      ===============================================================================
+
+      The LocalizedFormatsTest class in the unit tests is an adapted version of
+      the OrekitMessagesTest class from the orekit library distributed under the
+      terms of the Apache 2 licence. Original source copyright:
+      Copyright 2010 CS Systèmes d'Information
+      ===============================================================================
+
+      The HermiteInterpolator class and its corresponding test have been imported from
+      the orekit library distributed under the terms of the Apache 2 licence. Original
+      source copyright:
+      Copyright 2010-2012 CS Systèmes d'Information
+      ===============================================================================
+
+      The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
+      by an original code donated by Sébastien Brisard.
+      ===============================================================================
+
+  (ASLv2) Apache Commons Net
+    The following NOTICE information applies:
+      Apache Commons Net
+      Copyright 2001-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Curator
+    The following NOTICE information applies:
+      Curator Framework
+      Copyright 2011-2014 The Apache Software Foundation
+
+      Curator Client
+      Copyright 2011-2014 The Apache Software Foundation
+
+      Curator Recipes
+      Copyright 2011-2014 The Apache Software Foundation
+
+  (ASLv2) Apache HttpComponents
+    The following NOTICE information applies:
+      Apache HttpClient
+      Copyright 1999-2015 The Apache Software Foundation
+
+      Apache HttpCore
+      Copyright 2005-2015 The Apache Software Foundation
+
+      Apache HttpMime
+      Copyright 1999-2013 The Apache Software Foundation
+
+      This project contains annotations derived from JCIP-ANNOTATIONS
+      Copyright (c) 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
+
+  (ASLv2) Apache Ranger
+    The following NOTICE information applies:
+      Apache Ranger Credential Builder
+      Copyright 2014-2016 The Apache Software Foundation
+
+      Apache Ranger Plugins Audit
+      Copyright 2014-2016 The Apache Software Foundation
+
+      Apache Ranger Plugins Common
+      Copyright 2014-2016 The Apache Software Foundation
+
+      Apache Ranger Plugins Cred
+      Copyright 2014-2016 The Apache Software Foundation
+
+  (ASLv2) Google GSON
+    The following NOTICE information applies:
+      Copyright 2008 Google Inc.
+
+  (ASLv2) HTrace Core
+    The following NOTICE information applies:
+      In addition, this product includes software dependencies. See
+      the accompanying LICENSE.txt for a listing of dependencies
+      that are NOT Apache licensed (with pointers to their licensing)
+
+      Apache HTrace includes an Apache Thrift connector to Zipkin. Zipkin
+      is a distributed tracing system that is Apache 2.0 Licensed.
+      Copyright 2012 Twitter, Inc.
+
+  (ASLv2) Jackson JSON processor
+    The following NOTICE information applies:
+      # Jackson JSON processor
+
+      Jackson is a high-performance, Free/Open Source JSON processing library.
+      It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+      been in development since 2007.
+      It is currently developed by a community of developers, as well as supported
+      commercially by FasterXML.com.
+
+      ## Licensing
+
+      Jackson core and extension components may licensed under different licenses.
+      To find the details that apply to this artifact see the accompanying LICENSE file.
+      For more information, including possible other licensing options, contact
+      FasterXML.com (http://fasterxml.com).
+
+      ## Credits
+
+      A list of contributors may be found from CREDITS file, which is included
+      in some artifacts (usually source distributions); but is always available
+      from the source code management (SCM) system project uses.
+
+  (ASLv2) Jettison
+    The following NOTICE information applies:
+      Copyright 2006 Envoi Solutions LLC
+
+  (ASLv2) Jets3t
+    The following NOTICE information applies:
+
+         This product includes software developed by:
+
+         The Apache Software Foundation (http://www.apache.org/).
+
+         The ExoLab Project (http://www.exolab.org/)
+
+         Sun Microsystems (http://www.sun.com/)
+
+         Codehaus (http://castor.codehaus.org)
+
+         Tatu Saloranta (http://wiki.fasterxml.com/TatuSaloranta)
+
+  (ASLv2) Jetty
+    The following NOTICE information applies:
+       Jetty Web Container
+       Copyright 1995-2015 Mort Bay Consulting Pty Ltd.
+
+   (ASLv2) Apache Kafka
+     The following NOTICE information applies:
+       Apache Kafka
+       Copyright 2012 The Apache Software Foundation.
+
+  (ASLv2) Apache log4j
+    The following NOTICE information applies:
+      Apache log4j
+      Copyright 2007 The Apache Software Foundation
+
+  (ASLv2) Apache Solr
+    The following NOTICE information applies:
+      Apache Solrj
+      Copyright 2006-2014 The Apache Software Foundation
+
+  (ASLv2) Apache ZooKeeper
+    The following NOTICE information applies:
+      Apache ZooKeeper
+      Copyright 2009-2012 The Apache Software Foundation
+
+  (ASLv2) The Netty Project
+    The following NOTICE information applies:
+      The Netty Project
+      Copyright 2011 The Netty Project
+
+  (ASLv2) Snappy Java
+    The following NOTICE information applies:
+      This product includes software developed by Google
+       Snappy: http://code.google.com/p/snappy/ (New BSD License)
+
+      This product includes software developed by Apache
+       PureJavaCrc32C from apache-hadoop-common http://hadoop.apache.org/
+       (Apache 2.0 license)
+
+      This library containd statically linked libstdc++. This inclusion is allowed by
+      "GCC RUntime Library Exception"
+      http://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
+
+  (ASLv2) Woodstox Core ASL
+    The following NOTICE information applies:
+      This product currently only contains code developed by authors
+      of specific components, as identified by the source code files.
+
+      Since product implements StAX API, it has dependencies to StAX API
+      classes.
+
+  (ASLv2) Yammer Metrics
+    The following NOTICE information applies:
+      Metrics
+      Copyright 2010-2012 Coda Hale and Yammer, Inc.
+
+      This product includes software developed by Coda Hale and Yammer, Inc.
+
+      This product includes code derived from the JSR-166 project (ThreadLocalRandom), which was released
+      with the following comments:
+
+          Written by Doug Lea with assistance from members of JCP JSR-166
+          Expert Group and released to the public domain, as explained at
+          http://creativecommons.org/publicdomain/zero/1.0/
+
+  (ASLv2) ZkClient
+    The following NOTICE information applies:
+      ZkClient
+      Copyright 2009 Stefan Groschupf
+
+************************
+Common Development and Distribution License 1.0
+************************
+
+The following binary components are provided under the Common Development and Distribution License 1.0.  See project link for details.
+
+    (CDDL 1.0) JavaBeans Activation Framework (JAF) (javax.activation:activation:jar:1.1 - http://java.sun.com/products/javabeans/jaf/index.jsp)
+    (CDDL 1.0) JSR311 API (javax.ws.rs:jsr311-api:jar:1.1.1 - https://jsr311.dev.java.net)
+    (CDDL 1.0) (GPL3) Streaming API For XML (javax.xml.stream:stax-api:jar:1.0-2 - no url provided)
+
+************************
+Common Development and Distribution License 1.1
+************************
+
+The following binary components are provided under the Common Development and Distribution License 1.1. See project link for details.
+
+    (CDDL 1.1) (GPL2 w/ CPE) Old JAXB Runtime (com.sun.xml.bind:jaxb-impl:jar:2.2.3-1 - http://jaxb.java.net/)
+    (CDDL 1.1) (GPL2 w/ CPE) Java Architecture For XML Binding (javax.xml.bind:jaxb-api:jar:2.2.2 - https://jaxb.dev.java.net/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-bundle (com.sun.jersey:jersey-bundle:jar:1.17 - https://jersey.java.net/jersey-bundle/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-core (com.sun.jersey:jersey-core:jar:1.19 - https://jersey.java.net/jersey-core/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-server (com.sun.jersey:jersey-server:jar:1.19 - https://jersey.java.net/jersey-server/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-json (com.sun.jersey:jersey-json:jar:1.19 - https://jersey.java.net/jersey-json/)
+    (CDDL 1.1) (GPL2 w/ CPE) JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:jar:2.1 - http://jsp.java.net)
+    (CDDL 1.1) (GPL2 w/ CPE) Java Servlet API  (javax.servlet:javax.servlet-api:jar:2.5 - http://servlet-spec.java.net)
+
+************************
+Eclipse Public License 1.0
+************************
+
+The following binary components are provided under the Eclipse Public License 1.0.  See project link for details.
+
+  (EPL 1.0) Eclipse Link (org.eclipse.persistence:eclipselink:2.5.2 - http://www.eclipse.org/eclipselink/)
+  (EPL 1.0) Common Service Data Objects (org.eclipse.persistence:commonj.sdo:2.1.1 - http://www.eclipse.org/eclipselink/)
+  (EPL 1.0) Java Persistence API (org.eclipse.persistence:javax.persistence:2.1.0 - http://www.eclipse.org/eclipselink/)

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-ranger-bundle</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-ranger-plugin</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-properties</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-plugins-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-plugins-audit</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>credentialbuilder</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
@@ -42,6 +42,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -67,6 +71,11 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
         </dependency>
 
         <dependency>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/main/java/org/apache/nifi/ranger/authorization/RangerBasePluginWithPolicies.java
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/main/java/org/apache/nifi/ranger/authorization/RangerBasePluginWithPolicies.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.ranger.authorization;
+
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.apache.ranger.plugin.util.ServicePolicies;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Extends the base plugin to add ability to check if a policy exists for a given resource.
+ */
+public class RangerBasePluginWithPolicies extends RangerBasePlugin {
+
+    private AtomicReference<Set<String>> resources = new AtomicReference<>(new HashSet<>());
+
+    public RangerBasePluginWithPolicies(String serviceType, String appId) {
+        super(serviceType, appId);
+    }
+
+    @Override
+    public void setPolicies(ServicePolicies policies) {
+        super.setPolicies(policies);
+
+        final Set<String> newResources = new HashSet<>();
+
+        if (policies.getPolicies() != null) {
+            for (RangerPolicy policy : policies.getPolicies()) {
+                if (policy.getResources() != null) {
+                    for (Map.Entry<String, RangerPolicy.RangerPolicyResource> entry : policy.getResources().entrySet()) {
+                        final RangerPolicy.RangerPolicyResource resource = entry.getValue();
+                        if (resource != null && resource.getValues() != null) {
+                            newResources.addAll(resource.getValues());
+                        }
+                    }
+                }
+            }
+        }
+
+        this.resources.set(newResources);
+    }
+
+    /**
+     * Determines if a policy exists for the given resource.
+     *
+     * @param resourceIdentifier the id of the resource
+     *
+     * @return true if a policy exists for the given resource, false otherwise
+     */
+    public boolean doesPolicyExist(String resourceIdentifier) {
+        if (resourceIdentifier == null) {
+            return false;
+        }
+
+        final Set<String> currResources = resources.get();
+        if (currResources == null) {
+            return false;
+        } else {
+            return currResources.contains(resourceIdentifier);
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/main/java/org/apache/nifi/ranger/authorization/RangerNiFiAuthorizer.java
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/main/java/org/apache/nifi/ranger/authorization/RangerNiFiAuthorizer.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.ranger.authorization;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.nifi.authorization.AuthorizationRequest;
+import org.apache.nifi.authorization.AuthorizationResult;
+import org.apache.nifi.authorization.Authorizer;
+import org.apache.nifi.authorization.AuthorizerConfigurationContext;
+import org.apache.nifi.authorization.AuthorizerInitializationContext;
+import org.apache.nifi.authorization.UserContextKeys;
+import org.apache.nifi.authorization.exception.AuthorizationAccessException;
+import org.apache.nifi.authorization.exception.AuthorizerCreationException;
+import org.apache.nifi.authorization.exception.AuthorizerDestructionException;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.ranger.authorization.hadoop.config.RangerConfiguration;
+import org.apache.ranger.plugin.audit.RangerDefaultAuditHandler;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.policyengine.RangerAccessResultProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.Date;
+
+/**
+ * Authorizer implementation that uses Apache Ranger to make authorization decisions.
+ */
+public class RangerNiFiAuthorizer implements Authorizer {
+
+    private static final Logger logger = LoggerFactory.getLogger(RangerNiFiAuthorizer.class);
+
+    static final String RANGER_AUDIT_PATH_PROP = "Ranger Audit Config Path";
+    static final String RANGER_SECURITY_PATH_PROP = "Ranger Security Config Path";
+    static final String RANGER_KERBEROS_ENABLED_PROP = "Ranger Kerberos Enabled";
+    static final String RANGER_ADMIN_IDENTITY_PROP = "Ranger Admin Identity";
+    static final String RANGER_SERVICE_TYPE_PROP = "Ranger Service Type";
+    static final String RANGER_APP_ID_PROP = "Ranger Application Id";
+
+    static final String RANGER_NIFI_RESOURCE_NAME = "nifi-resource";
+    static final String DEFAULT_SERVICE_TYPE = "nifi";
+    static final String DEFAULT_APP_ID = "nifi";
+    static final String RESOURCES_RESOURCE = "/resources";
+    static final String HADOOP_SECURITY_AUTHENTICATION = "hadoop.security.authentication";
+    static final String KERBEROS_AUTHENTICATION = "kerberos";
+
+    private volatile RangerBasePluginWithPolicies nifiPlugin = null;
+    private volatile RangerDefaultAuditHandler defaultAuditHandler = null;
+    private volatile String rangerAdminIdentity = null;
+    private volatile boolean rangerKerberosEnabled = false;
+
+    @Override
+    public void initialize(AuthorizerInitializationContext initializationContext) throws AuthorizerCreationException {
+
+    }
+
+    @Override
+    public void onConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
+        try {
+            if (nifiPlugin == null) {
+                logger.info("RangerNiFiAuthorizer(): initializing base plugin");
+
+                final PropertyValue securityConfigValue = configurationContext.getProperty(RANGER_SECURITY_PATH_PROP);
+                addRequiredResource(RANGER_SECURITY_PATH_PROP, securityConfigValue);
+
+                final PropertyValue auditConfigValue = configurationContext.getProperty(RANGER_AUDIT_PATH_PROP);
+                addRequiredResource(RANGER_AUDIT_PATH_PROP, auditConfigValue);
+
+                final String rangerKerberosEnabledValue = getConfigValue(configurationContext, RANGER_KERBEROS_ENABLED_PROP, Boolean.FALSE.toString());
+                rangerKerberosEnabled = rangerKerberosEnabledValue.equals(Boolean.TRUE.toString()) ? true : false;
+
+                if (rangerKerberosEnabled) {
+                    // configure UGI for when RangerAdminRESTClient calls UserGroupInformation.isSecurityEnabled()
+                    final Configuration securityConf = new Configuration();
+                    securityConf.set(HADOOP_SECURITY_AUTHENTICATION, KERBEROS_AUTHENTICATION);
+                    UserGroupInformation.setConfiguration(securityConf);
+
+                    // login with the nifi principal and keytab, RangerAdminRESTClient will use Ranger's MiscUtil which
+                    // will grab UserGroupInformation.getLoginUser() and call ugi.checkTGTAndReloginFromKeytab();
+                    final String nifiPrincipal = NiFiProperties.getInstance().getKerberosServicePrincipal();
+                    final String nifiKeytab = NiFiProperties.getInstance().getKerberosKeytabLocation();
+                    UserGroupInformation.loginUserFromKeytab(nifiPrincipal.trim(), nifiKeytab.trim());
+                }
+
+                final String serviceType = getConfigValue(configurationContext, RANGER_SERVICE_TYPE_PROP, DEFAULT_SERVICE_TYPE);
+                final String appId = getConfigValue(configurationContext, RANGER_APP_ID_PROP, DEFAULT_APP_ID);
+
+                nifiPlugin = createRangerBasePlugin(serviceType, appId);
+                nifiPlugin.init();
+
+                defaultAuditHandler = new RangerDefaultAuditHandler();
+                rangerAdminIdentity = getConfigValue(configurationContext, RANGER_ADMIN_IDENTITY_PROP, null);
+
+            } else {
+                logger.info("RangerNiFiAuthorizer(): base plugin already initialized");
+            }
+        } catch (Throwable t) {
+            throw new AuthorizerCreationException("Error creating RangerBasePlugin", t);
+        }
+    }
+
+    protected RangerBasePluginWithPolicies createRangerBasePlugin(final String serviceType, final String appId) {
+        return new RangerBasePluginWithPolicies(serviceType, appId);
+    }
+
+    @Override
+    public AuthorizationResult authorize(final AuthorizationRequest request) throws AuthorizationAccessException {
+        final String identity = request.getIdentity();
+        final String resourceIdentifier = request.getResource().getIdentifier();
+
+        // if a ranger admin identity was provided, and it equals the identity making the request,
+        // and the request is to retrieve the resources, then allow it through
+        if (StringUtils.isNotBlank(rangerAdminIdentity) && rangerAdminIdentity.equals(identity)
+                && resourceIdentifier.equals(RESOURCES_RESOURCE)) {
+            return AuthorizationResult.approved();
+        }
+
+        final String clientIp;
+        if (request.getUserContext() != null) {
+            clientIp = request.getUserContext().get(UserContextKeys.CLIENT_ADDRESS.name());
+        } else {
+            clientIp = null;
+        }
+
+        final RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue(RANGER_NIFI_RESOURCE_NAME, resourceIdentifier);
+
+        final RangerAccessRequestImpl rangerRequest = new RangerAccessRequestImpl();
+        rangerRequest.setResource(resource);
+        rangerRequest.setAction(request.getAction().name());
+        rangerRequest.setAccessType(request.getAction().name());
+        rangerRequest.setUser(identity);
+        rangerRequest.setAccessTime(new Date());
+
+        if (!StringUtils.isBlank(clientIp)) {
+            rangerRequest.setClientIPAddress(clientIp);
+        }
+
+        // for a direct access request use the default audit handler so we generate audit logs
+        // for non-direct access provide a null result processor so no audit logs get generated
+        final RangerAccessResultProcessor resultProcessor = request.isAccessAttempt() ?  defaultAuditHandler : null;
+
+        final RangerAccessResult result = nifiPlugin.isAccessAllowed(rangerRequest, resultProcessor);
+
+        if (result != null && result.getIsAllowed()) {
+            return AuthorizationResult.approved();
+        } else {
+            // if result.getIsAllowed() is false, then we need to determine if it was because no policy exists for the
+            // given resource, or if it was because a policy exists but not for the given user or action
+            final boolean doesPolicyExist = nifiPlugin.doesPolicyExist(request.getResource().getIdentifier());
+
+            if (doesPolicyExist) {
+                // a policy does exist for the resource so we were really denied access here
+                final String reason = result == null ? null : result.getReason();
+                if (reason == null) {
+                    return AuthorizationResult.denied();
+                } else {
+                    return AuthorizationResult.denied(result.getReason());
+                }
+            } else {
+                // a policy doesn't exist so return resource not found so NiFi can work back up the resource hierarchy
+                return AuthorizationResult.resourceNotFound();
+            }
+        }
+    }
+
+    @Override
+    public void preDestruction() throws AuthorizerDestructionException {
+        if (nifiPlugin != null) {
+            try {
+                nifiPlugin.cleanup();
+                nifiPlugin = null;
+            } catch (Throwable t) {
+                throw new AuthorizerDestructionException("Error cleaning up RangerBasePlugin", t);
+            }
+        }
+    }
+
+    /**
+     * Adds a resource to the RangerConfiguration singleton so it is already there by the time RangerBasePlugin.init()
+     * is called.
+     *
+     * @param name the name of the given PropertyValue from the AuthorizationConfigurationContext
+     * @param resourceValue the value for the given name, should be a full path to a file
+     */
+    private void addRequiredResource(final String name, final PropertyValue resourceValue) {
+        if (resourceValue == null || StringUtils.isBlank(resourceValue.getValue())) {
+            throw new AuthorizerCreationException(name + " must be specified.");
+        }
+
+        final File resourceFile = new File(resourceValue.getValue());
+        if (!resourceFile.exists() || !resourceFile.canRead()) {
+            throw new AuthorizerCreationException(resourceValue + " does not exist, or can not be read");
+        }
+
+        try {
+            RangerConfiguration.getInstance().addResource(resourceFile.toURI().toURL());
+        } catch (MalformedURLException e) {
+            throw new AuthorizerCreationException("Error creating URI for " + resourceValue, e);
+        }
+    }
+
+    private String getConfigValue(final AuthorizerConfigurationContext context, final String name, final String defaultValue) {
+        final PropertyValue configValue = context.getProperty(name);
+
+        String retValue = defaultValue;
+        if (configValue != null && !StringUtils.isBlank(configValue.getValue())) {
+            retValue = configValue.getValue();
+        }
+
+        return retValue;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/main/resources/META-INF/services/org.apache.nifi.authorization.Authorizer
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/main/resources/META-INF/services/org.apache.nifi.authorization.Authorizer
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.ranger.authorization.RangerNiFiAuthorizer

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/TestRangerBasePluginWithPolicies.java
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/TestRangerBasePluginWithPolicies.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.ranger.authorization;
+
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.util.ServicePolicies;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+public class TestRangerBasePluginWithPolicies {
+
+    @Test
+    public void testDoesPolicyExist() {
+        final String resourceIdentifier1 = "resource1";
+        RangerPolicy.RangerPolicyResource resource1 = new RangerPolicy.RangerPolicyResource(resourceIdentifier1);
+
+        final Map<String, RangerPolicy.RangerPolicyResource> policy1Resources = new HashMap<>();
+        policy1Resources.put(resourceIdentifier1, resource1);
+
+        final RangerPolicy policy1 = new RangerPolicy();
+        policy1.setResources(policy1Resources);
+
+        final String resourceIdentifier2 = "resource2";
+        RangerPolicy.RangerPolicyResource resource2 = new RangerPolicy.RangerPolicyResource(resourceIdentifier2);
+
+        final Map<String, RangerPolicy.RangerPolicyResource> policy2Resources = new HashMap<>();
+        policy2Resources.put(resourceIdentifier2, resource2);
+
+        final RangerPolicy policy2 = new RangerPolicy();
+        policy2.setResources(policy2Resources);
+
+        final List<RangerPolicy> policies = new ArrayList<>();
+        policies.add(policy1);
+        policies.add(policy2);
+
+        final ServicePolicies servicePolicies = new ServicePolicies();
+        servicePolicies.setPolicies(policies);
+
+        // set all the policies in the plugin
+        final RangerBasePluginWithPolicies pluginWithPolicies = new RangerBasePluginWithPolicies("nifi", "nifi");
+        pluginWithPolicies.setPolicies(servicePolicies);
+
+        Assert.assertTrue(pluginWithPolicies.doesPolicyExist(resourceIdentifier1));
+        Assert.assertTrue(pluginWithPolicies.doesPolicyExist(resourceIdentifier2));
+        Assert.assertFalse(pluginWithPolicies.doesPolicyExist("resource3"));
+    }
+
+}

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/TestRangerNiFiAuthorizer.java
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/TestRangerNiFiAuthorizer.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.ranger.authorization;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.nifi.authorization.AuthorizationRequest;
+import org.apache.nifi.authorization.AuthorizationResult;
+import org.apache.nifi.authorization.Authorizer;
+import org.apache.nifi.authorization.AuthorizerConfigurationContext;
+import org.apache.nifi.authorization.AuthorizerInitializationContext;
+import org.apache.nifi.authorization.RequestAction;
+import org.apache.nifi.authorization.Resource;
+import org.apache.nifi.authorization.UserContextKeys;
+import org.apache.nifi.util.MockPropertyValue;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.policyengine.RangerAccessResultProcessor;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestRangerNiFiAuthorizer {
+
+    private MockRangerNiFiAuthorizer authorizer;
+    private RangerBasePluginWithPolicies rangerBasePlugin;
+    private AuthorizerConfigurationContext configurationContext;
+
+    private String serviceType = "nifiService";
+    private String appId = "nifiAppId";
+
+    private RangerAccessResult allowedResult;
+    private RangerAccessResult notAllowedResult;
+
+    @Before
+    public void setup() {
+        configurationContext = createMockConfigContext();
+        rangerBasePlugin = Mockito.mock(RangerBasePluginWithPolicies.class);
+        authorizer = new MockRangerNiFiAuthorizer(rangerBasePlugin);
+        authorizer.onConfigured(configurationContext);
+
+        assertFalse(UserGroupInformation.isSecurityEnabled());
+
+        allowedResult = Mockito.mock(RangerAccessResult.class);
+        when(allowedResult.getIsAllowed()).thenReturn(true);
+
+        notAllowedResult = Mockito.mock(RangerAccessResult.class);
+        when(notAllowedResult.getIsAllowed()).thenReturn(false);
+    }
+
+    private AuthorizerConfigurationContext createMockConfigContext() {
+        AuthorizerConfigurationContext configurationContext = Mockito.mock(AuthorizerConfigurationContext.class);
+
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_SECURITY_PATH_PROP)))
+                .thenReturn(new MockPropertyValue("src/test/resources/ranger/ranger-nifi-security.xml", null));
+
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_AUDIT_PATH_PROP)))
+                .thenReturn(new MockPropertyValue("src/test/resources/ranger/ranger-nifi-audit.xml", null));
+
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_APP_ID_PROP)))
+                .thenReturn(new MockPropertyValue(appId, null));
+
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_SERVICE_TYPE_PROP)))
+                .thenReturn(new MockPropertyValue(serviceType, null));
+
+        return configurationContext;
+    }
+
+    @Test
+    public void testOnConfigured() {
+        verify(rangerBasePlugin, times(1)).init();
+
+        assertEquals(appId, authorizer.mockRangerBasePlugin.getAppId());
+        assertEquals(serviceType, authorizer.mockRangerBasePlugin.getServiceType());
+    }
+
+    @Test
+    public void testApprovedWithDirectAccess() {
+        final String systemResource = "/system";
+        final RequestAction action = RequestAction.WRITE;
+        final String user = "admin";
+        final String clientIp = "192.168.1.1";
+
+        final Map<String,String> userContext = new HashMap<>();
+        userContext.put(UserContextKeys.CLIENT_ADDRESS.name(), clientIp);
+
+        // the incoming NiFi request to test
+        final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                .resource(new MockResource(systemResource, systemResource))
+                .action(action)
+                .identity(user)
+                .resourceContext(new HashMap<>())
+                .userContext(userContext)
+                .accessAttempt(true)
+                .anonymous(false)
+                .build();
+
+        // the expected Ranger resource and request that are created
+        final RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue(RangerNiFiAuthorizer.RANGER_NIFI_RESOURCE_NAME, systemResource);
+
+        final RangerAccessRequestImpl expectedRangerRequest = new RangerAccessRequestImpl();
+        expectedRangerRequest.setResource(resource);
+        expectedRangerRequest.setAction(request.getAction().name());
+        expectedRangerRequest.setAccessType(request.getAction().name());
+        expectedRangerRequest.setUser(request.getIdentity());
+        expectedRangerRequest.setClientIPAddress(clientIp);
+
+        // a non-null result processor should be used for direct access
+        when(rangerBasePlugin.isAccessAllowed(
+                argThat(new RangerAccessRequestMatcher(expectedRangerRequest)),
+                notNull(RangerAccessResultProcessor.class))
+        ).thenReturn(allowedResult);
+
+        final AuthorizationResult result = authorizer.authorize(request);
+        assertEquals(AuthorizationResult.approved().getResult(), result.getResult());
+    }
+
+    @Test
+    public void testApprovedWithNonDirectAccess() {
+        final String systemResource = "/system";
+        final RequestAction action = RequestAction.WRITE;
+        final String user = "admin";
+
+        // the incoming NiFi request to test
+        final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                .resource(new MockResource(systemResource, systemResource))
+                .action(action)
+                .identity(user)
+                .resourceContext(new HashMap<>())
+                .accessAttempt(false)
+                .anonymous(false)
+                .build();
+
+        // the expected Ranger resource and request that are created
+        final RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue(RangerNiFiAuthorizer.RANGER_NIFI_RESOURCE_NAME, systemResource);
+
+        final RangerAccessRequestImpl expectedRangerRequest = new RangerAccessRequestImpl();
+        expectedRangerRequest.setResource(resource);
+        expectedRangerRequest.setAction(request.getAction().name());
+        expectedRangerRequest.setAccessType(request.getAction().name());
+        expectedRangerRequest.setUser(request.getIdentity());
+
+        // no result processor should be provided used non-direct access
+        when(rangerBasePlugin.isAccessAllowed(
+                argThat(new RangerAccessRequestMatcher(expectedRangerRequest)),
+                eq(null))
+        ).thenReturn(allowedResult);
+
+        final AuthorizationResult result = authorizer.authorize(request);
+        assertEquals(AuthorizationResult.approved().getResult(), result.getResult());
+    }
+
+    @Test
+    public void testResourceNotFound() {
+        final String systemResource = "/system";
+        final RequestAction action = RequestAction.WRITE;
+        final String user = "admin";
+
+        // the incoming NiFi request to test
+        final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                .resource(new MockResource(systemResource, systemResource))
+                .action(action)
+                .identity(user)
+                .resourceContext(new HashMap<>())
+                .accessAttempt(true)
+                .anonymous(false)
+                .build();
+
+        // the expected Ranger resource and request that are created
+        final RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue(RangerNiFiAuthorizer.RANGER_NIFI_RESOURCE_NAME, systemResource);
+
+        final RangerAccessRequestImpl expectedRangerRequest = new RangerAccessRequestImpl();
+        expectedRangerRequest.setResource(resource);
+        expectedRangerRequest.setAction(request.getAction().name());
+        expectedRangerRequest.setAccessType(request.getAction().name());
+        expectedRangerRequest.setUser(request.getIdentity());
+
+        // no result processor should be provided used non-direct access
+        when(rangerBasePlugin.isAccessAllowed(
+                argThat(new RangerAccessRequestMatcher(expectedRangerRequest)),
+                notNull(RangerAccessResultProcessor.class))
+        ).thenReturn(notAllowedResult);
+
+        // return false when checking if a policy exists for the resource
+        when(rangerBasePlugin.doesPolicyExist(systemResource)).thenReturn(false);
+
+        final AuthorizationResult result = authorizer.authorize(request);
+        assertEquals(AuthorizationResult.resourceNotFound().getResult(), result.getResult());
+    }
+
+    @Test
+    public void testDenied() {
+        final String systemResource = "/system";
+        final RequestAction action = RequestAction.WRITE;
+        final String user = "admin";
+
+        // the incoming NiFi request to test
+        final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                .resource(new MockResource(systemResource, systemResource))
+                .action(action)
+                .identity(user)
+                .resourceContext(new HashMap<>())
+                .accessAttempt(true)
+                .anonymous(false)
+                .build();
+
+        // the expected Ranger resource and request that are created
+        final RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue(RangerNiFiAuthorizer.RANGER_NIFI_RESOURCE_NAME, systemResource);
+
+        final RangerAccessRequestImpl expectedRangerRequest = new RangerAccessRequestImpl();
+        expectedRangerRequest.setResource(resource);
+        expectedRangerRequest.setAction(request.getAction().name());
+        expectedRangerRequest.setAccessType(request.getAction().name());
+        expectedRangerRequest.setUser(request.getIdentity());
+
+        // no result processor should be provided used non-direct access
+        when(rangerBasePlugin.isAccessAllowed(
+                argThat(new RangerAccessRequestMatcher(expectedRangerRequest)),
+                notNull(RangerAccessResultProcessor.class))
+        ).thenReturn(notAllowedResult);
+
+        // return true when checking if a policy exists for the resource
+        when(rangerBasePlugin.doesPolicyExist(systemResource)).thenReturn(true);
+
+        final AuthorizationResult result = authorizer.authorize(request);
+        assertEquals(AuthorizationResult.denied().getResult(), result.getResult());
+    }
+
+    @Test
+    public void testRangerAdminApproved() {
+        runRangerAdminTest(RangerNiFiAuthorizer.RESOURCES_RESOURCE, AuthorizationResult.approved().getResult());
+    }
+
+    @Test
+    public void testRangerAdminDenied() {
+        runRangerAdminTest("/flow", AuthorizationResult.denied().getResult());
+    }
+
+    private void runRangerAdminTest(final String resourceIdentifier, final AuthorizationResult.Result expectedResult) {
+        configurationContext = createMockConfigContext();
+
+        final String rangerAdminIdentity = "ranger-admin";
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_ADMIN_IDENTITY_PROP)))
+                .thenReturn(new MockPropertyValue(rangerAdminIdentity, null));
+
+        rangerBasePlugin = Mockito.mock(RangerBasePluginWithPolicies.class);
+        authorizer = new MockRangerNiFiAuthorizer(rangerBasePlugin);
+        authorizer.onConfigured(configurationContext);
+
+        final RequestAction action = RequestAction.WRITE;
+
+        // the incoming NiFi request to test
+        final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                .resource(new MockResource(resourceIdentifier, resourceIdentifier))
+                .action(action)
+                .identity(rangerAdminIdentity)
+                .resourceContext(new HashMap<>())
+                .accessAttempt(true)
+                .anonymous(false)
+                .build();
+
+        // the expected Ranger resource and request that are created
+        final RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue(RangerNiFiAuthorizer.RANGER_NIFI_RESOURCE_NAME, resourceIdentifier);
+
+        final RangerAccessRequestImpl expectedRangerRequest = new RangerAccessRequestImpl();
+        expectedRangerRequest.setResource(resource);
+        expectedRangerRequest.setAction(request.getAction().name());
+        expectedRangerRequest.setAccessType(request.getAction().name());
+        expectedRangerRequest.setUser(request.getIdentity());
+
+        // return true when checking if a policy exists for the resource
+        when(rangerBasePlugin.doesPolicyExist(resourceIdentifier)).thenReturn(true);
+
+        // a non-null result processor should be used for direct access
+        when(rangerBasePlugin.isAccessAllowed(
+                argThat(new RangerAccessRequestMatcher(expectedRangerRequest)),
+                notNull(RangerAccessResultProcessor.class))
+        ).thenReturn(notAllowedResult);
+
+        final AuthorizationResult result = authorizer.authorize(request);
+        assertEquals(expectedResult, result.getResult());
+    }
+
+    @Test
+    @Ignore
+    public void testIntegration() {
+        final AuthorizerInitializationContext initializationContext = Mockito.mock(AuthorizerInitializationContext.class);
+        final AuthorizerConfigurationContext configurationContext = Mockito.mock(AuthorizerConfigurationContext.class);
+
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_SECURITY_PATH_PROP)))
+                .thenReturn(new MockPropertyValue("src/test/resources/ranger/ranger-nifi-security.xml", null));
+
+        when(configurationContext.getProperty(eq(RangerNiFiAuthorizer.RANGER_AUDIT_PATH_PROP)))
+                .thenReturn(new MockPropertyValue("src/test/resources/ranger/ranger-nifi-audit.xml", null));
+
+        Authorizer authorizer = new RangerNiFiAuthorizer();
+        try {
+            authorizer.initialize(initializationContext);
+            authorizer.onConfigured(configurationContext);
+
+            final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                    .resource(new Resource() {
+                        @Override
+                        public String getIdentifier() {
+                            return "/system";
+                        }
+
+                        @Override
+                        public String getName() {
+                            return "/system";
+                        }
+                    })
+                    .action(RequestAction.WRITE)
+                    .identity("admin")
+                    .resourceContext(new HashMap<>())
+                    .accessAttempt(true)
+                    .anonymous(false)
+                    .build();
+
+
+            final AuthorizationResult result = authorizer.authorize(request);
+
+            Assert.assertEquals(AuthorizationResult.denied().getResult(), result.getResult());
+
+        } finally {
+            authorizer.preDestruction();
+        }
+    }
+
+    /**
+     * Extend RangerNiFiAuthorizer to inject a mock base plugin for testing.
+     */
+    private static class MockRangerNiFiAuthorizer extends RangerNiFiAuthorizer {
+
+        RangerBasePluginWithPolicies mockRangerBasePlugin;
+
+        public MockRangerNiFiAuthorizer(RangerBasePluginWithPolicies mockRangerBasePlugin) {
+            this.mockRangerBasePlugin = mockRangerBasePlugin;
+        }
+
+        @Override
+        protected RangerBasePluginWithPolicies createRangerBasePlugin(String serviceType, String appId) {
+            when(mockRangerBasePlugin.getAppId()).thenReturn(appId);
+            when(mockRangerBasePlugin.getServiceType()).thenReturn(serviceType);
+            return mockRangerBasePlugin;
+        }
+    }
+
+    /**
+     * Resource implementation for testing.
+     */
+    private static class MockResource implements Resource {
+
+        private String identifier;
+        private String name;
+
+        public MockResource(String identifier, String name) {
+            this.identifier = identifier;
+            this.name = name;
+        }
+
+        @Override
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * Custom Mockito matcher for RangerAccessRequest objects.
+     */
+    private static class RangerAccessRequestMatcher extends ArgumentMatcher<RangerAccessRequest> {
+
+        private final RangerAccessRequest request;
+
+        public RangerAccessRequestMatcher(RangerAccessRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            if (!(o instanceof RangerAccessRequest)) {
+                return false;
+            }
+
+            final RangerAccessRequest other = (RangerAccessRequest) o;
+
+            final boolean clientIpsMatch = (other.getClientIPAddress() == null && request.getClientIPAddress() == null)
+                    || (other.getClientIPAddress() != null && request.getClientIPAddress() != null && other.getClientIPAddress().equals(request.getClientIPAddress()));
+
+            return other.getResource().equals(request.getResource())
+                    && other.getAccessType().equals(request.getAccessType())
+                    && other.getAction().equals(request.getAction())
+                    && other.getUser().equals(request.getUser())
+                    && clientIpsMatch;
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/authorizers.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/authorizers.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<authorizers>
+    <authorizer>
+        <identifier>ranger-provider</identifier>
+        <class>org.apache.nifi.ranger.authorization.RangerNiFiAuthorizer</class>
+        <property name="Ranger Audit Config Path">src/test/resources/ranger/ranger-nifi-audit.xml</property>
+        <property name="Ranger Security Config Path">src/test/resources/ranger/ranger-nifi-security.xml</property>
+        <property name="Ranger Service Type">nifi</property>
+        <property name="Ranger Application Id">nifi</property>
+        <property name="Ranger Admin Identity">CN=ranger-admin, OU=Apache Ranger, O=Apache, L=Santa Monica, ST=CA, C=US</property>
+        <property name="Ranger Kerberos Enabled">false</property>
+    </authorizer>
+</authorizers>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/krb5.conf
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/krb5.conf
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[libdefaults]
+         default_realm = EXAMPLE.COM
+         dns_lookup_kdc = false
+         dns_lookup_realm = false
+
+[realms]
+         EXAMPLE.COM = {
+             kdc = kerberos.example.com
+             admin_server = kerberos.example.com
+         }

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/log4j.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/log4j.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="console_appender" class="org.apache.log4j.ConsoleAppender">
+        <param name="target" value="System.out" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%p]: %m%n" />
+        </layout>
+    </appender>
+
+    <category name="org.apache.ranger" additivity="false">
+        <priority value="info" />
+        <appender-ref ref="console_appender" />
+    </category>
+
+    <category name="ranger_audit_logger">
+        <level value="info" />
+        <appender-ref ref="console_appender" />
+    </category>
+
+    <root>
+        <priority value="info" />
+        <appender-ref ref="console_appender" />
+    </root>
+</log4j:configuration>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/core-site.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/core-site.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+    <property>
+        <name>hadoop.security.authentication</name>
+        <value>simple</value>
+    </property>
+</configuration>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/ranger-nifi-audit.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/ranger-nifi-audit.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration xmlns:xi="http://www.w3.org/2001/XInclude">
+	<property>
+		<name>xasecure.audit.is.enabled</name>
+		<value>true</value>
+	</property>
+
+	<!-- DB audit provider configuration -->
+	<property>
+		<name>xasecure.audit.destination.db</name>
+		<value>false</value>
+	</property>	
+	
+	<property>
+		<name>xasecure.audit.destination.db.jdbc.driver</name>
+		<value>com.mysql.jdbc.Driver</value>
+	</property>	
+	
+	<property>
+		<name>xasecure.audit.destination.db.jdbc.url</name>
+		<value>jdbc:mysql://localhost/ranger_audit</value>
+	</property>	
+
+	<property>
+		<name>xasecure.audit.destination.db.password</name>
+		<value>rangerlogger</value>
+	</property>	
+
+	<property>
+		<name>xasecure.audit.destination.db.user</name>
+		<value>rangerlogger</value>
+	</property>	
+
+	<property>
+		<name>xasecure.audit.destination.db.batch.filespool.dir</name>
+		<value>/tmp/audit/db/spool</value>
+	</property>
+
+
+	<!-- HDFS audit provider configuration -->
+	<property>
+		<name>xasecure.audit.destination.hdfs</name>
+		<value>false</value>
+	</property>
+
+	<property>
+		<name>xasecure.audit.destination.hdfs.dir</name>
+		<value>hdfs://localhost:8020/ranger/audit</value>
+	</property>
+
+	<property>
+		<name>xasecure.audit.destination.hdfs.batch.filespool.dir</name>
+		<value>/tmp/audit/hdfs/spool</value>
+	</property>
+
+
+	<!-- Log4j audit provider configuration -->
+	<property>
+		<name>xasecure.audit.destination.log4j</name>
+		<value>false</value>
+	</property>	
+
+	<property>
+		<name>xasecure.audit.destination.log4j.logger</name>
+		<value>ranger_audit_logger</value>
+	</property>
+
+	<!-- Solr audit provider configuration -->
+	<property>
+		<name>xasecure.audit.destination.solr</name>
+		<value>true</value>
+	</property>
+
+	<property>
+		<name>xasecure.audit.destination.solr.batch.filespool.dir</name>
+		<value>/tmp/audit/solr/spool</value>
+	</property>
+
+	<property>
+		<name>xasecure.audit.destination.solr.urls</name>
+		<value>http://localhost:6083/solr/ranger_audits</value>
+	</property>
+
+</configuration>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/ranger-nifi-security.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/ranger-nifi-security.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration xmlns:xi="http://www.w3.org/2001/XInclude">
+	<property>
+		<name>ranger.plugin.nifi.policy.rest.url</name>
+		<value>http://localhost:6080</value>
+		<description>
+			URL to Ranger Admin
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.service.name</name>
+		<value>nifi</value>
+		<description>
+			Name of the Ranger service containing policies for this nifi instance
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.policy.source.impl</name>
+		<value>org.apache.ranger.admin.client.RangerAdminRESTClient</value>
+		<description>
+			Class to retrieve policies from the source
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.policy.rest.ssl.config.file</name>
+		<value>ranger-policymgr-ssl.xml</value>
+		<description>
+			Path to the file containing SSL details to contact Ranger Admin
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.policy.pollIntervalMs</name>
+		<value>30000</value>
+		<description>
+			How often to poll for changes in policies?
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.policy.cache.dir</name>
+		<value>/tmp</value>
+		<description>
+			Directory where Ranger policies are cached after successful retrieval from the source
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.policy.rest.client.connection.timeoutMs</name>
+		<value>120000</value>
+		<description>
+			RangerRestClient Connection Timeout in Milli Seconds
+		</description>
+	</property>
+
+	<property>
+		<name>ranger.plugin.nifi.policy.rest.client.read.timeoutMs</name>
+		<value>30000</value>
+		<description>
+			RangerRestClient read Timeout in Milli Seconds
+		</description>
+	</property>
+</configuration>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/ranger-policymgr-ssl.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/resources/ranger/ranger-policymgr-ssl.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration xmlns:xi="http://www.w3.org/2001/XInclude">
+	<!--  The following properties are used for 2-way SSL client server validation -->
+	<property>
+		<name>xasecure.policymgr.clientssl.keystore</name>
+		<value></value>
+		<description> 
+			Java Keystore files 
+		</description>
+	</property>
+	<property>
+		<name>xasecure.policymgr.clientssl.keystore.password</name>
+		<value>none</value>
+		<description> 
+			password for keystore 
+		</description>
+	</property>
+	<property>
+		<name>xasecure.policymgr.clientssl.truststore</name>
+		<value></value>
+		<description> 
+			java truststore file
+		</description>
+	</property>
+	<property>
+		<name>xasecure.policymgr.clientssl.truststore.password</name>
+		<value>none</value>
+		<description> 
+			java  truststore password
+		</description>
+	</property>
+    <property>
+		<name>xasecure.policymgr.clientssl.keystore.credential.file</name>
+		<value></value>
+		<description> 
+			java  keystore credential file
+		</description>
+	</property>
+	<property>
+		<name>xasecure.policymgr.clientssl.truststore.credential.file</name>
+		<value></value>
+		<description> 
+			java  truststore credential file
+		</description>
+	</property>
+</configuration>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-ranger-bundle</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-ranger-resources</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/src/main/resources/scripts/ranger_credential_helper.py
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/src/main/resources/scripts/ranger_credential_helper.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+from subprocess import  Popen,PIPE
+from optparse import OptionParser
+
+if os.getenv('JAVA_HOME') is None:
+	print "[W] ---------- JAVA_HOME environment property not defined, using java in path. ----------"
+	JAVA_BIN='java'
+else:
+	JAVA_BIN=os.path.join(os.getenv('JAVA_HOME'),'bin','java')
+print "Using Java:" + str(JAVA_BIN)
+
+def main():
+
+	parser = OptionParser()
+
+	parser.add_option("-l", "--libpath", dest="library_path", help="Path to folder where credential libs are present")
+	parser.add_option("-f", "--file",  dest="jceks_file_path", help="Path to jceks file to use")
+	parser.add_option("-k", "--key",  dest="key", help="Key to use")
+	parser.add_option("-v", "--value",  dest="value", help="Value to use")
+	parser.add_option("-c", "--create",  dest="create", help="Add a new alias")
+
+	(options, args) = parser.parse_args()
+	library_path = options.library_path
+	jceks_file_path = options.jceks_file_path
+	key = options.key
+	value = options.value
+	getorcreate = 'create' if options.create else 'get'
+	call_keystore(library_path, jceks_file_path, key, value, getorcreate)
+
+
+def call_keystore(libpath, filepath, aliasKey, aliasValue='', getorcreate='get'):
+	finalLibPath = libpath.replace('\\','/').replace('//','/')
+	finalFilePath = 'jceks://file/'+filepath.replace('\\','/').replace('//','/')
+	if getorcreate == 'create':
+		commandtorun = [JAVA_BIN, '-cp', finalLibPath, 'org.apache.ranger.credentialapi.buildks' ,'create', aliasKey, '-value', aliasValue, '-provider',finalFilePath]
+		p = Popen(commandtorun,stdin=PIPE, stdout=PIPE, stderr=PIPE)
+		output, error = p.communicate()
+		statuscode = p.returncode
+		if statuscode == 0:
+			print "Alias " + aliasKey + " created successfully!"
+		else :
+			print "Error creating Alias!! Error: " + str(error)
+		
+	elif getorcreate == 'get':
+		commandtorun = [JAVA_BIN, '-cp', finalLibPath, 'org.apache.ranger.credentialapi.buildks' ,'get', aliasKey, '-provider',finalFilePath]
+		p = Popen(commandtorun,stdin=PIPE, stdout=PIPE, stderr=PIPE)
+		output, error = p.communicate()
+		statuscode = p.returncode
+		if statuscode == 0:
+			print "Alias : " + aliasKey + " Value : " + str(output)
+		else :
+			print "Error getting value!! Error: " + str(error)
+		
+	else:
+		print 'Invalid Arguments!!'
+	
+if __name__ == '__main__':
+	main()

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-bundles</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.nifi</groupId>
+    <artifactId>nifi-ranger-bundle</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <httpcomponents.httpclient.version>4.4.1</httpcomponents.httpclient.version>
+        <httpcomponents.httpcore.version>4.4.1</httpcomponents.httpcore.version>
+        <httpcomponents.httpmime.version>4.4.1</httpcomponents.httpmime.version>
+    </properties>
+
+    <modules>
+        <module>nifi-ranger-plugin</module>
+        <module>nifi-ranger-nar</module>
+	    <module>nifi-ranger-resources</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpcomponents.httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>${httpcomponents.httpcore.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>${httpcomponents.httpmime.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/nifi-nar-bundles/nifi-social-media-bundle/nifi-twitter-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-social-media-bundle/nifi-twitter-processors/pom.xml
@@ -38,6 +38,17 @@
             <groupId>com.twitter</groupId>
             <artifactId>hbc-twitter4j</artifactId>
             <version>2.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/pom.xml
@@ -44,6 +44,12 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hadoop-utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -53,7 +59,16 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -55,13 +55,13 @@
         <module>nifi-scripting-bundle</module>
         <module>nifi-elasticsearch-bundle</module>
         <module>nifi-amqp-bundle</module>
-	    <module>nifi-splunk-bundle</module>
+	<module>nifi-splunk-bundle</module>
         <module>nifi-jms-bundle</module>
         <module>nifi-lumberjack-bundle</module>
         <module>nifi-cassandra-bundle</module>
         <module>nifi-spring-bundle</module>
         <module>nifi-hive-bundle</module>
-	    <module>nifi-site-to-site-reporting-bundle</module>
+	<module>nifi-site-to-site-reporting-bundle</module>
         <module>nifi-mqtt-bundle</module>
         <module>nifi-evtx-bundle</module>
         <module>nifi-slack-bundle</module>
@@ -69,9 +69,10 @@
         <module>nifi-windows-event-log-bundle</module>
         <module>nifi-ignite-bundle</module>
         <module>nifi-email-bundle</module>
-    </modules>
-
-    <dependencyManagement>
+    	<module>nifi-ranger-bundle</module>
+  </modules>
+    
+  <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.apache.nifi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@ language governing permissions and limitations under the License. -->
         <hadoop.guava.version>12.0.1</hadoop.guava.version>
         <hadoop.http.client.version>4.2.5</hadoop.http.client.version>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
+        <ranger.version>0.6.0</ranger.version>
     </properties>
 
 
@@ -1150,8 +1151,8 @@ language governing permissions and limitations under the License. -->
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-elasticsearch-nar</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
-		        <type>nar</type>
-	         </dependency>
+		<type>nar</type>
+	     </dependency>
              <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-lumberjack-nar</artifactId>
@@ -1182,13 +1183,13 @@ language governing permissions and limitations under the License. -->
                 <version>1.0.0-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
-	    <dependency>
+	        <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-site-to-site-reporting-nar</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
-	    <dependency>
+	        <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-evtx-nar</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
@@ -1270,6 +1271,33 @@ language governing permissions and limitations under the License. -->
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk</artifactId>
                 <version>1.11.8</version>
+            </dependency>
+            <!-- Ranger dependencies, only included when using -Pinclude-ranger -->
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-ranger-nar</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <type>nar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-ranger-resources</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ranger</groupId>
+                <artifactId>ranger-plugins-common</artifactId>
+                <version>${ranger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ranger</groupId>
+                <artifactId>ranger-plugins-audit</artifactId>
+                <version>${ranger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ranger</groupId>
+                <artifactId>credentialbuilder</artifactId>
+                <version>${ranger.version}</version>
             </dependency>
             <!-- Groovy support is primarily as a test dependency -->
             <dependency>


### PR DESCRIPTION
This PR adds an Authorizer implementation that uses Apache Ranger and also modifies the build so that Ranger related artifacts are only included when using -Pinclude-ranger, this way the normal build does not need to include anything related to Ranger, and those that want it can also easily build it themselves.

When using NiFi with Ranger you would declare an Authorizer like the following in authorizers.xml:
```
    <authorizer>
        <identifier>ranger-provider</identifier>
        <class>org.apache.nifi.ranger.authorization.RangerNiFiAuthorizer</class>
        <property name="Ranger Audit Config Path">src/test/resources/ranger/ranger-nifi-audit.xml</property>
        <property name="Ranger Security Config Path">src/test/resources/ranger/ranger-nifi-security.xml</property>
        <property name="Ranger Service Type">nifi</property>
        <property name="Ranger Application Id">nifi</property>
        <property name="Ranger Admin Identity">CN=ranger-admin, OU=Apache Ranger, O=Apache, L=Santa Monica, ST=CA, C=US</property>
        <property name="Ranger Kerberos Enabled">false</property>
    </authorizer>
```

For anyone interested in playing around with this, I created a Vagrant VM that can run a build of Ranger:
https://github.com/bbende/apache-ranger-vagrant