### PR TITLE
NIFI-619: Make MonitorActivity more cluster friendly

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/NodeTypeProvider.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/NodeTypeProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.controller;
+
+/**
+ * <p>
+ * This interface provides a set of methods for checking NiFi node type.
+ * <p>
+ */
+public interface NodeTypeProvider {
+
+    /**
+     * @return true if this instance is clustered, false otherwise.
+     * Clustered means that a node is either connected or trying to connect to the cluster.
+     */
+    boolean isClustered();
+
+    /**
+     * @return true if this instance is the primary node in the cluster; false otherwise
+     */
+    boolean isPrimary();
+}

--- a/nifi-api/src/main/java/org/apache/nifi/processor/AbstractSessionFactoryProcessor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/AbstractSessionFactoryProcessor.java
@@ -24,6 +24,7 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AbstractConfigurableComponent;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 
 /**
@@ -50,6 +51,7 @@ public abstract class AbstractSessionFactoryProcessor extends AbstractConfigurab
     private volatile boolean scheduled = false;
     private volatile boolean configurationRestored = false;
     private ControllerServiceLookup serviceLookup;
+    private NodeTypeProvider nodeTypeProvider;
     private String description;
 
     @Override
@@ -57,6 +59,7 @@ public abstract class AbstractSessionFactoryProcessor extends AbstractConfigurab
         identifier = context.getIdentifier();
         logger = context.getLogger();
         serviceLookup = context.getControllerServiceLookup();
+        nodeTypeProvider = context.getNodeTypeProvider();
         init(context);
 
         description = getClass().getSimpleName() + "[id=" + identifier + "]";
@@ -68,6 +71,14 @@ public abstract class AbstractSessionFactoryProcessor extends AbstractConfigurab
      */
     protected final ControllerServiceLookup getControllerServiceLookup() {
         return serviceLookup;
+    }
+
+    /**
+     * @return the {@link NodeTypeProvider} that was passed to the
+     * {@link #init(ProcessorInitializationContext)} method
+     */
+    protected final NodeTypeProvider getNodeTypeProvider() {
+        return nodeTypeProvider;
     }
 
     @Override

--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessorInitializationContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessorInitializationContext.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processor;
 
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 
 /**
@@ -44,4 +45,9 @@ public interface ProcessorInitializationContext {
      * Controller Services
      */
     ControllerServiceLookup getControllerServiceLookup();
+
+    /**
+     * @return the {@link NodeTypeProvider} which can be used to detect the node type of this NiFi instance.
+     */
+    NodeTypeProvider getNodeTypeProvider();
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessorInitializationContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessorInitializationContext.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 
@@ -79,5 +80,10 @@ public class MockProcessorInitializationContext implements ProcessorInitializati
     @Override
     public boolean isControllerServiceEnabling(final String serviceIdentifier) {
         return context.isControllerServiceEnabling(serviceIdentifier);
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return context;
     }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -812,4 +812,13 @@ public class StandardProcessorTestRunner implements TestRunner {
         return controllerServiceLoggers.get(identifier);
     }
 
+    @Override
+    public void setClustered(boolean clustered) {
+        context.setClustered(clustered);
+    }
+
+    @Override
+    public void setPrimaryNode(boolean primaryNode) {
+        context.setPrimaryNode(primaryNode);
+    }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -891,4 +891,14 @@ public interface TestRunner {
      * @return the State Manager that is used to store and retrieve state for the given controller service
      */
     MockStateManager getStateManager(ControllerService service);
+
+    /**
+     * @param clustered Specify if this test emulates running in a clustered environment
+     */
+    void setClustered(boolean clustered);
+
+    /**
+     * @param primaryNode Specify if this test emulates running as a primary node
+     */
+    void setPrimaryNode(boolean primaryNode);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/mock/MockNodeTypeProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/mock/MockNodeTypeProvider.java
@@ -16,36 +16,25 @@
  */
 package org.apache.nifi.documentation.mock;
 
-import org.apache.nifi.controller.ControllerServiceLookup;
 import org.apache.nifi.controller.NodeTypeProvider;
-import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 
 /**
- * A Mock ProcessorInitializationContext that can be used so that Processors can
- * be initialized for the purpose of generating documentation.
+ * A Mock NodeTypeProvider that can be used so that
+ * ConfigurableComponents can be initialized for the purpose of generating
+ * documentation
  *
  *
  */
-public class MockProcessorInitializationContext implements ProcessorInitializationContext {
+public class MockNodeTypeProvider implements NodeTypeProvider {
 
     @Override
-    public String getIdentifier() {
-        return "mock-processor";
+    public boolean isClustered() {
+        return false;
     }
 
     @Override
-    public ComponentLog getLogger() {
-        return new MockComponentLogger();
+    public boolean isPrimary() {
+        return false;
     }
 
-    @Override
-    public ControllerServiceLookup getControllerServiceLookup() {
-        return new MockControllerServiceLookup();
-    }
-
-    @Override
-    public NodeTypeProvider getNodeTypeProvider() {
-        return new MockNodeTypeProvider();
-    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -237,7 +237,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sun.jersey.api.client.ClientHandlerException;
 
-public class FlowController implements EventAccess, ControllerServiceProvider, ReportingTaskProvider, QueueProvider, Authorizable, ProvenanceAuthorizableFactory {
+public class FlowController implements EventAccess, ControllerServiceProvider, ReportingTaskProvider, QueueProvider, Authorizable, ProvenanceAuthorizableFactory, NodeTypeProvider {
 
     // default repository implementations
     public static final String DEFAULT_FLOWFILE_REPO_IMPLEMENTATION = "org.apache.nifi.controller.repository.WriteAheadFlowFileRepository";
@@ -1053,7 +1053,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
             final Class<? extends Processor> processorClass = rawClass.asSubclass(Processor.class);
             processor = processorClass.newInstance();
             final ComponentLog componentLogger = new SimpleProcessLogger(identifier, processor);
-            final ProcessorInitializationContext ctx = new StandardProcessorInitializationContext(identifier, componentLogger, this);
+            final ProcessorInitializationContext ctx = new StandardProcessorInitializationContext(identifier, componentLogger, this, this);
             processor.initialize(ctx);
 
             LogRepositoryFactory.getRepository(identifier).setLogger(componentLogger);
@@ -3148,6 +3148,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     /**
      * @return true if this instance is clustered; false otherwise. Clustered means that a node is either connected or trying to connect to the cluster.
      */
+    @Override
     public boolean isClustered() {
         readLock.lock();
         try {
@@ -3323,6 +3324,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     /**
      * @return true if this instance is the primary node in the cluster; false otherwise
      */
+    @Override
     public boolean isPrimary() {
         return leaderElectionManager != null && leaderElectionManager.isLeader(ClusterRoles.PRIMARY_NODE);
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessorInitializationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessorInitializationContext.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processor;
 
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
 import org.apache.nifi.logging.ComponentLog;
 
@@ -25,11 +26,13 @@ public class StandardProcessorInitializationContext implements ProcessorInitiali
     private final String identifier;
     private final ComponentLog logger;
     private final ControllerServiceProvider serviceProvider;
+    private final NodeTypeProvider nodeTypeProvider;
 
-    public StandardProcessorInitializationContext(final String identifier, final ComponentLog componentLog, final ControllerServiceProvider serviceProvider) {
+    public StandardProcessorInitializationContext(final String identifier, final ComponentLog componentLog, final ControllerServiceProvider serviceProvider, NodeTypeProvider nodeTypeProvider) {
         this.identifier = identifier;
         this.logger = componentLog;
         this.serviceProvider = serviceProvider;
+        this.nodeTypeProvider = nodeTypeProvider;
     }
 
     @Override
@@ -45,5 +48,10 @@ public class StandardProcessorInitializationContext implements ProcessorInitiali
     @Override
     public ControllerServiceLookup getControllerServiceLookup() {
         return serviceProvider;
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return nodeTypeProvider;
     }
 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/InvokeScriptedProcessor.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/InvokeScriptedProcessor.java
@@ -42,6 +42,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSessionFactory;
@@ -347,6 +348,11 @@ public class InvokeScriptedProcessor extends AbstractScriptProcessor {
                                 @Override
                                 public ControllerServiceLookup getControllerServiceLookup() {
                                     return InvokeScriptedProcessor.super.getControllerServiceLookup();
+                                }
+
+                                @Override
+                                public NodeTypeProvider getNodeTypeProvider() {
+                                    return InvokeScriptedProcessor.super.getNodeTypeProvider();
                                 }
                             });
                         } catch (final Exception e) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MonitorActivity.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MonitorActivity.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.Stateful;
 import org.apache.nifi.annotation.behavior.TriggerSerially;
 import org.apache.nifi.annotation.behavior.TriggerWhenEmpty;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -40,7 +41,13 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.components.state.StateManager;
+import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
@@ -51,6 +58,7 @@ import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.util.StringUtils;
 
 @SideEffectFree
 @TriggerSerially
@@ -62,7 +70,14 @@ import org.apache.nifi.processor.util.StandardValidators;
 @WritesAttributes({
     @WritesAttribute(attribute = "inactivityStartMillis", description = "The time at which Inactivity began, in the form of milliseconds since Epoch"),
     @WritesAttribute(attribute = "inactivityDurationMillis", description = "The number of milliseconds that the inactivity has spanned")})
+@Stateful(scopes = Scope.CLUSTER, description = "MonitorActivity stores the last timestamp at each node as state, so that it can examine activity at cluster wide." +
+        "If 'Copy Attribute' is set to true, then flow file attributes are also persisted.")
 public class MonitorActivity extends AbstractProcessor {
+
+    public static final AllowableValue SCOPE_NODE = new AllowableValue("node");
+    public static final AllowableValue SCOPE_CLUSTER = new AllowableValue("cluster");
+    public static final AllowableValue REPORT_NODE_ALL = new AllowableValue("all");
+    public static final AllowableValue REPORT_NODE_PRIMARY = new AllowableValue("primary");
 
     public static final PropertyDescriptor THRESHOLD = new PropertyDescriptor.Builder()
             .name("Threshold Duration")
@@ -102,6 +117,33 @@ public class MonitorActivity extends AbstractProcessor {
             .allowableValues("true", "false")
             .defaultValue("false")
             .build();
+    public static final PropertyDescriptor MONITORING_SCOPE = new PropertyDescriptor.Builder()
+            .name("Monitoring Scope")
+            .description("Specify how to determine activeness of the flow. 'node' means that activeness is examined at individual node separately." +
+                    " It can be useful if DFM expects each node should receive flow files in a distributed manner." +
+                    " With 'cluster', it defines the flow is active while at least one node receives flow files actively." +
+                    " If NiFi is running as standalone mode, this should be set as 'node'," +
+                    " if it's 'cluster', NiFi logs a warning message and act as 'node' scope.")
+            .required(true)
+            .allowableValues(SCOPE_NODE, SCOPE_CLUSTER)
+            .defaultValue(SCOPE_NODE.getValue())
+            .build();
+    public static final PropertyDescriptor REPORTING_NODE = new PropertyDescriptor.Builder()
+            .name("Reporting Node")
+            .description("Specify which node should send notification flow-files to inactive and activity.restored relationships." +
+                    " With 'all', every node in this cluster send notification flow-files." +
+                    " 'primary' means flow-files will be sent only from a primary node." +
+                    " If NiFi is running as standalone mode, this should be set as 'all'," +
+                    " even if it's 'primary', NiFi act as 'all'.")
+            .required(true)
+            .allowableValues(REPORT_NODE_ALL, REPORT_NODE_PRIMARY)
+            .addValidator(((subject, input, context) -> {
+                boolean invalid = REPORT_NODE_PRIMARY.equals(input) && SCOPE_NODE.equals(context.getProperty(MONITORING_SCOPE).getValue());
+                return new ValidationResult.Builder().subject(subject).input(input)
+                        .explanation("'" + REPORT_NODE_PRIMARY + "' is only available with '" + SCOPE_CLUSTER + "' scope.").valid(!invalid).build();
+            }))
+            .defaultValue(REPORT_NODE_ALL.getValue())
+            .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
@@ -123,8 +165,10 @@ public class MonitorActivity extends AbstractProcessor {
     private Set<Relationship> relationships;
 
     private final AtomicLong latestSuccessTransfer = new AtomicLong(System.currentTimeMillis());
+    private final AtomicLong latestReportedNodeState = new AtomicLong(System.currentTimeMillis());
     private final AtomicBoolean inactive = new AtomicBoolean(false);
     private final AtomicLong lastInactiveMessage = new AtomicLong(System.currentTimeMillis());
+    public static final String STATE_KEY_LATEST_SUCCESS_TRANSFER = "MonitorActivity.latestSuccessTransfer";
 
     @Override
     protected void init(final ProcessorInitializationContext context) {
@@ -134,6 +178,8 @@ public class MonitorActivity extends AbstractProcessor {
         properties.add(INACTIVITY_MESSAGE);
         properties.add(ACTIVITY_RESTORED_MESSAGE);
         properties.add(COPY_ATTRIBUTES);
+        properties.add(MONITORING_SCOPE);
+        properties.add(REPORTING_NODE);
         this.properties = Collections.unmodifiableList(properties);
 
         final Set<Relationship> relationships = new HashSet<>();
@@ -154,12 +200,43 @@ public class MonitorActivity extends AbstractProcessor {
     }
 
     @OnScheduled
-    public void resetLastSuccessfulTransfer() {
+    public void onScheduled(final ProcessContext context) {
+        // Check configuration.
+        isClusterScope(context, true);
+        resetLastSuccessfulTransfer();
+        inactive.set(false);
+    }
+
+
+    protected void resetLastSuccessfulTransfer() {
         setLastSuccessfulTransfer(System.currentTimeMillis());
     }
 
     protected final void setLastSuccessfulTransfer(final long timestamp) {
         latestSuccessTransfer.set(timestamp);
+        latestReportedNodeState.set(timestamp);
+    }
+
+    private boolean isClusterScope(final ProcessContext context, boolean logInvalidConfig) {
+        if (SCOPE_CLUSTER.equals(context.getProperty(MONITORING_SCOPE).getValue())) {
+            if (getNodeTypeProvider().isClustered()) {
+                return true;
+            }
+            if (logInvalidConfig) {
+                getLogger().warn("NiFi is running as a Standalone mode, but 'cluster' scope is set." +
+                        " Fallback to 'node' scope. Fix configuration to stop this message.");
+            }
+        }
+        return false;
+    }
+
+    private boolean shouldReportOnlyOnPrimary(boolean isClusterScope, final ProcessContext context) {
+        if (REPORT_NODE_PRIMARY.equals(context.getProperty(REPORTING_NODE).getValue())) {
+            if (isClusterScope) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -168,17 +245,47 @@ public class MonitorActivity extends AbstractProcessor {
         final long now = System.currentTimeMillis();
 
         final ComponentLog logger = getLogger();
+        final boolean copyAttributes = context.getProperty(COPY_ATTRIBUTES).asBoolean();
+        final boolean isClusterScope = isClusterScope(context, false);
+        final boolean shouldReportOnlyOnPrimary = shouldReportOnlyOnPrimary(isClusterScope, context);
         final List<FlowFile> flowFiles = session.get(50);
+
+        boolean isInactive = false;
+        long updatedLatestSuccessTransfer = -1;
+        StateMap clusterState = null;
+
         if (flowFiles.isEmpty()) {
             final long previousSuccessMillis = latestSuccessTransfer.get();
+
             boolean sendInactiveMarker = false;
 
-            if (now >= previousSuccessMillis + thresholdMillis) {
+            isInactive = (now >= previousSuccessMillis + thresholdMillis);
+            logger.debug("isInactive={}, previousSuccessMillis={}, now={}", new Object[]{isInactive, previousSuccessMillis, now});
+            if (isInactive && isClusterScope) {
+                // Even if this node has been inactive, there may be other nodes handling flow actively.
+                // However, if this node is active, we don't have to look at cluster state.
+                try {
+                    clusterState = context.getStateManager().getState(Scope.CLUSTER);
+                    if (clusterState != null && !StringUtils.isEmpty(clusterState.get(STATE_KEY_LATEST_SUCCESS_TRANSFER))) {
+                        final long latestReportedClusterActivity = Long.valueOf(clusterState.get(STATE_KEY_LATEST_SUCCESS_TRANSFER));
+                        isInactive = (now >= latestReportedClusterActivity + thresholdMillis);
+                        if (!isInactive) {
+                            // This node has been inactive, but other node has more recent activity.
+                            updatedLatestSuccessTransfer = latestReportedClusterActivity;
+                        }
+                        logger.debug("isInactive={}, latestReportedClusterActivity={}", new Object[]{isInactive, latestReportedClusterActivity});
+                    }
+                } catch (IOException e) {
+                    logger.error("Failed to access cluster state. Activity will not be monitored properly until this is addressed.", e);
+                }
+            }
+
+            if (isInactive) {
                 final boolean continual = context.getProperty(CONTINUALLY_SEND_MESSAGES).asBoolean();
                 sendInactiveMarker = !inactive.getAndSet(true) || (continual && (now > lastInactiveMessage.get() + thresholdMillis));
             }
 
-            if (sendInactiveMarker) {
+            if (sendInactiveMarker && shouldThisNodeReport(isClusterScope, shouldReportOnlyOnPrimary)) {
                 lastInactiveMessage.set(System.currentTimeMillis());
 
                 FlowFile inactiveFlowFile = session.create();
@@ -199,19 +306,66 @@ public class MonitorActivity extends AbstractProcessor {
             } else {
                 context.yield();    // no need to dominate CPU checking times; let other processors run for a bit.
             }
+
         } else {
             session.transfer(flowFiles, REL_SUCCESS);
+            updatedLatestSuccessTransfer = now;
             logger.info("Transferred {} FlowFiles to 'success'", new Object[]{flowFiles.size()});
 
-            final long inactivityStartMillis = latestSuccessTransfer.getAndSet(now);
-            if (inactive.getAndSet(false)) {
+            final long latestStateReportTimestamp = latestReportedNodeState.get();
+            if (isClusterScope
+                    && (now - latestStateReportTimestamp) > (thresholdMillis / 3)) {
+                // We don't want to hit the state manager every onTrigger(), but often enough to detect activeness.
+                try {
+                    final StateManager stateManager = context.getStateManager();
+                    final StateMap state = stateManager.getState(Scope.CLUSTER);
+
+                    final Map<String, String> newValues = new HashMap<>();
+
+                    // Persist attributes so that other nodes can copy it
+                    if (copyAttributes) {
+                        newValues.putAll(flowFiles.get(0).getAttributes());
+                    }
+                    newValues.put(STATE_KEY_LATEST_SUCCESS_TRANSFER, String.valueOf(now));
+
+                    if (state == null || state.getVersion() == -1) {
+                        stateManager.setState(newValues, Scope.CLUSTER);
+                    } else {
+                        final String existingTimestamp = state.get(STATE_KEY_LATEST_SUCCESS_TRANSFER);
+                        if (StringUtils.isEmpty(existingTimestamp)
+                                || Long.parseLong(existingTimestamp) < now) {
+                            // If this returns false due to race condition, it's not a problem since we just need
+                            // the latest active timestamp.
+                            stateManager.replace(state, newValues, Scope.CLUSTER);
+                        } else {
+                            logger.debug("Existing state has more recent timestamp, didn't update state.");
+                        }
+                    }
+                    latestReportedNodeState.set(now);
+                } catch (IOException e) {
+                    logger.error("Failed to access cluster state. Activity will not be monitored properly until this is addressed.", e);
+                }
+            }
+        }
+
+        if (!isInactive) {
+            final long inactivityStartMillis = latestSuccessTransfer.get();
+            if (updatedLatestSuccessTransfer > -1) {
+                latestSuccessTransfer.set(updatedLatestSuccessTransfer);
+            }
+            if (inactive.getAndSet(false) && shouldThisNodeReport(isClusterScope, shouldReportOnlyOnPrimary)) {
                 FlowFile activityRestoredFlowFile = session.create();
 
-                final boolean copyAttributes = context.getProperty(COPY_ATTRIBUTES).asBoolean();
                 if (copyAttributes) {
 
-                    // copy attributes from the first flow file in the list
-                    Map<String, String> attributes = new HashMap<>(flowFiles.get(0).getAttributes());
+                    final Map<String, String> attributes = new HashMap<>();
+                    if (flowFiles.size() > 0) {
+                        // copy attributes from the first flow file in the list
+                        attributes.putAll(flowFiles.get(0).getAttributes());
+                    } else if (clusterState != null) {
+                        attributes.putAll(clusterState.toMap());
+                        attributes.remove(STATE_KEY_LATEST_SUCCESS_TRANSFER);
+                    }
                     // don't copy the UUID
                     attributes.remove(CoreAttributes.UUID.key());
                     activityRestoredFlowFile = session.putAllAttributes(activityRestoredFlowFile, attributes);
@@ -221,12 +375,7 @@ public class MonitorActivity extends AbstractProcessor {
                 activityRestoredFlowFile = session.putAttribute(activityRestoredFlowFile, "inactivityDurationMillis", String.valueOf(now - inactivityStartMillis));
 
                 final byte[] outBytes = context.getProperty(ACTIVITY_RESTORED_MESSAGE).evaluateAttributeExpressions(activityRestoredFlowFile).getValue().getBytes(UTF8);
-                activityRestoredFlowFile = session.write(activityRestoredFlowFile, new OutputStreamCallback() {
-                    @Override
-                    public void process(final OutputStream out) throws IOException {
-                        out.write(outBytes);
-                    }
-                });
+                activityRestoredFlowFile = session.write(activityRestoredFlowFile, out -> out.write(outBytes));
 
                 session.getProvenanceReporter().create(activityRestoredFlowFile);
                 session.transfer(activityRestoredFlowFile, REL_ACTIVITY_RESTORED);
@@ -234,4 +383,23 @@ public class MonitorActivity extends AbstractProcessor {
             }
         }
     }
+
+    @OnStopped
+    public void onStopped(final ProcessContext context) {
+        if (getNodeTypeProvider().isPrimary()) {
+            final StateManager stateManager = context.getStateManager();
+            try {
+                stateManager.clear(Scope.CLUSTER);
+            } catch (IOException e) {
+                getLogger().error("Failed to clear cluster state due to " + e, e);
+            }
+        }
+    }
+
+    private boolean shouldThisNodeReport(boolean isClusterScope, boolean isReportOnlyOnPrimary) {
+        return !isClusterScope
+                || !isReportOnlyOnPrimary
+                || getNodeTypeProvider().isPrimary();
+    }
+
 }


### PR DESCRIPTION
- Added 'Monitoring Scope' property
- Persist the latest activity as Cluster state
- Examine cluster state on each node if necessary

<img width="762" alt="monitoractivity-config" src="https://cloud.githubusercontent.com/assets/1107620/16346160/d7526104-3a80-11e6-85eb-f9a6fd8af206.png">

## Test

- Setup data flow as shown in the screenshot, using a 3 node cluster
- GenerateFlowFile is scheduled on primary.
- Monitoring Scope = Node
     - [ok] Even if GenerateFlowFile is running, non-primary nodes will report inactive messages.
     - [ok] If GenerateFlowFile stops, all nodes report inactive messages.
     - [ok] If GenerateFlowFile resumes, primary node reports activity.restored, but other nodes don't
- Monitoring Scope = Cluster && Reporting = all
     - [ok] While GenerateFlowFile is running, none of nodes reports inactive messages.
     - [ok] If GenerateFlowFile stops, all nodes report inactive messages.
     - [ok] If GenerateFlowFile resumes, all nodes report activity.restored, if copy attribute is true, then non-primary nodes copy attributes from state.
- Monitoring Scope = Cluster && Reporting = primary
     - [ok] While GenerateFlowFile is running, none of nodes reports inactive messages.
     - [ok] If GenerateFlowFile stops, primary node reports inactive messages. Others don't.
     - [ok] If GenerateFlowFile resumes, primary node reports activity.restored. Others don't.
     - [ok] Disconnect primary node and other node takes over primary node.
     - [ok] Login to the disconnected node, if GenerateFlowFile stops, inactive message should be reported, even if MonitorActivity is using cluster & primary, fallback to standalone mode
     - [ok] And when it resumes, activity restored message should be reported, even if MonitorActivity is using cluster & primary, fallback to standalone mode
- [ok] Confirmed it works on Standalone NiFi instance, too

<img width="955" alt="monitoractivity-test" src="https://cloud.githubusercontent.com/assets/1107620/16346162/d920d344-3a80-11e6-886b-2acd54315968.png">

