### PR TITLE
NIFI-2118 Addresssing License/Notice issues in nifi-assumbly

### DIFF
--- a/nifi-assembly/LICENSE
+++ b/nifi-assembly/LICENSE
@@ -1151,23 +1151,6 @@ For details see https://github.com/svenkubiak/jBCrypt/blob/0.4.1/LICENSE
     ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-This product bundles 'Jolt' which is available under an Apache License.
-For details see https://github.com/bazaarvoice/jolt/blob/jolt-0.0.20/LICENSE
-
-    Copyright 2013-2014 Bazaarvoice, Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
 This product bundles 'Angular' which is available under an MIT license.
 
     Copyright (c) 2010-2016 Google, Inc. http://angularjs.org
@@ -1426,3 +1409,35 @@ This product bundles 'jsonlint' which is available under an MIT license.
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
+
+This project bundles 'Jython' which is available under a Python Software Foundation License Version 2.
+
+    Copyright (c) 2000-2009 Jython Developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+     - Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+     - Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the distribution.
+
+     - Neither the name of the Jython Developers nor the names of
+       its contributors may be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+    OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -617,10 +617,6 @@ The following binary components are provided under the Apache Software License v
      The following NOTICE information applies:
        Copyright 2011 JsonPath authors
 
-  (ASLv2) Jolt
-    The following NOTICE information applies:
-      Copyright 2013-2014 Bazaarvoice, Inc
-
   (ASLv2) Kite SDK
     The following NOTICE information applies:
       This product includes software developed by Cloudera, Inc.
@@ -919,17 +915,8 @@ The following binary components are provided under the Python Software Foundatio
 
   (PSFLv2) Jython (org.python:jython-standalone:2.7.0 - http://www.jython.org/)
     The following NOTICE information applies:
-        Copyright (c) 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007 Jython Developers All rights reserved.
-
-******************
-MIT License
-******************
-
-The following binary components are provided under an MIT-style license
-
-  (MIT) Luaj (org.luaj:luaj-jse:3.0.1 - http://www.luaj.org/luaj/3.0/README.html)
-    The following NOTICE information applies:
-        Copyright (c) 2009-2011 Luaj.org. All rights reserved.
+        This product includes software developed by:
+            o The Apache Software Foundation (http://www.apache.org/)
 
 *****************
 Public Domain


### PR DESCRIPTION
Jython's license and notice information can be found here: https://hg.python.org/jython/file/tip

Jolt's license can be found here (no notice): https://github.com/bazaarvoice/jolt/tree/jolt-0.0.20