### PR TITLE
NIFI-2142 Cache compiled XSLT in TransformXml

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -190,6 +190,10 @@ language governing permissions and limitations under the License. -->
             <version>0.4.1</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <scope>test</scope>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -16,12 +16,15 @@
  */
 package org.apache.nifi.processors.standard;
 
+import java.io.*;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,8 +32,8 @@ import java.util.Map;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Ignore;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestTransformXml {
@@ -59,7 +62,6 @@ public class TestTransformXml {
         original.assertContentEquals("not xml");
     }
 
-    @Ignore("this test fails")
     @Test
     public void testTransformMath() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
@@ -72,12 +74,11 @@ public class TestTransformXml {
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
-        final String transformedContent = new String(transformed.toByteArray(), StandardCharsets.UTF_8);
+        final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/math.html"))).trim();
 
-        transformed.assertContentEquals(Paths.get("src/test/resources/TestTransformXml/math.html"));
+        transformed.assertContentEquals(expectedContent);
     }
 
-    @Ignore("this test fails")
     @Test
     public void testTransformCsv() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
@@ -108,9 +109,28 @@ public class TestTransformXml {
             runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
             final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
             final String transformedContent = new String(transformed.toByteArray(), StandardCharsets.ISO_8859_1);
+            final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/tokens.xml")));
 
-            transformed.assertContentEquals(Paths.get("src/test/resources/TestTransformXml/tokens.xml"));
+            transformed.assertContentEquals(expectedContent);
         }
+    }
+
+    @Test
+    public void testTransformExpressionLanguage() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
+        runner.setProperty("header", "Test for mod");
+        runner.setProperty(TransformXml.XSLT_FILE_NAME, "${xslt.path}");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("xslt.path", "src/test/resources/TestTransformXml/math.xsl");
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/math.xml"), attributes);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
+        final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/math.html"))).trim();
+
+        transformed.assertContentEquals(expectedContent);
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.html
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.html
@@ -1,8 +1,8 @@
 <HTML xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <H1>Test for mod</H1>
-    <HR>
-    <P>Should say "1": 1</P>
-    <P>Should say "1": 1</P>
-    <P>Should say "-1": -1</P>
-    <P>true</P>
+   <H1>Test for mod</H1>
+   <HR>
+   <P>Should say "1": 1</P>
+   <P>Should say "1": 1</P>
+   <P>Should say "-1": -1</P>
+   <P>true</P>
 </HTML>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.xsl
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.xsl
@@ -13,10 +13,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<xsl:stylesheet version="2.0" 
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema">
-		
+
     <xsl:param name="header" />
 
     <xsl:template match="doc">

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/tokens.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/tokens.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <test release="0.0" id="uuid_0">
-    <event id="uuid_1">
-        <token>1</token>
-        <token>2</token>
-        <token>3</token>
-        <token>4</token>
-        <token>C:\dir$abc</token>
-        <token>6</token>
-        <token>7</token>
-        <token>A,B</token>
-        <token>"don't"</token>
-        <token>2014-05-01T30:23:00Z</token>
-        <token>11</token>
-        <token>12</token>
-    </event>
+   <event id="uuid_1">
+      <token>1</token>
+      <token>2</token>
+      <token>3</token>
+      <token>4</token>
+      <token>C:\dir$abc</token>
+      <token>6</token>
+      <token>7</token>
+      <token>A,B</token>
+      <token>"don't"</token>
+      <token>2014-05-01T30:23:00Z</token>
+      <token>11</token>
+      <token>12</token>
+   </event>
 </test>


### PR DESCRIPTION
Two other tidbits:
1. This also modifies the XSLT_FILENAME attribute to support expression language.
2. This updated the test files to have 3 space indents because Saxon defaults to that and AFAICT the free version doesn't let you change that -- it's either no indent or 3 space. Could be wrong though.