### PR TITLE
NIFI-2158 : return 'true' for isXYZEnabled() for ComponentLog if 

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/logging/LogRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/logging/LogRepository.java
@@ -76,4 +76,12 @@ public interface LogRepository {
      * @return the current logger for the component
      */
     ComponentLog getLogger();
+
+    boolean isDebugEnabled();
+
+    boolean isInfoEnabled();
+
+    boolean isWarnEnabled();
+
+    boolean isErrorEnabled();
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/logging/repository/StandardLogRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/logging/repository/StandardLogRepository.java
@@ -183,4 +183,29 @@ public class StandardLogRepository implements LogRepository {
     public ComponentLog getLogger() {
         return componentLogger;
     }
+
+    private boolean hasObserver(final LogLevel logLevel) {
+        final Collection<LogObserver> logLevelObservers = observers.get(logLevel);
+        return (logLevelObservers != null && !logLevelObservers.isEmpty());
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return hasObserver(LogLevel.DEBUG);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return hasObserver(LogLevel.INFO);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return hasObserver(LogLevel.WARN);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return hasObserver(LogLevel.ERROR);
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
@@ -168,28 +168,28 @@ public class SimpleProcessLogger implements ComponentLog {
     }
 
     @Override
-    public boolean isWarnEnabled() {
-        return logger.isWarnEnabled();
-    }
-
-    @Override
     public boolean isTraceEnabled() {
         return logger.isTraceEnabled();
     }
 
     @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled() || logRepository.isDebugEnabled();
+    }
+
+    @Override
     public boolean isInfoEnabled() {
-        return logger.isInfoEnabled();
+        return logger.isInfoEnabled() || logRepository.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled() || logRepository.isWarnEnabled();
     }
 
     @Override
     public boolean isErrorEnabled() {
-        return logger.isErrorEnabled();
-    }
-
-    @Override
-    public boolean isDebugEnabled() {
-        return logger.isDebugEnabled();
+        return logger.isErrorEnabled() || logRepository.isErrorEnabled();
     }
 
     @Override


### PR DESCRIPTION
either the slf4j logger has that level enabled or the bulletin repository does, instead of only checking if slf4j logger has it enabled