### PR TITLE
NIFI-2171 Removing list of groups from User

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/authorization/User.java
+++ b/nifi-api/src/main/java/org/apache/nifi/authorization/User.java
@@ -16,10 +16,7 @@
  */
 package org.apache.nifi.authorization;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * A user to create authorization policies for.
@@ -30,12 +27,9 @@ public class User {
 
     private final String identity;
 
-    private final Set<String> groups;
-
     private User(final Builder builder) {
         this.identifier = builder.identifier;
         this.identity = builder.identity;
-        this.groups = Collections.unmodifiableSet(new HashSet<>(builder.groups));
 
         if (identifier == null || identifier.trim().isEmpty()) {
             throw new IllegalArgumentException("Identifier can not be null or empty");
@@ -59,13 +53,6 @@ public class User {
      */
     public String getIdentity() {
         return identity;
-    }
-
-    /**
-     * @return an unmodifiable set of group ids
-     */
-    public Set<String> getGroups() {
-        return groups;
     }
 
     @Override
@@ -98,7 +85,6 @@ public class User {
 
         private String identifier;
         private String identity;
-        private Set<String> groups = new HashSet<>();
         private final boolean fromUser;
 
         /**
@@ -122,8 +108,6 @@ public class User {
 
             this.identifier = other.getIdentifier();
             this.identity = other.getIdentity();
-            this.groups.clear();
-            this.groups.addAll(other.getGroups());
             this.fromUser = true;
         }
 
@@ -152,68 +136,6 @@ public class User {
          */
         public Builder identity(final String identity) {
             this.identity = identity;
-            return this;
-        }
-
-        /**
-         * Adds all groups from the provided set to the builder's set of groups.
-         *
-         * @param groups the groups to add
-         * @return the builder
-         */
-        public Builder addGroups(final Set<String> groups) {
-            if (groups != null) {
-                this.groups.addAll(groups);
-            }
-            return this;
-        }
-
-        /**
-         * Adds the provided group to the builder's set of groups.
-         *
-         * @param group the group to add
-         * @return the builder
-         */
-        public Builder addGroup(final String group) {
-            if (group != null) {
-                this.groups.add(group);
-            }
-            return this;
-        }
-
-        /**
-         * Removes all groups in the provided set from the builder's set of groups.
-         *
-         * @param groups the groups to remove
-         * @return the builder
-         */
-        public Builder removeGroups(final Set<String> groups) {
-            if (groups != null) {
-                this.groups.removeAll(groups);
-            }
-            return this;
-        }
-
-        /**
-         * Removes the provided group from the builder's set of groups.
-         *
-         * @param group the group to remove
-         * @return the builder
-         */
-        public Builder removeGroup(final String group) {
-            if (group != null) {
-                this.groups.remove(group);
-            }
-            return this;
-        }
-
-        /**
-         * Clears the builder's set of groups so that groups is non-null with size == 0.
-         *
-         * @return the builder
-         */
-        public Builder clearGroups() {
-            this.groups.clear();
             return this;
         }
 

--- a/nifi-api/src/main/java/org/apache/nifi/authorization/UsersAndAccessPolicies.java
+++ b/nifi-api/src/main/java/org/apache/nifi/authorization/UsersAndAccessPolicies.java
@@ -40,4 +40,12 @@ public interface UsersAndAccessPolicies {
      */
     public User getUser(final String identity);
 
+    /**
+     * Retrieves the groups for a given user identity.
+     *
+     * @param userIdentity a user identity
+     * @return the set of groups for the given user identity
+     */
+    public Set<Group> getGroups(final String userIdentity);
+
 }

--- a/nifi-api/src/test/java/org/apache/nifi/authorization/TestAbstractPolicyBasedAuthorizer.java
+++ b/nifi-api/src/test/java/org/apache/nifi/authorization/TestAbstractPolicyBasedAuthorizer.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -104,10 +105,17 @@ public class TestAbstractPolicyBasedAuthorizer {
         final User user = new User.Builder()
                 .identity(userIdentity)
                 .identifier(userIdentifier)
-                .addGroup(groupIdentifier)
                 .build();
 
         when(usersAndAccessPolicies.getUser(userIdentity)).thenReturn(user);
+
+        final Group group = new Group.Builder()
+                .identifier(groupIdentifier)
+                .name(groupIdentifier)
+                .addUser(user.getIdentifier())
+                .build();
+
+        when(usersAndAccessPolicies.getGroups(userIdentity)).thenReturn(Collections.singleton(group));
 
         final AuthorizationRequest request = new AuthorizationRequest.Builder()
                 .identity(userIdentity)
@@ -180,11 +188,11 @@ public class TestAbstractPolicyBasedAuthorizer {
     public void testGetFingerprint() {
         // create the users, groups, and policies
 
-        Group group1 = new Group.Builder().identifier("group-id-1").name("group-1").build();
-        Group group2 = new Group.Builder().identifier("group-id-2").name("group-2").build();
+        User user1 = new User.Builder().identifier("user-id-1").identity("user-1").build();
+        User user2 = new User.Builder().identifier("user-id-2").identity("user-2").build();
 
-        User user1 = new User.Builder().identifier("user-id-1").identity("user-1").addGroup(group1.getIdentifier()).build();
-        User user2 = new User.Builder().identifier("user-id-2").identity("user-2").addGroup(group2.getIdentifier()).build();
+        Group group1 = new Group.Builder().identifier("group-id-1").name("group-1").addUser(user1.getIdentifier()).build();
+        Group group2 = new Group.Builder().identifier("group-id-2").name("group-2").addUser(user2.getIdentifier()).build();
 
         AccessPolicy policy1 = new AccessPolicy.Builder()
                 .identifier("policy-id-1")
@@ -251,11 +259,12 @@ public class TestAbstractPolicyBasedAuthorizer {
 
     @Test
     public void testInheritFingerprint() {
-        Group group1 = new Group.Builder().identifier("group-id-1").name("group-1").build();
-        Group group2 = new Group.Builder().identifier("group-id-2").name("group-2").build();
 
-        User user1 = new User.Builder().identifier("user-id-1").identity("user-1").addGroup(group1.getIdentifier()).build();
+        User user1 = new User.Builder().identifier("user-id-1").identity("user-1").build();
         User user2 = new User.Builder().identifier("user-id-2").identity("user-2").build();
+
+        Group group1 = new Group.Builder().identifier("group-id-1").name("group-1").addUser(user1.getIdentifier()).build();
+        Group group2 = new Group.Builder().identifier("group-id-2").name("group-2").build();
 
         AccessPolicy policy1 = new AccessPolicy.Builder()
                 .identifier("policy-id-1")
@@ -392,7 +401,7 @@ public class TestAbstractPolicyBasedAuthorizer {
         }
 
         @Override
-        public AccessPolicy addAccessPolicy(AccessPolicy accessPolicy) throws AuthorizationAccessException {
+        protected AccessPolicy doAddAccessPolicy(AccessPolicy accessPolicy) throws AuthorizationAccessException {
             policies.add(accessPolicy);
             return accessPolicy;
         }
@@ -428,7 +437,7 @@ public class TestAbstractPolicyBasedAuthorizer {
         }
 
         @Override
-        public void onConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
+        public void doOnConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
 
         }
 

--- a/nifi-api/src/test/java/org/apache/nifi/authorization/TestUser.java
+++ b/nifi-api/src/test/java/org/apache/nifi/authorization/TestUser.java
@@ -18,12 +18,7 @@ package org.apache.nifi.authorization;
 
 import org.junit.Test;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class TestUser {
 
@@ -37,25 +32,16 @@ public class TestUser {
         final User user = new User.Builder()
                 .identifier(identifier)
                 .identity(identity)
-                .addGroup(group1)
-                .addGroup(group2)
                 .build();
 
         assertEquals(identifier, user.getIdentifier());
         assertEquals(identity, user.getIdentity());
-
-        assertNotNull(user.getGroups());
-        assertEquals(2, user.getGroups().size());
-        assertTrue(user.getGroups().contains(group1));
-        assertTrue(user.getGroups().contains(group2));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMissingIdentifier() {
         new User.Builder()
                 .identity("user1")
-                .addGroup("group1")
-                .addGroup("group2")
                 .build();
     }
 
@@ -63,26 +49,7 @@ public class TestUser {
     public void testMissingIdentity() {
         new User.Builder()
                 .identifier("1")
-                .addGroup("group1")
-                .addGroup("group2")
                 .build();
-    }
-
-    @Test
-    public void testMissingGroups() {
-        final String identifier = "1";
-        final String identity = "user1";
-
-        final User user = new User.Builder()
-                .identifier(identifier)
-                .identity(identity)
-                .build();
-
-        assertEquals(identifier, user.getIdentifier());
-        assertEquals(identity, user.getIdentity());
-
-        assertNotNull(user.getGroups());
-        assertEquals(0, user.getGroups().size());
     }
 
     @Test
@@ -95,22 +62,14 @@ public class TestUser {
         final User user = new User.Builder()
                 .identifier(identifier)
                 .identity(identity)
-                .addGroup(group1)
-                .addGroup(group2)
                 .build();
 
         assertEquals(identifier, user.getIdentifier());
         assertEquals(identity, user.getIdentity());
 
-        assertNotNull(user.getGroups());
-        assertEquals(2, user.getGroups().size());
-        assertTrue(user.getGroups().contains(group1));
-        assertTrue(user.getGroups().contains(group2));
-
         final User user2 = new User.Builder(user).build();
         assertEquals(user.getIdentifier(), user2.getIdentifier());
         assertEquals(user.getIdentity(), user2.getIdentity());
-        assertEquals(user.getGroups(), user2.getGroups());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -118,53 +77,9 @@ public class TestUser {
         final User user = new User.Builder()
                 .identifier("1")
                 .identity("user1")
-                .addGroup("group1")
-                .addGroup("group2")
                 .build();
 
         new User.Builder(user).identifier("2").build();
-    }
-
-    @Test
-    public void testAddRemoveClearGroups() {
-        final User.Builder builder = new User.Builder()
-                .identifier("1")
-                .identity("user1")
-                .addGroup("group1");
-
-        final User user1 = builder.build();
-        assertNotNull(user1.getGroups());
-        assertEquals(1, user1.getGroups().size());
-        assertTrue(user1.getGroups().contains("group1"));
-
-        final Set<String> moreGroups = new HashSet<>();
-        moreGroups.add("group2");
-        moreGroups.add("group3");
-        moreGroups.add("group4");
-
-        final User user2 = builder.addGroups(moreGroups).build();
-        assertEquals(4, user2.getGroups().size());
-        assertTrue(user2.getGroups().contains("group1"));
-        assertTrue(user2.getGroups().contains("group2"));
-        assertTrue(user2.getGroups().contains("group3"));
-        assertTrue(user2.getGroups().contains("group4"));
-
-        final User user3 = builder.removeGroup("group2").build();
-        assertEquals(3, user3.getGroups().size());
-        assertTrue(user3.getGroups().contains("group1"));
-        assertTrue(user3.getGroups().contains("group3"));
-        assertTrue(user3.getGroups().contains("group4"));
-
-        final Set<String> removeGroups = new HashSet<>();
-        removeGroups.add("group1");
-        removeGroups.add("group4");
-
-        final User user4 = builder.removeGroups(removeGroups).build();
-        assertEquals(1, user4.getGroups().size());
-        assertTrue(user4.getGroups().contains("group3"));
-
-        final User user5 = builder.clearGroups().build();
-        assertEquals(0, user5.getGroups().size());
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-authorizer/src/main/java/org/apache/nifi/authorization/AuthorizerFactoryBean.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-authorizer/src/main/java/org/apache/nifi/authorization/AuthorizerFactoryBean.java
@@ -369,7 +369,7 @@ public class AuthorizerFactoryBean implements FactoryBean, DisposableBean, Autho
                 }
 
                 @Override
-                public AccessPolicy addAccessPolicy(AccessPolicy accessPolicy) throws AuthorizationAccessException {
+                public AccessPolicy doAddAccessPolicy(AccessPolicy accessPolicy) throws AuthorizationAccessException {
                     try (final NarCloseable narCloseable = NarCloseable.withNarLoader()) {
                         return policyBasedAuthorizer.addAccessPolicy(accessPolicy);
                     }
@@ -418,7 +418,7 @@ public class AuthorizerFactoryBean implements FactoryBean, DisposableBean, Autho
                 }
 
                 @Override
-                public void onConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
+                public void doOnConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
                     try (final NarCloseable narCloseable = NarCloseable.withNarLoader()) {
                         policyBasedAuthorizer.onConfigured(configurationContext);
                     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/main/java/org/apache/nifi/authorization/RoleAccessPolicy.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/main/java/org/apache/nifi/authorization/RoleAccessPolicy.java
@@ -33,19 +33,19 @@ public final class RoleAccessPolicy {
     static final String WRITE_ACTION = "W";
 
     private final String resource;
-    private final String actions;
+    private final String action;
 
-    private RoleAccessPolicy(final String resource, final String actions) {
+    private RoleAccessPolicy(final String resource, final String action) {
         this.resource = resource;
-        this.actions = actions;
+        this.action = action;
     }
 
     public String getResource() {
         return resource;
     }
 
-    public String getActions() {
-        return actions;
+    public String getAction() {
+        return action;
     }
 
     public static Map<Role,Set<RoleAccessPolicy>> getMappings(final String rootGroupId) {
@@ -62,13 +62,18 @@ public final class RoleAccessPolicy {
 
         final Set<RoleAccessPolicy> provenancePolicies = new HashSet<>();
         provenancePolicies.add(new RoleAccessPolicy(ResourceType.Provenance.getValue(), READ_ACTION));
+        if (rootGroupId != null) {
+            provenancePolicies.add(new RoleAccessPolicy(ResourceType.ProvenanceEvent.getValue() + ResourceType.ProcessGroup.getValue() + "/" + rootGroupId, READ_ACTION));
+        }
         roleAccessPolicies.put(Role.ROLE_PROVENANCE, Collections.unmodifiableSet(provenancePolicies));
 
         final Set<RoleAccessPolicy> dfmPolicies = new HashSet<>();
         dfmPolicies.add(new RoleAccessPolicy(ResourceType.Flow.getValue(), READ_ACTION));
+        dfmPolicies.add(new RoleAccessPolicy(ResourceType.Controller.getValue(), READ_ACTION));
         dfmPolicies.add(new RoleAccessPolicy(ResourceType.Controller.getValue(), WRITE_ACTION));
         dfmPolicies.add(new RoleAccessPolicy(ResourceType.System.getValue(), READ_ACTION));
         if (rootGroupId != null) {
+            dfmPolicies.add(new RoleAccessPolicy(ResourceType.ProcessGroup.getValue() + "/" + rootGroupId, READ_ACTION));
             dfmPolicies.add(new RoleAccessPolicy(ResourceType.ProcessGroup.getValue() + "/" + rootGroupId, WRITE_ACTION));
         }
         roleAccessPolicies.put(Role.ROLE_DFM, Collections.unmodifiableSet(dfmPolicies));
@@ -79,16 +84,20 @@ public final class RoleAccessPolicy {
         if (rootGroupId != null) {
             adminPolicies.add(new RoleAccessPolicy(ResourceType.ProcessGroup.getValue() + "/" + rootGroupId, READ_ACTION));
         }
+        adminPolicies.add(new RoleAccessPolicy(ResourceType.Tenant.getValue(), READ_ACTION));
         adminPolicies.add(new RoleAccessPolicy(ResourceType.Tenant.getValue(), WRITE_ACTION));
+        adminPolicies.add(new RoleAccessPolicy(ResourceType.Policy.getValue(), READ_ACTION));
         adminPolicies.add(new RoleAccessPolicy(ResourceType.Policy.getValue(), WRITE_ACTION));
         roleAccessPolicies.put(Role.ROLE_ADMIN, Collections.unmodifiableSet(adminPolicies));
 
         final Set<RoleAccessPolicy> proxyPolicies = new HashSet<>();
+        proxyPolicies.add(new RoleAccessPolicy(ResourceType.Proxy.getValue(), READ_ACTION));
         proxyPolicies.add(new RoleAccessPolicy(ResourceType.Proxy.getValue(), WRITE_ACTION));
         roleAccessPolicies.put(Role.ROLE_PROXY, Collections.unmodifiableSet(proxyPolicies));
 
         final Set<RoleAccessPolicy> nifiPolicies = new HashSet<>();
         nifiPolicies.add(new RoleAccessPolicy(ResourceType.Controller.getValue(), READ_ACTION));
+        nifiPolicies.add(new RoleAccessPolicy(ResourceType.SiteToSite.getValue(), READ_ACTION));
         nifiPolicies.add(new RoleAccessPolicy(ResourceType.SiteToSite.getValue(), WRITE_ACTION));
         roleAccessPolicies.put(Role.ROLE_NIFI, Collections.unmodifiableSet(nifiPolicies));
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/main/xsd/authorizations.xsd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/main/xsd/authorizations.xsd
@@ -17,6 +17,20 @@
 
     <!-- group -->
     <xs:complexType name="Group">
+        <xs:sequence>
+            <xs:element name="user" minOccurs="0" maxOccurs="unbounded" >
+                <xs:complexType>
+                    <xs:attribute name="identifier">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:minLength value="1"/>
+                                <xs:pattern value=".*[^\s].*"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
         <xs:attribute name="identifier">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
@@ -44,20 +58,6 @@
 
     <!-- user -->
     <xs:complexType name="User">
-        <xs:sequence>
-            <xs:element name="group" minOccurs="0" maxOccurs="unbounded" >
-                <xs:complexType>
-                    <xs:attribute name="identifier">
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:minLength value="1"/>
-                                <xs:pattern value=".*[^\s].*"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
         <xs:attribute name="identifier">
             <xs:simpleType>
                 <xs:restriction base="xs:string">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFlowController.java
@@ -71,11 +71,11 @@ public class TestFlowController {
         properties.setProperty("nifi.remote.input.socket.port", "");
         properties.setProperty("nifi.remote.input.secure", "");
 
-        Group group1 = new Group.Builder().identifier("group-id-1").name("group-1").build();
-        Group group2 = new Group.Builder().identifier("group-id-2").name("group-2").build();
-
-        User user1 = new User.Builder().identifier("user-id-1").identity("user-1").addGroup(group1.getIdentifier()).build();
+        User user1 = new User.Builder().identifier("user-id-1").identity("user-1").build();
         User user2 = new User.Builder().identifier("user-id-2").identity("user-2").build();
+
+        Group group1 = new Group.Builder().identifier("group-id-1").name("group-1").addUser(user1.getIdentifier()).build();
+        Group group2 = new Group.Builder().identifier("group-id-2").name("group-2").build();
 
         AccessPolicy policy1 = new AccessPolicy.Builder()
                 .identifier("policy-id-1")
@@ -135,7 +135,7 @@ public class TestFlowController {
         // had a problem verifying the call to inheritFingerprint didn't happen, so just verify none of the add methods got called
         verify(authorizer, times(0)).addUser(any(User.class));
         verify(authorizer, times(0)).addGroup(any(Group.class));
-        verify(authorizer, times(0)).addAccessPolicy(any(AccessPolicy.class));
+        //verify(authorizer, times(0)).addAccessPolicy(any(AccessPolicy.class));
     }
 
     @Test(expected = UninheritableFlowException.class)

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/UserGroupDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/UserGroupDAO.java
@@ -46,6 +46,14 @@ public interface UserGroupDAO {
     Group getUserGroup(String userGroupId);
 
     /**
+     * Gets the groups for the user with the specified ID.
+     *
+     * @param userId The user ID
+     * @return The set of groups
+     */
+    Set<Group> getUserGroupsForUser(String userId);
+
+    /**
      * Gets all user groups.
      *
      * @return The user group transfer objects

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardPolicyBasedAuthorizerDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardPolicyBasedAuthorizerDAO.java
@@ -107,7 +107,7 @@ public class StandardPolicyBasedAuthorizerDAO implements AccessPolicyDAO, UserGr
                 }
 
                 @Override
-                public AccessPolicy addAccessPolicy(final AccessPolicy accessPolicy) throws AuthorizationAccessException {
+                public AccessPolicy doAddAccessPolicy(final AccessPolicy accessPolicy) throws AuthorizationAccessException {
                     throw new IllegalStateException(MSG_NON_ABSTRACT_POLICY_BASED_AUTHORIZER);
                 }
 
@@ -141,7 +141,7 @@ public class StandardPolicyBasedAuthorizerDAO implements AccessPolicyDAO, UserGr
                 }
 
                 @Override
-                public void onConfigured(final AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
+                public void doOnConfigured(final AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
                 }
 
                 @Override
@@ -220,6 +220,13 @@ public class StandardPolicyBasedAuthorizerDAO implements AccessPolicyDAO, UserGr
     }
 
     @Override
+    public Set<Group> getUserGroupsForUser(String userId) {
+        return authorizer.getGroups().stream()
+                .filter(g -> g.getUsers().contains(userId))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
     public Set<Group> getUserGroups() {
         return authorizer.getGroups();
     }
@@ -278,11 +285,7 @@ public class StandardPolicyBasedAuthorizerDAO implements AccessPolicyDAO, UserGr
     }
 
     private User buildUser(final String identifier, final UserDTO userDTO) {
-        final Set<TenantEntity> groups = userDTO.getUserGroups();
         final User.Builder builder = new User.Builder().identifier(identifier).identity(userDTO.getIdentity());
-        if (groups != null) {
-            builder.addGroups(groups.stream().map(ComponentEntity::getId).collect(Collectors.toSet()));
-        }
         return builder.build();
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/groovy/org/apache/nifi/web/dao/impl/StandardPolicyBasedAuthorizerDAOSpec.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/groovy/org/apache/nifi/web/dao/impl/StandardPolicyBasedAuthorizerDAOSpec.groovy
@@ -16,19 +16,12 @@
  */
 package org.apache.nifi.web.dao.impl
 
-import org.apache.nifi.authorization.AbstractPolicyBasedAuthorizer
-import org.apache.nifi.authorization.AccessPolicy
-import org.apache.nifi.authorization.Authorizer
-import org.apache.nifi.authorization.Group
-import org.apache.nifi.authorization.RequestAction
-import org.apache.nifi.authorization.User
+import org.apache.nifi.authorization.*
 import org.apache.nifi.web.ResourceNotFoundException
 import org.apache.nifi.web.api.dto.AccessPolicyDTO
 import org.apache.nifi.web.api.dto.UserDTO
 import org.apache.nifi.web.api.dto.UserGroupDTO
 import org.apache.nifi.web.api.entity.TenantEntity
-import org.apache.nifi.web.api.entity.UserEntity
-import org.apache.nifi.web.api.entity.UserGroupEntity
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -100,14 +93,15 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
         noExceptionThrown()
 
         then:
-        1 * authorizer.addAccessPolicy(accessPolicy) >> accessPolicy
+        1 * authorizer.getAccessPolicies() >> accessPolicies
+        1 * authorizer.doAddAccessPolicy(accessPolicy) >> accessPolicy
         0 * _
         result?.equals accessPolicy
 
         where:
-        accessPolicy                                                                  | _
+        accessPolicy                                 | accessPolicies
         new AccessPolicy.Builder().identifier('policy-id-1').resource('/fake/resource').addUser('user-id-1').addGroup('user-group-id-1')
-                .action(RequestAction.WRITE).build() | _
+                .action(RequestAction.WRITE).build() | [] as Set
     }
 
     @Unroll
@@ -409,7 +403,7 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
 
         where:
         user                                                                                                     | _
-        new User.Builder().identifier('user-id-1').identity('user identity').addGroup('user-group-id-1').build() | _
+        new User.Builder().identifier('user-id-1').identity('user identity').build() | _
     }
 
     @Unroll
@@ -432,7 +426,7 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
 
         where:
         user                                                                                                     | _
-        new User.Builder().identifier('user-id-1').identity('user identity').addGroup('user-group-id-1').build() | _
+        new User.Builder().identifier('user-id-1').identity('user identity').build() | _
     }
 
     @Unroll
@@ -451,7 +445,7 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
 
         where:
         user                                                                                                     | _
-        new User.Builder().identifier('user-id-1').identity('user identity').addGroup('user-group-id-1').build() | _
+        new User.Builder().identifier('user-id-1').identity('user identity').build() | _
     }
 
     @Unroll
@@ -485,7 +479,7 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
 
         where:
         users                                                                                                             | _
-        [new User.Builder().identifier('user-id-1').identity('user identity').addGroup('user-group-id-1').build()] as Set | _
+        [new User.Builder().identifier('user-id-1').identity('user identity').build()] as Set | _
     }
 
     @Unroll
@@ -506,7 +500,7 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
 
         where:
         user                                                                                                     | _
-        new User.Builder().identifier('user-id-1').identity('user identity').addGroup('user-group-id-1').build() | _
+        new User.Builder().identifier('user-id-1').identity('user identity').build() | _
     }
 
     @Unroll
@@ -542,7 +536,7 @@ class StandardPolicyBasedAuthorizerDAOSpec extends Specification {
 
         where:
         user                                                                                                     | _
-        new User.Builder().identifier('user-id-1').identity('user identity').addGroup('user-group-id-1').build() | _
+        new User.Builder().identifier('user-id-1').identity('user identity').build() | _
     }
 
     @Unroll


### PR DESCRIPTION
- Making FileAuthorizer not update the resource or action when updating an AccessPolicy
- Adding corresponding READ policies during initial seeding and legacy conversions
- Adding checks to FileAuthorizer to ensure only one policy per resource-action
- Removing merging of policies on legacy conversion since we have one action per policy now