### PR TITLE
NIFI-2142 Cache compiled XSLT in TransformXml

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -190,6 +190,10 @@ language governing permissions and limitations under the License. -->
             <version>0.4.1</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <scope>test</scope>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -28,7 +29,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -41,6 +45,7 @@ import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
@@ -60,6 +65,10 @@ import org.apache.nifi.stream.io.BufferedInputStream;
 import org.apache.nifi.util.StopWatch;
 import org.apache.nifi.util.Tuple;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
 @EventDriven
 @SideEffectFree
 @SupportsBatching
@@ -76,13 +85,43 @@ public class TransformXml extends AbstractProcessor {
             .name("XSLT file name")
             .description("Provides the name (including full path) of the XSLT file to apply to the flowfile XML content.")
             .required(true)
+            .expressionLanguageSupported(true)
             .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor INDENT_OUTPUT = new PropertyDescriptor.Builder()
+            .name("indent-output")
+            .displayName("Indent")
+            .description("Whether or not to indent the output.")
+            .required(true)
+            .defaultValue("true")
+            .allowableValues("true", "false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor CACHE_SIZE = new PropertyDescriptor.Builder()
+            .name("cache-size")
+            .displayName("Cache size")
+            .description("Maximum size of the stylesheet cache.")
+            .required(true)
+            .defaultValue("100")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor CACHE_DURATION = new PropertyDescriptor.Builder()
+            .name("cache-duration")
+            .displayName("Cache duration")
+            .description("How long to keep stylesheets in the cache.")
+            .required(true)
+            .defaultValue("60 secs")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("The FlowFile with transformed content will be routed to this relationship")
             .build();
+
     public static final Relationship REL_FAILURE = new Relationship.Builder()
             .name("failure")
             .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid XML), it will be routed to this relationship")
@@ -90,11 +129,15 @@ public class TransformXml extends AbstractProcessor {
 
     private List<PropertyDescriptor> properties;
     private Set<Relationship> relationships;
+    private LoadingCache<String, Templates> cache;
 
     @Override
     protected void init(final ProcessorInitializationContext context) {
         final List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(XSLT_FILE_NAME);
+        properties.add(INDENT_OUTPUT);
+        properties.add(CACHE_SIZE);
+        properties.add(CACHE_DURATION);
         this.properties = Collections.unmodifiableList(properties);
 
         final Set<Relationship> relationships = new HashSet<>();
@@ -124,6 +167,28 @@ public class TransformXml extends AbstractProcessor {
                 .build();
     }
 
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        final Long cacheSize = context.getProperty(CACHE_SIZE).asLong();
+        final Long cacheDuration = context.getProperty(CACHE_DURATION).asTimePeriod(TimeUnit.SECONDS);
+
+        CacheBuilder cacheBuilder = CacheBuilder.newBuilder();
+        if (cacheSize > 0) {
+            cacheBuilder = cacheBuilder.maximumSize(cacheSize);
+            if (cacheDuration > 0) {
+                cacheBuilder = cacheBuilder.expireAfterAccess(cacheDuration, TimeUnit.SECONDS);
+            }
+        }
+
+        cache = cacheBuilder.build(
+           new CacheLoader<String, Templates>() {
+               public Templates load(String path) throws TransformerConfigurationException {
+                   TransformerFactory factory = TransformerFactory.newInstance();
+                   return factory.newTemplates(new StreamSource(path));
+               }
+           });
+    }
+
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) {
         final FlowFile original = session.get();
@@ -133,17 +198,19 @@ public class TransformXml extends AbstractProcessor {
 
         final ComponentLog logger = getLogger();
         final StopWatch stopWatch = new StopWatch(true);
+        final String xsltFileName = context.getProperty(XSLT_FILE_NAME)
+            .evaluateAttributeExpressions(original)
+            .getValue();
+        final Boolean indentOutput = context.getProperty(INDENT_OUTPUT).asBoolean();
 
         try {
             FlowFile transformed = session.write(original, new StreamCallback() {
                 @Override
                 public void process(final InputStream rawIn, final OutputStream out) throws IOException {
                     try (final InputStream in = new BufferedInputStream(rawIn)) {
-
-                        File stylesheet = new File(context.getProperty(XSLT_FILE_NAME).getValue());
-                        StreamSource styleSource = new StreamSource(stylesheet);
-                        TransformerFactory tfactory = new net.sf.saxon.TransformerFactoryImpl();
-                        Transformer transformer = tfactory.newTransformer(styleSource);
+                        final Templates templates = cache.get(xsltFileName);
+                        final Transformer transformer = templates.newTransformer();
+                        transformer.setOutputProperty(OutputKeys.INDENT, (indentOutput ? "yes" : "no"));
 
                         // pass all dynamic properties to the transformer
                         for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -16,12 +16,15 @@
  */
 package org.apache.nifi.processors.standard;
 
+import java.io.*;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,8 +32,8 @@ import java.util.Map;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Ignore;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestTransformXml {
@@ -59,7 +62,6 @@ public class TestTransformXml {
         original.assertContentEquals("not xml");
     }
 
-    @Ignore("this test fails")
     @Test
     public void testTransformMath() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
@@ -72,12 +74,11 @@ public class TestTransformXml {
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
-        final String transformedContent = new String(transformed.toByteArray(), StandardCharsets.UTF_8);
+        final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/math.html"))).trim();
 
-        transformed.assertContentEquals(Paths.get("src/test/resources/TestTransformXml/math.html"));
+        transformed.assertContentEquals(expectedContent);
     }
 
-    @Ignore("this test fails")
     @Test
     public void testTransformCsv() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
@@ -108,9 +109,28 @@ public class TestTransformXml {
             runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
             final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
             final String transformedContent = new String(transformed.toByteArray(), StandardCharsets.ISO_8859_1);
+            final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/tokens.xml")));
 
-            transformed.assertContentEquals(Paths.get("src/test/resources/TestTransformXml/tokens.xml"));
+            transformed.assertContentEquals(expectedContent);
         }
+    }
+
+    @Test
+    public void testTransformExpressionLanguage() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
+        runner.setProperty("header", "Test for mod");
+        runner.setProperty(TransformXml.XSLT_FILE_NAME, "${xslt.path}");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("xslt.path", "src/test/resources/TestTransformXml/math.xsl");
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/math.xml"), attributes);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
+        final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/math.html"))).trim();
+
+        transformed.assertContentEquals(expectedContent);
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -16,7 +16,7 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.io.*;
+import java.io.IOException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -33,7 +33,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestTransformXml {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -132,4 +132,20 @@ public class TestTransformXml {
         transformed.assertContentEquals(expectedContent);
     }
 
+    @Test
+    public void testTransformNoCache() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
+        runner.setProperty("header", "Test for mod");
+        runner.setProperty(TransformXml.CACHE_SIZE, "0");
+        runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/math.xsl");
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/math.xml"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
+        final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/math.html"))).trim();
+
+        transformed.assertContentEquals(expectedContent);
+    }
+
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.html
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.html
@@ -1,8 +1,8 @@
 <HTML xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <H1>Test for mod</H1>
-    <HR>
-    <P>Should say "1": 1</P>
-    <P>Should say "1": 1</P>
-    <P>Should say "-1": -1</P>
-    <P>true</P>
+   <H1>Test for mod</H1>
+   <HR>
+   <P>Should say "1": 1</P>
+   <P>Should say "1": 1</P>
+   <P>Should say "-1": -1</P>
+   <P>true</P>
 </HTML>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.xsl
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/math.xsl
@@ -13,10 +13,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<xsl:stylesheet version="2.0" 
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema">
-		
+
     <xsl:param name="header" />
 
     <xsl:template match="doc">

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/tokens.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/tokens.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <test release="0.0" id="uuid_0">
-    <event id="uuid_1">
-        <token>1</token>
-        <token>2</token>
-        <token>3</token>
-        <token>4</token>
-        <token>C:\dir$abc</token>
-        <token>6</token>
-        <token>7</token>
-        <token>A,B</token>
-        <token>"don't"</token>
-        <token>2014-05-01T30:23:00Z</token>
-        <token>11</token>
-        <token>12</token>
-    </event>
+   <event id="uuid_1">
+      <token>1</token>
+      <token>2</token>
+      <token>3</token>
+      <token>4</token>
+      <token>C:\dir$abc</token>
+      <token>6</token>
+      <token>7</token>
+      <token>A,B</token>
+      <token>"don't"</token>
+      <token>2014-05-01T30:23:00Z</token>
+      <token>11</token>
+      <token>12</token>
+   </event>
 </test>


### PR DESCRIPTION
Two other tidbits:

1. This also modifies the XSLT_FILENAME attribute to support expression language.
2. This updated the test files to have 3 space indents because Saxon defaults to that and AFAICT the free version doesn't let you change that -- it's either no indent or 3 space. Could be wrong though.

See https://github.com/apache/nifi/pull/591 for PR against 0.x and past discussion.