### PR TITLE
NIFI-2119 Fixed 0.7.0 release blocker for cluster secure communications

### DIFF
--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/CertificateUtils.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/CertificateUtils.java
@@ -166,10 +166,48 @@ public final class CertificateUtils {
         return result;
     }
 
-    public static String extractClientDNFromSSLSocket(Socket socket) throws CertificateException {
+    /**
+     * Returns the DN extracted from the peer certificate (the server DN if run on the client; the client DN (if available) if run on the server).
+     *
+     * If the client auth setting is WANT or NONE and a client certificate is not present, this method will return {@code null}.
+     * If the client auth is NEED, it will throw a {@link CertificateException}.
+     *
+     * @param socket the SSL Socket
+     * @return the extracted DN
+     * @throws CertificateException if there is a problem parsing the certificate
+     */
+    public static String extractPeerDNFromSSLSocket(Socket socket) throws CertificateException {
         String dn = null;
         if (socket instanceof SSLSocket) {
             final SSLSocket sslSocket = (SSLSocket) socket;
+
+            boolean clientMode = sslSocket.getUseClientMode();
+            logger.debug("SSL Socket in {} mode", clientMode ? "client" : "server");
+            ClientAuth clientAuth = getClientAuthStatus(sslSocket);
+            logger.debug("SSL Socket client auth status: {}", clientAuth);
+
+            if (clientMode) {
+               dn = extractPeerDNFromClientSSLSocket(sslSocket);
+            } else {
+               dn = extractPeerDNFromServerSSLSocket(sslSocket);
+            }
+        }
+
+        return dn;
+    }
+
+    /**
+     * Returns the DN extracted from the client certificate.
+     *
+     * If the client auth setting is WANT or NONE and a certificate is not present (and {@code respectClientAuth} is {@code true}), this method will return {@code null}.
+     * If the client auth is NEED, it will throw a {@link CertificateException}.
+     *
+     * @param sslSocket the SSL Socket
+     * @return the extracted DN
+     * @throws CertificateException if there is a problem parsing the certificate
+     */
+    private static String extractPeerDNFromClientSSLSocket(SSLSocket sslSocket) throws CertificateException {
+        String dn = null;
 
             /** The clientAuth value can be "need", "want", or "none"
              * A client must send client certificates for need, should for want, and will not for none.
@@ -198,8 +236,34 @@ public final class CertificateUtils {
                     throw new CertificateException(e);
                 }
             }
-        }
+        return dn;
+    }
 
+    /**
+     * Returns the DN extracted from the server certificate.
+     *
+     * @param socket the SSL Socket
+     * @return the extracted DN
+     * @throws CertificateException if there is a problem parsing the certificate
+     */
+    private static String extractPeerDNFromServerSSLSocket(Socket socket) throws CertificateException {
+        String dn = null;
+        if (socket instanceof SSLSocket) {
+            final SSLSocket sslSocket = (SSLSocket) socket;
+                try {
+                    final Certificate[] certChains = sslSocket.getSession().getPeerCertificates();
+                    if (certChains != null && certChains.length > 0) {
+                        X509Certificate x509Certificate = convertAbstractX509Certificate(certChains[0]);
+                        dn = x509Certificate.getSubjectDN().getName().trim();
+                    }
+                } catch (SSLPeerUnverifiedException e) {
+                    if (e.getMessage().equals(PEER_NOT_AUTHENTICATED_MSG)) {
+                        logger.error("The server did not present a certificate and thus the DN cannot" +
+                                " be extracted. Check that the other endpoint is providing a complete  certificate chain");
+                    }
+                    throw new CertificateException(e);
+                }
+        }
         return dn;
     }
 

--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/CertificateUtils.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/CertificateUtils.java
@@ -187,9 +187,11 @@ public final class CertificateUtils {
             logger.debug("SSL Socket client auth status: {}", clientAuth);
 
             if (clientMode) {
-               dn = extractPeerDNFromClientSSLSocket(sslSocket);
-            } else {
+                logger.debug("This socket is in client mode, so attempting to extract certificate from remote 'server' socket");
                dn = extractPeerDNFromServerSSLSocket(sslSocket);
+            } else {
+                logger.debug("This socket is in server mode, so attempting to extract certificate from remote 'client' socket");
+               dn = extractPeerDNFromClientSSLSocket(sslSocket);
             }
         }
 
@@ -223,6 +225,7 @@ public final class CertificateUtils {
                     if (certChains != null && certChains.length > 0) {
                         X509Certificate x509Certificate = convertAbstractX509Certificate(certChains[0]);
                         dn = x509Certificate.getSubjectDN().getName().trim();
+                        logger.debug("Extracted DN={} from client certificate", dn);
                     }
                 } catch (SSLPeerUnverifiedException e) {
                     if (e.getMessage().equals(PEER_NOT_AUTHENTICATED_MSG)) {
@@ -255,11 +258,12 @@ public final class CertificateUtils {
                     if (certChains != null && certChains.length > 0) {
                         X509Certificate x509Certificate = convertAbstractX509Certificate(certChains[0]);
                         dn = x509Certificate.getSubjectDN().getName().trim();
+                        logger.debug("Extracted DN={} from server certificate", dn);
                     }
                 } catch (SSLPeerUnverifiedException e) {
                     if (e.getMessage().equals(PEER_NOT_AUTHENTICATED_MSG)) {
                         logger.error("The server did not present a certificate and thus the DN cannot" +
-                                " be extracted. Check that the other endpoint is providing a complete  certificate chain");
+                                " be extracted. Check that the other endpoint is providing a complete certificate chain");
                     }
                     throw new CertificateException(e);
                 }

--- a/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/CertificateUtilsTest.groovy
+++ b/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/CertificateUtilsTest.groovy
@@ -307,23 +307,25 @@ class CertificateUtilsTest extends GroovyTestCase {
 
         SSLSession mockSession = [getPeerCertificates: { -> certificateChain }] as SSLSession
 
+        // This socket is in client mode, so the peer ("target") is a server
+
         // Create mock sockets for each possible value of ClientAuth
         SSLSocket mockNoneSocket = [
-                getUseClientMode : { -> false },
+                getUseClientMode : { -> true },
                 getNeedClientAuth: { -> false },
                 getWantClientAuth: { -> false },
                 getSession       : { -> mockSession }
         ] as SSLSocket
 
         SSLSocket mockNeedSocket = [
-                getUseClientMode : { -> false },
+                getUseClientMode : { -> true },
                 getNeedClientAuth: { -> true },
                 getWantClientAuth: { -> false },
                 getSession       : { -> mockSession }
         ] as SSLSocket
 
         SSLSocket mockWantSocket = [
-                getUseClientMode : { -> false },
+                getUseClientMode : { -> true },
                 getNeedClientAuth: { -> false },
                 getWantClientAuth: { -> true },
                 getSession       : { -> mockSession }
@@ -346,8 +348,10 @@ class CertificateUtilsTest extends GroovyTestCase {
     @Test
     void testShouldNotExtractClientCertificatesFromSSLClientSocketWithClientAuthNone() {
         // Arrange
+
+        // This socket is in server mode, so the peer ("target") is a client
         SSLSocket mockSocket = [
-                getUseClientMode : { -> true },
+                getUseClientMode : { -> false },
                 getNeedClientAuth: { -> false },
                 getWantClientAuth: { -> false }
         ] as SSLSocket
@@ -370,8 +374,9 @@ class CertificateUtilsTest extends GroovyTestCase {
 
         SSLSession mockSession = [getPeerCertificates: { -> certificateChain }] as SSLSession
 
+        // This socket is in server mode, so the peer ("target") is a client
         SSLSocket mockSocket = [
-                getUseClientMode : { -> true },
+                getUseClientMode : { -> false },
                 getNeedClientAuth: { -> false },
                 getWantClientAuth: { -> true },
                 getSession       : { -> mockSession }
@@ -392,8 +397,9 @@ class CertificateUtilsTest extends GroovyTestCase {
             throw new SSLPeerUnverifiedException("peer not authenticated")
         }] as SSLSession
 
+        // This socket is in server mode, so the peer ("target") is a client
         SSLSocket mockSocket = [
-                getUseClientMode : { -> true },
+                getUseClientMode : { -> false },
                 getNeedClientAuth: { -> false },
                 getWantClientAuth: { -> true },
                 getSession       : { -> mockSession }
@@ -418,8 +424,9 @@ class CertificateUtilsTest extends GroovyTestCase {
 
         SSLSession mockSession = [getPeerCertificates: { -> certificateChain }] as SSLSession
 
+        // This socket is in server mode, so the peer ("target") is a client
         SSLSocket mockSocket = [
-                getUseClientMode : { -> true },
+                getUseClientMode : { -> false },
                 getNeedClientAuth: { -> true },
                 getWantClientAuth: { -> false },
                 getSession       : { -> mockSession }
@@ -440,8 +447,9 @@ class CertificateUtilsTest extends GroovyTestCase {
             throw new SSLPeerUnverifiedException("peer not authenticated")
         }] as SSLSession
 
+        // This socket is in server mode, so the peer ("target") is a client
         SSLSocket mockSocket = [
-                getUseClientMode : { -> true },
+                getUseClientMode : { -> false },
                 getNeedClientAuth: { -> true },
                 getWantClientAuth: { -> false },
                 getSession       : { -> mockSession }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/NodeProtocolSenderImpl.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/NodeProtocolSenderImpl.java
@@ -98,7 +98,7 @@ public class NodeProtocolSenderImpl implements NodeProtocolSender {
 
     private String getNCMDN(Socket socket) {
         try {
-            return CertificateUtils.extractClientDNFromSSLSocket(socket);
+            return CertificateUtils.extractPeerDNFromSSLSocket(socket);
         } catch (CertificateException e) {
             throw new ProtocolException(e);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/SocketProtocolListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/SocketProtocolListener.java
@@ -182,7 +182,7 @@ public class SocketProtocolListener extends SocketListener implements ProtocolLi
 
     private String getRequestorDN(Socket socket) {
         try {
-            return CertificateUtils.extractClientDNFromSSLSocket(socket);
+            return CertificateUtils.extractPeerDNFromSSLSocket(socket);
         } catch (CertificateException e) {
             throw new ProtocolException(e);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
@@ -122,7 +122,7 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
      * the request contains an authentication request but it could not be authenticated.
      *
      * @param request The request
-     * @return The NiFiAutorizationRequestToken used to later authorized the client
+     * @return The NiFiAuthorizationRequestToken used to later authorized the client
      * @throws InvalidAuthenticationException If the request contained an authentication attempt, but could not authenticate
      */
     public abstract NiFiAuthorizationRequestToken attemptAuthentication(HttpServletRequest request);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
@@ -52,8 +52,9 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (log.isDebugEnabled()) {
-            log.debug("Checking secure context token: " + SecurityContextHolder.getContext().getAuthentication());
+            log.debug("Checking secure context token: " + authentication);
         }
 
         if (requiresAuthentication((HttpServletRequest) request)) {


### PR DESCRIPTION
The client and server sockets were being treated the same when attempting to extract the peer certificate DN (server sockets should not be subject to the influence of `nifi.security.needClientAuth` in `nifi.properties`). 

This has been tested on 2- and 3-node clusters with `needClientAuth` set to both *true* and *false*. 