### PR TITLE
NIFI-1998: Update Cassandra processor docs to include 3.0.x clusters

### DIFF
--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/PutCassandraQL.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/PutCassandraQL.java
@@ -69,7 +69,7 @@ import java.util.regex.Pattern;
 @Tags({"cassandra", "cql", "put", "insert", "update", "set"})
 @EventDriven
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
-@CapabilityDescription("Execute provided Cassandra Query Language (CQL) statement on a Cassandra 1.x or 2.x cluster. "
+@CapabilityDescription("Execute provided Cassandra Query Language (CQL) statement on a Cassandra 1.x, 2.x, or 3.0.x cluster. "
         + "The content of an incoming FlowFile is expected to be the CQL command to execute. The CQL command may use "
         + "the ? to escape parameters. In this case, the parameters to use must exist as FlowFile attributes with the "
         + "naming convention cql.args.N.type and cql.args.N.value, where N is a positive integer. The cql.args.N.type "

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -75,7 +75,7 @@ import java.util.concurrent.TimeoutException;
 @Tags({"cassandra", "cql", "select"})
 @EventDriven
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
-@CapabilityDescription("Execute provided Cassandra Query Language (CQL) select query on a Cassandra 1.x or 2.x cluster. Query result "
+@CapabilityDescription("Execute provided Cassandra Query Language (CQL) select query on a Cassandra 1.x, 2.x, or 3.0.x cluster. Query result "
         + "may be converted to Avro or JSON format. Streaming is used so arbitrarily large result sets are supported. This processor can be "
         + "scheduled to run on a timer, or cron expression, using the standard scheduling methods, or it can be triggered by an incoming FlowFile. "
         + "If it is triggered by an incoming FlowFile, then attributes of that FlowFile will be available when evaluating the "


### PR DESCRIPTION
Compatibility matrix here: http://datastax.github.io/java-driver/manual/native_protocol/