### PR TITLE
NIFI-2157: Add GenerateTableFetch processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.dbcp.DBCPService;
+import org.apache.nifi.processor.AbstractSessionFactoryProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import static java.sql.Types.ARRAY;
+import static java.sql.Types.BIGINT;
+import static java.sql.Types.BINARY;
+import static java.sql.Types.BIT;
+import static java.sql.Types.BLOB;
+import static java.sql.Types.BOOLEAN;
+import static java.sql.Types.CLOB;
+import static java.sql.Types.DECIMAL;
+import static java.sql.Types.DOUBLE;
+import static java.sql.Types.FLOAT;
+import static java.sql.Types.INTEGER;
+import static java.sql.Types.LONGVARBINARY;
+import static java.sql.Types.NUMERIC;
+import static java.sql.Types.CHAR;
+import static java.sql.Types.DATE;
+import static java.sql.Types.LONGNVARCHAR;
+import static java.sql.Types.LONGVARCHAR;
+import static java.sql.Types.NCHAR;
+import static java.sql.Types.NVARCHAR;
+import static java.sql.Types.REAL;
+import static java.sql.Types.ROWID;
+import static java.sql.Types.SMALLINT;
+import static java.sql.Types.TIME;
+import static java.sql.Types.TIMESTAMP;
+import static java.sql.Types.TINYINT;
+import static java.sql.Types.VARBINARY;
+import static java.sql.Types.VARCHAR;
+
+/**
+ * A base class for common code shared by processors that fetch RDBMS data.
+ */
+public abstract class AbstractDatabaseFetchProcessor extends AbstractSessionFactoryProcessor {
+
+    // Relationships
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Successfully created FlowFile from SQL query result set.")
+            .build();
+
+    protected Set<Relationship> relationships;
+
+    // Properties
+    public static final PropertyDescriptor DBCP_SERVICE = new PropertyDescriptor.Builder()
+            .name("Database Connection Pooling Service")
+            .description("The Controller Service that is used to obtain a connection to the database.")
+            .required(true)
+            .identifiesControllerService(DBCPService.class)
+            .build();
+
+    public static final PropertyDescriptor TABLE_NAME = new PropertyDescriptor.Builder()
+            .name("Table Name")
+            .description("The name of the database table to be queried.")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor COLUMN_NAMES = new PropertyDescriptor.Builder()
+            .name("Columns to Return")
+            .description("A comma-separated list of column names to be used in the query. If your database requires "
+                    + "special treatment of the names (quoting, e.g.), each name should include such treatment. If no "
+                    + "column names are supplied, all columns in the specified table will be returned.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor MAX_VALUE_COLUMN_NAMES = new PropertyDescriptor.Builder()
+            .name("Maximum-value Columns")
+            .description("A comma-separated list of column names. The processor will keep track of the maximum value "
+                    + "for each column that has been returned since the processor started running. This can be used to "
+                    + "retrieve only those rows that have been added/updated since the last retrieval. Note that some "
+                    + "JDBC types such as bit/boolean are not conducive to maintaining maximum value, so columns of these "
+                    + "types should not be listed in this property, and will result in error(s) during processing.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor QUERY_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("Max Wait Time")
+            .description("The maximum amount of time allowed for a running SQL select query "
+                    + ", zero means there is no limit. Max time less than 1 second will be equal to zero.")
+            .defaultValue("0 seconds")
+            .required(true)
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .build();
+
+    protected List<PropertyDescriptor> propDescriptors;
+
+    public static final PropertyDescriptor DB_TYPE;
+
+    protected final static Map<String, DatabaseAdapter> dbAdapters = new HashMap<>();
+    protected final Map<String, Integer> columnTypeMap = new HashMap<>();
+
+    static {
+        // Load the DatabaseAdapters
+        ServiceLoader<DatabaseAdapter> dbAdapterLoader = ServiceLoader.load(DatabaseAdapter.class);
+        dbAdapterLoader.forEach(it -> dbAdapters.put(it.getName(), it));
+
+        DB_TYPE = new PropertyDescriptor.Builder()
+                .name("db-fetch-db-type")
+                .displayName("Database Type")
+                .description("The type/flavor of database, used for generating database-specific code. In many cases the Generic type "
+                        + "should suffice, but some databases (such as Oracle) require custom SQL clauses. ")
+                .allowableValues(dbAdapters.keySet())
+                .defaultValue(dbAdapters.values().stream().findFirst().get().getName())
+                .required(true)
+                .build();
+    }
+
+    public void setup(final ProcessContext context) {
+        // Try to fill the columnTypeMap with the types of the desired max-value columns
+        final DBCPService dbcpService = context.getProperty(DBCP_SERVICE).asControllerService(DBCPService.class);
+        final String tableName = context.getProperty(TABLE_NAME).getValue();
+        final String maxValueColumnNames = context.getProperty(MAX_VALUE_COLUMN_NAMES).getValue();
+        final DatabaseAdapter dbAdapter = dbAdapters.get(context.getProperty(DB_TYPE).getValue());
+
+        try (final Connection con = dbcpService.getConnection();
+             final Statement st = con.createStatement()) {
+
+            // Try a query that returns no rows, for the purposes of getting metadata about the columns. It is possible
+            // to use DatabaseMetaData.getColumns(), but not all drivers support this, notably the schema-on-read
+            // approach as in Apache Drill
+            String query = dbAdapter.getSelectStatement(tableName, maxValueColumnNames, "1 = 0", null, null, null);
+            ResultSet resultSet = st.executeQuery(query);
+            ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+            int numCols = resultSetMetaData.getColumnCount();
+            if (numCols > 0) {
+                columnTypeMap.clear();
+                for (int i = 1; i <= numCols; i++) {
+                    String colName = resultSetMetaData.getColumnName(i).toLowerCase();
+                    int colType = resultSetMetaData.getColumnType(i);
+                    columnTypeMap.put(colName, colType);
+                }
+
+            } else {
+                throw new ProcessException("No columns found in table from those specified: " + maxValueColumnNames);
+            }
+
+        } catch (SQLException e) {
+            throw new ProcessException("Unable to communicate with database in order to determine column types", e);
+        }
+    }
+
+    protected static String getMaxValueFromRow(ResultSet resultSet,
+                                            int columnIndex,
+                                            Integer type,
+                                            String maxValueString,
+                                            String preProcessStrategy)
+            throws ParseException, IOException, SQLException {
+
+        // Skip any columns we're not keeping track of or whose value is null
+        if (type == null || resultSet.getObject(columnIndex) == null) {
+            return null;
+        }
+
+        switch (type) {
+            case CHAR:
+            case LONGNVARCHAR:
+            case LONGVARCHAR:
+            case NCHAR:
+            case NVARCHAR:
+            case VARCHAR:
+            case ROWID:
+                String colStringValue = resultSet.getString(columnIndex);
+                if (maxValueString == null || colStringValue.compareTo(maxValueString) > 0) {
+                    return colStringValue;
+                }
+                break;
+
+            case INTEGER:
+            case SMALLINT:
+            case TINYINT:
+                Integer colIntValue = resultSet.getInt(columnIndex);
+                Integer maxIntValue = null;
+                if (maxValueString != null) {
+                    maxIntValue = Integer.valueOf(maxValueString);
+                }
+                if (maxIntValue == null || colIntValue > maxIntValue) {
+                    return colIntValue.toString();
+                }
+                break;
+
+            case BIGINT:
+                Long colLongValue = resultSet.getLong(columnIndex);
+                Long maxLongValue = null;
+                if (maxValueString != null) {
+                    maxLongValue = Long.valueOf(maxValueString);
+                }
+                if (maxLongValue == null || colLongValue > maxLongValue) {
+                    return colLongValue.toString();
+                }
+                break;
+
+            case FLOAT:
+            case REAL:
+            case DOUBLE:
+                Double colDoubleValue = resultSet.getDouble(columnIndex);
+                Double maxDoubleValue = null;
+                if (maxValueString != null) {
+                    maxDoubleValue = Double.valueOf(maxValueString);
+                }
+                if (maxDoubleValue == null || colDoubleValue > maxDoubleValue) {
+                    return colDoubleValue.toString();
+                }
+                break;
+
+            case DECIMAL:
+            case NUMERIC:
+                BigDecimal colBigDecimalValue = resultSet.getBigDecimal(columnIndex);
+                BigDecimal maxBigDecimalValue = null;
+                if (maxValueString != null) {
+                    DecimalFormat df = new DecimalFormat();
+                    df.setParseBigDecimal(true);
+                    maxBigDecimalValue = (BigDecimal) df.parse(maxValueString);
+                }
+                if (maxBigDecimalValue == null || colBigDecimalValue.compareTo(maxBigDecimalValue) > 0) {
+                    return colBigDecimalValue.toString();
+                }
+                break;
+
+            case DATE:
+                Date rawColDateValue = resultSet.getDate(columnIndex);
+                java.sql.Date colDateValue = new java.sql.Date(rawColDateValue.getTime());
+                java.sql.Date maxDateValue = null;
+                if (maxValueString != null) {
+                    maxDateValue = java.sql.Date.valueOf(maxValueString);
+                }
+                if (maxDateValue == null || colDateValue.after(maxDateValue)) {
+                    return colDateValue.toString();
+                }
+                break;
+
+            case TIME:
+                Date rawColTimeValue = resultSet.getDate(columnIndex);
+                java.sql.Time colTimeValue = new java.sql.Time(rawColTimeValue.getTime());
+                java.sql.Time maxTimeValue = null;
+                if (maxValueString != null) {
+                    maxTimeValue = java.sql.Time.valueOf(maxValueString);
+                }
+                if (maxTimeValue == null || colTimeValue.after(maxTimeValue)) {
+                    return colTimeValue.toString();
+                }
+                break;
+
+            case TIMESTAMP:
+                // Oracle timestamp queries must use literals in java.sql.Date format
+                if ("Oracle".equals(preProcessStrategy)) {
+                    Date rawColOracleTimestampValue = resultSet.getDate(columnIndex);
+                    java.sql.Date oracleTimestampValue = new java.sql.Date(rawColOracleTimestampValue.getTime());
+                    java.sql.Date maxOracleTimestampValue = null;
+                    if (maxValueString != null) {
+                        maxOracleTimestampValue = java.sql.Date.valueOf(maxValueString);
+                    }
+                    if (maxOracleTimestampValue == null || oracleTimestampValue.after(maxOracleTimestampValue)) {
+                        return oracleTimestampValue.toString();
+                    }
+                } else {
+                    Timestamp rawColTimestampValue = resultSet.getTimestamp(columnIndex);
+                    java.sql.Timestamp colTimestampValue = new java.sql.Timestamp(rawColTimestampValue.getTime());
+                    java.sql.Timestamp maxTimestampValue = null;
+                    if (maxValueString != null) {
+                        maxTimestampValue = java.sql.Timestamp.valueOf(maxValueString);
+                    }
+                    if (maxTimestampValue == null || colTimestampValue.after(maxTimestampValue)) {
+                        return colTimestampValue.toString();
+                    }
+                }
+                break;
+
+            case BIT:
+            case BOOLEAN:
+            case BINARY:
+            case VARBINARY:
+            case LONGVARBINARY:
+            case ARRAY:
+            case BLOB:
+            case CLOB:
+            default:
+                throw new IOException("Type for column " + columnIndex + " is not valid for maintaining maximum value");
+        }
+        return null;
+    }
+
+    /**
+     * Returns a SQL literal for the given value based on its type. For example, values of character type need to be enclosed
+     * in single quotes, whereas values of numeric type should not be.
+     *
+     * @param type  The JDBC type for the desired literal
+     * @param value The value to be converted to a SQL literal
+     * @return A String representing the given value as a literal of the given type
+     */
+    protected static String getLiteralByType(int type, String value, String preProcessStrategy) {
+        // Format value based on column type. For example, strings and timestamps need to be quoted
+        switch (type) {
+            // For string-represented values, put in single quotes
+            case CHAR:
+            case LONGNVARCHAR:
+            case LONGVARCHAR:
+            case NCHAR:
+            case NVARCHAR:
+            case VARCHAR:
+            case ROWID:
+            case DATE:
+            case TIME:
+                return "'" + value + "'";
+            case TIMESTAMP:
+                // Timestamp literals in Oracle need to be cast with TO_DATE
+                if ("Oracle".equals(preProcessStrategy)) {
+                    return "to_date('" + value + "', 'yyyy-mm-dd HH24:MI:SS')";
+                } else {
+                    return "'" + value + "'";
+                }
+                // Else leave as is (numeric types, e.g.)
+            default:
+                return value;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -17,11 +17,10 @@
 package org.apache.nifi.processors.standard;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.Stateful;
-import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.TriggerSerially;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -59,21 +58,20 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 
-@EventDriven
+@TriggerSerially
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @Tags({"sql", "select", "jdbc", "query", "database", "fetch", "generate"})
 @SeeAlso(QueryDatabaseTable.class)
 @CapabilityDescription("Generates SQL select queries that fetch \"pages\" of rows from a table. The partition size property, along with the table's row count, "
         + "determine the size and number of pages and generated FlowFiles. In addition, incremental fetching can be achieved by setting Maximum-Value Columns, "
-        + "which causes the processor to track the columns' maximum values, thus only fetching rows whose columns' values exceed the observed maximums.")
+        + "which causes the processor to track the columns' maximum values, thus only fetching rows whose columns' values exceed the observed maximums. This "
+        + "processor is intended to be run on the Primary Node only.")
 @Stateful(scopes = Scope.CLUSTER, description = "After performing a query on the specified table, the maximum values for "
         + "the specified column(s) will be retained for use in future executions of the query. This allows the Processor "
         + "to fetch only those records that have max values greater than the retained values. This can be used for "
         + "incremental fetching, fetching of newly added rows, etc. To clear the maximum values, clear the state of the processor "
         + "per the State Management documentation")
-@WritesAttribute(attribute = "querydbtable.row.count")
 public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
-
 
     public static final PropertyDescriptor PARTITION_SIZE = new PropertyDescriptor.Builder()
             .name("gen-table-fetch-partition-size")
@@ -142,111 +140,112 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
             context.yield();
             return;
         }
-        // Make a mutable copy of the current state property map. This will be updated by the result row callback, and eventually
-        // set as the current state map (after the session has been committed)
-        final Map<String, String> statePropertyMap = new HashMap<>(stateMap.toMap());
+        try {
+            // Make a mutable copy of the current state property map. This will be updated by the result row callback, and eventually
+            // set as the current state map (after the session has been committed)
+            final Map<String, String> statePropertyMap = new HashMap<>(stateMap.toMap());
 
-        // Build a WHERE clause with maximum-value columns (if they exist), and a list of column names that will contain MAX(<column>) aliases. The
-        // executed SQL query will retrieve the count of all records after the filter(s) have been applied, as well as the new maximum values for the
-        // specified columns. This allows the processor to generate the correctly partitioned SQL statements as well as to update the state with the
-        // latest observed maximum values.
-        String whereClause = null;
-        List<String> maxValueColumnNameList = StringUtils.isEmpty(maxValueColumnNames)
-                ? new ArrayList<>(0)
-                : Arrays.asList(maxValueColumnNames.split("\\s*,\\s*"));
-        List<String> maxValueClauses = new ArrayList<>(maxValueColumnNameList.size());
+            // Build a WHERE clause with maximum-value columns (if they exist), and a list of column names that will contain MAX(<column>) aliases. The
+            // executed SQL query will retrieve the count of all records after the filter(s) have been applied, as well as the new maximum values for the
+            // specified columns. This allows the processor to generate the correctly partitioned SQL statements as well as to update the state with the
+            // latest observed maximum values.
+            String whereClause = null;
+            List<String> maxValueColumnNameList = StringUtils.isEmpty(maxValueColumnNames)
+                    ? new ArrayList<>(0)
+                    : Arrays.asList(maxValueColumnNames.split("\\s*,\\s*"));
+            List<String> maxValueClauses = new ArrayList<>(maxValueColumnNameList.size());
 
-        String columnsClause = null;
-        List<String> maxValueSelectColumns = new ArrayList<>(maxValueColumnNameList.size() + 1);
-        maxValueSelectColumns.add("COUNT(*)");
+            String columnsClause = null;
+            List<String> maxValueSelectColumns = new ArrayList<>(maxValueColumnNameList.size() + 1);
+            maxValueSelectColumns.add("COUNT(*)");
 
-        // For each maximum-value column, get a WHERE filter and a MAX(column) alias
-        maxValueColumnNameList.forEach(colName -> {
-            maxValueSelectColumns.add("MAX(" + colName + ") " + colName);
-            String maxValue = statePropertyMap.get(colName.toLowerCase());
-            if (!StringUtils.isEmpty(maxValue)) {
-                Integer type = columnTypeMap.get(colName.toLowerCase());
-                if (type == null) {
-                    // This shouldn't happen as we are populating columnTypeMap when the processor is scheduled.
-                    throw new IllegalArgumentException("No column type found for: " + colName);
-                }
-                // Add a condition for the WHERE clause
-                maxValueClauses.add(colName + " > " + getLiteralByType(type, maxValue, dbAdapter.getName()));
-            }
-        });
-
-        whereClause = StringUtils.join(maxValueClauses, " AND ");
-        columnsClause = StringUtils.join(maxValueSelectColumns, ", ");
-
-        // Build a SELECT query with maximum-value columns (if present)
-        final String selectQuery = dbAdapter.getSelectStatement(tableName, columnsClause, whereClause, null, null, null);
-
-        try (final Connection con = dbcpService.getConnection();
-             final Statement st = con.createStatement()) {
-
-            final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).asTimePeriod(TimeUnit.SECONDS).intValue();
-            st.setQueryTimeout(queryTimeout); // timeout in seconds
-
-            logger.debug("Executing {}", new Object[]{selectQuery});
-            ResultSet resultSet = st.executeQuery(selectQuery);
-            if (resultSet.next()) {
-                // Total row count is in the first column
-                int rowCount = resultSet.getInt(1);
-
-                // Update the state map with the newly-observed maximum values
-                ResultSetMetaData rsmd = resultSet.getMetaData();
-                for (int i = 2; i <= rsmd.getColumnCount(); i++) {
-                    String resultColumnName = rsmd.getColumnName(i).toLowerCase();
-                    int type = rsmd.getColumnType(i);
-                    try {
-                        String newMaxValue = getMaxValueFromRow(resultSet, i, type, statePropertyMap.get(resultColumnName.toLowerCase()), dbAdapter.getName());
-                        if (newMaxValue != null) {
-                            statePropertyMap.put(resultColumnName, newMaxValue);
-                        }
-                    } catch (ParseException | IOException pie) {
-                        // Fail the whole thing here before we start creating flow files and such
-                        throw new ProcessException(pie);
+            // For each maximum-value column, get a WHERE filter and a MAX(column) alias
+            maxValueColumnNameList.forEach(colName -> {
+                maxValueSelectColumns.add("MAX(" + colName + ") " + colName);
+                String maxValue = statePropertyMap.get(colName.toLowerCase());
+                if (!StringUtils.isEmpty(maxValue)) {
+                    Integer type = columnTypeMap.get(colName.toLowerCase());
+                    if (type == null) {
+                        // This shouldn't happen as we are populating columnTypeMap when the processor is scheduled.
+                        throw new IllegalArgumentException("No column type found for: " + colName);
                     }
+                    // Add a condition for the WHERE clause
+                    maxValueClauses.add(colName + " > " + getLiteralByType(type, maxValue, dbAdapter.getName()));
                 }
+            });
 
-                final int numberOfFetches = (partitionSize == 0) ? rowCount : (rowCount / partitionSize) + (rowCount % partitionSize == 0 ? 0 : 1);
+            whereClause = StringUtils.join(maxValueClauses, " AND ");
+            columnsClause = StringUtils.join(maxValueSelectColumns, ", ");
 
-                // Generate SQL statements to read "pages" of data
-                for (int i = 0; i < numberOfFetches; i++) {
-                    FlowFile sqlFlowFile = null;
-                    try {
-                        Integer limit = partitionSize == 0 ? null : partitionSize;
-                        Integer offset = partitionSize == 0 ? null : i * partitionSize;
-                        final String query = dbAdapter.getSelectStatement(tableName, columnNames, StringUtils.join(maxValueClauses, " AND "), null, limit, offset);
-                        sqlFlowFile = session.create();
-                        sqlFlowFile = session.write(sqlFlowFile, out -> {
-                            out.write(query.getBytes());
-                        });
-                        session.transfer(sqlFlowFile, REL_SUCCESS);
+            // Build a SELECT query with maximum-value columns (if present)
+            final String selectQuery = dbAdapter.getSelectStatement(tableName, columnsClause, whereClause, null, null, null);
+            int rowCount = 0;
 
-                    } catch (Exception e) {
-                        logger.error("Error while generating SQL statement", e);
-                        if (sqlFlowFile != null) {
-                            session.remove(sqlFlowFile);
+            try (final Connection con = dbcpService.getConnection();
+                 final Statement st = con.createStatement()) {
+
+                final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).asTimePeriod(TimeUnit.SECONDS).intValue();
+                st.setQueryTimeout(queryTimeout); // timeout in seconds
+
+                logger.debug("Executing {}", new Object[]{selectQuery});
+                ResultSet resultSet;
+
+                resultSet = st.executeQuery(selectQuery);
+
+                if (resultSet.next()) {
+                    // Total row count is in the first column
+                    rowCount = resultSet.getInt(1);
+
+                    // Update the state map with the newly-observed maximum values
+                    ResultSetMetaData rsmd = resultSet.getMetaData();
+                    for (int i = 2; i <= rsmd.getColumnCount(); i++) {
+                        String resultColumnName = rsmd.getColumnName(i).toLowerCase();
+                        int type = rsmd.getColumnType(i);
+                        try {
+                            String newMaxValue = getMaxValueFromRow(resultSet, i, type, statePropertyMap.get(resultColumnName.toLowerCase()), dbAdapter.getName());
+                            if (newMaxValue != null) {
+                                statePropertyMap.put(resultColumnName, newMaxValue);
+                            }
+                        } catch (ParseException | IOException pie) {
+                            // Fail the whole thing here before we start creating flow files and such
+                            throw new ProcessException(pie);
                         }
                     }
+                } else {
+                    // Something is very wrong here, one row (even if count is zero) should be returned
+                    throw new SQLException("No rows returned from metadata query: " + selectQuery);
                 }
-
-            } else {
-                // Something is very wrong here, one row (even if count is zero) should be returned
-                throw new SQLException("No rows returned from metadata query: " + selectQuery);
+            } catch (SQLException e) {
+                logger.error("Unable to execute SQL select query {} due to {}", new Object[]{selectQuery, e});
+                throw new ProcessException(e);
             }
+            final int numberOfFetches = (partitionSize == 0) ? rowCount : (rowCount / partitionSize) + (rowCount % partitionSize == 0 ? 0 : 1);
 
+
+            // Generate SQL statements to read "pages" of data
+            for (int i = 0; i < numberOfFetches; i++) {
+                FlowFile sqlFlowFile;
+
+                Integer limit = partitionSize == 0 ? null : partitionSize;
+                Integer offset = partitionSize == 0 ? null : i * partitionSize;
+                final String query = dbAdapter.getSelectStatement(tableName, columnNames, StringUtils.join(maxValueClauses, " AND "), null, limit, offset);
+                sqlFlowFile = session.create();
+                sqlFlowFile = session.write(sqlFlowFile, out -> {
+                    out.write(query.getBytes());
+                });
+                session.transfer(sqlFlowFile, REL_SUCCESS);
+            }
 
             session.commit();
             try {
                 // Update the state
                 stateManager.setState(statePropertyMap, Scope.CLUSTER);
             } catch (IOException ioe) {
-                getLogger().error("{} failed to update State Manager, observed maximum values will not be recorded", new Object[]{this, ioe});
+                getLogger().error("{} failed to update State Manager, observed maximum values will not be recorded. "
+                                + "Also, any generated SQL statements may be duplicated.",
+                        new Object[]{this, ioe});
             }
-        } catch (final ProcessException | SQLException e) {
-            logger.error("Unable to execute SQL select query {} due to {}", new Object[]{selectQuery, e});
+        } catch (final ProcessException pe) {
             session.rollback();
             context.yield();
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.Stateful;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.components.state.StateManager;
+import org.apache.nifi.components.state.StateMap;
+import org.apache.nifi.dbcp.DBCPService;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessSessionFactory;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+
+@EventDriven
+@InputRequirement(Requirement.INPUT_FORBIDDEN)
+@Tags({"sql", "select", "jdbc", "query", "database", "fetch", "generate"})
+@SeeAlso(QueryDatabaseTable.class)
+@CapabilityDescription("Generates SQL select queries that fetch \"pages\" of rows from a table. The partition size property, along with the table's row count, "
+        + "determine the size and number of pages and generated FlowFiles. In addition, incremental fetching can be achieved by setting Maximum-Value Columns, "
+        + "which causes the processor to track the columns' maximum values, thus only fetching rows whose columns' values exceed the observed maximums.")
+@Stateful(scopes = Scope.CLUSTER, description = "After performing a query on the specified table, the maximum values for "
+        + "the specified column(s) will be retained for use in future executions of the query. This allows the Processor "
+        + "to fetch only those records that have max values greater than the retained values. This can be used for "
+        + "incremental fetching, fetching of newly added rows, etc. To clear the maximum values, clear the state of the processor "
+        + "per the State Management documentation")
+@WritesAttribute(attribute = "querydbtable.row.count")
+public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
+
+
+    public static final PropertyDescriptor PARTITION_SIZE = new PropertyDescriptor.Builder()
+            .name("gen-table-fetch-partition-size")
+            .displayName("Partition Size")
+            .description("The number of result rows to be fetched by each generated SQL statement. The total number of rows in "
+                    + "the table divided by the partition size gives the number of SQL statements (i.e. FlowFiles) generated. A "
+                    + "value of zero indicates that a single FlowFile is to be generated whose SQL statement will fetch all rows "
+                    + "in the table.")
+            .defaultValue("10000")
+            .required(true)
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public GenerateTableFetch() {
+        final Set<Relationship> r = new HashSet<>();
+        r.add(REL_SUCCESS);
+        relationships = Collections.unmodifiableSet(r);
+
+        final List<PropertyDescriptor> pds = new ArrayList<>();
+        pds.add(DBCP_SERVICE);
+        pds.add(DB_TYPE);
+        pds.add(TABLE_NAME);
+        pds.add(COLUMN_NAMES);
+        pds.add(MAX_VALUE_COLUMN_NAMES);
+        pds.add(QUERY_TIMEOUT);
+        pds.add(PARTITION_SIZE);
+        propDescriptors = Collections.unmodifiableList(pds);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return propDescriptors;
+    }
+
+    @OnScheduled
+    public void setup(final ProcessContext context) {
+        super.setup(context);
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSessionFactory sessionFactory) throws ProcessException {
+        ProcessSession session = sessionFactory.createSession();
+        final ComponentLog logger = getLogger();
+
+        final DBCPService dbcpService = context.getProperty(DBCP_SERVICE).asControllerService(DBCPService.class);
+        final DatabaseAdapter dbAdapter = dbAdapters.get(context.getProperty(DB_TYPE).getValue());
+        final String tableName = context.getProperty(TABLE_NAME).getValue();
+        final String columnNames = context.getProperty(COLUMN_NAMES).getValue();
+        final String maxValueColumnNames = context.getProperty(MAX_VALUE_COLUMN_NAMES).getValue();
+        final int partitionSize = context.getProperty(PARTITION_SIZE).asInteger();
+
+        final StateManager stateManager = context.getStateManager();
+        final StateMap stateMap;
+
+        try {
+            stateMap = stateManager.getState(Scope.CLUSTER);
+        } catch (final IOException ioe) {
+            getLogger().error("Failed to retrieve observed maximum values from the State Manager. Will not perform "
+                    + "query until this is accomplished.", ioe);
+            context.yield();
+            return;
+        }
+        // Make a mutable copy of the current state property map. This will be updated by the result row callback, and eventually
+        // set as the current state map (after the session has been committed)
+        final Map<String, String> statePropertyMap = new HashMap<>(stateMap.toMap());
+
+        // Build a WHERE clause with maximum-value columns (if they exist), and a list of column names that will contain MAX(<column>) aliases. The
+        // executed SQL query will retrieve the count of all records after the filter(s) have been applied, as well as the new maximum values for the
+        // specified columns. This allows the processor to generate the correctly partitioned SQL statements as well as to update the state with the
+        // latest observed maximum values.
+        String whereClause = null;
+        List<String> maxValueColumnNameList = StringUtils.isEmpty(maxValueColumnNames)
+                ? new ArrayList<>(0)
+                : Arrays.asList(maxValueColumnNames.split("\\s*,\\s*"));
+        List<String> maxValueClauses = new ArrayList<>(maxValueColumnNameList.size());
+
+        String columnsClause = null;
+        List<String> maxValueSelectColumns = new ArrayList<>(maxValueColumnNameList.size() + 1);
+        maxValueSelectColumns.add("COUNT(*)");
+
+        // For each maximum-value column, get a WHERE filter and a MAX(column) alias
+        maxValueColumnNameList.forEach(colName -> {
+            maxValueSelectColumns.add("MAX(" + colName + ") " + colName);
+            String maxValue = statePropertyMap.get(colName.toLowerCase());
+            if (!StringUtils.isEmpty(maxValue)) {
+                Integer type = columnTypeMap.get(colName.toLowerCase());
+                if (type == null) {
+                    // This shouldn't happen as we are populating columnTypeMap when the processor is scheduled.
+                    throw new IllegalArgumentException("No column type found for: " + colName);
+                }
+                // Add a condition for the WHERE clause
+                maxValueClauses.add(colName + " > " + getLiteralByType(type, maxValue, dbAdapter.getName()));
+            }
+        });
+
+        whereClause = StringUtils.join(maxValueClauses, " AND ");
+        columnsClause = StringUtils.join(maxValueSelectColumns, ", ");
+
+        // Build a SELECT query with maximum-value columns (if present)
+        final String selectQuery = dbAdapter.getSelectStatement(tableName, columnsClause, whereClause, null, null, null);
+
+        try (final Connection con = dbcpService.getConnection();
+             final Statement st = con.createStatement()) {
+
+            final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).asTimePeriod(TimeUnit.SECONDS).intValue();
+            st.setQueryTimeout(queryTimeout); // timeout in seconds
+
+            logger.debug("Executing {}", new Object[]{selectQuery});
+            ResultSet resultSet = st.executeQuery(selectQuery);
+            if (resultSet.next()) {
+                // Total row count is in the first column
+                int rowCount = resultSet.getInt(1);
+
+                // Update the state map with the newly-observed maximum values
+                ResultSetMetaData rsmd = resultSet.getMetaData();
+                for (int i = 2; i <= rsmd.getColumnCount(); i++) {
+                    String resultColumnName = rsmd.getColumnName(i).toLowerCase();
+                    int type = rsmd.getColumnType(i);
+                    try {
+                        String newMaxValue = getMaxValueFromRow(resultSet, i, type, statePropertyMap.get(resultColumnName.toLowerCase()), dbAdapter.getName());
+                        if (newMaxValue != null) {
+                            statePropertyMap.put(resultColumnName, newMaxValue);
+                        }
+                    } catch (ParseException | IOException pie) {
+                        // Fail the whole thing here before we start creating flow files and such
+                        throw new ProcessException(pie);
+                    }
+                }
+
+                final int numberOfFetches = (partitionSize == 0) ? rowCount : (rowCount / partitionSize) + (rowCount % partitionSize == 0 ? 0 : 1);
+
+                // Generate SQL statements to read "pages" of data
+                for (int i = 0; i < numberOfFetches; i++) {
+                    FlowFile sqlFlowFile = null;
+                    try {
+                        Integer limit = partitionSize == 0 ? null : partitionSize;
+                        Integer offset = partitionSize == 0 ? null : i * partitionSize;
+                        final String query = dbAdapter.getSelectStatement(tableName, columnNames, StringUtils.join(maxValueClauses, " AND "), null, limit, offset);
+                        sqlFlowFile = session.create();
+                        sqlFlowFile = session.write(sqlFlowFile, out -> {
+                            out.write(query.getBytes());
+                        });
+                        session.transfer(sqlFlowFile, REL_SUCCESS);
+
+                    } catch (Exception e) {
+                        logger.error("Error while generating SQL statement", e);
+                        if (sqlFlowFile != null) {
+                            session.remove(sqlFlowFile);
+                        }
+                    }
+                }
+
+            } else {
+                // Something is very wrong here, one row (even if count is zero) should be returned
+                throw new SQLException("No rows returned from metadata query: " + selectQuery);
+            }
+
+
+            session.commit();
+            try {
+                // Update the state
+                stateManager.setState(statePropertyMap, Scope.CLUSTER);
+            } catch (IOException ioe) {
+                getLogger().error("{} failed to update State Manager, observed maximum values will not be recorded", new Object[]{this, ioe});
+            }
+        } catch (final ProcessException | SQLException e) {
+            logger.error("Unable to execute SQL select query {} due to {}", new Object[]{selectQuery, e});
+            session.rollback();
+            context.yield();
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.db;
+
+/**
+ * Interface for RDBMS/JDBC-specific code.
+ */
+public interface DatabaseAdapter {
+
+    String getName();
+
+    /**
+     * Returns a SQL SELECT statement with the given clauses applied.
+     *
+     * @param tableName     The name of the table to fetch rows from
+     * @param columnNames   The names of the columns to fetch from the table
+     * @param whereClause   The filter to apply to the statement. This should not include the WHERE keyword
+     * @param orderByClause The columns/clause used for ordering the result rows. This should not include the ORDER BY keywords
+     * @param limit         The value for the LIMIT clause (i.e. the number of rows to return)
+     * @param offset        The value for the OFFSET clause (i.e. the number of rows to skip)
+     * @return A String containing a SQL SELECT statement with the given clauses applied
+     */
+    String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Integer limit, Integer offset);
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/GenericDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/GenericDatabaseAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.db.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+
+/**
+ * A generic database adapter that generates ANSI SQL.
+ */
+public class GenericDatabaseAdapter implements DatabaseAdapter {
+    @Override
+    public String getName() {
+        return "Generic";
+    }
+
+    @Override
+    public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Integer limit, Integer offset) {
+        if (StringUtils.isEmpty(tableName)) {
+            throw new IllegalArgumentException("Table name cannot be null or empty");
+        }
+        final StringBuilder query = new StringBuilder("SELECT ");
+        if (StringUtils.isEmpty(columnNames) || columnNames.trim().equals("*")) {
+            query.append("*");
+        } else {
+            query.append(columnNames);
+        }
+        query.append(" FROM ");
+        query.append(tableName);
+
+        if (!StringUtils.isEmpty(whereClause)) {
+            query.append(" WHERE ");
+            query.append(whereClause);
+        }
+        if (!StringUtils.isEmpty(orderByClause)) {
+            query.append(" ORDER BY ");
+            query.append(whereClause);
+        }
+        if (limit != null) {
+            query.append(" LIMIT ");
+            query.append(limit);
+        }
+        if (offset != null && offset > 0) {
+            query.append(" OFFSET ");
+            query.append(offset);
+        }
+
+        return query.toString();
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.db.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+
+/**
+ * A DatabaseAdapter that generates Oracle-compliant SQL.
+ */
+public class OracleDatabaseAdapter implements DatabaseAdapter {
+    @Override
+    public String getName() {
+        return "Oracle";
+    }
+
+    @Override
+    public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Integer limit, Integer offset) {
+        if (StringUtils.isEmpty(tableName)) {
+            throw new IllegalArgumentException("Table name cannot be null or empty");
+        }
+
+        final StringBuilder query = new StringBuilder();
+        boolean nestedSelect = (limit != null || offset != null);
+        if (nestedSelect) {
+            // Need a nested SELECT query here in order to use ROWNUM to limit the results
+            query.append("SELECT ");
+            if (StringUtils.isEmpty(columnNames) || columnNames.trim().equals("*")) {
+                query.append("*");
+            } else {
+                query.append(columnNames);
+            }
+            query.append(" FROM (SELECT a.*, ROWNUM rnum FROM (");
+        }
+
+        query.append("SELECT ");
+        if (StringUtils.isEmpty(columnNames) || columnNames.trim().equals("*")) {
+            query.append("*");
+        } else {
+            query.append(columnNames);
+        }
+        query.append(" FROM ");
+        query.append(tableName);
+
+        if (!StringUtils.isEmpty(whereClause)) {
+            query.append(" WHERE ");
+            query.append(whereClause);
+        }
+        if (!StringUtils.isEmpty(orderByClause)) {
+            query.append(" ORDER BY ");
+            query.append(whereClause);
+        }
+        if (nestedSelect) {
+            query.append(") a");
+            int offsetVal = 0;
+            if (offset != null) {
+                offsetVal = offset;
+            }
+            if (limit != null) {
+                query.append(" WHERE ROWNUM <= ");
+                query.append(offsetVal + limit);
+            }
+            query.append(") WHERE rnum > ");
+            query.append(offsetVal);
+        }
+        return query.toString();
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -43,6 +43,7 @@ org.apache.nifi.processors.standard.HashContent
 org.apache.nifi.processors.standard.IdentifyMimeType
 org.apache.nifi.processors.standard.InvokeHTTP
 org.apache.nifi.processors.standard.JoltTransformJSON
+org.apache.nifi.processors.standard.GenerateTableFetch
 org.apache.nifi.processors.standard.GetJMSQueue
 org.apache.nifi.processors.standard.GetJMSTopic
 org.apache.nifi.processors.standard.ListFile

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processors.standard.db.DatabaseAdapter
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processors.standard.db.DatabaseAdapter
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.standard.db.impl.GenericDatabaseAdapter
+org.apache.nifi.processors.standard.db.impl.OracleDatabaseAdapter

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.dbcp.DBCPService;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processors.standard.db.impl.DerbyDatabaseAdapter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.nifi.util.file.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.DB_TYPE;
+import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.REL_SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit tests for the GenerateTableFetch processor.
+ */
+public class TestGenerateTableFetch {
+
+    TestRunner runner;
+    GenerateTableFetch processor;
+
+    private final static String DB_LOCATION = "target/db_gtf";
+
+    @BeforeClass
+    public static void setupBeforeClass() throws IOException {
+        System.setProperty("derby.stream.error.file", "target/derby.log");
+
+        // remove previous test database, if any
+        final File dbLocation = new File(DB_LOCATION);
+        try {
+            FileUtils.deleteFile(dbLocation, true);
+        } catch (IOException ioe) {
+            // Do nothing, may not have existed
+        }
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        try {
+            DriverManager.getConnection("jdbc:derby:" + DB_LOCATION + ";shutdown=true");
+        } catch (SQLNonTransientConnectionException e) {
+            // Do nothing, this is what happens at Derby shutdown
+        }
+        // remove previous test database, if any
+        final File dbLocation = new File(DB_LOCATION);
+        try {
+            FileUtils.deleteFile(dbLocation, true);
+        } catch (IOException ioe) {
+            // Do nothing, may not have existed
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        processor = new GenerateTableFetch();
+        final DBCPService dbcp = new DBCPServiceSimpleImpl();
+        final Map<String, String> dbcpProperties = new HashMap<>();
+
+        runner = TestRunners.newTestRunner(GenerateTableFetch.class);
+        runner.addControllerService("dbcp", dbcp, dbcpProperties);
+        runner.enableControllerService(dbcp);
+        runner.setProperty(GenerateTableFetch.DBCP_SERVICE, "dbcp");
+        runner.setProperty(DB_TYPE, new DerbyDatabaseAdapter().getName());
+    }
+
+    @Test
+    public void testAddedRows() throws ClassNotFoundException, SQLException, InitializationException, IOException {
+
+        // load test data to database
+        final Connection con = ((DBCPService) runner.getControllerService("dbcp")).getConnection();
+        Statement stmt = con.createStatement();
+
+        try {
+            stmt.execute("drop table TEST_QUERY_DB_TABLE");
+        } catch (final SQLException sqle) {
+            // Ignore this error, probably a "table does not exist" since Derby doesn't yet support DROP IF EXISTS [DERBY-4842]
+        }
+
+        stmt.execute("create table TEST_QUERY_DB_TABLE (id integer not null, name varchar(100), scale float, created_on timestamp, bignum bigint default 0)");
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (0, 'Joe Smith', 1.0, '1962-09-23 03:23:34.234')");
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (1, 'Carrie Jones', 5.0, '2000-01-01 03:23:34.234')");
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (2, NULL, 2.0, '2010-01-01 00:00:00')");
+
+        runner.setProperty(GenerateTableFetch.TABLE_NAME, "TEST_QUERY_DB_TABLE");
+        runner.setIncomingConnection(false);
+        runner.setProperty(GenerateTableFetch.MAX_VALUE_COLUMN_NAMES, "ID");
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        String query = new String(flowFile.toByteArray());
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE FETCH NEXT 10000 ROWS ONLY", query);
+        ResultSet resultSet = stmt.executeQuery(query);
+        // Should be three records
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
+        runner.clearTransferState();
+
+        // Run again, this time no flowfiles/rows should be transferred
+        runner.run();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 0);
+        runner.clearTransferState();
+
+        // Add 3 new rows with a higher ID and run with a partition size of 2. Two flow files should be transferred
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (3, 'Mary West', 15.0, '2000-01-01 03:23:34.234')");
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (4, 'Marty Johnson', 15.0, '2011-01-01 03:23:34.234')");
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (5, 'Marty Johnson', 15.0, '2011-01-01 03:23:34.234')");
+        runner.setProperty(GenerateTableFetch.PARTITION_SIZE, "2");
+        runner.run();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 2);
+
+        // Verify first flow file's contents
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        query = new String(flowFile.toByteArray());
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE WHERE ID > 2 FETCH NEXT 2 ROWS ONLY", query);
+        resultSet = stmt.executeQuery(query);
+        // Should be two records
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
+
+        // Verify second flow file's contents
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(1);
+        query = new String(flowFile.toByteArray());
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE WHERE ID > 2 OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY", query);
+        resultSet = stmt.executeQuery(query);
+        // Should be one record
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
+        runner.clearTransferState();
+
+        // Add a new row with a higher ID and run, one flow file will be transferred
+        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, name, scale, created_on) VALUES (6, 'Mr. NiFi', 1.0, '2012-01-01 03:23:34.234')");
+        runner.run();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        query = new String(flowFile.toByteArray());
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE WHERE ID > 5 FETCH NEXT 2 ROWS ONLY", query);
+        resultSet = stmt.executeQuery(query);
+        // Should be one record
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
+        runner.clearTransferState();
+
+        // Set name as the max value column name (and clear the state), all rows should be returned since the max value for name has not been set
+        runner.getStateManager().clear(Scope.CLUSTER);
+        runner.setProperty(GenerateTableFetch.MAX_VALUE_COLUMN_NAMES, "name");
+        runner.run();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 4); // 7 records with partition size 2 means 4 generated FlowFiles
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE FETCH NEXT 2 ROWS ONLY", new String(flowFile.toByteArray()));
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(1);
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY", new String(flowFile.toByteArray()));
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(2);
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE OFFSET 4 ROWS FETCH NEXT 2 ROWS ONLY", new String(flowFile.toByteArray()));
+        flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).get(3);
+        assertEquals("SELECT * FROM TEST_QUERY_DB_TABLE OFFSET 6 ROWS FETCH NEXT 2 ROWS ONLY", new String(flowFile.toByteArray()));
+
+        runner.clearTransferState();
+    }
+
+
+    /**
+     * Simple implementation only for ListDatabaseTables processor testing.
+     */
+    private class DBCPServiceSimpleImpl extends AbstractControllerService implements DBCPService {
+
+        @Override
+        public String getIdentifier() {
+            return "dbcp";
+        }
+
+        @Override
+        public Connection getConnection() throws ProcessException {
+            try {
+                Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+                return DriverManager.getConnection("jdbc:derby:" + DB_LOCATION + ";create=true");
+            } catch (final Exception e) {
+                throw new ProcessException("getConnection failed: " + e);
+            }
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.db.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+
+/**
+ * An implementation of DatabaseAdapter for Derby (used for testing).
+ */
+public class DerbyDatabaseAdapter implements DatabaseAdapter {
+
+    @Override
+    public String getName() {
+        return "Derby";
+    }
+
+    @Override
+    public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Integer limit, Integer offset) {
+        if (StringUtils.isEmpty(tableName)) {
+            throw new IllegalArgumentException("Table name cannot be null or empty");
+        }
+        final StringBuilder query = new StringBuilder("SELECT ");
+        if (StringUtils.isEmpty(columnNames) || columnNames.trim().equals("*")) {
+            query.append("*");
+        } else {
+            query.append(columnNames);
+        }
+        query.append(" FROM ");
+        query.append(tableName);
+
+        if (!StringUtils.isEmpty(whereClause)) {
+            query.append(" WHERE ");
+            query.append(whereClause);
+        }
+        if (!StringUtils.isEmpty(orderByClause)) {
+            query.append(" ORDER BY ");
+            query.append(whereClause);
+        }
+        if (offset != null && offset > 0) {
+            query.append(" OFFSET ");
+            query.append(offset);
+            query.append(" ROWS");
+        }
+
+        if (limit != null) {
+            query.append(" FETCH NEXT ");
+            query.append(limit);
+            query.append(" ROWS ONLY");
+        }
+
+        return query.toString();
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/META-INF/services/org.apache.nifi.processors.standard.db.DatabaseAdapter
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/META-INF/services/org.apache.nifi.processors.standard.db.DatabaseAdapter
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.standard.db.impl.DerbyDatabaseAdapter


### PR DESCRIPTION
Refactored common code out of QueryDatabaseTable into an Abstract base class, which involved some refactor of QueryDatabaseTable as well as the added GenerateTableFetch processor.

This includes the addition of the DatabaseAdapter interface and its implementations, going forward this is to isolate database-specific code behind an interface for use by database-related processors.