### PR TITLE
NIFI-2267: A way for Processor to know node type

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/NodeTypeProvider.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/NodeTypeProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.controller;
+
+/**
+ * <p>
+ * This interface provides a set of methods for checking NiFi node type.
+ * <p>
+ */
+public interface NodeTypeProvider {
+
+    /**
+     * @return true if this instance is clustered, false otherwise.
+     * Clustered means that a node is either connected or trying to connect to the cluster.
+     */
+    boolean isClustered();
+
+    /**
+     * @return true if this instance is the primary node in the cluster; false otherwise
+     */
+    boolean isPrimary();
+}

--- a/nifi-api/src/main/java/org/apache/nifi/processor/AbstractSessionFactoryProcessor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/AbstractSessionFactoryProcessor.java
@@ -24,6 +24,7 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AbstractConfigurableComponent;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 
 /**
@@ -50,6 +51,7 @@ public abstract class AbstractSessionFactoryProcessor extends AbstractConfigurab
     private volatile boolean scheduled = false;
     private volatile boolean configurationRestored = false;
     private ControllerServiceLookup serviceLookup;
+    private NodeTypeProvider nodeTypeProvider;
     private String description;
 
     @Override
@@ -57,6 +59,7 @@ public abstract class AbstractSessionFactoryProcessor extends AbstractConfigurab
         identifier = context.getIdentifier();
         logger = context.getLogger();
         serviceLookup = context.getControllerServiceLookup();
+        nodeTypeProvider = context.getNodeTypeProvider();
         init(context);
 
         description = getClass().getSimpleName() + "[id=" + identifier + "]";
@@ -68,6 +71,14 @@ public abstract class AbstractSessionFactoryProcessor extends AbstractConfigurab
      */
     protected final ControllerServiceLookup getControllerServiceLookup() {
         return serviceLookup;
+    }
+
+    /**
+     * @return the {@link NodeTypeProvider} that was passed to the
+     * {@link #init(ProcessorInitializationContext)} method
+     */
+    protected final NodeTypeProvider getNodeTypeProvider() {
+        return nodeTypeProvider;
     }
 
     @Override

--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessorInitializationContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessorInitializationContext.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processor;
 
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 
 /**
@@ -44,4 +45,9 @@ public interface ProcessorInitializationContext {
      * Controller Services
      */
     ControllerServiceLookup getControllerServiceLookup();
+
+    /**
+     * @return the {@link NodeTypeProvider} which can be used to detect the node type of this NiFi instance.
+     */
+    NodeTypeProvider getNodeTypeProvider();
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessorInitializationContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessorInitializationContext.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 
@@ -79,5 +80,10 @@ public class MockProcessorInitializationContext implements ProcessorInitializati
     @Override
     public boolean isControllerServiceEnabling(final String serviceIdentifier) {
         return context.isControllerServiceEnabling(serviceIdentifier);
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return context;
     }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -812,4 +812,13 @@ public class StandardProcessorTestRunner implements TestRunner {
         return controllerServiceLoggers.get(identifier);
     }
 
+    @Override
+    public void setClustered(boolean clustered) {
+        context.setClustered(clustered);
+    }
+
+    @Override
+    public void setPrimaryNode(boolean primaryNode) {
+        context.setPrimaryNode(primaryNode);
+    }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -891,4 +891,14 @@ public interface TestRunner {
      * @return the State Manager that is used to store and retrieve state for the given controller service
      */
     MockStateManager getStateManager(ControllerService service);
+
+    /**
+     * @param clustered Specify if this test emulates running in a clustered environment
+     */
+    void setClustered(boolean clustered);
+
+    /**
+     * @param primaryNode Specify if this test emulates running as a primary node
+     */
+    void setPrimaryNode(boolean primaryNode);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/mock/MockNodeTypeProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/mock/MockNodeTypeProvider.java
@@ -16,36 +16,25 @@
  */
 package org.apache.nifi.documentation.mock;
 
-import org.apache.nifi.controller.ControllerServiceLookup;
 import org.apache.nifi.controller.NodeTypeProvider;
-import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 
 /**
- * A Mock ProcessorInitializationContext that can be used so that Processors can
- * be initialized for the purpose of generating documentation.
+ * A Mock NodeTypeProvider that can be used so that
+ * ConfigurableComponents can be initialized for the purpose of generating
+ * documentation
  *
  *
  */
-public class MockProcessorInitializationContext implements ProcessorInitializationContext {
+public class MockNodeTypeProvider implements NodeTypeProvider {
 
     @Override
-    public String getIdentifier() {
-        return "mock-processor";
+    public boolean isClustered() {
+        return false;
     }
 
     @Override
-    public ComponentLog getLogger() {
-        return new MockComponentLogger();
+    public boolean isPrimary() {
+        return false;
     }
 
-    @Override
-    public ControllerServiceLookup getControllerServiceLookup() {
-        return new MockControllerServiceLookup();
-    }
-
-    @Override
-    public NodeTypeProvider getNodeTypeProvider() {
-        return new MockNodeTypeProvider();
-    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -237,7 +237,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sun.jersey.api.client.ClientHandlerException;
 
-public class FlowController implements EventAccess, ControllerServiceProvider, ReportingTaskProvider, QueueProvider, Authorizable, ProvenanceAuthorizableFactory {
+public class FlowController implements EventAccess, ControllerServiceProvider, ReportingTaskProvider, QueueProvider, Authorizable, ProvenanceAuthorizableFactory, NodeTypeProvider {
 
     // default repository implementations
     public static final String DEFAULT_FLOWFILE_REPO_IMPLEMENTATION = "org.apache.nifi.controller.repository.WriteAheadFlowFileRepository";
@@ -1053,7 +1053,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
             final Class<? extends Processor> processorClass = rawClass.asSubclass(Processor.class);
             processor = processorClass.newInstance();
             final ComponentLog componentLogger = new SimpleProcessLogger(identifier, processor);
-            final ProcessorInitializationContext ctx = new StandardProcessorInitializationContext(identifier, componentLogger, this);
+            final ProcessorInitializationContext ctx = new StandardProcessorInitializationContext(identifier, componentLogger, this, this);
             processor.initialize(ctx);
 
             LogRepositoryFactory.getRepository(identifier).setLogger(componentLogger);
@@ -3148,6 +3148,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     /**
      * @return true if this instance is clustered; false otherwise. Clustered means that a node is either connected or trying to connect to the cluster.
      */
+    @Override
     public boolean isClustered() {
         readLock.lock();
         try {
@@ -3323,6 +3324,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     /**
      * @return true if this instance is the primary node in the cluster; false otherwise
      */
+    @Override
     public boolean isPrimary() {
         return leaderElectionManager != null && leaderElectionManager.isLeader(ClusterRoles.PRIMARY_NODE);
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessorInitializationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessorInitializationContext.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processor;
 
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
 import org.apache.nifi.logging.ComponentLog;
 
@@ -25,11 +26,13 @@ public class StandardProcessorInitializationContext implements ProcessorInitiali
     private final String identifier;
     private final ComponentLog logger;
     private final ControllerServiceProvider serviceProvider;
+    private final NodeTypeProvider nodeTypeProvider;
 
-    public StandardProcessorInitializationContext(final String identifier, final ComponentLog componentLog, final ControllerServiceProvider serviceProvider) {
+    public StandardProcessorInitializationContext(final String identifier, final ComponentLog componentLog, final ControllerServiceProvider serviceProvider, NodeTypeProvider nodeTypeProvider) {
         this.identifier = identifier;
         this.logger = componentLog;
         this.serviceProvider = serviceProvider;
+        this.nodeTypeProvider = nodeTypeProvider;
     }
 
     @Override
@@ -45,5 +48,10 @@ public class StandardProcessorInitializationContext implements ProcessorInitiali
     @Override
     public ControllerServiceLookup getControllerServiceLookup() {
         return serviceProvider;
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return nodeTypeProvider;
     }
 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/InvokeScriptedProcessor.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/InvokeScriptedProcessor.java
@@ -42,6 +42,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSessionFactory;
@@ -347,6 +348,11 @@ public class InvokeScriptedProcessor extends AbstractScriptProcessor {
                                 @Override
                                 public ControllerServiceLookup getControllerServiceLookup() {
                                     return InvokeScriptedProcessor.super.getControllerServiceLookup();
+                                }
+
+                                @Override
+                                public NodeTypeProvider getNodeTypeProvider() {
+                                    return InvokeScriptedProcessor.super.getNodeTypeProvider();
                                 }
                             });
                         } catch (final Exception e) {


### PR DESCRIPTION
- Added NodeTypeProvider to expose flowController's isClustered and
  isPrimaryNode so that processor can know if it's running on a cluster
  and if it's a primary node.
- Added mechanism to simulate clustered or not, and primary or not, for testing