### PR TITLE
NIFI-2310 - Shiftr Transform in JoltTransformJSON Processor Does Not Support Escaping Special Characters

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/pom.xml
@@ -26,7 +26,7 @@ language governing permissions and limitations under the License. -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <source.skip>true</source.skip>
         <jersey.version>1.19.1</jersey.version>
-        <jolt.version>0.0.20</jolt.version>
+        <jolt.version>0.0.21</jolt.version>
         <frontend.dependency.configs>${basedir}/src/main/frontend</frontend.dependency.configs>
         <frontend.working.dir>${project.build.directory}/frontend-working-directory</frontend.working.dir>
         <frontend.assets>${project.build.directory}/${project.build.finalName}/assets</frontend.assets>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -228,12 +228,12 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
-            <version>0.0.20</version>
+            <version>0.0.21</version>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>json-utils</artifactId>
-            <version>0.0.20</version>
+            <version>0.0.21</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-utils/pom.xml
@@ -30,12 +30,12 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
-            <version>0.0.20</version>
+            <version>0.0.21</version>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>json-utils</artifactId>
-            <version>0.0.20</version>
+            <version>0.0.21</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
upgrade Jolt version to 0.0.21 which resolved issue.