### PR TITLE
NIFI-826 (part 3)

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/TypeOneUUIDGenerator.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/TypeOneUUIDGenerator.java
@@ -49,11 +49,11 @@ public class TypeOneUUIDGenerator {
         long time;
 
         synchronized (lock) {
-            if (currentTime > lastTime) {
+            if (currentTime == lastTime) {
+                ++clockSequence;
+            } else {
                 lastTime = currentTime;
                 clockSequence = 0;
-            } else {
-                ++clockSequence;
             }
         }
 


### PR DESCRIPTION
- fixed ID generation routine that was causing miss-identification of the components