### PR TITLE
NIFI-2289: Ensure that we include Node ID's of all nodes when finding…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
@@ -532,7 +532,7 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
             return null;
         }
 
-        final Set<NodeIdentifier> connectedNodeIds = getNodeIdentifiers(NodeConnectionState.CONNECTED);
+        final Set<NodeIdentifier> connectedNodeIds = getNodeIdentifiers();
         final NodeIdentifier electedNodeId = connectedNodeIds.stream()
             .filter(nodeId -> nodeId.getSocketAddress().equals(electedNodeHostname) && nodeId.getSocketPort() == electedNodePort)
             .findFirst()


### PR DESCRIPTION
… cluster coordinator, even if the node is currently still connecting or has not yet joined the cluster, which ccan be the case if all nodes in the cluster are restarting at the same time.