### PR TITLE
* NIFI-2026 - Add Cloudera, Hortonworks and MapR repositories to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,45 @@ language governing permissions and limitations under the License. -->
                 <enabled>true</enabled>
             </releases>
         </repository>
+        <!-- Vendor repositories must be at the bottom and ordered by alphabetical order
+             so that Maven repository, Apache and jcenter are reached before vendor based 
+             artifacts are used -->
+        <repository>
+            <id>cloudera-repo</id>
+            <name>Cloudera Repository</name>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>HDPReleases</id>
+            <name>HDP Releases</name>
+            <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>mapr-releases</id>
+            <url>http://repository.mapr.com/maven/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
  enable users to seamlessly build NiFi using 3rd party (non-Apache)
  Maven artifacts

