### PR TITLE
NIFI-2374 and NIFI-2375 - Minor improve to documentation and version bump

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.8</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -155,7 +155,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.7</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.IdentifyMimeType/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.IdentifyMimeType/additionalDetails.html
@@ -22,7 +22,7 @@
     </head>
 
     <body>
-        <p>The following MIME Types are detected:
+        <p>The following is a non-exhaustive list of MIME Types detected:
         </p>
         <ul>
             <li>application/gzip</li>
@@ -55,5 +55,10 @@
             <li>application/zip</li>
             <li>application/x-lzh</li>
         </ul>
+        <p>For a complete list, please refer to
+            <a href="https://git-wip-us.apache.org/repos/asf?p=tika.git;a=blob;f=tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml;h=49314cc5351c11cd2bd245501f66e8649d2a2742;hb=386b68b5ae87beafacfb63f33e0a9888dedb9c30">
+                Apache Tika's source code</a>
+        </p>
+
     </body>
 </html>


### PR DESCRIPTION
NIFI-2374 - Today when I was about to raise an ISSUE I've noticed that although the IdentifyMimeType documentation provides a list of MIME-types that list is far from complete. This commit slightly changes wording to reflect this

NIFI-2375 - Bump Apache Tika's version used by IdentifyMimeType and ExtractMediaMetada processors
