### PR TITLE
NIFI-2337: Turn off logging for org.apache.curator.framework.recipes.…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -96,6 +96,8 @@
     <logger name="org.apache.zookeeper.server.NIOServerCnxnFactory" level="ERROR" />
     <logger name="org.apache.zookeeper.server.quorum" level="ERROR" />
     <logger name="org.apache.zookeeper.ZooKeeper" level="ERROR" />
+
+    <logger name="org.apache.curator.framework.recipes.leader.LeaderSelector" level="OFF" />
     
     <!-- Logger for managing logging statements for nifi clusters. -->
     <logger name="org.apache.nifi.cluster" level="INFO"/>


### PR DESCRIPTION
…leader.LeaderSelector since it logs only a single error, and that error is a but in Curator