### PR TITLE
NIFI-2431: Before registering for the Cluster Coordinator role, check…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -772,12 +772,12 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                 try {
                     response = senderListener.requestConnection(requestMsg).getConnectionResponse();
                     if (response.getRejectionReason() != null) {
-                        logger.warn("Connection request was blocked by cluster manager with the explanation: " + response.getRejectionReason());
+                        logger.warn("Connection request was blocked by cluster coordinator with the explanation: " + response.getRejectionReason());
                         // set response to null and treat a firewall blockage the same as getting no response from manager
                         response = null;
                         break;
                     } else if (response.shouldTryLater()) {
-                        logger.info("Flow controller requested by cluster manager to retry connection in " + response.getTryLaterSeconds() + " seconds.");
+                        logger.info("Flow controller requested by cluster coordinator to retry connection in " + response.getTryLaterSeconds() + " seconds.");
                         try {
                             Thread.sleep(response.getTryLaterSeconds() * 1000);
                         } catch (final InterruptedException ie) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
@@ -90,7 +90,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
         logger.debug("{} Registering new Leader Selector for role {}", this, roleName);
 
         if (leaderRoles.containsKey(roleName)) {
-            logger.warn("{} Attempted to register Leader Election for role '{}' but this role is already registered", this, roleName);
+            logger.info("{} Attempted to register Leader Election for role '{}' but this role is already registered", this, roleName);
             return;
         }
 
@@ -130,6 +130,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
         }
 
         leaderSelector.close();
+        logger.info("This node is no longer registered to be elected as the Leader for Role '{}'", roleName);
     }
 
     @Override


### PR DESCRIPTION
… if another node already has this role. If so, do not register for this role until after the node has joined the cluster and inherited the flow.