### PR TITLE
Removing client side check for component move eligibility

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -2445,7 +2445,7 @@ public final class StandardProcessGroup implements ProcessGroup {
                 final String portName = port.getName();
 
                 if (newProcessGroup.getInputPortByName(portName) != null) {
-                    throw new IllegalStateException("Cannot perform Move Operation because the destination Process Group already has an Input Port with the name " + portName);
+                    throw new IllegalStateException("Cannot perform Move Operation because of a naming conflict with another port in the destination Process Group");
                 }
             }
 
@@ -2454,7 +2454,7 @@ public final class StandardProcessGroup implements ProcessGroup {
                 final String portName = port.getName();
 
                 if (newProcessGroup.getOutputPortByName(portName) != null) {
-                    throw new IllegalStateException("Cannot perform Move Operation because the destination Process Group already has an Output Port with the name " + portName);
+                    throw new IllegalStateException("Cannot perform Move Operation because of a naming conflict with another port in the destination Process Group");
                 }
             }
         } finally {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardSnippetDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardSnippetDAO.java
@@ -169,6 +169,10 @@ public class StandardSnippetDAO implements SnippetDAO {
 
     @Override
     public void deleteSnippetComponents(String snippetId) {
+        // verify the action
+        verifyDeleteSnippetComponents(snippetId);
+
+        // locate the snippet in question
         final Snippet snippet = locateSnippet(snippetId);
 
         // remove the contents
@@ -223,6 +227,10 @@ public class StandardSnippetDAO implements SnippetDAO {
 
     @Override
     public Snippet updateSnippetComponents(final SnippetDTO snippetDTO) {
+        // verify the action
+        verifyUpdateSnippetComponent(snippetDTO);
+
+        // find the snippet in question
         final StandardSnippet snippet = locateSnippet(snippetDTO.getId());
 
         // if the group is changing move it

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
@@ -1152,16 +1152,13 @@ nf.Actions = (function () {
                 return;
             }
 
-            // ensure the selected components are eligible being moved into a new group
-            $.when(nf.CanvasUtils.eligibleForMove(selection)).done(function () {
-                // determine the origin of the bounding box for the selected components
-                var origin = nf.CanvasUtils.getOrigin(selection);
+            // determine the origin of the bounding box for the selected components
+            var origin = nf.CanvasUtils.getOrigin(selection);
 
-                var pt = {'x': origin.x, 'y': origin.y};
-                $.when(nf.ng.Bridge.injector.get('groupComponent').promptForGroupName(pt)).done(function (processGroup) {
-                    var group = d3.select('#id-' + processGroup.id);
-                    nf.CanvasUtils.moveComponents(selection, group);
-                });
+            var pt = {'x': origin.x, 'y': origin.y};
+            $.when(nf.ng.Bridge.injector.get('groupComponent').promptForGroupName(pt)).done(function (processGroup) {
+                var group = d3.select('#id-' + processGroup.id);
+                nf.CanvasUtils.moveComponents(selection, group);
             });
         },
 


### PR DESCRIPTION
NIFI-2402:
- Removing client side check component move eligibility and instead relaying on verification server side. Cannot check client side as the current user may not have permissions to inspect required fields.