### PR TITLE
NIFI-2441: View state fails with a JS error

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-state.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-state.js
@@ -90,20 +90,9 @@ nf.ComponentState = (function () {
     var sort = function (sortDetails, data) {
         // defines a function for sorting
         var comparer = function (a, b) {
-            if(a.permissions.canRead && b.permissions.canRead) {
-                var aString = nf.Common.isDefinedAndNotNull(a.component[sortDetails.columnId]) ? a.component[sortDetails.columnId] : '';
-                var bString = nf.Common.isDefinedAndNotNull(b.component[sortDetails.columnId]) ? b.component[sortDetails.columnId] : '';
-                return aString === bString ? 0 : aString > bString ? 1 : -1;
-            } else {
-                if (!a.permissions.canRead && !b.permissions.canRead){
-                    return 0;
-                }
-                if(a.permissions.canRead){
-                    return 1;
-                } else {
-                    return -1;
-                }
-            }
+            var aString = nf.Common.isDefinedAndNotNull(a[sortDetails.columnId]) ? a[sortDetails.columnId] : '';
+            var bString = nf.Common.isDefinedAndNotNull(b[sortDetails.columnId]) ? b[sortDetails.columnId] : '';
+            return aString === bString ? 0 : aString > bString ? 1 : -1;
         };
 
         // perform the sort


### PR DESCRIPTION
Removed permission check causing "Cannot read property 'canRead' of
undefined". A given user won't have record level permission
difference for component state. It's not required here.

Before this fix, "View state" menu didn't show component state window, due to the JS error.

Please clear the browser cache when you test this PR.
You can test with whatever processor that manages its state, for example ListFile.

![image](https://cloud.githubusercontent.com/assets/1107620/17314638/dba8d1aa-58a0-11e6-9a00-af1366915295.png)
