### PR TITLE
NIFI-2452

### DIFF
--- a/nifi-framework-api/src/main/java/org/apache/nifi/provenance/ProvenanceRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/provenance/ProvenanceRepository.java
@@ -107,6 +107,29 @@ public interface ProvenanceRepository extends ProvenanceEventRepository {
     ComputeLineageSubmission submitLineageComputation(String flowFileUuid, NiFiUser user);
 
     /**
+     * Submits a Lineage Computation to be completed and returns the
+     * AsynchronousLineageResult that indicates the status of the request and
+     * the results, if the computation is complete. If the given user does not
+     * have authorization to view one of the events in the lineage, a placeholder
+     * event will be used instead that provides none of the event details except
+     * for the identifier of the component that emitted the Provenance Event. It is
+     * necessary to include this node in the lineage view so that the lineage makes
+     * sense, rather than showing disconnected graphs when the user is not authorized
+     * for all components' provenance events.
+     *
+     * This method is preferred to {@link #submitLineageComputation(String, NiFiUser)} because
+     * it is much more efficient, but the former may be used if a particular Event ID is not
+     * available.
+     *
+     * @param eventId the numeric ID of the event that the lineage is for
+     * @param user the NiFi User to authorize events against
+     *
+     * @return a {@link ComputeLineageSubmission} object that can be used to
+     *         check if the computing is complete and if so get the results
+     */
+    ComputeLineageSubmission submitLineageComputation(long eventId, NiFiUser user);
+
+    /**
      * @param lineageIdentifier identifier of lineage to compute
      * @param user the user who is retrieving the lineage submission
      *

--- a/nifi-mock/src/main/java/org/apache/nifi/provenance/MockProvenanceRepository.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/provenance/MockProvenanceRepository.java
@@ -100,6 +100,11 @@ public class MockProvenanceRepository implements ProvenanceRepository {
     }
 
     @Override
+    public ComputeLineageSubmission submitLineageComputation(long eventId, NiFiUser user) {
+        throw new UnsupportedOperationException("MockProvenanceRepository does not support Lineage Computation");
+    }
+
+    @Override
     public ComputeLineageSubmission retrieveLineageSubmission(String lineageIdentifier, NiFiUser user) {
         throw new UnsupportedOperationException("MockProvenanceRepository does not support Lineage Computation");
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -98,6 +98,7 @@
     <logger name="org.apache.zookeeper.ZooKeeper" level="ERROR" />
 
     <logger name="org.apache.curator.framework.recipes.leader.LeaderSelector" level="OFF" />
+    <logger name="org.apache.curator.ConnectionState" level="OFF" />
     
     <!-- Logger for managing logging statements for nifi clusters. -->
     <logger name="org.apache.nifi.cluster" level="INFO"/>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProvenanceResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProvenanceResource.java
@@ -464,8 +464,8 @@ public class ProvenanceResource extends ApplicationResource {
                 break;
             case FLOWFILE:
                 // ensure the uuid has been specified
-                if (requestDto.getUuid() == null) {
-                    throw new IllegalArgumentException("The flowfile uuid must be specified when the event type is FLOWFILE.");
+                if (requestDto.getUuid() == null && requestDto.getEventId() == null) {
+                    throw new IllegalArgumentException("The flowfile uuid or event id must be specified when the event type is FLOWFILE.");
                 }
                 break;
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -1013,7 +1013,11 @@ public class ControllerFacade implements Authorizable {
         // submit the event
         if (LineageRequestType.FLOWFILE.equals(requestDto.getLineageRequestType())) {
             // submit uuid
-            result = provenanceRepository.submitLineageComputation(requestDto.getUuid(), NiFiUserUtils.getNiFiUser());
+            if (requestDto.getEventId() == null) {
+                result = provenanceRepository.submitLineageComputation(requestDto.getUuid(), NiFiUserUtils.getNiFiUser());
+            } else {
+                result = provenanceRepository.submitLineageComputation(requestDto.getEventId(), NiFiUserUtils.getNiFiUser());
+            }
         } else {
             // submit event... (parents or children)
             if (LineageRequestType.PARENTS.equals(requestDto.getLineageRequestType())) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/provenance/nf-provenance-lineage.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/provenance/nf-provenance-lineage.js
@@ -1293,7 +1293,8 @@ nf.ng.ProvenanceLineage = function () {
             var lineageRequest = {
                 lineageRequestType: 'FLOWFILE',
                 uuid: flowFileUuid,
-                clusterNodeId: clusterNodeId
+                clusterNodeId: clusterNodeId,
+                eventId: eventId
             };
 
             // update the progress bar value

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/IndexConfiguration.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/IndexConfiguration.java
@@ -212,13 +212,14 @@ public class IndexConfiguration {
         final List<File> dirs = new ArrayList<>();
         lock.lock();
         try {
+            // Sort directories so that we return the newest index first
             final List<File> sortedIndexDirectories = getIndexDirectories();
             Collections.sort(sortedIndexDirectories, new Comparator<File>() {
                 @Override
                 public int compare(final File o1, final File o2) {
                     final long epochTimestamp1 = getIndexStartTime(o1);
                     final long epochTimestamp2 = getIndexStartTime(o2);
-                    return Long.compare(epochTimestamp1, epochTimestamp2);
+                    return Long.compare(epochTimestamp2, epochTimestamp1);
                 }
             });
 

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/DocsReader.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/DocsReader.java
@@ -55,11 +55,12 @@ class DocsReader {
         }
 
         final long start = System.nanoTime();
-        final int numDocs = Math.min(topDocs.scoreDocs.length, maxResults);
+        final ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        final int numDocs = Math.min(scoreDocs.length, maxResults);
         final List<Document> docs = new ArrayList<>(numDocs);
 
-        for (final ScoreDoc scoreDoc : topDocs.scoreDocs) {
-            final int docId = scoreDoc.doc;
+        for (int i = numDocs - 1; i >= 0; i--) {
+            final int docId = scoreDocs[i].doc;
             final Document d = indexReader.document(docId);
             docs.add(d);
         }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/IndexManager.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/IndexManager.java
@@ -234,6 +234,9 @@ public class IndexManager implements Closeable {
                 }
             }
 
+            // We found no cached Index Readers. Create a new one. To do this, we need to check
+            // if we have an Index Writer, and if so create a Reader based on the Index Writer.
+            // This will provide us a 'near real time' index reader.
             final IndexWriterCount writerCount = writerCounts.remove(absoluteFile);
             if ( writerCount == null ) {
                 final Directory directory = FSDirectory.open(absoluteFile);

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/IndexSearch.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/IndexSearch.java
@@ -92,11 +92,12 @@ public class IndexSearch {
             final long searchStartNanos = System.nanoTime();
             final long openSearcherNanos = searchStartNanos - start;
 
+            logger.debug("Searching {} for {}", this, provenanceQuery);
             final TopDocs topDocs = searcher.search(luceneQuery, provenanceQuery.getMaxResults());
             final long finishSearch = System.nanoTime();
             final long searchNanos = finishSearch - searchStartNanos;
 
-            logger.debug("Searching {} took {} millis; opening searcher took {} millis", this,
+            logger.debug("Searching {} for {} took {} millis; opening searcher took {} millis", this, provenanceQuery,
                     TimeUnit.NANOSECONDS.toMillis(searchNanos), TimeUnit.NANOSECONDS.toMillis(openSearcherNanos));
 
             if (topDocs.totalHits == 0) {

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/LineageQuery.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/LineageQuery.java
@@ -74,6 +74,7 @@ public class LineageQuery {
                 }
 
                 final long searchStart = System.nanoTime();
+                logger.debug("Searching {} for {}", indexDirectory, flowFileIdQuery);
                 final TopDocs uuidQueryTopDocs = searcher.search(flowFileIdQuery, MAX_QUERY_RESULTS);
                 final long searchEnd = System.nanoTime();
 

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestPersistentProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestPersistentProvenanceRepository.java
@@ -485,8 +485,7 @@ public class TestPersistentProvenanceRepository {
         assertTrue(newRecordSet.getMatchingEvents().isEmpty());
     }
 
-    // TODO: Switch to 10,000.
-    @Test(timeout = 1000000)
+    @Test(timeout = 10000)
     public void testModifyIndexWhileSearching() throws IOException, InterruptedException, ParseException {
         final RepositoryConfiguration config = createConfiguration();
         config.setMaxRecordLife(30, TimeUnit.SECONDS);


### PR DESCRIPTION
Ensure that we keep track of how many references we have to each lucene searcher and only close the underlying index reader if there are no references to the searcher.  Also updated to prefer newer provenance events over older provenance events, and calculate FlowFile lineage based on an event id instead of a FlowFile UUID, as it's much more efficient