### PR TITLE
NIFI-2478 Fixed Zk leaders path to include root.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
@@ -95,7 +95,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
         }
 
         final String rootPath = zkConfig.getRootPath();
-        final String leaderPath = (rootPath.endsWith("/") ? "" : "/") + "leaders/" + roleName;
+        final String leaderPath = rootPath + (rootPath.endsWith("/") ? "" : "/") + "leaders/" + roleName;
 
         try {
             PathUtils.validatePath(rootPath);


### PR DESCRIPTION
This enables the same Zookeeper to be used by multiple NiFi clusters. Please see the [NIFI-2478](https://issues.apache.org/jira/browse/NIFI-2478) for detail.

I've tested with a dedicated external zookeeper and two NiFi clusters, confirmed clustering functionalities works fine.