### PR TITLE
NIFI-2493: Do not fingerprint Remote Ports' running state. When synch…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/fingerprint/FingerprintFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/fingerprint/FingerprintFactory.java
@@ -778,7 +778,7 @@ public final class FingerprintFactory {
     }
 
     private StringBuilder addRemoteGroupPortFingerprint(final StringBuilder builder, final Element remoteGroupPortElement) {
-        for (final String childName : new String[]{"id", "scheduledState", "maxConcurrentTasks", "useCompression"}) {
+        for (final String childName : new String[] {"id", "maxConcurrentTasks", "useCompression"}) {
             appendFirstValue(builder, DomUtils.getChildNodesByTagName(remoteGroupPortElement, childName));
         }
 
@@ -787,7 +787,6 @@ public final class FingerprintFactory {
 
     private StringBuilder addRemoteGroupPortFingerprint(final StringBuilder builder, final RemoteProcessGroupPortDTO port) {
         builder.append(port.getId());
-        builder.append(Boolean.TRUE.equals(port.isTransmitting()) ? "RUNNING" : "STOPPED");
         builder.append(port.getConcurrentlySchedulableTaskCount());
         builder.append(port.getUseCompression());
         return builder;


### PR DESCRIPTION
…ronizing remote flow with local flow, start/stop remote group ports as appropriate based on the inherited flow