### PR TITLE
Extend REST API docs template to handle read only properties.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConnectionDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConnectionDTO.java
@@ -149,7 +149,7 @@ public class ConnectionDTO extends ComponentDTO {
      * @return relationships that the source of the connection currently supports. This property is read only
      */
     @ApiModelProperty(
-            value = "The relationships that the source of the connection currently supports. This property is read only.",
+            value = "The relationships that the source of the connection currently supports.",
             readOnly = true
     )
     public Set<String> getAvailableRelationships() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
@@ -185,7 +185,8 @@ public class ProcessorDTO extends ComponentDTO {
      * @return The available relationships
      */
     @ApiModelProperty(
-            value = "The available relationships that the processor currently supports."
+            value = "The available relationships that the processor currently supports.",
+            readOnly = true
     )
     public List<RelationshipDTO> getRelationships() {
         return relationships;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/resources/templates/type.hbs
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/resources/templates/type.hbs
@@ -43,7 +43,9 @@
                         {{/ifeq}}
                     </td>
                     <td>{{#required}}required{{/required}}{{^required}}optional{{/required}}</td>
-                    <td>{{#description}}{{{description}}}{{/description}}{{#if enum}} Allowable values: {{join enum ", "}}{{/if}}</td>
+                    <td>{{#description}}{{{description}}}{{/description}}
+                        {{#if enum}} Allowable values: {{join enum ", "}}{{/if}}
+                        {{#if readOnly}} This property is read only.{{/if}}</td>
                 </tr>
             {{/each}}
         </table>


### PR DESCRIPTION
* Add read only property handling to type.hbs template.
* Add flag to ProcessorDTO.getRelationships to reflect read only nature of the property.
* Remove explicit "read only" message from ConnectionDTO.getAvailableRelationships to avoid duplicate text.