### PR TITLE
NIFI-2026: Moved vendor repositories into Maven profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,61 +138,6 @@ language governing permissions and limitations under the License. -->
                 <enabled>true</enabled>
             </releases>
         </repository>
-        <!-- Vendor repositories must be at the bottom and ordered by alphabetical order
-             so that Maven repository, Apache and jcenter are reached before vendor based 
-             artifacts are used -->
-        <repository>
-            <id>cloudera-repo</id>
-            <name>Cloudera Repository</name>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>hortonworks-releases</id>
-            <name>Hortonworks Repository</name>
-            <url>http://repo.hortonworks.com/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-                <updatePolicy>never</updatePolicy>
-                <checksumPolicy>fail</checksumPolicy>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>hortonworks-jetty</id>
-            <name>Hortonworks Jetty Repository</name>
-            <url>http://repo.hortonworks.com/content/repositories/jetty-hadoop/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-                <updatePolicy>never</updatePolicy>
-                <checksumPolicy>fail</checksumPolicy>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>mapr-releases</id>
-            <name>MapR Repository</name>
-            <url>http://repository.mapr.com/maven/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
     </repositories>
 
     <dependencyManagement>
@@ -1839,6 +1784,99 @@ language governing permissions and limitations under the License. -->
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <!-- The following profiles are here as a convenience for folks that want to build against vendor-specific
+         distributions of the various Hadoop ecosystem libraries.  These will alter which dependencies are sourced
+         in a manner that can adjust the correct LICENSE and NOTICE requirements for any affected jar and the
+         resulting assembly overall.  These L&N impacts are not automatically handled by the build process and are
+         the responsibility of those creating and using the resulting binary artifacts. -->
+        <profile>
+            <!-- This profile adds the Hortonworks repository for resolving Hortonworks Data Platform (HDP)
+                 artifacts for the Hadoop bundles -->
+            <id>hortonworks</id>
+            <repositories>
+                <repository>
+                    <id>hortonworks-releases</id>
+                    <name>Hortonworks Repository</name>
+                    <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>hortonworks-jetty</id>
+                    <name>Hortonworks Jetty Repository</name>
+                    <url>http://repo.hortonworks.com/content/repositories/jetty-hadoop/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <properties>
+                <!-- Vendor-specific version number included here as default, should be overridden on the
+                     command-line -->
+                <hadoop.version>2.7.1.2.4.0.0-169</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <!-- This profile will add the MapR repository for resolving MapR Hadoop
+                 artifacts for the Hadoop bundles -->
+            <id>mapr</id>
+            <repositories>
+                <repository>
+                    <id>mapr-releases</id>
+                    <name>MapR Repository</name>
+                    <url>http://repository.mapr.com/maven/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+            <properties>
+                <!-- Vendor-specific version number included here as default, should be overridden on the
+                     command-line -->
+                <hadoop.version>2.7.0-mapr-1602</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <!-- This profile will add the Cloudera repository for resolving Cloudera Distribution of Hadoop (CDH)
+                 artifacts for the Hadoop bundles -->
+            <id>cloudera</id>
+            <repositories>
+                <repository>
+                    <id>cloudera-repo</id>
+                    <name>Cloudera Repository</name>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <properties>
+                <!-- Vendor-specific version number included here as default, should be overridden on the
+                     command-line -->
+                <hadoop.version>2.6.0-cdh5.8.1</hadoop.version>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
@trixpan Basically moved the repos into profiles and added default properties so users can see the naming pattern (might help them select the correct version).

@joewitt I incorporated your Jira comments into the PR, please let me know if everything is copacetic!