### PR TITLE
Enforcing READ permissions when referencing ControllerServices

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
@@ -34,7 +34,17 @@ public interface AuthorizableLookup {
      * @param id processor id
      * @return authorizable
      */
-    Authorizable getProcessor(String id);
+    ControllerServiceReferencingComponentAuthorizable getProcessor(String id);
+
+    /**
+     * Get the authorizable for this Processor. This will create a dummy instance of the
+     * processor. The intent of this method is to provide access to the PropertyDescriptors
+     * prior to the component being created.
+     *
+     * @param type processor type
+     * @return authorizable
+     */
+    ControllerServiceReferencingComponentAuthorizable getProcessorByType(String type);
 
     /**
      * Get the authorizable for querying Provenance.
@@ -130,7 +140,17 @@ public interface AuthorizableLookup {
      * @param id controller service id
      * @return authorizable
      */
-    Authorizable getControllerService(String id);
+    ControllerServiceReferencingComponentAuthorizable getControllerService(String id);
+
+    /**
+     * Get the authorizable for this Controller Service. This will create a dummy instance of the
+     * controller service. The intent of this method is to provide access to the PropertyDescriptors
+     * prior to the component being created.
+     *
+     * @param type processor type
+     * @return authorizable
+     */
+    ControllerServiceReferencingComponentAuthorizable getControllerServiceByType(String type);
 
     /**
      * Get the authorizable referencing component.
@@ -147,7 +167,17 @@ public interface AuthorizableLookup {
      * @param id reporting task id
      * @return authorizable
      */
-    Authorizable getReportingTask(String id);
+    ControllerServiceReferencingComponentAuthorizable getReportingTask(String id);
+
+    /**
+     * Get the authorizable for this Reporting Task. This will create a dummy instance of the
+     * reporting task. The intent of this method is to provide access to the PropertyDescriptors
+     * prior to the component being created.
+     *
+     * @param type processor type
+     * @return authorizable
+     */
+    ControllerServiceReferencingComponentAuthorizable getReportingTaskByType(String type);
 
     /**
      * Get the authorizable Template.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizeControllerServiceReference.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizeControllerServiceReference.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization;
+
+import org.apache.nifi.authorization.resource.Authorizable;
+import org.apache.nifi.authorization.user.NiFiUser;
+import org.apache.nifi.authorization.user.NiFiUserUtils;
+import org.apache.nifi.components.PropertyDescriptor;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Authorizes references to Controller Services. Utilizes when Processors, Controller Services, and Reporting Tasks are created and updated.
+ */
+public final class AuthorizeControllerServiceReference {
+
+    /**
+     * Authorizes the proposed properties for the specified authorizable.
+     *
+     * @param proposedProperties proposed properties
+     * @param authorizable authorizable that may reference a controller service
+     * @param authorizer authorizer
+     * @param lookup lookup
+     */
+    public static void authorizeControllerServiceReferences(final Map<String, String> proposedProperties, final ControllerServiceReferencingComponentAuthorizable authorizable,
+                                                            final Authorizer authorizer, final AuthorizableLookup lookup) {
+
+        // only attempt to authorize if properties are changing
+        if (proposedProperties != null) {
+            final NiFiUser user = NiFiUserUtils.getNiFiUser();
+
+            for (final Map.Entry<String, String> entry : proposedProperties.entrySet()) {
+                final String propertyName = entry.getKey();
+                final PropertyDescriptor propertyDescriptor = authorizable.getPropertyDescriptor(propertyName);
+
+                // if this descriptor identifies a controller service
+                if (propertyDescriptor.getControllerServiceDefinition() != null) {
+                    final String currentValue = authorizable.getValue(propertyDescriptor);
+                    final String proposedValue = entry.getValue();
+
+                    // if the value is changing
+                    if (!Objects.equals(currentValue, proposedValue)) {
+                        // ensure access to the old service
+                        if (currentValue != null) {
+                            final Authorizable currentServiceAuthorizable = lookup.getControllerService(currentValue).getAuthorizable();
+                            currentServiceAuthorizable.authorize(authorizer, RequestAction.READ, user);
+                        }
+
+                        // ensure access to the new service
+                        if (proposedValue != null) {
+                            final Authorizable newServiceAuthorizable = lookup.getControllerService(proposedValue).getAuthorizable();
+                            newServiceAuthorizable.authorize(authorizer, RequestAction.READ, user);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/ControllerServiceReferencingComponentAuthorizable.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/ControllerServiceReferencingComponentAuthorizable.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization;
+
+import org.apache.nifi.authorization.resource.Authorizable;
+import org.apache.nifi.components.PropertyDescriptor;
+
+/**
+ * Authorizable for a component that references a ControllerService.
+ */
+public interface ControllerServiceReferencingComponentAuthorizable {
+    /**
+     * Returns the base authorizable for this ControllerServiceReference. Non null
+     *
+     * @return authorizable
+     */
+    Authorizable getAuthorizable();
+
+    /**
+     * Returns the property descriptor for the specified property.
+     *
+     * @param propertyName property name
+     * @return property descriptor
+     */
+    PropertyDescriptor getPropertyDescriptor(String propertyName);
+
+    /**
+     * Returns the current value of the specified property.
+     *
+     * @param propertyDescriptor property descriptor
+     * @return value
+     */
+    String getValue(PropertyDescriptor propertyDescriptor);
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -2275,13 +2275,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         try {
             switch (type) {
                 case PROCESSOR:
-                    authorizable = authorizableLookup.getProcessor(sourceId);
+                    authorizable = authorizableLookup.getProcessor(sourceId).getAuthorizable();
                     break;
                 case REPORTING_TASK:
-                    authorizable = authorizableLookup.getReportingTask(sourceId);
+                    authorizable = authorizableLookup.getReportingTask(sourceId).getAuthorizable();
                     break;
                 case CONTROLLER_SERVICE:
-                    authorizable = authorizableLookup.getControllerService(sourceId);
+                    authorizable = authorizableLookup.getControllerService(sourceId).getAuthorizable();
                     break;
                 case FLOW_CONTROLLER:
                     authorizable = controllerFacade;
@@ -2465,7 +2465,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final List<Bulletin> authorizedControllerServiceBulletins = new ArrayList<>();
         for (final Bulletin bulletin : allControllerServiceBulletins) {
             try {
-                final Authorizable controllerServiceAuthorizable = authorizableLookup.getControllerService(bulletin.getSourceId());
+                final Authorizable controllerServiceAuthorizable = authorizableLookup.getControllerService(bulletin.getSourceId()).getAuthorizable();
                 if (controllerServiceAuthorizable.isAuthorized(authorizer, RequestAction.READ, user)) {
                     authorizedControllerServiceBulletins.add(bulletin);
                 }
@@ -2481,7 +2481,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final List<Bulletin> authorizedReportingTaskBulletins = new ArrayList<>();
         for (final Bulletin bulletin : allReportingTaskBulletins) {
             try {
-                final Authorizable reportingTaskAuthorizable = authorizableLookup.getReportingTask(bulletin.getSourceId());
+                final Authorizable reportingTaskAuthorizable = authorizableLookup.getReportingTask(bulletin.getSourceId()).getAuthorizable();
                 if (reportingTaskAuthorizable.isAuthorized(authorizer, RequestAction.READ, user)) {
                     authorizedReportingTaskBulletins.add(bulletin);
                 }
@@ -2957,13 +2957,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         try {
             switch (type) {
                 case Processor:
-                    authorizable = authorizableLookup.getProcessor(sourceId);
+                    authorizable = authorizableLookup.getProcessor(sourceId).getAuthorizable();
                     break;
                 case ReportingTask:
-                    authorizable = authorizableLookup.getReportingTask(sourceId);
+                    authorizable = authorizableLookup.getReportingTask(sourceId).getAuthorizable();
                     break;
                 case ControllerService:
-                    authorizable = authorizableLookup.getControllerService(sourceId);
+                    authorizable = authorizableLookup.getControllerService(sourceId).getAuthorizable();
                     break;
                 case Controller:
                     authorizable = controllerFacade;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
@@ -426,7 +426,7 @@ public abstract class ApplicationResource {
             processGroupAuthorizable.getEncapsulatedAuthorizables().forEach(authorize);
         });
         snippet.getRemoteProcessGroups().keySet().stream().map(id -> lookup.getRemoteProcessGroup(id)).forEach(authorize);
-        snippet.getProcessors().keySet().stream().map(id -> lookup.getProcessor(id)).forEach(authorize);
+        snippet.getProcessors().keySet().stream().map(id -> lookup.getProcessor(id).getAuthorizable()).forEach(authorize);
         snippet.getInputPorts().keySet().stream().map(id -> lookup.getInputPort(id)).forEach(authorize);
         snippet.getOutputPorts().keySet().stream().map(id -> lookup.getOutputPort(id)).forEach(authorize);
         snippet.getConnections().keySet().stream().map(id -> lookup.getConnection(id)).forEach(connAuth -> authorize.accept(connAuth.getAuthorizable()));
@@ -451,7 +451,7 @@ public abstract class ApplicationResource {
             processGroupAuthorizable.getEncapsulatedAuthorizables().forEach(authorize);
         });
         snippet.getRemoteProcessGroups().keySet().stream().map(id -> lookup.getRemoteProcessGroup(id)).forEach(authorize);
-        snippet.getProcessors().keySet().stream().map(id -> lookup.getProcessor(id)).forEach(authorize);
+        snippet.getProcessors().keySet().stream().map(id -> lookup.getProcessor(id).getAuthorizable()).forEach(authorize);
         snippet.getInputPorts().keySet().stream().map(id -> lookup.getInputPort(id)).forEach(authorize);
         snippet.getOutputPorts().keySet().stream().map(id -> lookup.getOutputPort(id)).forEach(authorize);
         snippet.getConnections().keySet().stream().map(id -> lookup.getConnection(id)).forEach(connAuth -> authorize.accept(connAuth.getAuthorizable()));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -26,7 +26,9 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import com.wordnik.swagger.annotations.Authorization;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.authorization.AuthorizableLookup;
+import org.apache.nifi.authorization.AuthorizeControllerServiceReference;
 import org.apache.nifi.authorization.Authorizer;
+import org.apache.nifi.authorization.ControllerServiceReferencingComponentAuthorizable;
 import org.apache.nifi.authorization.ProcessGroupAuthorizable;
 import org.apache.nifi.authorization.RequestAction;
 import org.apache.nifi.authorization.resource.Authorizable;
@@ -38,7 +40,10 @@ import org.apache.nifi.web.NiFiServiceFacade;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.Revision;
 import org.apache.nifi.web.api.dto.ConnectionDTO;
+import org.apache.nifi.web.api.dto.ControllerServiceDTO;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
+import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
+import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
 import org.apache.nifi.web.api.dto.TemplateDTO;
 import org.apache.nifi.web.api.dto.flow.FlowDTO;
@@ -553,7 +558,8 @@ public class ProcessGroupResource extends ApplicationResource {
             value = "Creates a new processor",
             response = ProcessorEntity.class,
             authorizations = {
-                    @Authorization(value = "Write - /process-groups/{uuid}", type = "")
+                    @Authorization(value = "Write - /process-groups/{uuid}", type = ""),
+                    @Authorization(value = "Read - any referenced Controller Services - /controller-services/{uuid}", type = "")
             }
     )
     @ApiResponses(
@@ -585,19 +591,20 @@ public class ProcessGroupResource extends ApplicationResource {
             throw new IllegalArgumentException("A revision of 0 must be specified when creating a new Processor.");
         }
 
-        if (processorEntity.getComponent().getId() != null) {
+        final ProcessorDTO requestProcessor = processorEntity.getComponent();
+        if (requestProcessor.getId() != null) {
             throw new IllegalArgumentException("Processor ID cannot be specified.");
         }
 
-        if (StringUtils.isBlank(processorEntity.getComponent().getType())) {
+        if (StringUtils.isBlank(requestProcessor.getType())) {
             throw new IllegalArgumentException("The type of processor to create must be specified.");
         }
 
-        if (processorEntity.getComponent().getParentGroupId() != null && !groupId.equals(processorEntity.getComponent().getParentGroupId())) {
+        if (requestProcessor.getParentGroupId() != null && !groupId.equals(requestProcessor.getParentGroupId())) {
             throw new IllegalArgumentException(String.format("If specified, the parent process group id %s must be the same as specified in the URI %s",
-                    processorEntity.getComponent().getParentGroupId(), groupId));
+                    requestProcessor.getParentGroupId(), groupId));
         }
-        processorEntity.getComponent().setParentGroupId(groupId);
+        requestProcessor.setParentGroupId(groupId);
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.POST, processorEntity);
@@ -610,6 +617,12 @@ public class ProcessGroupResource extends ApplicationResource {
             serviceFacade.authorizeAccess(lookup -> {
                 final Authorizable processGroup = lookup.getProcessGroup(groupId).getAuthorizable();
                 processGroup.authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());
+
+                final ProcessorConfigDTO config = requestProcessor.getConfig();
+                if (config != null && config.getProperties() != null) {
+                    final ControllerServiceReferencingComponentAuthorizable authorizable = lookup.getProcessorByType(requestProcessor.getType());
+                    AuthorizeControllerServiceReference.authorizeControllerServiceReferences(config.getProperties(), authorizable, authorizer, lookup);
+                }
             });
         }
         if (validationPhase) {
@@ -617,11 +630,11 @@ public class ProcessGroupResource extends ApplicationResource {
         }
 
         // set the processor id as appropriate
-        processorEntity.getComponent().setId(generateUuid());
+        requestProcessor.setId(generateUuid());
 
         // create the new processor
-        final Revision revision = getRevision(processorEntity, processorEntity.getComponent().getId());
-        final ProcessorEntity entity = serviceFacade.createProcessor(revision, groupId, processorEntity.getComponent());
+        final Revision revision = getRevision(processorEntity, requestProcessor.getId());
+        final ProcessorEntity entity = serviceFacade.createProcessor(revision, groupId, requestProcessor);
         processorResource.populateRemainingProcessorEntityContent(entity);
 
         // generate a 201 created response
@@ -2074,7 +2087,8 @@ public class ProcessGroupResource extends ApplicationResource {
             value = "Creates a new controller service",
             response = ControllerServiceEntity.class,
             authorizations = {
-                    @Authorization(value = "Write - /process-groups/{uuid}", type = "")
+                    @Authorization(value = "Write - /process-groups/{uuid}", type = ""),
+                    @Authorization(value = "Read - any referenced Controller Services - /controller-services/{uuid}", type = "")
             }
     )
     @ApiResponses(
@@ -2105,19 +2119,20 @@ public class ProcessGroupResource extends ApplicationResource {
             throw new IllegalArgumentException("A revision of 0 must be specified when creating a new Controller service.");
         }
 
-        if (controllerServiceEntity.getComponent().getId() != null) {
+        final ControllerServiceDTO requestControllerService = controllerServiceEntity.getComponent();
+        if (requestControllerService.getId() != null) {
             throw new IllegalArgumentException("Controller service ID cannot be specified.");
         }
 
-        if (StringUtils.isBlank(controllerServiceEntity.getComponent().getType())) {
+        if (StringUtils.isBlank(requestControllerService.getType())) {
             throw new IllegalArgumentException("The type of controller service to create must be specified.");
         }
 
-        if (controllerServiceEntity.getComponent().getParentGroupId() != null && !groupId.equals(controllerServiceEntity.getComponent().getParentGroupId())) {
+        if (requestControllerService.getParentGroupId() != null && !groupId.equals(requestControllerService.getParentGroupId())) {
             throw new IllegalArgumentException(String.format("If specified, the parent process group id %s must be the same as specified in the URI %s",
-                    controllerServiceEntity.getComponent().getParentGroupId(), groupId));
+                    requestControllerService.getParentGroupId(), groupId));
         }
-        controllerServiceEntity.getComponent().setParentGroupId(groupId);
+        requestControllerService.setParentGroupId(groupId);
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.POST, controllerServiceEntity);
@@ -2130,6 +2145,11 @@ public class ProcessGroupResource extends ApplicationResource {
             serviceFacade.authorizeAccess(lookup -> {
                 final Authorizable processGroup = lookup.getProcessGroup(groupId).getAuthorizable();
                 processGroup.authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());
+
+                if (requestControllerService.getProperties() != null) {
+                    final ControllerServiceReferencingComponentAuthorizable authorizable = lookup.getControllerServiceByType(requestControllerService.getType());
+                    AuthorizeControllerServiceReference.authorizeControllerServiceReferences(requestControllerService.getProperties(), authorizable, authorizer, lookup);
+                }
             });
         }
         if (validationPhase) {
@@ -2137,11 +2157,11 @@ public class ProcessGroupResource extends ApplicationResource {
         }
 
         // set the processor id as appropriate
-        controllerServiceEntity.getComponent().setId(generateUuid());
+        requestControllerService.setId(generateUuid());
 
         // create the controller service and generate the json
-        final Revision revision = getRevision(controllerServiceEntity, controllerServiceEntity.getComponent().getId());
-        final ControllerServiceEntity entity = serviceFacade.createControllerService(revision, groupId, controllerServiceEntity.getComponent());
+        final Revision revision = getRevision(controllerServiceEntity, requestControllerService.getId());
+        final ControllerServiceEntity entity = serviceFacade.createControllerService(revision, groupId, requestControllerService);
         controllerServiceResource.populateRemainingControllerServiceEntityContent(entity);
 
         // build the response

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -43,9 +43,11 @@ import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.Template;
+import org.apache.nifi.controller.exception.ProcessorInstantiationException;
 import org.apache.nifi.controller.label.Label;
 import org.apache.nifi.controller.queue.FlowFileQueue;
 import org.apache.nifi.controller.queue.QueueSize;
+import org.apache.nifi.controller.reporting.ReportingTaskInstantiationException;
 import org.apache.nifi.controller.repository.ContentNotFoundException;
 import org.apache.nifi.controller.repository.claim.ContentDirection;
 import org.apache.nifi.controller.service.ControllerServiceNode;
@@ -126,6 +128,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TimeZone;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -187,6 +190,38 @@ public class ControllerFacade implements Authorizable {
      */
     public void setComments(String comments) {
         flowController.setComments(comments);
+    }
+
+    /**
+     * Create a temporary Processor used for extracting PropertyDescriptor's for ControllerService reference authorization.
+     *
+     * @param type type of processor
+     * @return processor
+     * @throws ProcessorInstantiationException when unable to instantiate the processor
+     */
+    public ProcessorNode createTemporaryProcessor(String type) throws ProcessorInstantiationException {
+        return flowController.createProcessor(type, UUID.randomUUID().toString(), false);
+    }
+
+    /**
+     * Create a temporary ReportingTask used for extracting PropertyDescriptor's for ControllerService reference authorization.
+     *
+     * @param type type of reporting task
+     * @return reporting task
+     * @throws ReportingTaskInstantiationException when unable to instantiate the reporting task
+     */
+    public ReportingTaskNode createTemporaryReportingTask(String type) throws ReportingTaskInstantiationException {
+        return flowController.createReportingTask(type, UUID.randomUUID().toString(), false);
+    }
+
+    /**
+     * Create a temporary ControllerService used for extracting PropertyDescriptor's for ControllerService reference authorization.
+     *
+     * @param type type of controller service
+     * @return controller service
+     */
+    public ControllerServiceNode createTemporaryControllerService(String type) {
+        return flowController.createControllerService(type, UUID.randomUUID().toString(), false);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/combo/jquery.combo.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/combo/jquery.combo.css
@@ -77,6 +77,10 @@ div.selected-disabled-option {
     padding: 0px 10px;
 }
 
+.combo-options ul > li.disabled {
+    font-style: italic;
+}
+
 .combo-option-text {
     overflow: hidden;
     white-space: nowrap;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/combo/jquery.combo.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/combo/jquery.combo.js
@@ -118,30 +118,6 @@
 
     };
 
-    var setDisabled = function (combo, optionElement, option, disabled) {
-        // reset the option element
-        optionElement.removeClass('unset').off('click');
-        
-        if (disabled === true) {
-            optionElement.addClass('unset');
-        } else {
-            optionElement.on('click', function () {
-                //remove active styles
-                $('.combo').removeClass('combo-open');
-
-                // select the option
-                selectOption(combo, option.text, option.value);
-
-                // click the glass pane which will hide the options
-                $('.combo-glass-pane').click();
-            }).hover(function () {
-                $(this).addClass('pointer').css('background', '#eaeef0');
-            }, function () {
-                $(this).removeClass('pointer').css('background', '#ffffff');
-            });
-        }
-    };
-
     var methods = {
 
         /**
@@ -212,7 +188,7 @@
 
                             // this is option is enabled register appropriate listeners
                             if (option.disabled === true) {
-                                optionElement.addClass('unset');
+                                optionElement.addClass('unset disabled');
                             } else {
                                 optionElement.click(function () {
                                     //remove active styles

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -530,6 +530,7 @@
                     options.push({
                         text: allowableValue.displayName,
                         value: allowableValue.value,
+                        disabled: allowableValueEntity.canRead === false && allowableValue.value !== args.item['previousValue'],
                         description: nf.Common.escapeHtml(allowableValue.description)
                     });
                 });


### PR DESCRIPTION
NIFI-2554:
- Requiring READ permissions on the referenced controller service when creating/updating processors, controller services, and reporting tasks.
- Preventing client side selection of unauthorized controller services unless they were the previously configured value.