### PR TITLE
NIFI-2577: Increased default stripe size in ConvertAvroToORC to 64MB

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/ConvertAvroToORC.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/ConvertAvroToORC.java
@@ -103,7 +103,7 @@ public class ConvertAvroToORC extends AbstractProcessor {
             .description("The size of the memory buffer (in bytes) for writing stripes to an ORC file")
             .required(true)
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
-            .defaultValue("100 KB")
+            .defaultValue("64 MB")
             .build();
 
     public static final PropertyDescriptor BUFFER_SIZE = new PropertyDescriptor.Builder()


### PR DESCRIPTION
This one's pretty straightforward ;)