### PR TITLE
NIFI-2584

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -779,7 +779,7 @@ public class PutSQL extends AbstractProcessor {
                     if(LONG_PATTERN.matcher(parameterValue).matches()){
                         lTimestamp = Long.parseLong(parameterValue);
                     }else {
-                        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS");
+                        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
                         java.util.Date parsedDate = dateFormat.parse(parameterValue);
                         lTimestamp = parsedDate.getTime();
                     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -276,9 +276,9 @@ public class TestPutSQL {
         runner.enableControllerService(service);
         runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
 
-        final String arg2TS = "2001-01-01 23:01:01.001";
-        final String art3TS = "2002-02-02 22:02:02.002";
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS");
+        final String arg2TS = "2001-01-01 00:01:01.001";
+        final String art3TS = "2002-02-02 12:02:02.002";
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         java.util.Date parsedDate = dateFormat.parse(arg2TS);
 
         final Map<String, String> attributes = new HashMap<>();


### PR DESCRIPTION
In NIFI-2576 I mistakenly put 'hh' into my timestamp format rather than 'HH', so it was running on 12-hour formatting without an am/pm qualifier. The correct format is 'HH'.

I fixed the test case to identify this issue.