### PR TITLE
NIFI-2591 - PutSQL has no handling for Binary data types

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.StreamUtils;
 
+import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -78,78 +79,84 @@ import java.util.regex.Pattern;
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"sql", "put", "rdbms", "database", "update", "insert", "relational"})
 @CapabilityDescription("Executes a SQL UPDATE or INSERT command. The content of an incoming FlowFile is expected to be the SQL command "
-    + "to execute. The SQL command may use the ? to escape parameters. In this case, the parameters to use must exist as FlowFile attributes "
-    + "with the naming convention sql.args.N.type and sql.args.N.value, where N is a positive integer. The sql.args.N.type is expected to be "
-    + "a number indicating the JDBC Type. The content of the FlowFile is expected to be in UTF-8 format.")
+        + "to execute. The SQL command may use the ? to escape parameters. In this case, the parameters to use must exist as FlowFile attributes "
+        + "with the naming convention sql.args.N.type and sql.args.N.value, where N is a positive integer. The sql.args.N.type is expected to be "
+        + "a number indicating the JDBC Type. The content of the FlowFile is expected to be in UTF-8 format.")
 @ReadsAttributes({
-    @ReadsAttribute(attribute = "fragment.identifier", description = "If the <Support Fragment Transactions> property is true, this attribute is used to determine whether or "
-        + "not two FlowFiles belong to the same transaction."),
-    @ReadsAttribute(attribute = "fragment.count", description = "If the <Support Fragment Transactions> property is true, this attribute is used to determine how many FlowFiles "
-        + "are needed to complete the transaction."),
-    @ReadsAttribute(attribute = "fragment.index", description = "If the <Support Fragment Transactions> property is true, this attribute is used to determine the order that the FlowFiles "
-        + "in a transaction should be evaluated."),
-    @ReadsAttribute(attribute = "sql.args.N.type", description = "Incoming FlowFiles are expected to be parameterized SQL statements. The type of each Parameter is specified as an integer "
-        + "that represents the JDBC Type of the parameter."),
-    @ReadsAttribute(attribute = "sql.args.N.value", description = "Incoming FlowFiles are expected to be parameterized SQL statements. The value of the Parameters are specified as "
-        + "sql.args.1.value, sql.args.2.value, sql.args.3.value, and so on. The type of the sql.args.1.value Parameter is specified by the sql.args.1.type attribute.")
+        @ReadsAttribute(attribute = "fragment.identifier", description = "If the <Support Fragment Transactions> property is true, this attribute is used to determine whether or "
+                + "not two FlowFiles belong to the same transaction."),
+        @ReadsAttribute(attribute = "fragment.count", description = "If the <Support Fragment Transactions> property is true, this attribute is used to determine how many FlowFiles "
+                + "are needed to complete the transaction."),
+        @ReadsAttribute(attribute = "fragment.index", description = "If the <Support Fragment Transactions> property is true, this attribute is used to determine the order that the FlowFiles "
+                + "in a transaction should be evaluated."),
+        @ReadsAttribute(attribute = "sql.args.N.type", description = "Incoming FlowFiles are expected to be parameterized SQL statements. The type of each Parameter is specified as an integer "
+                + "that represents the JDBC Type of the parameter."),
+        @ReadsAttribute(attribute = "sql.args.N.value", description = "Incoming FlowFiles are expected to be parameterized SQL statements. The value of the Parameters are specified as "
+                + "sql.args.1.value, sql.args.2.value, sql.args.3.value, and so on. The type of the sql.args.1.value Parameter is specified by the sql.args.1.type attribute."),
+        @ReadsAttribute(attribute = "sql.args.N.format", description = "This attribute is always optional, but default options may not always work for your data. "
+                + "Incoming FlowFiles are expected to be parameterized SQL statements. In some cases "
+                + "a format option needs to be specified, currently this is only applicable for binary data types. For binary data types "
+                + "available options are 'ascii', 'base64' and 'hex'.  In 'ascii' format each string character in your attribute value represents a single byte, this is the default format "
+                + "and the format provided by Avro Processors. In 'base64' format your string is a Base64 encoded string.  In 'hex' format the string is hex encoded with all "
+                + "letters in upper case and no '0x' at the beginning.")
 })
 @WritesAttributes({
-    @WritesAttribute(attribute = "sql.generated.key", description = "If the database generated a key for an INSERT statement and the Obtain Generated Keys property is set to true, "
-        + "this attribute will be added to indicate the generated key, if possible. This feature is not supported by all database vendors.")
+        @WritesAttribute(attribute = "sql.generated.key", description = "If the database generated a key for an INSERT statement and the Obtain Generated Keys property is set to true, "
+                + "this attribute will be added to indicate the generated key, if possible. This feature is not supported by all database vendors.")
 })
 public class PutSQL extends AbstractProcessor {
 
     static final PropertyDescriptor CONNECTION_POOL = new PropertyDescriptor.Builder()
-        .name("JDBC Connection Pool")
-        .description("Specifies the JDBC Connection Pool to use in order to convert the JSON message to a SQL statement. "
-            + "The Connection Pool is necessary in order to determine the appropriate database column types.")
-        .identifiesControllerService(DBCPService.class)
-        .required(true)
-        .build();
+            .name("JDBC Connection Pool")
+            .description("Specifies the JDBC Connection Pool to use in order to convert the JSON message to a SQL statement. "
+                    + "The Connection Pool is necessary in order to determine the appropriate database column types.")
+            .identifiesControllerService(DBCPService.class)
+            .required(true)
+            .build();
     static final PropertyDescriptor SUPPORT_TRANSACTIONS = new PropertyDescriptor.Builder()
-        .name("Support Fragmented Transactions")
-        .description("If true, when a FlowFile is consumed by this Processor, the Processor will first check the fragment.identifier and fragment.count attributes of that FlowFile. "
-            + "If the fragment.count value is greater than 1, the Processor will not process any FlowFile will that fragment.identifier until all are available; "
-            + "at that point, it will process all FlowFiles with that fragment.identifier as a single transaction, in the order specified by the FlowFiles' fragment.index attributes. "
-            + "This Provides atomicity of those SQL statements. If this value is false, these attributes will be ignored and the updates will occur independent of one another.")
-        .allowableValues("true", "false")
-        .defaultValue("true")
-        .build();
+            .name("Support Fragmented Transactions")
+            .description("If true, when a FlowFile is consumed by this Processor, the Processor will first check the fragment.identifier and fragment.count attributes of that FlowFile. "
+                    + "If the fragment.count value is greater than 1, the Processor will not process any FlowFile will that fragment.identifier until all are available; "
+                    + "at that point, it will process all FlowFiles with that fragment.identifier as a single transaction, in the order specified by the FlowFiles' fragment.index attributes. "
+                    + "This Provides atomicity of those SQL statements. If this value is false, these attributes will be ignored and the updates will occur independent of one another.")
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .build();
     static final PropertyDescriptor TRANSACTION_TIMEOUT = new PropertyDescriptor.Builder()
-        .name("Transaction Timeout")
-        .description("If the <Support Fragmented Transactions> property is set to true, specifies how long to wait for all FlowFiles for a particular fragment.identifier attribute "
-            + "to arrive before just transferring all of the FlowFiles with that identifier to the 'failure' relationship")
-        .required(false)
-        .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-        .build();
+            .name("Transaction Timeout")
+            .description("If the <Support Fragmented Transactions> property is set to true, specifies how long to wait for all FlowFiles for a particular fragment.identifier attribute "
+                    + "to arrive before just transferring all of the FlowFiles with that identifier to the 'failure' relationship")
+            .required(false)
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .build();
     static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
-        .name("Batch Size")
-        .description("The preferred number of FlowFiles to put to the database in a single transaction")
-        .required(true)
-        .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-        .defaultValue("100")
-        .build();
+            .name("Batch Size")
+            .description("The preferred number of FlowFiles to put to the database in a single transaction")
+            .required(true)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .defaultValue("100")
+            .build();
     static final PropertyDescriptor OBTAIN_GENERATED_KEYS = new PropertyDescriptor.Builder()
-        .name("Obtain Generated Keys")
-        .description("If true, any key that is automatically generated by the database will be added to the FlowFile that generated it using the sql.generate.key attribute. "
-            + "This may result in slightly slower performance and is not supported by all databases.")
-        .allowableValues("true", "false")
-        .defaultValue("false")
-        .build();
+            .name("Obtain Generated Keys")
+            .description("If true, any key that is automatically generated by the database will be added to the FlowFile that generated it using the sql.generate.key attribute. "
+                    + "This may result in slightly slower performance and is not supported by all databases.")
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .build();
 
     static final Relationship REL_SUCCESS = new Relationship.Builder()
-        .name("success")
-        .description("A FlowFile is routed to this relationship after the database is successfully updated")
-        .build();
+            .name("success")
+            .description("A FlowFile is routed to this relationship after the database is successfully updated")
+            .build();
     static final Relationship REL_RETRY = new Relationship.Builder()
-        .name("retry")
-        .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
-        .build();
+            .name("retry")
+            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
+            .build();
     static final Relationship REL_FAILURE = new Relationship.Builder()
-        .name("failure")
-        .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
-            + "such as an invalid query or an integrity constraint violation")
-        .build();
+            .name("failure")
+            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
+                    + "such as an invalid query or an integrity constraint violation")
+            .build();
 
     private static final Pattern SQL_TYPE_ATTRIBUTE_PATTERN = Pattern.compile("sql\\.args\\.(\\d+)\\.type");
     private static final Pattern NUMBER_PATTERN = Pattern.compile("-?\\d+");
@@ -296,7 +303,7 @@ public class PutSQL extends AbstractProcessor {
                             conn.rollback();
                             final FlowFile offendingFlowFile = batchFlowFiles.get(offendingFlowFileIndex);
                             getLogger().error("Failed to update database due to a failed batch update. A total of {} FlowFiles are required for this transaction, so routing all to failure. "
-                                + "Offending FlowFile was {}, which caused the following error: {}", new Object[] {flowFiles.size(), offendingFlowFile, e});
+                                    + "Offending FlowFile was {}, which caused the following error: {}", new Object[] {flowFiles.size(), offendingFlowFile, e});
                             session.transfer(flowFiles, REL_FAILURE);
                             return;
                         }
@@ -339,7 +346,7 @@ public class PutSQL extends AbstractProcessor {
                         }
 
                         getLogger().error("Failed to update database due to a failed batch update. There were a total of {} FlowFiles that failed, {} that succeeded, "
-                            + "and {} that were not execute and will be routed to retry; ", new Object[] {failureCount, successCount, retryCount});
+                                + "and {} that were not execute and will be routed to retry; ", new Object[] {failureCount, successCount, retryCount});
                     } catch (final SQLNonTransientException e) {
                         getLogger().error("Failed to update database for {} due to {}; routing to failure", new Object[] {enclosure.getFlowFiles(), e});
 
@@ -349,7 +356,7 @@ public class PutSQL extends AbstractProcessor {
                         continue;
                     } catch (final SQLException e) {
                         getLogger().error("Failed to update database for {} due to {}; it is possible that retrying the operation will succeed, so routing to retry",
-                            new Object[] {enclosure.getFlowFiles(), e});
+                                new Object[] {enclosure.getFlowFiles(), e});
 
                         for (final FlowFile flowFile : enclosure.getFlowFiles()) {
                             destinationRelationships.put(flowFile, REL_RETRY);
@@ -524,7 +531,7 @@ public class PutSQL extends AbstractProcessor {
      * @throws SQLException if unable to create the appropriate PreparedStatement
      */
     private StatementFlowFileEnclosure getEnclosure(final String sql, final Connection conn, final Map<String, StatementFlowFileEnclosure> stmtMap,
-        final boolean obtainKeys, final boolean fragmentedTransaction) throws SQLException {
+                                                    final boolean obtainKeys, final boolean fragmentedTransaction) throws SQLException {
         StatementFlowFileEnclosure enclosure = stmtMap.get(sql);
         if (enclosure != null) {
             return enclosure;
@@ -612,9 +619,11 @@ public class PutSQL extends AbstractProcessor {
                 final int jdbcType = Integer.parseInt(entry.getValue());
                 final String valueAttrName = "sql.args." + parameterIndex + ".value";
                 final String parameterValue = attributes.get(valueAttrName);
+                final String formatAttrName = "sql.args." + parameterIndex + ".format";
+                final String parameterFormat = attributes.containsKey(formatAttrName)? attributes.get(formatAttrName):"";
 
                 try {
-                    setParameter(stmt, valueAttrName, parameterIndex, parameterValue, jdbcType);
+                    setParameter(stmt, valueAttrName, parameterIndex, parameterValue, jdbcType, parameterFormat);
                 } catch (final NumberFormatException nfe) {
                     throw new ProcessException("The value of the " + valueAttrName + " is '" + parameterValue + "', which cannot be converted into the necessary data type", nfe);
                 } catch (ParseException pe) {
@@ -648,7 +657,7 @@ public class PutSQL extends AbstractProcessor {
                 return null;
             } else if (fragmentCount == null) {
                 getLogger().error("Cannot process {} because there are {} FlowFiles with the same fragment.identifier "
-                    + "attribute but not all FlowFiles have a fragment.count attribute; routing all to failure", new Object[] {flowFile, flowFiles.size()});
+                        + "attribute but not all FlowFiles have a fragment.count attribute; routing all to failure", new Object[] {flowFile, flowFiles.size()});
                 return REL_FAILURE;
             }
 
@@ -657,13 +666,13 @@ public class PutSQL extends AbstractProcessor {
                 numFragments = Integer.parseInt(fragmentCount);
             } catch (final NumberFormatException nfe) {
                 getLogger().error("Cannot process {} because the fragment.count attribute has a value of '{}', which is not an integer; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentCount});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentCount});
                 return REL_FAILURE;
             }
 
             if (numFragments < 1) {
                 getLogger().error("Cannot process {} because the fragment.count attribute has a value of '{}', which is not a positive integer; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentCount});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentCount});
                 return REL_FAILURE;
             }
 
@@ -671,14 +680,14 @@ public class PutSQL extends AbstractProcessor {
                 selectedNumFragments = numFragments;
             } else if (numFragments != selectedNumFragments) {
                 getLogger().error("Cannot process {} because the fragment.count attribute has different values for different FlowFiles with the same fragment.identifier; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile});
                 return REL_FAILURE;
             }
 
             final String fragmentIndex = flowFile.getAttribute(FRAGMENT_INDEX_ATTR);
             if (fragmentIndex == null) {
                 getLogger().error("Cannot process {} because the fragment.index attribute is missing; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile});
                 return REL_FAILURE;
             }
 
@@ -687,19 +696,19 @@ public class PutSQL extends AbstractProcessor {
                 idx = Integer.parseInt(fragmentIndex);
             } catch (final NumberFormatException nfe) {
                 getLogger().error("Cannot process {} because the fragment.index attribute has a value of '{}', which is not an integer; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentIndex});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentIndex});
                 return REL_FAILURE;
             }
 
             if (idx < 0) {
                 getLogger().error("Cannot process {} because the fragment.index attribute has a value of '{}', which is not a positive integer; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentIndex});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile, fragmentIndex});
                 return REL_FAILURE;
             }
 
             if (bitSet.get(idx)) {
                 getLogger().error("Cannot process {} because it has the same value for the fragment.index attribute as another FlowFile with the same fragment.identifier; "
-                    + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile});
+                        + "routing all FlowFiles with this fragment.identifier to failure", new Object[] {flowFile});
                 return REL_FAILURE;
             }
 
@@ -739,7 +748,8 @@ public class PutSQL extends AbstractProcessor {
      * @param jdbcType the JDBC Type of the SQL parameter to set
      * @throws SQLException if the PreparedStatement throws a SQLException when calling the appropriate setter
      */
-    private void setParameter(final PreparedStatement stmt, final String attrName, final int parameterIndex, final String parameterValue, final int jdbcType)
+    private void setParameter(final PreparedStatement stmt, final String attrName, final int parameterIndex, final String parameterValue, final int jdbcType,
+                              final String valueFormat)
             throws SQLException, ParseException, UnsupportedEncodingException {
         if (parameterValue == null) {
             stmt.setNull(parameterIndex, jdbcType);
@@ -795,8 +805,25 @@ public class PutSQL extends AbstractProcessor {
                 case Types.BINARY:
                 case Types.VARBINARY:
                 case Types.LONGVARBINARY:
-                    byte[] bValue = parameterValue.getBytes("ASCII");
+                    byte[] bValue;
+
+                    switch(valueFormat){
+                        case "":
+                        case "ascii":
+                            bValue = parameterValue.getBytes("ASCII");
+                            break;
+                        case "hex":
+                            bValue = DatatypeConverter.parseHexBinary(parameterValue);
+                            break;
+                        case "base64":
+                            bValue = DatatypeConverter.parseBase64Binary(parameterValue);
+                            break;
+                        default:
+                            throw new ParseException("Unable to parse binary data using the formatter `" + valueFormat + "`.",0);
+                    }
+
                     stmt.setBinaryStream(parameterIndex, new ByteArrayInputStream(bValue), bValue.length);
+
                     break;
                 case Types.CHAR:
                 case Types.VARCHAR:

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.StreamUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -738,7 +739,8 @@ public class PutSQL extends AbstractProcessor {
      * @param jdbcType the JDBC Type of the SQL parameter to set
      * @throws SQLException if the PreparedStatement throws a SQLException when calling the appropriate setter
      */
-    private void setParameter(final PreparedStatement stmt, final String attrName, final int parameterIndex, final String parameterValue, final int jdbcType) throws SQLException, ParseException, UnsupportedEncodingException {
+    private void setParameter(final PreparedStatement stmt, final String attrName, final int parameterIndex, final String parameterValue, final int jdbcType)
+            throws SQLException, ParseException, UnsupportedEncodingException {
         if (parameterValue == null) {
             stmt.setNull(parameterIndex, jdbcType);
         } else {
@@ -792,7 +794,9 @@ public class PutSQL extends AbstractProcessor {
                     break;
                 case Types.BINARY:
                 case Types.VARBINARY:
-                    stmt.setBytes(parameterIndex, parameterValue.getBytes("UTF-8"));
+                case Types.LONGVARBINARY:
+                    byte[] bValue = parameterValue.getBytes("ASCII");
+                    stmt.setBinaryStream(parameterIndex, new ByteArrayInputStream(bValue), bValue.length);
                     break;
                 case Types.CHAR:
                 case Types.VARCHAR:

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -34,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.nifi.controller.AbstractControllerService;
@@ -334,7 +333,6 @@ public class TestPutSQL {
         attributes.put("sql.args.3.type", String.valueOf(Types.LONGVARBINARY));
         attributes.put("sql.args.3.value", art4LongBin);
 
-        //runner.enqueue("INSERT INTO BINARYTESTS (ID, bn1, bn2) VALUES (1, ?, ?)".getBytes(), attributes);
         runner.enqueue("INSERT INTO BINARYTESTS (ID, bn1, bn2, bn3) VALUES (1, ?, ?, ?)".getBytes(), attributes);
         runner.run();
 


### PR DESCRIPTION
PutSQL has no handling for Binary data types.
The only path into PutSQL is for your binary data to be serialized as a string in an attribute.  Currently if you follow the Avro->JSON->SQL path Avro will encode the binary data as 1 byte characters (ASCII). JSON to SQL takes these strings and tries to insert them as Objects, since there was no case for any of the binary types.

I added in handling for all three binary types and included a Derby test case.