### PR TITLE
Updating ReportingTasks to use ComponentLogger instead of creating Controller level bulletins

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/reporting/ReportingContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/reporting/ReportingContext.java
@@ -16,12 +16,12 @@
  */
 package org.apache.nifi.reporting;
 
-import java.util.Map;
-
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ControllerServiceLookup;
+
+import java.util.Map;
 
 /**
  * This interface provides a bridge between the NiFi Framework and a
@@ -59,9 +59,10 @@ public interface ReportingContext {
     BulletinRepository getBulletinRepository();
 
     /**
-     * Creates a system-level {@link Bulletin} with the given category, severity
+     * Creates a controller-level {@link Bulletin} with the given category, severity
      * level, and message, so that the Bulletin can be added to the
-     * {@link BulletinRepository}.
+     * {@link BulletinRepository}. Access to this bulletin will be enforce through
+     * permissions on the controller.
      *
      * @param category of bulletin
      * @param severity of bulletin
@@ -72,7 +73,7 @@ public interface ReportingContext {
 
     /**
      * Creates a {@link Bulletin} for the component with the specified
-     * identifier
+     * identifier.
      *
      * @param componentId the ID of the component
      * @param category the name of the bulletin's category

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/events/VolatileBulletinRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/events/VolatileBulletinRepository.java
@@ -193,15 +193,6 @@ public class VolatileBulletinRepository implements BulletinRepository {
             }
         }
 
-        for (final String key : new String[] { SERVICE_BULLETIN_STORE_KEY, REPORTING_TASK_BULLETIN_STORE_KEY }) {
-            final ConcurrentMap<String, RingBuffer<Bulletin>> bulletinMap = bulletinStoreMap.get(key);
-            if (bulletinMap != null) {
-                for (final RingBuffer<Bulletin> buffer : bulletinMap.values()) {
-                    controllerBulletins.addAll(buffer.getSelectedElements(filter, max));
-                }
-            }
-        }
-
         // We only want the newest bulletin, so we sort based on time and take the top 'max' entries
         Collections.sort(controllerBulletins);
         if (controllerBulletins.size() > max) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -1195,7 +1195,7 @@ nf.Common = (function () {
             if ($.isArray(bulletins) && $.isArray(otherBulletins)) {
                 if (bulletins.length === otherBulletins.length) {
                     for (var i = 0; i < bulletins.length; i++) {
-                        if (bulletins[i].id !== otherBulletins[i].id) {
+                        if (bulletins[i].id !== otherBulletins[i].id || bulletins[i].canRead !== otherBulletins[i].canRead) {
                             return true;
                         }
                     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorDiskUsage.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorDiskUsage.java
@@ -22,9 +22,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.reporting.AbstractReportingTask;
-import org.apache.nifi.reporting.Bulletin;
 import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.reporting.Severity;
 import org.apache.nifi.util.FormatUtils;
 
 import java.io.File;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorDiskUsage.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorDiskUsage.java
@@ -16,6 +16,17 @@
  */
 package org.apache.nifi.controller;
 
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.reporting.AbstractReportingTask;
+import org.apache.nifi.reporting.Bulletin;
+import org.apache.nifi.reporting.ReportingContext;
+import org.apache.nifi.reporting.Severity;
+import org.apache.nifi.util.FormatUtils;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -23,25 +34,11 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.nifi.annotation.documentation.CapabilityDescription;
-import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.reporting.AbstractReportingTask;
-import org.apache.nifi.reporting.Bulletin;
-import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.reporting.Severity;
-import org.apache.nifi.util.FormatUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 @Tags({"disk", "storage", "warning", "monitoring", "repo"})
 @CapabilityDescription("Checks the amount of storage space available for the specified directory"
         + " and warns (via a log message and a System-Level Bulletin) if the partition on which it lives exceeds"
         + " some configurable threshold of storage space")
 public class MonitorDiskUsage extends AbstractReportingTask {
-
-    private static final Logger logger = LoggerFactory.getLogger(MonitorDiskUsage.class);
 
     private static final Pattern PERCENT_PATTERN = Pattern.compile("(\\d+{1,2})%");
 
@@ -88,11 +85,11 @@ public class MonitorDiskUsage extends AbstractReportingTask {
         final File dir = new File(context.getProperty(DIR_LOCATION).getValue());
         final String dirName = context.getProperty(DIR_DISPLAY_NAME).getValue();
 
-        checkThreshold(dirName, dir.toPath(), contentRepoThreshold, context);
+        checkThreshold(dirName, dir.toPath(), contentRepoThreshold, getLogger());
 
     }
 
-    static void checkThreshold(final String pathName, final Path path, final int threshold, final ReportingContext context) {
+    static void checkThreshold(final String pathName, final Path path, final int threshold, final ComponentLog logger) {
         final File file = path.toFile();
         final long totalBytes = file.getTotalSpace();
         final long freeBytes = file.getFreeSpace();
@@ -109,8 +106,6 @@ public class MonitorDiskUsage extends AbstractReportingTask {
 
             final String message = String.format("%1$s exceeds configured threshold of %2$s%%, having %3$s / %4$s (%5$.2f%%) used and %6$s (%7$.2f%%) free",
                     pathName, threshold, usedSpace, totalSpace, usedPercent, freeSpace, freePercent);
-            final Bulletin bulletin = context.createBulletin("Disk Usage", Severity.WARNING, message);
-            context.getBulletinRepository().addBulletin(bulletin);
             logger.warn(message);
         }
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorMemory.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorMemory.java
@@ -16,15 +16,6 @@
  */
 package org.apache.nifi.controller;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryPoolMXBean;
-import java.lang.management.MemoryUsage;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
-
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -36,13 +27,18 @@ import org.apache.nifi.components.Validator;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.reporting.AbstractReportingTask;
-import org.apache.nifi.reporting.Bulletin;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.reporting.Severity;
 import org.apache.nifi.util.FormatUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Reporting task used to monitor usage of memory after Garbage Collection has
@@ -130,8 +126,6 @@ public class MonitorMemory extends AbstractReportingTask {
     public static final Pattern DATA_SIZE_PATTERN = DataUnit.DATA_SIZE_PATTERN;
     public static final Pattern TIME_PERIOD_PATTERN = FormatUtils.TIME_DURATION_PATTERN;
 
-    private static final Logger logger = LoggerFactory.getLogger(MonitorMemory.class);
-
     private volatile MemoryPoolMXBean monitoredBean;
     private volatile String threshold = "65%";
     private volatile long lastReportTime;
@@ -200,8 +194,8 @@ public class MonitorMemory extends AbstractReportingTask {
 
         final MemoryUsage usage = bean.getUsage();
         if (usage == null) {
-            logger.warn("{} could not determine memory usage for pool with name {}", this,
-                    context.getProperty(MEMORY_POOL_PROPERTY));
+            getLogger().warn("{} could not determine memory usage for pool with name {}", new Object[] {this,
+                    context.getProperty(MEMORY_POOL_PROPERTY)});
             return;
         }
 
@@ -217,9 +211,7 @@ public class MonitorMemory extends AbstractReportingTask {
                     bean.getName(), threshold, FormatUtils.formatDataSize(usage.getUsed()),
                     FormatUtils.formatDataSize(usage.getMax()), percentageUsed);
 
-            logger.warn("{}", message);
-            final Bulletin bulletin = context.createBulletin("Memory Management", Severity.WARNING, message);
-            context.getBulletinRepository().addBulletin(bulletin);
+            getLogger().warn("{}", new Object[] {message});
         } else if (lastValueWasExceeded) {
             lastValueWasExceeded = false;
             lastReportTime = System.currentTimeMillis();
@@ -227,9 +219,7 @@ public class MonitorMemory extends AbstractReportingTask {
                     bean.getName(), threshold, FormatUtils.formatDataSize(usage.getUsed()),
                     FormatUtils.formatDataSize(usage.getMax()), percentageUsed);
 
-            logger.info("{}", message);
-            final Bulletin bulletin = context.createBulletin("Memory Management", Severity.INFO, message);
-            context.getBulletinRepository().addBulletin(bulletin);
+            getLogger().info("{}", new Object[] {message});
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/reporting/ganglia/StandardGangliaReporter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/reporting/ganglia/StandardGangliaReporter.java
@@ -16,12 +16,10 @@
  */
 package org.apache.nifi.reporting.ganglia;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.reporting.GangliaReporter;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -33,13 +31,12 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.reporting.AbstractReportingTask;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.reporting.ReportingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.yammer.metrics.core.Gauge;
-import com.yammer.metrics.core.MetricName;
-import com.yammer.metrics.core.MetricsRegistry;
-import com.yammer.metrics.reporting.GangliaReporter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Configuration of this reporting task requires a "host" property that points
@@ -76,7 +73,6 @@ public class StandardGangliaReporter extends AbstractReportingTask {
             .build();
 
     public static final String METRICS_GROUP = "NiFi";
-    private static final Logger logger = LoggerFactory.getLogger(StandardGangliaReporter.class);
 
     private MetricsRegistry metricsRegistry;
     private GangliaReporter gangliaReporter;
@@ -245,7 +241,7 @@ public class StandardGangliaReporter extends AbstractReportingTask {
         this.latestStatus.set(rootGroupStatus);
         gangliaReporter.run();
 
-        logger.info("{} Sent metrics to Ganglia", this);
+        getLogger().info("{} Sent metrics to Ganglia", new Object[] {this});
     }
 
     private long calculateProcessingNanos(final ProcessGroupStatus status) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/TestMonitorDiskUsage.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/TestMonitorDiskUsage.java
@@ -17,12 +17,8 @@
 package org.apache.nifi.controller;
 
 import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.reporting.Severity;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,19 +31,13 @@ public class TestMonitorDiskUsage {
     public void testGeneratesMessageIfTooFull() {
         final AtomicInteger callCounter = new AtomicInteger(0);
 
-        final ReportingContext context = Mockito.mock(ReportingContext.class);
-        Mockito.doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(final InvocationOnMock invocation) throws Throwable {
-                final String message = (String) invocation.getArguments()[2];
-                System.out.println(message);
-                callCounter.incrementAndGet();
-                return null;
-            }
-
-        }).when(context).createBulletin(Mockito.any(String.class), Mockito.any(Severity.class), Mockito.any(String.class));
-
         final ComponentLog logger = Mockito.mock(ComponentLog.class);
+        Mockito.doAnswer(invocation -> {
+            final String message = (String) invocation.getArguments()[0];
+            System.out.println(message);
+            callCounter.incrementAndGet();
+            return null;
+        }).when(logger).warn(Mockito.anyString());
 
         MonitorDiskUsage.checkThreshold("Test Path", Paths.get("."), 0, logger);
         assertEquals(1, callCounter.get());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/TestMonitorDiskUsage.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/TestMonitorDiskUsage.java
@@ -16,21 +16,18 @@
  */
 package org.apache.nifi.controller;
 
-import org.apache.nifi.controller.MonitorDiskUsage;
-import static org.junit.Assert.assertEquals;
-
-import java.nio.file.Paths;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.nifi.reporting.Bulletin;
-import org.apache.nifi.reporting.BulletinRepository;
+import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.reporting.ReportingContext;
 import org.apache.nifi.reporting.Severity;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestMonitorDiskUsage {
 
@@ -50,11 +47,9 @@ public class TestMonitorDiskUsage {
 
         }).when(context).createBulletin(Mockito.any(String.class), Mockito.any(Severity.class), Mockito.any(String.class));
 
-        final BulletinRepository brepo = Mockito.mock(BulletinRepository.class);
-        Mockito.doNothing().when(brepo).addBulletin(Mockito.any(Bulletin.class));
-        Mockito.doReturn(brepo).when(context).getBulletinRepository();
+        final ComponentLog logger = Mockito.mock(ComponentLog.class);
 
-        MonitorDiskUsage.checkThreshold("Test Path", Paths.get("."), 0, context);
+        MonitorDiskUsage.checkThreshold("Test Path", Paths.get("."), 0, logger);
         assertEquals(1, callCounter.get());
     }
 


### PR DESCRIPTION
NIFI-2595:
- Updating ReportingTasks to use ComponentLogger instead of creating Controller level bulletins.
- Making the bulletin responses consistent in that all bulletins will be included but in redacted form as appropriate.