### PR TITLE
NIFI-2440 - Add 'file.lastModifiedTime' attribute to ListSFTP processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -45,9 +45,11 @@ import org.apache.nifi.processors.standard.util.SFTPTransfer;
     @WritesAttribute(attribute = "sftp.remote.host", description = "The hostname of the SFTP Server"),
     @WritesAttribute(attribute = "sftp.remote.port", description = "The port that was connected to on the SFTP Server"),
     @WritesAttribute(attribute = "sftp.listing.user", description = "The username of the user that performed the SFTP Listing"),
-    @WritesAttribute(attribute = "file.owner", description = "The numeric owner id of the source file"),
-    @WritesAttribute(attribute = "file.group", description = "The numeric group id of the source file"),
-    @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_OWNER_ATTRIBUTE, description = "The numeric owner id of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_GROUP_ATTRIBUTE, description = "The numeric group id of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_PERMISSIONS_ATTRIBUTE, description = "The read/write/execute permissions of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_LAST_MODIFY_TIME_ATTRIBUTE, description = "The timestamp of when the file in the filesystem was" +
+                  "last modified as 'yyyy-MM-dd'T'HH:mm:ssZ'"),
     @WritesAttribute(attribute = "filename", description = "The name of the file on the SFTP Server"),
     @WritesAttribute(attribute = "path", description = "The fully qualified name of the directory on the SFTP Server from which the file was pulled"),
 })


### PR DESCRIPTION
Added 'file.lastModifiedTime' attribute to ListFileTransfer, which is
the abstract class extended by ListSFTP.
String literal attribute names were replaced with static references to
attribute name constants in ListFile.
ListFileTransfer stores the 'file.lastModifiedTime' attribute in the
format specified in ListFile.FILE_MODIFY_DATE_ATTR_FORMAT
