### PR TITLE
NIFI-2525: Fix Proxy auth issue with async send.

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/pom.xml
+++ b/nifi-commons/nifi-site-to-site-client/pom.xml
@@ -79,5 +79,11 @@
             <artifactId>jetty-servlet</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.littleshoot</groupId>
+            <artifactId>littleproxy</artifactId>
+            <version>1.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/AbstractTransaction.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/AbstractTransaction.java
@@ -296,7 +296,7 @@ public abstract class AbstractTransaction implements Transaction {
                         transactionResponse = readTransactionResponse();
                     } catch (final IOException e) {
                         throw new IOException(this + " Failed to receive a response from " + peer + " when expecting a TransactionFinished Indicator. "
-                                + "It is unknown whether or not the peer successfully received/processed the data.", e);
+                                + "It is unknown whether or not the peer successfully received/processed the data. " + e, e);
                     }
 
                     logger.debug("{} Received {} from {}", this, transactionResponse, peer);


### PR DESCRIPTION
Without this fix, NiFi fails to send data via HTTP Site-to-Site through
Proxy which requires authentication due to AsynchronousCloseException.

It happens when async client replays producing contents in order to re-send the
request with auth credential for the proxy server, however the
connection is already closed.

This fix makes NiFi to send actual data only at the second round of requests, so that flow-file
contents can be sent without reading it twice.

Unit test cases using LittleProxy are also added to confirm HTTP Site-to-Site works with Proxy with/without authentication.

I've tested with Apache mod_proxy and Squid proxy servers with basic/digest auth.