### PR TITLE
NIFI-2459: HTTP Site-to-Site can't update remote peer topology if the "bootstrap url" node is down	

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerStatusProvider.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerStatusProvider.java
@@ -16,12 +16,45 @@
  */
 package org.apache.nifi.remote.client;
 
+import org.apache.nifi.remote.PeerDescription;
 import org.apache.nifi.remote.PeerStatus;
 
 import java.io.IOException;
 import java.util.Set;
 
+/**
+ * This interface defines methods used from {@link PeerSelector}.
+ */
 public interface PeerStatusProvider {
 
-    Set<PeerStatus> fetchRemotePeerStatuses() throws IOException;
+    /**
+     * <p>
+     * Returns a PeerDescription instance, which represents a bootstrap remote NiFi node.
+     * The bootstrap node is always used to fetch remote peer statuses.
+     * </p>
+     * <p>
+     * Once the PeerSelector successfully got remote peer statuses, it periodically fetches remote peer statuses,
+     * so that it can detect remote NiFi cluster topology changes such as addition or removal of nodes.
+     * To refresh remote peer statuses, PeerSelector calls {@link #fetchRemotePeerStatuses} with one of query-able nodes
+     * lastly fetched from the remote NiFi cluster, until it gets a successful result,
+     * or throws IOException if none of them responds successfully.
+     * </p>
+     * <p>
+     * This mechanism lets PeerSelector works even if the bootstrap remote NiFi node goes down.
+     * </p>
+     * @return peer description of a bootstrap remote NiFi node
+     * @throws IOException thrown when it fails to retrieve the bootstrap remote node information
+     */
+    PeerDescription getBootstrapPeerDescription() throws IOException;
+
+    /**
+     * Fetch peer statuses from a remote NiFi cluster.
+     * Implementation of this method should fetch peer statuses from the node
+     * represented by the passed PeerDescription using its transport protocol.
+     * @param peerDescription a bootstrap node or one of query-able nodes lastly fetched successfully
+     * @return Remote peer statuses
+     * @throws IOException thrown when it fails to fetch peer statuses of the remote cluster from the specified peer
+     */
+    Set<PeerStatus> fetchRemotePeerStatuses(final PeerDescription peerDescription) throws IOException;
+
 }


### PR DESCRIPTION
This PR migrates existing code which handles the situation, from EndpointConnectionPool to PeerSelector, so that both RAW and HTTP transport protocol has the same capability.

Added a unit test to confirm this scenario.

Also did an IT test using running NiFi cluster:
Used a 3 node cluster. Setup S2S specifying node 2 as the bootstrap node, then stop node 2. Confirm data is sent to only node 1 and 3. Remote peer status can still be refreshed. Then add Node 2 back, Confirm data is sent to node 1, 2 and 3.