### PR TITLE
NIFI-2643 Fixed bootstrap issue with vanilla instance

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
@@ -1021,7 +1021,7 @@ public class RunNiFi {
         cmd.add("-Dapp=NiFi");
         cmd.add("-Dorg.apache.nifi.bootstrap.config.log.dir=" + nifiLogDir);
         cmd.add("org.apache.nifi.NiFi");
-        if (props.containsKey(NIFI_BOOTSTRAP_SENSITIVE_KEY) && props.get(NIFI_BOOTSTRAP_SENSITIVE_KEY) != null) {
+        if (props.containsKey(NIFI_BOOTSTRAP_SENSITIVE_KEY) && !StringUtils.isBlank(props.get(NIFI_BOOTSTRAP_SENSITIVE_KEY))) {
             cmd.add("-k " + props.get(NIFI_BOOTSTRAP_SENSITIVE_KEY));
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
@@ -51,7 +51,7 @@ java.arg.13=-XX:+UseG1GC
 #Set headless mode by default
 java.arg.14=-Djava.awt.headless=true
 
-#Set sensitive properties key
+# Master key in hexadecimal format for encrypted sensitive configuration values
 nifi.bootstrap.sensitive.key=
 
 ###


### PR DESCRIPTION
The `RunNiFi` invocation checked if the key was `null` instead of `blank`. 