### PR TITLE
[NIFI-2658] Use bulletinEntity id instead of bulletin id since the i…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/bulletin-board/nf-bulletin-board.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/bulletin-board/nf-bulletin-board.js
@@ -388,7 +388,7 @@ nf.ng.BulletinBoardCtrl = function (serviceProvider) {
 
                         // record the id of the last bulletin in this request
                         if (i + 1 === bulletinEntities.length) {
-                            lastBulletin = bulletin.id;
+                            lastBulletin = bulletinEntity.id;
                         }
                     });
 


### PR DESCRIPTION
…ds match but bulletinEntities do not get bulletin objects if user is not authorized