### PR TITLE
NIFI-2664 Moving System.setProperty for krb5.conf to NiFi startup, an…

### DIFF
--- a/nifi-commons/nifi-hadoop-utils/src/main/java/org/apache/nifi/hadoop/KerberosProperties.java
+++ b/nifi-commons/nifi-hadoop-utils/src/main/java/org/apache/nifi/hadoop/KerberosProperties.java
@@ -55,10 +55,6 @@ public class KerberosProperties {
     public KerberosProperties(final File kerberosConfigFile) {
         this.kerberosConfigFile = kerberosConfigFile;
 
-        if (this.kerberosConfigFile != null) {
-            System.setProperty("java.security.krb5.conf", kerberosConfigFile.getAbsolutePath());
-        }
-
         this.kerberosConfigValidator = new Validator() {
             @Override
             public ValidationResult validate(String subject, String input, ValidationContext context) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/login-identity-providers.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/login-identity-providers.xml
@@ -94,7 +94,6 @@
         Identity Provider for users logging in with username/password against a Kerberos KDC server.
 
         'Default Realm' - Default realm to provide when user enters incomplete user principal (i.e. NIFI.APACHE.ORG).
-        'Kerberos Config File' - Absolute path to Kerberos client configuration file.
         'Authentication Expiration' - The duration of how long the user authentication is valid for. If the user never logs out, they will be required to log back in following this duration.
     -->
     <!-- To enable the kerberos-provider remove 2 lines. This is 1 of 2.
@@ -102,7 +101,6 @@
         <identifier>kerberos-provider</identifier>
         <class>org.apache.nifi.kerberos.KerberosProvider</class>
         <property name="Default Realm">NIFI.APACHE.ORG</property>
-        <property name="Kerberos Config File">/etc/krb5.conf</property>
         <property name="Authentication Expiration">12 hours</property>
     </provider>
     To enable the kerberos-provider remove 2 lines. This is 2 of 2. -->

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/NiFi.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/NiFi.java
@@ -58,6 +58,16 @@ public class NiFi {
 
     public NiFi(final NiFiProperties properties)
             throws ClassNotFoundException, IOException, NoSuchMethodException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+
+        // There can only be one krb5.conf for the overall Java process so set this globally during
+        // start up so that processors and our Kerberos authentication code don't have to set this
+        final File kerberosConfigFile = properties.getKerberosConfigurationFile();
+        if (kerberosConfigFile != null) {
+            final String kerberosConfigFilePath = kerberosConfigFile.getAbsolutePath();
+            logger.info("Setting java.security.krb5.conf to {}", new Object[] {kerberosConfigFilePath});
+            System.setProperty("java.security.krb5.conf", kerberosConfigFilePath);
+        }
+
         Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(final Thread t, final Throwable e) {

--- a/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers/src/main/java/org/apache/nifi/kerberos/KerberosProvider.java
+++ b/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers/src/main/java/org/apache/nifi/kerberos/KerberosProvider.java
@@ -33,7 +33,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.kerberos.authentication.KerberosAuthenticationProvider;
-import org.springframework.security.kerberos.authentication.sun.GlobalSunJaasKerberosConfig;
 import org.springframework.security.kerberos.authentication.sun.SunJaasKerberosClient;
 
 import java.util.concurrent.TimeUnit;
@@ -65,17 +64,6 @@ public class KerberosProvider implements LoginIdentityProvider {
             expiration = FormatUtils.getTimeDuration(rawExpiration, TimeUnit.MILLISECONDS);
         } catch (final IllegalArgumentException iae) {
             throw new ProviderCreationException(String.format("The Expiration Duration '%s' is not a valid time duration", rawExpiration));
-        }
-
-        try {
-            final String krb5ConfigFile = configurationContext.getProperty("Kerberos Config File");
-            if (StringUtils.isNotEmpty(krb5ConfigFile)) {
-                final GlobalSunJaasKerberosConfig krb5Config = new GlobalSunJaasKerberosConfig();
-                krb5Config.setKrbConfLocation(krb5ConfigFile);
-                krb5Config.afterPropertiesSet();
-            }
-        } catch (final Exception e) {
-            throw new ProviderCreationException(e.getMessage(), e);
         }
 
         provider = new KerberosAuthenticationProvider();


### PR DESCRIPTION
…d removing conflicting property from KerberosProvider config

Rather than add code to all of the Kafka processors to set the system property, it makes more sense for NiFi to set it once during start up. Then it will be available to HDFS, HBase, and Kafka processors, as well as the Kerberos login provider. 

We also had a potentially conflicting property in the login provider, where you could set the krb5.conf file there which would eventually set the system property and potentially overwrite the one that could have been set from nifi.properties. Now there is on the value in nifi.properties.