### PR TITLE
NIFI-2669: Ensure that if Exception is thrown during Transaction init…

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteInfoProvider.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteInfoProvider.java
@@ -16,15 +16,6 @@
  */
 package org.apache.nifi.remote.client;
 
-import org.apache.nifi.remote.TransferDirection;
-import org.apache.nifi.remote.protocol.http.HttpProxy;
-import org.apache.nifi.remote.util.SiteToSiteRestApiClient;
-import org.apache.nifi.web.api.dto.ControllerDTO;
-import org.apache.nifi.web.api.dto.PortDTO;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
@@ -34,9 +25,16 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class SiteInfoProvider {
+import javax.net.ssl.SSLContext;
 
-    private static final Logger logger = LoggerFactory.getLogger(SiteInfoProvider.class);
+import org.apache.nifi.events.EventReporter;
+import org.apache.nifi.remote.TransferDirection;
+import org.apache.nifi.remote.protocol.http.HttpProxy;
+import org.apache.nifi.remote.util.SiteToSiteRestApiClient;
+import org.apache.nifi.web.api.dto.ControllerDTO;
+import org.apache.nifi.web.api.dto.PortDTO;
+
+public class SiteInfoProvider {
 
     private static final long REMOTE_REFRESH_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
 
@@ -60,7 +58,7 @@ public class SiteInfoProvider {
     private ControllerDTO refreshRemoteInfo() throws IOException {
         final ControllerDTO controller;
 
-        try (final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, proxy)) {
+        try (final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, proxy, EventReporter.NO_OP)) {
             apiClient.resolveBaseUrl(clusterUrl);
             apiClient.setConnectTimeoutMillis(connectTimeoutMillis);
             apiClient.setReadTimeoutMillis(readTimeoutMillis);

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteToSiteClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteToSiteClient.java
@@ -157,7 +157,7 @@ public interface SiteToSiteClient extends Closeable {
         private String truststoreFilename;
         private String truststorePass;
         private KeystoreType truststoreType;
-        private EventReporter eventReporter;
+        private EventReporter eventReporter = EventReporter.NO_OP;
         private File peerPersistenceFile;
         private boolean useCompression;
         private String portName;

--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/util/TestSiteToSiteRestApiClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/util/TestSiteToSiteRestApiClient.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.remote.util;
 
+import org.apache.nifi.events.EventReporter;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,7 +25,7 @@ public class TestSiteToSiteRestApiClient {
     @Test
     public void testResolveBaseUrlHttp() throws Exception{
 
-        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null);
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
 
         final String baseUrl = apiClient.resolveBaseUrl("http://nifi.example.com/nifi");
         Assert.assertEquals("http://nifi.example.com/nifi-api", baseUrl);
@@ -33,7 +34,7 @@ public class TestSiteToSiteRestApiClient {
     @Test
     public void testResolveBaseUrlHttpSub() throws Exception{
 
-        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null);
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
 
         final String baseUrl = apiClient.resolveBaseUrl("http://nifi.example.com/foo/bar/baz/nifi");
         Assert.assertEquals("http://nifi.example.com/foo/bar/baz/nifi-api", baseUrl);
@@ -41,7 +42,7 @@ public class TestSiteToSiteRestApiClient {
 
     @Test
     public void testResolveBaseUrlHttpPort() {
-        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null);
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
 
         final String baseUrl = apiClient.resolveBaseUrl("http://nifi.example.com:8080/nifi");
         Assert.assertEquals("http://nifi.example.com:8080/nifi-api", baseUrl);
@@ -50,7 +51,7 @@ public class TestSiteToSiteRestApiClient {
     @Test
     public void testResolveBaseUrlHttps() throws Exception{
 
-        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null);
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
 
         final String baseUrl = apiClient.resolveBaseUrl("https://nifi.example.com/nifi");
         Assert.assertEquals("https://nifi.example.com/nifi-api", baseUrl);
@@ -58,7 +59,7 @@ public class TestSiteToSiteRestApiClient {
 
     @Test
     public void testResolveBaseUrlHttpsPort() {
-        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null);
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
 
         final String baseUrl = apiClient.resolveBaseUrl("https://nifi.example.com:8443/nifi");
         Assert.assertEquals("https://nifi.example.com:8443/nifi-api", baseUrl);

--- a/nifi-framework-api/src/main/java/org/apache/nifi/events/EventReporter.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/events/EventReporter.java
@@ -24,6 +24,15 @@ import org.apache.nifi.reporting.Severity;
  * Implementations MUST be thread-safe
  */
 public interface EventReporter extends Serializable {
+    /**
+     * An Event Reporter that performs no action and ignores all given input
+     */
+    public static final EventReporter NO_OP = new EventReporter() {
+        @Override
+        public void reportEvent(Severity severity, String category, String message) {
+        }
+    };
 
     void reportEvent(Severity severity, String category, String message);
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -835,8 +835,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
         try {
             // perform the request
             final ControllerDTO dto;
-            try (
-                    final SiteToSiteRestApiClient apiClient = getSiteToSiteRestApiClient()) {
+            try (final SiteToSiteRestApiClient apiClient = getSiteToSiteRestApiClient()) {
                 dto = apiClient.getController();
             } catch (IOException e) {
                 writeLock.lock();
@@ -928,7 +927,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
     }
 
     private SiteToSiteRestApiClient getSiteToSiteRestApiClient() {
-        SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, new HttpProxy(proxyHost, proxyPort, proxyUser, proxyPassword));
+        SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, new HttpProxy(proxyHost, proxyPort, proxyUser, proxyPassword), getEventReporter());
         apiClient.setBaseUrl(getApiUri());
         apiClient.setConnectTimeoutMillis(getCommunicationsTimeout(TimeUnit.MILLISECONDS));
         apiClient.setReadTimeoutMillis(getCommunicationsTimeout(TimeUnit.MILLISECONDS));


### PR DESCRIPTION
…ialization that the underlying client is closed/cleaned up. Also ensure that we generate bulletins when logging error/warn level log messages