### PR TITLE
NIFI-2480: Fix for multibyte chars in breadcrumbs

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-breadcrumbs-controller.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-breadcrumbs-controller.js
@@ -45,10 +45,9 @@ nf.ng.BreadcrumbsCtrl = function (serviceProvider, $sanitize) {
             if (breadcrumbEntity.permissions.canRead) {
                 label = breadcrumbEntity.breadcrumb.name;
             }
-            
-            //explicitly sanitize processGroup.name
+
             this.breadcrumbs.unshift($.extend({
-                'label': $sanitize(label)
+                'label': label
             }, breadcrumbEntity));
 
             if (nf.Common.isDefinedAndNotNull(breadcrumbEntity.parentBreadcrumb)) {


### PR DESCRIPTION
Removed $sanitize from breadcrumbs controller, as it escapes multibyte chars with numerical reference, and non-English names are not displayed in human readable way.
Even without $sanitize, html tags can be escaped when Angular binds the value to text content.

I confirmed that HTML tags are escaped without $sanitize as following screen-shots:

![image](https://cloud.githubusercontent.com/assets/1107620/17996071/745b2084-6ba1-11e6-9f4a-ae98fc6a8702.png)

I hope this can be merged, and it doesn't have any negative impact by removing $sanitize.

Thanks!