### PR TITLE
Port NIFI-2688 to NIFI 1.0.0 RC1 branch

### DIFF
--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/groovy/org/apache/nifi/properties/ConfigEncryptionToolTest.groovy
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/groovy/org/apache/nifi/properties/ConfigEncryptionToolTest.groovy
@@ -971,7 +971,7 @@ class ConfigEncryptionToolTest extends GroovyTestCase {
         // Format -- #Fri Aug 19 16:51:16 PDT 2016
         // Alternate format -- #Fri Aug 19 16:51:16 GMT-05:00 2016
         // \u0024 == '$' to avoid escaping
-        String datePattern = /^#\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} \w{3}([\-+]\d{2}:\d{2})? \d{4}\u0024/
+        String datePattern = /^#\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} \w{3,4}([\-+]\d{2}:\d{2})? \d{4}\u0024/
 
         // One extra line for the date
         assert lines.size() == properties.size() + 1


### PR DESCRIPTION
adjust ConfigEncryptionToolTest datePattern regex to cater for timezones with 4 characters