### PR TITLE
NIFI-2686: Confusing log No hostnames specified

### DIFF
--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/standalone/TlsToolkitStandalone.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/standalone/TlsToolkitStandalone.java
@@ -132,7 +132,7 @@ public class TlsToolkitStandalone {
         boolean overwrite = standaloneConfig.isOverwrite();
 
         List<InstanceDefinition> instanceDefinitions = standaloneConfig.getInstanceDefinitions();
-        if (!instanceDefinitions.isEmpty() && logger.isInfoEnabled()) {
+        if (instanceDefinitions.isEmpty() && logger.isInfoEnabled()) {
             logger.info("No " + TlsToolkitStandaloneCommandLine.HOSTNAMES_ARG + " specified, not generating any host certificates or configuration.");
         }
         for (InstanceDefinition instanceDefinition : instanceDefinitions) {


### PR DESCRIPTION
instanceDefinitions.isEmpty() was negate wrongly.