### PR TITLE
NIFI-2629 - Hide add property "+" in Processors, Controller Services and Reporting Tasks that don't allow dynamic properties

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
@@ -37,6 +37,7 @@ public class ControllerServiceDTO extends ComponentDTO {
     private String comments;
     private String state;
     private Boolean persistsState;
+    private Boolean hasDynamicProperty;
 
     private Map<String, String> properties;
     private Map<String, PropertyDescriptorDTO> descriptors;
@@ -104,6 +105,19 @@ public class ControllerServiceDTO extends ComponentDTO {
         this.persistsState = persistsState;
     }
 
+    /**
+     * @return whether this controller supports dynamic properties
+     */
+    @ApiModelProperty(
+            value = "Whether the controller service supports dynamic properties."
+    )
+    public Boolean getHasDynamicProperty() {
+        return hasDynamicProperty;
+    }
+
+    public void setHasDynamicProperty(Boolean dynamic) {
+        this.hasDynamicProperty = dynamic;
+    }
     /**
      * @return The state of this controller service. Possible values are ENABLED, ENABLING, DISABLED, DISABLING
      */

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
@@ -38,6 +38,7 @@ public class ProcessorDTO extends ComponentDTO {
     private Boolean supportsEventDriven;
     private Boolean supportsBatching;
     private Boolean persistsState;
+    private Boolean hasDynamicProperty;
     private String inputRequirement;
 
     private ProcessorConfigDTO config;
@@ -151,6 +152,15 @@ public class ProcessorDTO extends ComponentDTO {
         this.inputRequirement = inputRequirement;
     }
 
+    @ApiModelProperty(
+            value = "Whether the processor supports dynamic properties."
+    )
+    public Boolean getHasDynamicProperty() {
+        return hasDynamicProperty;
+    }
+    public void setHasDynamicProperty(Boolean dynamic) {
+        this.hasDynamicProperty = dynamic;
+    }
     /**
      * @return whether this processor supports event driven scheduling
      */

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
@@ -33,6 +33,7 @@ public class ReportingTaskDTO extends ComponentDTO {
     private String state;
     private String comments;
     private Boolean persistsState;
+    private Boolean hasDynamicProperty;
 
     private String schedulingPeriod;
     private String schedulingStrategy;
@@ -103,6 +104,20 @@ public class ReportingTaskDTO extends ComponentDTO {
 
     public void setSchedulingPeriod(String schedulingPeriod) {
         this.schedulingPeriod = schedulingPeriod;
+    }
+
+    /**
+     * @return whether this reporting task supports dynamic properties
+     */
+    @ApiModelProperty(
+            value = "Whether the reporting task supports dynamic properties."
+    )
+    public Boolean getHasDynamicProperty() {
+        return hasDynamicProperty;
+    }
+
+    public void setHasDynamicProperty(Boolean dynamic) {
+        this.hasDynamicProperty = dynamic;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -31,6 +31,7 @@ import org.apache.nifi.action.details.FlowChangeMoveDetails;
 import org.apache.nifi.action.details.FlowChangePurgeDetails;
 import org.apache.nifi.action.details.MoveDetails;
 import org.apache.nifi.action.details.PurgeDetails;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.Stateful;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -1209,6 +1210,7 @@ public final class DtoFactory {
         dto.setAnnotationData(reportingTaskNode.getAnnotationData());
         dto.setComments(reportingTaskNode.getComments());
         dto.setPersistsState(reportingTaskNode.getReportingTask().getClass().isAnnotationPresent(Stateful.class));
+        dto.setHasDynamicProperty(reportingTaskNode.getReportingTask().getClass().isAnnotationPresent(DynamicProperty.class));
 
         final Map<String, String> defaultSchedulingPeriod = new HashMap<>();
         defaultSchedulingPeriod.put(SchedulingStrategy.TIMER_DRIVEN.name(), SchedulingStrategy.TIMER_DRIVEN.getDefaultSchedulingPeriod());
@@ -1278,6 +1280,7 @@ public final class DtoFactory {
         dto.setAnnotationData(controllerServiceNode.getAnnotationData());
         dto.setComments(controllerServiceNode.getComments());
         dto.setPersistsState(controllerServiceNode.getControllerServiceImplementation().getClass().isAnnotationPresent(Stateful.class));
+        dto.setHasDynamicProperty(controllerServiceNode.getControllerServiceImplementation().getClass().isAnnotationPresent(DynamicProperty.class));
 
         // sort a copy of the properties
         final Map<PropertyDescriptor, String> sortedProperties = new TreeMap<>(new Comparator<PropertyDescriptor>() {
@@ -2027,6 +2030,7 @@ public final class DtoFactory {
         dto.setStyle(node.getStyle());
         dto.setParentGroupId(node.getProcessGroup().getIdentifier());
         dto.setInputRequirement(node.getInputRequirement().name());
+        dto.setHasDynamicProperty(node.getProcessor().getClass().isAnnotationPresent(DynamicProperty.class));
         dto.setPersistsState(node.getProcessor().getClass().isAnnotationPresent(Stateful.class));
 
         dto.setType(node.getCanonicalClassName());
@@ -2572,6 +2576,7 @@ public final class DtoFactory {
         copy.setState(original.getState());
         copy.setType(original.getType());
         copy.setValidationErrors(copy(original.getValidationErrors()));
+        copy.setHasDynamicProperty(original.getHasDynamicProperty());
         return copy;
     }
 
@@ -2631,6 +2636,7 @@ public final class DtoFactory {
         copy.setSupportsParallelProcessing(original.getSupportsParallelProcessing());
         copy.setSupportsEventDriven(original.getSupportsEventDriven());
         copy.setValidationErrors(copy(original.getValidationErrors()));
+        copy.setHasDynamicProperty(original.getHasDynamicProperty());
 
         return copy;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
@@ -1873,6 +1873,14 @@ nf.ControllerService = (function () {
                     .propertytable('setGroupId', controllerService.parentGroupId)
                     .propertytable('loadProperties', controllerService.properties, controllerService.descriptors, controllerServiceHistory.propertyHistory);
 
+                // hide add property '+' if necessary
+                if (controllerService.hasDynamicProperty) {
+                    $(".add-property").show();
+                }
+                else {
+                    $(".add-property").hide();
+                }
+
                 // show the details
                 controllerServiceDialog.modal('show');
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -805,6 +805,14 @@ nf.ProcessorConfiguration = (function () {
                         .propertytable('setGroupId', processor.parentGroupId)
                         .propertytable('loadProperties', processor.config.properties, processor.config.descriptors, processorHistory.propertyHistory);
 
+                    // hide add property '+' if necessary
+                    if (processor.hasDynamicProperty) {
+                        $(".add-property").show();
+                    }
+                    else {
+                        $(".add-property").hide();
+                    }
+
                     // show the details
                     $('#processor-configuration').modal('show');
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
@@ -565,6 +565,14 @@ nf.ReportingTask = (function () {
                     .propertytable('setGroupId', reportingTask.parentGroupId)
                     .propertytable('loadProperties', reportingTask.properties, reportingTask.descriptors, reportingTaskHistory.propertyHistory);
 
+                // hide add property '+' if necessary
+                if (reportingTask.hasDynamicProperty) {
+                    $(".add-property").show();
+                }
+                else {
+                    $(".add-property").hide();
+                }
+
                 // show the details
                 $('#reporting-task-configuration').modal('show');
 


### PR DESCRIPTION
Dto for Processor, Controller Service, and Reporting Task were modified to include a 'hasDynamicProperty' property, which is passed to the UI. Components that have a DynamicProperty annotation are true. False otherwise.

Client side javascript was modified to show/hide the '+' icon in the 'Properties' tab of the component configuration dialog.
