### PR TITLE
Ensuring the component stats on the canvas refresh

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/controller-service.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/controller-service.css
@@ -39,11 +39,6 @@
 
 /* controller-service settings */
 
-#controller-service-name {
-    width: 250px;
-    float: left;
-}
-
 /*
     Service references
 */

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/reporting-task.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/reporting-task.css
@@ -44,7 +44,6 @@
 /* reporting-task settings */
 
 #reporting-task-name {
-    font-size: 11px !important;
     width: 250px;
     float: left;
 }
@@ -63,7 +62,6 @@ div.reporting-task-enabled-container {
 }
 
 input.reporting-task-scheduling-period {
-    font-size: 11px !important;
     width: 150px;
 }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/settings.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/settings.css
@@ -47,8 +47,8 @@ div.settings-container {
 #settings-refresh-container {
     position: absolute;
     bottom: 20px;
-    right: 20px;
-    left: 20px;
+    right: 0px;
+    left: 0px;
 }
 
 /* settings tabs */

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1021,10 +1021,15 @@
                             data.updateItem(item.id, $.extend(item, {
                                 value: response.component.id
                             }));
-
+                            
                             // close the dialog
                             newControllerServiceDialog.modal('hide');
                         });
+
+                        // invoke callback if necessary
+                        if (typeof configurationOptions.controllerServiceCreatedDeferred === 'function') {
+                            configurationOptions.controllerServiceCreatedDeferred(response);
+                        }
                     }).fail(nf.Common.handleAjaxError);
                 };
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
@@ -23,7 +23,10 @@ nf.ControllerService = (function () {
         edit: 'edit',
         readOnly: 'read-only',
         serviceOnly: 'SERVICE_ONLY',
-        serviceAndReferencingComponents: 'SERVICE_AND_REFERENCING_COMPONENTS'
+        serviceAndReferencingComponents: 'SERVICE_AND_REFERENCING_COMPONENTS',
+        urls: {
+            api: '../nifi-api'
+        }
     };
 
     /**
@@ -1728,6 +1731,23 @@ nf.ControllerService = (function () {
                     readOnly: false,
                     dialogContainer: '#new-controller-service-property-container',
                     descriptorDeferred: getControllerServicePropertyDescriptor,
+                    controllerServiceCreatedDeferred: function(response) {
+                        var controllerServicesUri;
+                        var createdControllerServicesTable;
+
+                        // calculate the correct uri
+                        var createdControllerService = response.component;
+                        if (nf.Common.isDefinedAndNotNull(createdControllerService.parentGroupId)) {
+                            createdControllerServicesTable = $('#process-group-controller-services-table');
+                            controllerServicesUri = config.urls.api + '/flow/process-groups/' + encodeURIComponent(createdControllerService.parentGroupId) + '/controller-services';
+                        } else {
+                            createdControllerServicesTable = $('#controller-services-table');
+                            controllerServicesUri = config.urls.api + '/flow/controller/controller-services';
+                        }
+
+                        // load the controller services accordingly
+                        return nf.ControllerServices.loadControllerServices(controllerServicesUri, createdControllerServicesTable);
+                    },
                     goToServiceDeferred: function () {
                         return goToServiceFromProperty(serviceTable);
                     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
@@ -790,6 +790,7 @@ nf.ControllerServices = (function () {
             controllerServicesData.setItems(services);
             controllerServicesData.reSort();
             controllerServicesGrid.invalidate();
+            controllerServicesGrid.render();
         });
     };
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
@@ -21,8 +21,14 @@ nf.ReportingTask = (function () {
 
     var config = {
         edit: 'edit',
-        readOnly: 'read-only'
+        readOnly: 'read-only',
+        urls: {
+            api: '../nifi-api'
+        }
     };
+
+    // load the controller services
+    var controllerServicesUri = config.urls.api + '/flow/controller/controller-services';
 
     /**
      * Gets the controller services table.
@@ -359,6 +365,9 @@ nf.ReportingTask = (function () {
                 readOnly: false,
                 dialogContainer: '#new-reporting-task-property-container',
                 descriptorDeferred: getReportingTaskPropertyDescriptor,
+                controllerServiceCreatedDeferred: function(response){
+                    return nf.ControllerServices.loadControllerServices(controllerServicesUri, $('#controller-services-table'));
+                },
                 goToServiceDeferred: goToServiceFromProperty
             });
         },
@@ -380,6 +389,9 @@ nf.ReportingTask = (function () {
                     readOnly: false,
                     dialogContainer: '#new-reporting-task-property-container',
                     descriptorDeferred: getReportingTaskPropertyDescriptor,
+                    controllerServiceCreatedDeferred: function(response){
+                        return nf.ControllerServices.loadControllerServices(controllerServicesUri, $('#controller-services-table'));
+                    },
                     goToServiceDeferred: goToServiceFromProperty
                 });
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-client.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-client.js
@@ -48,7 +48,7 @@ nf.Client = (function() {
         },
 
         /**
-         * Determines whether the proposedData is newer than the currentData.
+         * Determines whether the proposedData is not older than the currentData.
          *
          * @param currentData Maybe be null, if the proposedData is new to this canvas
          * @param proposedData Maybe not be null
@@ -59,8 +59,8 @@ nf.Client = (function() {
                 var currentRevision = currentData.revision;
                 var proposedRevision = proposedData.revision;
 
-                // return whether the proposed revision is newer
-                return proposedRevision.version > currentRevision.version;
+                // return whether the proposed revision is not less
+                return proposedRevision.version >= currentRevision.version;
             } else {
                 return true;
             }


### PR DESCRIPTION
NIFI-2722:
- Updating the component entity as long as the proposed entity is not older than the current one since stats are bundled in the entity too.

NOTE: This is showing as two commits but it's not. It appears the Github mirror hasn't refreshed yet [1].

[1] https://git-wip-us.apache.org/repos/asf?p=nifi.git;a=shortlog;h=refs/heads/master