### PR TITLE
NIFI-2754

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowFileQueue.java
@@ -548,13 +548,9 @@ public class StandardFlowFileQueue implements FlowFileQueue {
             return;
         }
 
-        int numSwapFiles = swapQueue.size() / SWAP_RECORD_POLL_SIZE;
+        migrateSwapToActive();
 
-        //if the Active Queue is empty, and the number of files just added to the swap queue is evenly splitable into swap files
-        // then reduce swap file count by 1, otherwise we won't have any active records.
-        if(activeQueue.size() == 0 && numSwapFiles > 0 && swapQueue.size() % SWAP_RECORD_POLL_SIZE == 0){
-            numSwapFiles -=1;
-        }
+        final int numSwapFiles = swapQueue.size() / SWAP_RECORD_POLL_SIZE;
 
         int originalSwapQueueCount = swapQueue.size();
         long originalSwapQueueBytes = 0L;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowFileQueue.java
@@ -389,7 +389,8 @@ public class StandardFlowFileQueue implements FlowFileQueue {
             if (flowFile != null) {
                 incrementActiveQueueSize(-1, -flowFile.getSize());
             }
-        } while (isExpired);
+        }
+        while (isExpired);
 
         if (!expiredRecords.isEmpty()) {
             incrementActiveQueueSize(-expiredRecords.size(), -expiredBytes);
@@ -547,7 +548,13 @@ public class StandardFlowFileQueue implements FlowFileQueue {
             return;
         }
 
-        final int numSwapFiles = swapQueue.size() / SWAP_RECORD_POLL_SIZE;
+        int numSwapFiles = swapQueue.size() / SWAP_RECORD_POLL_SIZE;
+
+        //if the Active Queue is empty, and the number of files just added to the swap queue is evenly splitable into swap files
+        // then reduce swap file count by 1, otherwise we won't have any active records.
+        if(activeQueue.size() == 0 && numSwapFiles > 0 && swapQueue.size() % SWAP_RECORD_POLL_SIZE == 0){
+            numSwapFiles -=1;
+        }
 
         int originalSwapQueueCount = swapQueue.size();
         long originalSwapQueueBytes = 0L;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -493,6 +494,29 @@ public class TestStandardFlowFileQueue {
         final ListFlowFileStatus status = queue.listFlowFiles(UUID.randomUUID().toString(), 100);
         assertNotNull(status);
         assertEquals(30050, status.getQueueSize().getObjectCount());
+
+        while (status.getState() != ListFlowFileState.COMPLETE) {
+            Thread.sleep(100);
+        }
+
+        assertEquals(100, status.getFlowFileSummaries().size());
+        assertEquals(100, status.getCompletionPercentage());
+        assertNull(status.getFailureReason());
+    }
+
+    @Test(timeout = 5000)
+    public void testListFlowFilesResultsLimitedCollection() throws InterruptedException {
+        Collection<FlowFileRecord> tff = new ArrayList<>();
+        //Swap Size is 10000 records, so 30000 is equal to 3 swap files.
+        for (int i = 0; i < 30000; i++) {
+            tff.add(new TestFlowFile());
+        }
+
+        queue.putAll(tff);
+
+        final ListFlowFileStatus status = queue.listFlowFiles(UUID.randomUUID().toString(), 100);
+        assertNotNull(status);
+        assertEquals(30000, status.getQueueSize().getObjectCount());
 
         while (status.getState() != ListFlowFileState.COMPLETE) {
             Thread.sleep(100);


### PR DESCRIPTION
If the Active queue is empty and the number of FlowFiles added to the queue is perfectly splitable by the current Swap size (100000 Flow Files / 20000 files per swap file = 5 with no remainder), then no FlowFiles will move to Active and all will remain in Swap.

Apart from NIFI-2754, there was also a style violation in the existing code, which I fixed.