### PR TITLE
NIFI-2756 - Add displayName to maven archetypes

### DIFF
--- a/nifi-maven-archetypes/nifi-processor-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-processors/src/main/java/MyProcessor.java
+++ b/nifi-maven-archetypes/nifi-processor-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-processors/src/main/java/MyProcessor.java
@@ -17,7 +17,6 @@
 package ${package};
 
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
 import org.apache.nifi.annotation.behavior.ReadsAttributes;

--- a/nifi-maven-archetypes/nifi-processor-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-processors/src/main/java/MyProcessor.java
+++ b/nifi-maven-archetypes/nifi-processor-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-processors/src/main/java/MyProcessor.java
@@ -19,7 +19,6 @@ package ${package};
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.processor.*;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
 import org.apache.nifi.annotation.behavior.ReadsAttributes;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -29,9 +28,18 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Tags({"example"})
 @CapabilityDescription("Provide a description")
@@ -41,14 +49,15 @@ import java.util.*;
 public class MyProcessor extends AbstractProcessor {
 
     public static final PropertyDescriptor MY_PROPERTY = new PropertyDescriptor
-            .Builder().name("My Property")
+            .Builder().name("MY_PROPERTY")
+            .displayName("My property")
             .description("Example Property")
             .required(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
     public static final Relationship MY_RELATIONSHIP = new Relationship.Builder()
-            .name("my_relationship")
+            .name("MY_RELATIONSHIP")
             .description("Example relationship")
             .build();
 

--- a/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__/src/main/java/StandardMyService.java
+++ b/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__/src/main/java/StandardMyService.java
@@ -19,7 +19,6 @@ package ${package};
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;

--- a/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__/src/main/java/StandardMyService.java
+++ b/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__/src/main/java/StandardMyService.java
@@ -37,7 +37,8 @@ import org.apache.nifi.reporting.InitializationException;
 public class StandardMyService extends AbstractControllerService implements MyService {
 
     public static final PropertyDescriptor MY_PROPERTY = new PropertyDescriptor
-            .Builder().name("My Property")
+            .Builder().name("MY_PROPERTY")
+            .displayName("My Property")
             .description("Example Property")
             .required(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)

--- a/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__/src/test/java/TestStandardMyService.java
+++ b/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__/src/test/java/TestStandardMyService.java
@@ -19,7 +19,6 @@ package ${package};
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
@alopresto Would you mind having a look on this PR?

I am not familiar with maven archetypes but I noticed that the ones we have seem to result in code lacking some of the present practices such as having displayName, including * imports, unused classes, etc.

This PR tries to address that.

Cheers

