### PR TITLE
Ensuring the root group is included in /resources

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -797,6 +797,12 @@ public class ControllerFacade implements Authorizable {
 
         final ProcessGroup root = flowController.getGroup(flowController.getRootGroupId());
 
+        // include the root group
+        final Resource rootResource = root.getResource();
+        resources.add(rootResource);
+        resources.add(ResourceFactory.getDataResource(rootResource));
+        resources.add(ResourceFactory.getPolicyResource(rootResource));
+
         // add each processor
         for (final ProcessorNode processor : root.findAllProcessors()) {
             final Resource processorResource = processor.getResource();


### PR DESCRIPTION
NIFI-2766:
- Ensuring the root group is included in /resources.