### PR TITLE
Correct authorization when destination changes

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectionResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectionResource.java
@@ -223,7 +223,7 @@ public class ConnectionResource extends ApplicationResource {
 
                     // if a destination has been specified and is different
                     final Connectable currentDestination = connAuth.getDestination();
-                    if (requestConnection.getDestination() != null && currentDestination.getIdentifier().equals(requestConnection.getDestination().getId())) {
+                    if (requestConnection.getDestination() != null && !currentDestination.getIdentifier().equals(requestConnection.getDestination().getId())) {
                         // verify access of the new destination (current destination was already authorized as part of the connection check)
                         final Authorizable newDestinationAuthorizable = lookup.getConnectable(requestConnection.getDestination().getId());
                         newDestinationAuthorizable.authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-connection.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-connection.js
@@ -1386,7 +1386,7 @@ nf.Connection = (function () {
                                 nf.CanvasUtils.reloadConnectionSourceAndDestination(null, previousDestinationId);
                                 nf.CanvasUtils.reloadConnectionSourceAndDestination(response.sourceId, response.destinationId);
                             }).fail(function (xhr, status, error) {
-                                if (xhr.status === 400 || xhr.status === 404 || xhr.status === 409) {
+                                if (xhr.status === 400 || xhr.status === 401 || xhr.status === 403 || xhr.status === 404 || xhr.status === 409) {
                                     nf.Dialog.showOkDialog({
                                         headerText: 'Connection',
                                         dialogContent: nf.Common.escapeHtml(xhr.responseText)


### PR DESCRIPTION
NIFI-2768:
- Ensuring we correctly enforce authorization when the destination of a connection changes. This includes source, destination, and parent process group.
- Ensuring the UI resetting accordingly when a request fails.