### PR TITLE
NIFI-2767 Periodically reload properties from file-based variable registry properties files

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -197,6 +197,7 @@ public abstract class NiFiProperties {
 
     // expression language properties
     public static final String VARIABLE_REGISTRY_PROPERTIES = "nifi.variable.registry.properties";
+    public static final String VARIABLE_REGISTRY_CHECK_SCHEDULE = "nifi.variable.registry.check.schedule";
 
     // defaults
     public static final Boolean DEFAULT_AUTO_RESUME_STATE = true;
@@ -248,6 +249,9 @@ public abstract class NiFiProperties {
 
     // Kerberos defaults
     public static final String DEFAULT_KERBEROS_AUTHENTICATION_EXPIRATION = "12 hours";
+
+    // variable registry defaults
+    public static final String DEFAULT_VARIABLE_REGISTRY_CHECK_SCHEDULE = "30 secs";
 
     /**
      * Retrieves the property value for the given property key.
@@ -1028,6 +1032,10 @@ public abstract class NiFiProperties {
             }
         }
         return networkInterfaces;
+    }
+
+    public String getVariableRegistryCheckSchedule() {
+        return getProperty(VARIABLE_REGISTRY_CHECK_SCHEDULE, DEFAULT_VARIABLE_REGISTRY_CHECK_SCHEDULE);
     }
 
     public int size() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -155,7 +155,6 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
@@ -166,7 +165,11 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/util/FileBasedVariableRegistry.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/util/FileBasedVariableRegistry.java
@@ -23,12 +23,19 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.VariableDescriptor;
 import org.apache.nifi.registry.VariableRegistry;
+import org.apache.nifi.util.FormatUtils;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.util.file.monitor.MD5SumMonitor;
+import org.apache.nifi.util.file.monitor.SynchronousFileWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,49 +47,104 @@ import org.slf4j.LoggerFactory;
 public class FileBasedVariableRegistry implements VariableRegistry {
 
     private final static Logger LOG = LoggerFactory.getLogger(FileBasedVariableRegistry.class);
-    final Map<VariableDescriptor, String> map;
+    final ConcurrentMap<VariableDescriptor, String> variables;
+    final ConcurrentMap<Path, SynchronousFileWatcher> watchers;
+    final long checkMillis;
 
-    public FileBasedVariableRegistry(final Path[] propertiesPaths) {
-        final Map<VariableDescriptor, String> newMap = new HashMap<>(VariableRegistry.ENVIRONMENT_SYSTEM_REGISTRY.getVariableMap());
-        final int systemEnvPropCount = newMap.size();
+    public FileBasedVariableRegistry(final Path[] propertiesPaths, final long checkMillis) {
+        this.checkMillis = checkMillis;
+
+        final ConcurrentMap<VariableDescriptor, String> variables = new ConcurrentHashMap<>(VariableRegistry.ENVIRONMENT_SYSTEM_REGISTRY.getVariableMap());
+        final ConcurrentMap<Path, SynchronousFileWatcher> watchers = new ConcurrentHashMap<>();
+        final int systemEnvPropCount = variables.size();
         int totalPropertiesLoaded = systemEnvPropCount;
-        LOG.info("Loaded {} properties from system properties and environment variables",systemEnvPropCount);
+
+        LOG.info("Loaded {} properties from system properties and environment variables", systemEnvPropCount);
+
         try {
             for (final Path path : propertiesPaths) {
-                if (Files.exists(path)) {
-                    final AtomicInteger propsLoaded = new AtomicInteger(0);
-                    try (final InputStream inStream = new BufferedInputStream(new FileInputStream(path.toFile()))) {
-                        Properties properties = new Properties();
-                        properties.load(inStream);
-                        properties.entrySet().stream().forEach((entry) -> {
-                            final VariableDescriptor desc = new VariableDescriptor.Builder(entry.getKey().toString())
-                                    .description(path.toString())
-                                    .sensitive(false)
-                                    .build();
-                            newMap.put(desc, entry.getValue().toString());
-                            propsLoaded.incrementAndGet();
-                        });
-                    }
-                    totalPropertiesLoaded += propsLoaded.get();
-                    if(propsLoaded.get() > 0){
-                        LOG.info("Loaded {} properties from '{}'", propsLoaded.get(), path);
-                    }else{
-                        LOG.warn("No properties loaded from '{}'", path);
-                    }
-                } else {
-                    LOG.warn("Skipping property file {} as it does not appear to exist", path);
-                }
+                totalPropertiesLoaded += loadProperties(path, variables, watchers, checkMillis);
             }
         } catch (final IOException ioe) {
             LOG.error("Unable to complete variable registry loading from files due to ", ioe);
         }
-        LOG.info("Loaded a total of {} properties.  Including precedence overrides effective accessible registry key size is {}", totalPropertiesLoaded, newMap.size());
-        map = newMap;
+
+        LOG.info("Loaded a total of {} properties.  Including precedence overrides effective accessible registry key size is {}", totalPropertiesLoaded, variables.size());
+
+        this.variables = variables;
+        this.watchers = watchers;
+    }
+
+    public FileBasedVariableRegistry(final Path[] propertiesPaths, final String checkSchedule) {
+        this(propertiesPaths, StringUtils.isNotBlank(checkSchedule) ? FormatUtils.getTimeDuration(checkSchedule, TimeUnit.MILLISECONDS) : 0L);
+    }
+
+    public FileBasedVariableRegistry(final Path[] propertiesPaths) {
+        this(propertiesPaths, NiFiProperties.createBasicNiFiProperties(null, null).getVariableRegistryCheckSchedule());
+    }
+
+    private int loadProperties(final Path path, final Map<VariableDescriptor, String> variables, final Map<Path, SynchronousFileWatcher> watchers, final long checkMillis) throws IOException {
+        int propertiesLoaded = 0;
+        if (Files.exists(path)) {
+            if (watchers != null && !watchers.containsKey(path)) {
+                if (checkMillis > 0) {
+                    watchers.put(path, new SynchronousFileWatcher(path, new MD5SumMonitor(), checkMillis));
+                } else {
+                    LOG.warn("Check schedule is zero, properties from {} will not be reloadable", path);
+                }
+            }
+
+            final AtomicInteger propsLoaded = new AtomicInteger(0);
+            try (final InputStream inStream = new BufferedInputStream(new FileInputStream(path.toFile()))) {
+                Properties properties = new Properties();
+                properties.load(inStream);
+                properties.entrySet().stream().forEach((entry) -> {
+                    final VariableDescriptor desc = new VariableDescriptor.Builder(entry.getKey().toString())
+                            .description(path.toString())
+                            .sensitive(false)
+                            .build();
+                    variables.put(desc, entry.getValue().toString());
+                    propsLoaded.incrementAndGet();
+                });
+            }
+            propertiesLoaded += propsLoaded.get();
+
+            if (propsLoaded.get() > 0) {
+                LOG.info("Loaded {} properties from '{}'", propsLoaded.get(), path);
+            } else {
+                LOG.warn("No properties loaded from '{}'", path);
+            }
+        } else {
+            LOG.warn("Skipping property file {} as it does not appear to exist", path);
+        }
+        return propertiesLoaded;
     }
 
     @Override
     public Map<VariableDescriptor, String> getVariableMap() {
-        return Collections.unmodifiableMap(map);
+        if (watchers != null && !watchers.isEmpty()) {
+            int propsReloaded = 0;
+
+            for (Map.Entry<Path, SynchronousFileWatcher> e : watchers.entrySet()) {
+                final Path path = e.getKey();
+                final SynchronousFileWatcher watcher = e.getValue();
+                try {
+                    if (watcher.checkAndReset()) {
+                        propsReloaded += loadProperties(path, variables, watchers, checkMillis);
+                    }
+                } catch (final IOException ioe) {
+                    LOG.error("Unable to reload variables from {} due to {}", new Object[]{path, ioe.getMessage()}, ioe);
+                }
+            }
+
+            if (propsReloaded > 0) {
+                LOG.info("Reloaded {} properties", propsReloaded);
+            } else {
+                LOG.debug("No properties reloaded");
+            }
+        }
+
+        return Collections.unmodifiableMap(variables);
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/nifi-context.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/nifi-context.xml
@@ -25,12 +25,13 @@
     <!-- variable registry -->
     <bean id="variableRegistry" class="org.apache.nifi.util.FileBasedVariableRegistry">
         <constructor-arg type="java.nio.file.Path[]" value="#{nifiProperties.getVariableRegistryPropertiesPaths()}" />
+        <constructor-arg type="java.lang.String" value="#{nifiProperties.getVariableRegistryCheckSchedule()}" />
     </bean>
 
     <!-- flow file event repository -->
     <bean id="flowFileEventRepository" class="org.apache.nifi.spring.RingBufferEventRepositoryBean">
     </bean>
-    
+
     <bean id="stringEncryptor" class="org.apache.nifi.encrypt.StringEncryptor" factory-method="createEncryptor">
         <constructor-arg ref="nifiProperties" />
     </bean>
@@ -53,7 +54,7 @@
         <property name="encryptor" ref="stringEncryptor" />
         <property name="authorizer" ref="authorizer" />
     </bean>
-    
+
     <!-- bulletin repository -->
     <bean id="bulletinRepository" class="org.apache.nifi.events.VolatileBulletinRepository" />
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/StandardFlowServiceTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/StandardFlowServiceTest.java
@@ -76,10 +76,7 @@ public class StandardFlowServiceTest {
     @Before
     public void setup() throws Exception {
         properties = NiFiProperties.createBasicNiFiProperties(null, null);
-
-
-
-        variableRegistry = new FileBasedVariableRegistry(properties.getVariableRegistryPropertiesPaths());
+        variableRegistry = new FileBasedVariableRegistry(properties.getVariableRegistryPropertiesPaths(), properties.getVariableRegistryCheckSchedule());
         mockFlowFileEventRepository = mock(FlowFileEventRepository.class);
         authorizer = mock(Authorizer.class);
         mockAuditService = mock(AuditService.class);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFlowController.java
@@ -159,7 +159,7 @@ public class TestFlowController {
         policies1.add(policy2);
 
         authorizer = new MockPolicyBasedAuthorizer(groups1, users1, policies1);
-        variableRegistry = new FileBasedVariableRegistry(nifiProperties.getVariableRegistryPropertiesPaths());
+        variableRegistry = new FileBasedVariableRegistry(nifiProperties.getVariableRegistryPropertiesPaths(), nifiProperties.getVariableRegistryCheckSchedule());
 
         bulletinRepo = Mockito.mock(BulletinRepository.class);
         controller = FlowController.createStandaloneInstance(flowFileEventRepo, nifiProperties, authorizer, auditService, encryptor, bulletinRepo, variableRegistry);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/StandardControllerServiceProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/StandardControllerServiceProviderTest.java
@@ -52,7 +52,7 @@ public class StandardControllerServiceProviderTest {
         systemBundle = SystemBundle.create(nifiProperties);
         ExtensionManager.discoverExtensions(systemBundle, NarClassLoaders.getInstance().getBundles());
 
-        variableRegistry = new FileBasedVariableRegistry(nifiProperties.getVariableRegistryPropertiesPaths());
+        variableRegistry = new FileBasedVariableRegistry(nifiProperties.getVariableRegistryPropertiesPaths(), nifiProperties.getVariableRegistryCheckSchedule());
     }
 
     @Before

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/util/TestFileBasedVariableRegistry.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/util/TestFileBasedVariableRegistry.java
@@ -16,14 +16,23 @@
  */
 package org.apache.nifi.util;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
 import org.apache.nifi.registry.VariableDescriptor;
 import org.apache.nifi.registry.VariableRegistry;
+
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 /**
  *
@@ -34,12 +43,140 @@ public class TestFileBasedVariableRegistry {
     public void testCreateCustomVariableRegistry() {
         final Path fooPath = Paths.get("src/test/resources/TestVariableRegistry/foobar.properties");
         final Path testPath = Paths.get("src/test/resources/TestVariableRegistry/test.properties");
-        Path[] paths = {fooPath, testPath};
+        final Path[] paths = {fooPath, testPath};
         final String vendorUrl = System.getProperty("java.vendor.url");
-        VariableRegistry variableRegistry = new FileBasedVariableRegistry(paths);
+        final VariableRegistry variableRegistry = new FileBasedVariableRegistry(paths);
         final Map<VariableDescriptor, String> variables = variableRegistry.getVariableMap();
-        assertTrue(variables.containsKey(new VariableDescriptor("fake.property.3")));
+
+        assertThat(variables, hasEntry(new VariableDescriptor("java.vendor.url"), vendorUrl));
         assertEquals(vendorUrl, variableRegistry.getVariableValue("java.vendor.url"));
+
+        assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3, test me out 4"));
         assertEquals("test me out 3, test me out 4", variableRegistry.getVariableValue("fake.property.3"));
     }
+
+    @Test
+    public void testCustomVariableRegistryWithCheckSchedule() throws IOException, InterruptedException {
+        final Path testPath = Files.createTempFile("test", "properties");
+        final File testFile = testPath.toFile();
+        try {
+            FileOutputStream fos = new FileOutputStream(testFile);
+            try {
+                fos.write("fake.property.3=test me out 3, test me out 4\n".getBytes("UTF-8"));
+                fos.getFD().sync();
+            } finally {
+                fos.close();
+            }
+
+            final Path[] paths = {testPath};
+            final VariableRegistry variableRegistry = new FileBasedVariableRegistry(paths, "10 ms");
+            Map<VariableDescriptor, String> variables = variableRegistry.getVariableMap();
+
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3, test me out 4"));
+            assertEquals("test me out 3, test me out 4", variableRegistry.getVariableValue("fake.property.3"));
+
+            fos = new FileOutputStream(testFile);
+            try {
+                fos.write("fake.property.3=test me out 3\n".getBytes("UTF-8"));
+                fos.write("fake.property.4=test me out 4\n".getBytes("UTF-8"));
+                fos.getFD().sync();
+            } finally {
+                fos.close();
+            }
+
+            Thread.sleep(100L);
+
+            variables = variableRegistry.getVariableMap();
+
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3"));
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.4"), "test me out 4"));
+            assertEquals("test me out 3", variableRegistry.getVariableValue("fake.property.3"));
+            assertEquals("test me out 4", variableRegistry.getVariableValue("fake.property.4"));
+        } finally {
+            Files.deleteIfExists(testPath);
+        }
+    }
+
+    @Test
+    public void testCustomVariableRegistryWithoutCheckSchedule() throws IOException, InterruptedException {
+        final Path testPath = Files.createTempFile("test", "properties");
+        final File testFile = testPath.toFile();
+        try {
+            FileOutputStream fos = new FileOutputStream(testFile);
+            try {
+                fos.write("fake.property.3=test me out 3, test me out 4\n".getBytes("UTF-8"));
+                fos.getFD().sync();
+            } finally {
+                fos.close();
+            }
+
+            final Path[] paths = {testPath};
+            final VariableRegistry variableRegistry = new FileBasedVariableRegistry(paths, "");
+            Map<VariableDescriptor, String> variables = variableRegistry.getVariableMap();
+
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3, test me out 4"));
+            assertEquals("test me out 3, test me out 4", variableRegistry.getVariableValue("fake.property.3"));
+
+            fos = new FileOutputStream(testFile);
+            try {
+                fos.write("fake.property.3=test me out 3\n".getBytes("UTF-8"));
+                fos.write("fake.property.4=test me out 4\n".getBytes("UTF-8"));
+                fos.getFD().sync();
+            } finally {
+                fos.close();
+            }
+
+            Thread.sleep(100L);
+
+            variables = variableRegistry.getVariableMap();
+
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3, test me out 4"));
+            assertThat(variables, not(hasKey(new VariableDescriptor("fake.property.4"))));
+            assertEquals("test me out 3, test me out 4", variableRegistry.getVariableValue("fake.property.3"));
+        } finally {
+            Files.deleteIfExists(testPath);
+        }
+    }
+
+    @Test
+    public void testCustomVariableRegistryWithZeroCheckSchedule() throws IOException, InterruptedException {
+        final Path testPath = Files.createTempFile("test", "properties");
+        final File testFile = testPath.toFile();
+        try {
+            FileOutputStream fos = new FileOutputStream(testFile);
+            try {
+                fos.write("fake.property.3=test me out 3, test me out 4\n".getBytes("UTF-8"));
+                fos.getFD().sync();
+            } finally {
+                fos.close();
+            }
+
+            final Path[] paths = {testPath};
+            final VariableRegistry variableRegistry = new FileBasedVariableRegistry(paths, "0 secs");
+            Map<VariableDescriptor, String> variables = variableRegistry.getVariableMap();
+
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3, test me out 4"));
+            assertEquals("test me out 3, test me out 4", variableRegistry.getVariableValue("fake.property.3"));
+
+            fos = new FileOutputStream(testFile);
+            try {
+                fos.write("fake.property.3=test me out 3\n".getBytes("UTF-8"));
+                fos.write("fake.property.4=test me out 4\n".getBytes("UTF-8"));
+                fos.getFD().sync();
+            } finally {
+                fos.close();
+            }
+
+            Thread.sleep(100L);
+
+            variables = variableRegistry.getVariableMap();
+
+            assertThat(variables, hasEntry(new VariableDescriptor("fake.property.3"), "test me out 3, test me out 4"));
+            assertThat(variables, not(hasKey(new VariableDescriptor("fake.property.4"))));
+            assertEquals("test me out 3, test me out 4", variableRegistry.getVariableValue("fake.property.3"));
+        } finally {
+            Files.deleteIfExists(testPath);
+        }
+    }
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -173,6 +173,9 @@
         <nifi.kerberos.spnego.principal />
         <nifi.kerberos.spnego.keytab.location />
         <nifi.kerberos.spnego.authentication.expiration>12 hours</nifi.kerberos.spnego.authentication.expiration>
+
+        <!-- nifi.properties: variable registry properties -->
+        <nifi.variable.registry.check.schedule>30 secs</nifi.variable.registry.check.schedule>
     </properties>
     <build>
         <plugins>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -93,7 +93,7 @@ nifi.provenance.repository.index.threads=${nifi.provenance.repository.index.thre
 nifi.provenance.repository.compress.on.rollover=${nifi.provenance.repository.compress.on.rollover}
 nifi.provenance.repository.always.sync=${nifi.provenance.repository.always.sync}
 nifi.provenance.repository.journal.count=${nifi.provenance.repository.journal.count}
-# Comma-separated list of fields. Fields that are not indexed will not be searchable. Valid fields are: 
+# Comma-separated list of fields. Fields that are not indexed will not be searchable. Valid fields are:
 # EventType, FlowFileUUID, Filename, TransitURI, ProcessorID, AlternateIdentifierURI, Relationship, Details
 nifi.provenance.repository.indexed.fields=${nifi.provenance.repository.indexed.fields}
 # FlowFile Attributes that should be indexed and made searchable.  Some examples to consider are filename, uuid, mime.type
@@ -198,3 +198,4 @@ nifi.kerberos.spnego.authentication.expiration=${nifi.kerberos.spnego.authentica
 # external properties files for variable registry
 # supports a comma delimited list of file locations
 nifi.variable.registry.properties=
+nifi.variable.registry.check.schedule=${nifi.variable.registry.check.schedule}


### PR DESCRIPTION
There's one implementation decision I'm curious to hear comments on: If the schedule property is blank or 0s, should it disable the reloading? It doesn't do that at the moment.
