### PR TITLE
Fixed issue uploading templates into descendant Process Groups

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-operate-controller.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-operate-controller.js
@@ -114,8 +114,12 @@ nf.ng.Canvas.OperateCtrl = function () {
                 init: function () {
                     // initialize the form
                     var templateForm = $('#template-upload-form').ajaxForm({
-                        url: '../nifi-api/process-groups/' + encodeURIComponent(nf.Canvas.getGroupId()) + '/templates/upload',
+                        url: '../nifi-api/process-groups/',
                         dataType: 'xml',
+                        beforeSubmit: function (formData, $form, options) {
+                            // ensure uploading to the current process group
+                            options.url += (encodeURIComponent(nf.Canvas.getGroupId()) + '/templates/upload');
+                        },
                         success: function (response, statusText, xhr, form) {
                             // see if the import was successful
                             if (response.documentElement.tagName === 'templateEntity') {


### PR DESCRIPTION
NIFI-2785:
- Ensure the URL is updated when uploading a template to ensure it's going to the appropriate Process Group.