### PR TITLE
Correcting documentation for ExecuteFlumeSink

### DIFF
--- a/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-processors/src/main/resources/docs/org.apache.nifi.processors.flume.ExecuteFlumeSink/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-processors/src/main/resources/docs/org.apache.nifi.processors.flume.ExecuteFlumeSink/additionalDetails.html
@@ -46,10 +46,6 @@
         <td>FlowFile#getLastQueueDate()</td>
     </tr>
     <tr>
-        <td>nifi.lineage.identifiers.${i}</td>
-        <td>FlowFile#getLineageIdentifiers()[i]</td>
-    </tr>
-    <tr>
         <td>nifi.lineage.start.date</td>
         <td>FlowFile#getLineageStartDate()</td>
     </tr>


### PR DESCRIPTION
Removing reference to removed lineage identifier header for ExecuteFlumeSink additional details.