### PR TITLE
NIFI-2802 The implementation classes don't support orderByClause.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/GenericDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/GenericDatabaseAdapter.java
@@ -48,7 +48,7 @@ public class GenericDatabaseAdapter implements DatabaseAdapter {
         }
         if (!StringUtils.isEmpty(orderByClause)) {
             query.append(" ORDER BY ");
-            query.append(whereClause);
+            query.append(orderByClause);
         }
         if (limit != null) {
             query.append(" LIMIT ");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
@@ -62,7 +62,7 @@ public class OracleDatabaseAdapter implements DatabaseAdapter {
         }
         if (!StringUtils.isEmpty(orderByClause)) {
             query.append(" ORDER BY ");
-            query.append(whereClause);
+            query.append(orderByClause);
         }
         if (nestedSelect) {
             query.append(") a");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
@@ -49,7 +49,7 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
         }
         if (!StringUtils.isEmpty(orderByClause)) {
             query.append(" ORDER BY ");
-            query.append(whereClause);
+            query.append(orderByClause);
         }
         if (offset != null && offset > 0) {
             query.append(" OFFSET ");


### PR DESCRIPTION
The implementation classes don't support orderByClause.
The below code is the part of GenericDatabaseAdapter class(even OracleDatabaseAdapter and DerbyDatabaseAdapter).

if (!StringUtils.isEmpty(orderByClause)) {
 query.append(" ORDER BY "); query.append(whereClause);
}

Expected:
if (!StringUtils.isEmpty(orderByClause)) {
 query.append(" ORDER BY "); query.append(orderByClause);
}