### PR TITLE
NIFI-1458: Added ScriptedReportingTask

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-nar/src/main/resources/META-INF/NOTICE
@@ -33,6 +33,20 @@ The following binary components are provided under the Apache Software License v
         This product includes software from the Spring Framework,
         under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 
+  (ASLv2) Yammer Metrics
+      The following NOTICE information applies:
+        Metrics
+        Copyright 2010-2012 Coda Hale and Yammer, Inc.
+
+        This product includes software developed by Coda Hale and Yammer, Inc.
+
+        This product includes code derived from the JSR-166 project (ThreadLocalRandom), which was released
+        with the following comments:
+
+            Written by Doug Lea with assistance from members of JCP JSR-166
+            Expert Group and released to the public domain, as explained at
+            http://creativecommons.org/publicdomain/zero/1.0/
+
 ******************
 Eclipse Public License v1.0
 ******************

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.yammer.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <scope>test</scope>

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ExecuteScript.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ExecuteScript.java
@@ -72,11 +72,11 @@ import java.util.Set;
 public class ExecuteScript extends AbstractSessionFactoryProcessor {
 
     // Constants maintained for backwards compatibility
-    public static final Relationship REL_SUCCESS = ScriptingComponentHelper.REL_SUCCESS;
-    public static final Relationship REL_FAILURE = ScriptingComponentHelper.REL_FAILURE;
+    public static final Relationship REL_SUCCESS = ScriptingComponentUtils.REL_SUCCESS;
+    public static final Relationship REL_FAILURE = ScriptingComponentUtils.REL_FAILURE;
 
     private String scriptToRun = null;
-    private volatile ScriptingComponentHelper scriptingComponentHelper = new ScriptingComponentHelper();
+    volatile ScriptingComponentHelper scriptingComponentHelper = new ScriptingComponentHelper();
 
 
     /**
@@ -107,7 +107,7 @@ public class ExecuteScript extends AbstractSessionFactoryProcessor {
             }
         }
 
-        return Collections.unmodifiableList(scriptingComponentHelper.descriptors);
+        return Collections.unmodifiableList(scriptingComponentHelper.getDescriptors());
     }
 
     /**
@@ -146,11 +146,11 @@ public class ExecuteScript extends AbstractSessionFactoryProcessor {
         // Create a script engine for each possible task
         int maxTasks = context.getMaxConcurrentTasks();
         scriptingComponentHelper.setup(maxTasks, getLogger());
-        scriptToRun = scriptingComponentHelper.scriptBody;
+        scriptToRun = scriptingComponentHelper.getScriptBody();
 
         try {
-            if (scriptToRun == null && scriptingComponentHelper.scriptPath != null) {
-                try (final FileInputStream scriptStream = new FileInputStream(scriptingComponentHelper.scriptPath)) {
+            if (scriptToRun == null && scriptingComponentHelper.getScriptPath() != null) {
+                try (final FileInputStream scriptStream = new FileInputStream(scriptingComponentHelper.getScriptPath())) {
                     scriptToRun = IOUtils.toString(scriptStream, Charset.defaultCharset());
                 }
             }
@@ -211,11 +211,11 @@ public class ExecuteScript extends AbstractSessionFactoryProcessor {
 
                 // Execute any engine-specific configuration before the script is evaluated
                 ScriptEngineConfigurator configurator =
-                        scriptingComponentHelper.scriptEngineConfiguratorMap.get(scriptingComponentHelper.scriptEngineName.toLowerCase());
+                        scriptingComponentHelper.scriptEngineConfiguratorMap.get(scriptingComponentHelper.getScriptEngineName().toLowerCase());
 
                 // Evaluate the script with the configurator (if it exists) or the engine
                 if (configurator != null) {
-                    configurator.eval(scriptEngine, scriptToRun, scriptingComponentHelper.modules);
+                    configurator.eval(scriptEngine, scriptToRun, scriptingComponentHelper.getModules());
                 } else {
                     scriptEngine.eval(scriptToRun);
                 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptingComponentUtils.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptingComponentUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.script;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.util.StandardValidators;
+
+/**
+ * Utility methods and constants used by the scripting components.
+ */
+public class ScriptingComponentUtils {
+    /** A relationship indicating flow files were processed successfully */
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles that were successfully processed")
+            .build();
+
+    /** A relationship indicating an error while processing flow files */
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("FlowFiles that failed to be processed")
+            .build();
+
+    /** A property descriptor for specifying the location of a script file */
+    public static final PropertyDescriptor SCRIPT_FILE = new PropertyDescriptor.Builder()
+            .name("Script File")
+            .required(false)
+            .description("Path to script file to execute. Only one of Script File or Script Body may be used")
+            .addValidator(new StandardValidators.FileExistsValidator(true))
+            .expressionLanguageSupported(true)
+            .build();
+
+    /** A property descriptor for specifying the body of a script */
+    public static final PropertyDescriptor SCRIPT_BODY = new PropertyDescriptor.Builder()
+            .name("Script Body")
+            .required(false)
+            .description("Body of script to execute. Only one of Script File or Script Body may be used")
+            .addValidator(Validator.VALID)
+            .expressionLanguageSupported(false)
+            .build();
+
+    /** A property descriptor for specifying the location of additional modules to be used by the script */
+    public static final PropertyDescriptor MODULES = new PropertyDescriptor.Builder()
+            .name("Module Directory")
+            .description("Comma-separated list of paths to files and/or directories which contain modules required by the script.")
+            .required(false)
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+}
+

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/reporting/script/ScriptedReportingTask.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/reporting/script/ScriptedReportingTask.java
@@ -18,6 +18,8 @@ package org.apache.nifi.reporting.script;
 
 import com.yammer.metrics.core.VirtualMachineMetrics;
 import org.apache.commons.io.IOUtils;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -55,6 +57,13 @@ import java.util.Map;
 @CapabilityDescription("Provides reporting and status information to a script. ReportingContext, ComponentLog, and VirtualMachineMetrics objects are made available "
         + "as variables (context, log, and vmMetrics, respectively) to the script for further processing. The context makes various information available such "
         + "as events, provenance, bulletins, controller services, process groups, Java Virtual Machine metrics, etc.")
+@DynamicProperty(
+        name = "A script engine property to update",
+        value = "The value to set it to",
+        supportsExpressionLanguage = true,
+        description = "Updates a script engine property specified by the Dynamic Property's key with the value "
+                + "specified by the Dynamic Property's value")
+@Restricted("Provides operator the ability to execute arbitrary code assuming all permissions that NiFi has.")
 public class ScriptedReportingTask extends AbstractReportingTask {
 
     protected volatile ScriptingComponentHelper scriptingComponentHelper = new ScriptingComponentHelper();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/resources/META-INF/services/org.apache.nifi.reporting.ReportingTask
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/resources/META-INF/services/org.apache.nifi.reporting.ReportingTask
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.reporting.script.ScriptedReportingTask

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
@@ -49,9 +49,9 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         super.setupExecuteScript()
 
         runner.setValidateExpressionUsage(false)
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy")
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
-        runner.setProperty(ExecuteScript.MODULES, TEST_RESOURCE_LOCATION + "groovy")
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy")
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
+        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy")
     }
 
     @After
@@ -65,9 +65,9 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         assertNotNull(executeScript.getSupportedPropertyDescriptors())
         runner = TestRunners.newTestRunner(executeScript)
         runner.setValidateExpressionUsage(false)
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy")
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
-        runner.setProperty(ExecuteScript.MODULES, TEST_RESOURCE_LOCATION + "groovy")
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy")
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
+        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy")
 
         // Override userContext value
         runner.processContext.maxConcurrentTasks = poolSize

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
@@ -49,9 +49,9 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         super.setupExecuteScript()
 
         runner.setValidateExpressionUsage(false)
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy")
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
-        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy")
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy")
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
+        runner.setProperty(ScriptingComponentUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy")
     }
 
     @After
@@ -65,9 +65,9 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         assertNotNull(executeScript.getSupportedPropertyDescriptors())
         runner = TestRunners.newTestRunner(executeScript)
         runner.setValidateExpressionUsage(false)
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy")
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
-        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy")
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy")
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
+        runner.setProperty(ScriptingComponentUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy")
 
         // Override userContext value
         runner.processContext.maxConcurrentTasks = poolSize

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.groovy
@@ -49,9 +49,9 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         super.setupExecuteScript()
 
         runner.setValidateExpressionUsage(false)
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy")
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
-        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy")
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy")
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
+        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy")
     }
 
     @After
@@ -65,9 +65,9 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         assertNotNull(executeScript.getSupportedPropertyDescriptors())
         runner = TestRunners.newTestRunner(executeScript)
         runner.setValidateExpressionUsage(false)
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy")
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
-        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy")
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy")
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/testAddTimeAndThreadAttribute.groovy")
+        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy")
 
         // Override userContext value
         runner.processContext.maxConcurrentTasks = poolSize

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/reporting/script/ScriptedReportingTaskGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/reporting/script/ScriptedReportingTaskGroovyTest.groovy
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.reporting.script
+
+import org.apache.commons.io.FileUtils
+import org.apache.nifi.components.PropertyDescriptor
+import org.apache.nifi.components.PropertyValue
+import org.apache.nifi.controller.ConfigurationContext
+import org.apache.nifi.logging.ComponentLog
+import org.apache.nifi.processors.script.ScriptUtils
+import org.apache.nifi.provenance.ProvenanceEventBuilder
+import org.apache.nifi.provenance.ProvenanceEventRecord
+import org.apache.nifi.provenance.ProvenanceEventRepository
+import org.apache.nifi.provenance.ProvenanceEventType
+import org.apache.nifi.provenance.StandardProvenanceEventRecord
+import org.apache.nifi.reporting.EventAccess
+import org.apache.nifi.reporting.ReportingContext
+import org.apache.nifi.reporting.ReportingInitializationContext
+import org.apache.nifi.state.MockStateManager
+import org.apache.nifi.util.MockFlowFile
+import org.apache.nifi.util.MockPropertyValue
+import org.apache.nifi.util.TestRunners
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mockito
+import org.mockito.stubbing.Answer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+import static org.mockito.Mockito.any
+import static org.mockito.Mockito.doAnswer
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
+
+/**
+ * Unit tests for ScriptedReportingTask.
+ */
+@RunWith(JUnit4.class)
+public class ScriptedReportingTaskGroovyTest {
+    private static final Logger logger = LoggerFactory.getLogger(ScriptedReportingTaskGroovyTest)
+    def task
+    def runner
+
+
+    @BeforeClass
+    static void setUpOnce() throws Exception {
+        logger.metaClass.methodMissing = { String name, args ->
+            logger.info("[${name?.toUpperCase()}] ${(args as List).join(" ")}")
+        }
+        FileUtils.copyDirectory('src/test/resources' as File, 'target/test/resources' as File)
+    }
+
+    @Before
+    void setUp() {
+        task = new MockScriptedReportingTask()
+        runner = TestRunners
+    }
+
+    @Test
+    void testProvenanceGroovyScript() {
+        def uuid = "10000000-0000-0000-0000-000000000000"
+        def attributes = ['abc': 'xyz', 'xyz': 'abc', 'filename': "file-$uuid", 'uuid': uuid]
+        def prevAttrs = ['filename': '1234.xyz']
+
+        def flowFile = new MockFlowFile(3L)
+        flowFile.putAttributes(attributes)
+        final ProvenanceEventBuilder builder = new StandardProvenanceEventRecord.Builder();
+        builder.eventTime = System.currentTimeMillis()
+        builder.eventType = ProvenanceEventType.RECEIVE
+        builder.transitUri = 'nifi://unit-test'
+        builder.setAttributes(prevAttrs, attributes)
+        builder.componentId = '1234'
+        builder.componentType = 'dummy processor'
+        builder.fromFlowFile(flowFile)
+        final ProvenanceEventRecord event = builder.build()
+
+        def properties = task.supportedPropertyDescriptors.collectEntries { descriptor ->
+            [descriptor: descriptor.getDefaultValue()]
+        }
+
+        // Mock the ConfigurationContext for setup(...)
+        def configurationContext = mock(ConfigurationContext)
+        when(configurationContext.getProperty(ScriptUtils.SCRIPT_ENGINE))
+                .thenReturn(new MockPropertyValue('Groovy'))
+        when(configurationContext.getProperty(ScriptUtils.SCRIPT_FILE))
+                .thenReturn(new MockPropertyValue('target/test/resources/groovy/test_log_provenance_events.groovy'))
+        when(configurationContext.getProperty(ScriptUtils.SCRIPT_BODY))
+                .thenReturn(new MockPropertyValue(null))
+        when(configurationContext.getProperty(ScriptUtils.MODULES))
+                .thenReturn(new MockPropertyValue(null))
+
+        // Set up ReportingContext
+        def context = mock(ReportingContext)
+        when(context.getStateManager()).thenReturn(new MockStateManager(task))
+        doAnswer({ invocation ->
+            def descriptor = invocation.getArgumentAt(0, PropertyDescriptor)
+            return new MockPropertyValue(properties[descriptor])
+        } as Answer<PropertyValue>
+        ).when(context).getProperty(any(PropertyDescriptor))
+
+
+        def eventAccess = mock(EventAccess)
+        // Return 3 events for the test
+        doAnswer({ invocation -> return [event, event, event] } as Answer<List<ProvenanceEventRecord>>
+        ).when(eventAccess).getProvenanceEvents(Mockito.anyLong(), Mockito.anyInt())
+
+        def provenanceRepository = mock(ProvenanceEventRepository.class)
+        doAnswer({ invocation -> return 3 } as Answer<Long>
+        ).when(provenanceRepository).getMaxEventId()
+
+        when(context.getEventAccess()).thenReturn(eventAccess);
+        when(eventAccess.getProvenanceRepository()).thenReturn(provenanceRepository)
+
+        def logger = mock(ComponentLog)
+        def initContext = mock(ReportingInitializationContext)
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString())
+        when(initContext.getLogger()).thenReturn(logger)
+
+        task.initialize initContext
+        task.setup configurationContext
+        task.onTrigger context
+
+        // This script should return a variable x with the number of events and a variable e with the first event
+        def se = task.scriptEngine
+        assertEquals 3, se.x
+        assertEquals '1234', se.e.componentId
+        assertEquals 'xyz', se.e.attributes.abc
+        task.offerScriptEngine(se)
+
+    }
+
+    @Test
+    void testVMEventsGroovyScript() {
+
+        def properties = [:] as Map<PropertyDescriptor, String>
+        task.getSupportedPropertyDescriptors().each { PropertyDescriptor descriptor ->
+            properties.put(descriptor, descriptor.getDefaultValue())
+        }
+
+        // Mock the ConfigurationContext for setup(...)
+        def configurationContext = mock(ConfigurationContext)
+        when(configurationContext.getProperty(ScriptUtils.SCRIPT_ENGINE))
+                .thenReturn(new MockPropertyValue('Groovy'))
+        when(configurationContext.getProperty(ScriptUtils.SCRIPT_FILE))
+                .thenReturn(new MockPropertyValue('target/test/resources/groovy/test_log_vm_stats.groovy'))
+        when(configurationContext.getProperty(ScriptUtils.SCRIPT_BODY))
+                .thenReturn(new MockPropertyValue(null))
+        when(configurationContext.getProperty(ScriptUtils.MODULES))
+                .thenReturn(new MockPropertyValue(null))
+
+        // Set up ReportingContext
+        def context = mock(ReportingContext)
+        when(context.getStateManager()).thenReturn(new MockStateManager(task))
+        doAnswer({ invocation ->
+            PropertyDescriptor descriptor = invocation.getArgumentAt(0, PropertyDescriptor)
+            return new MockPropertyValue(properties[descriptor])
+        } as Answer<PropertyValue>
+        ).when(context).getProperty(any(PropertyDescriptor))
+
+
+        def logger = mock(ComponentLog)
+        def initContext = mock(ReportingInitializationContext)
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString())
+        when(initContext.getLogger()).thenReturn(logger)
+
+        task.initialize initContext
+        task.setup configurationContext
+        task.onTrigger context
+        def se = task.scriptEngine
+        // This script should store a variable called x with a map of stats to values
+        assertTrue se.x?.uptime > 0
+        task.offerScriptEngine(se)
+
+    }
+
+    class MockScriptedReportingTask extends ScriptedReportingTask {
+        def getScriptEngine() {
+            return scriptUtils.engineQ.poll()
+        }
+
+        def offerScriptEngine(engine) {
+            this.scriptUtils.engineQ.offer(engine)
+        }
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/reporting/script/ScriptedReportingTaskGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/groovy/org/apache/nifi/reporting/script/ScriptedReportingTaskGroovyTest.groovy
@@ -21,7 +21,7 @@ import org.apache.nifi.components.PropertyDescriptor
 import org.apache.nifi.components.PropertyValue
 import org.apache.nifi.controller.ConfigurationContext
 import org.apache.nifi.logging.ComponentLog
-import org.apache.nifi.processors.script.ScriptUtils
+import org.apache.nifi.processors.script.ScriptingComponentHelper
 import org.apache.nifi.provenance.ProvenanceEventBuilder
 import org.apache.nifi.provenance.ProvenanceEventRecord
 import org.apache.nifi.provenance.ProvenanceEventRepository
@@ -100,13 +100,13 @@ public class ScriptedReportingTaskGroovyTest {
 
         // Mock the ConfigurationContext for setup(...)
         def configurationContext = mock(ConfigurationContext)
-        when(configurationContext.getProperty(ScriptUtils.SCRIPT_ENGINE))
+        when(configurationContext.getProperty(ScriptingComponentHelper.SCRIPT_ENGINE))
                 .thenReturn(new MockPropertyValue('Groovy'))
-        when(configurationContext.getProperty(ScriptUtils.SCRIPT_FILE))
+        when(configurationContext.getProperty(ScriptingComponentHelper.SCRIPT_FILE))
                 .thenReturn(new MockPropertyValue('target/test/resources/groovy/test_log_provenance_events.groovy'))
-        when(configurationContext.getProperty(ScriptUtils.SCRIPT_BODY))
+        when(configurationContext.getProperty(ScriptingComponentHelper.SCRIPT_BODY))
                 .thenReturn(new MockPropertyValue(null))
-        when(configurationContext.getProperty(ScriptUtils.MODULES))
+        when(configurationContext.getProperty(ScriptingComponentHelper.MODULES))
                 .thenReturn(new MockPropertyValue(null))
 
         // Set up ReportingContext
@@ -159,13 +159,13 @@ public class ScriptedReportingTaskGroovyTest {
 
         // Mock the ConfigurationContext for setup(...)
         def configurationContext = mock(ConfigurationContext)
-        when(configurationContext.getProperty(ScriptUtils.SCRIPT_ENGINE))
+        when(configurationContext.getProperty(ScriptingComponentHelper.SCRIPT_ENGINE))
                 .thenReturn(new MockPropertyValue('Groovy'))
-        when(configurationContext.getProperty(ScriptUtils.SCRIPT_FILE))
+        when(configurationContext.getProperty(ScriptingComponentHelper.SCRIPT_FILE))
                 .thenReturn(new MockPropertyValue('target/test/resources/groovy/test_log_vm_stats.groovy'))
-        when(configurationContext.getProperty(ScriptUtils.SCRIPT_BODY))
+        when(configurationContext.getProperty(ScriptingComponentHelper.SCRIPT_BODY))
                 .thenReturn(new MockPropertyValue(null))
-        when(configurationContext.getProperty(ScriptUtils.MODULES))
+        when(configurationContext.getProperty(ScriptingComponentHelper.MODULES))
                 .thenReturn(new MockPropertyValue(null))
 
         // Set up ReportingContext
@@ -195,11 +195,11 @@ public class ScriptedReportingTaskGroovyTest {
 
     class MockScriptedReportingTask extends ScriptedReportingTask {
         def getScriptEngine() {
-            return scriptUtils.engineQ.poll()
+            return scriptingComponentHelper.engineQ.poll()
         }
 
         def offerScriptEngine(engine) {
-            this.scriptUtils.engineQ.offer(engine)
+            this.scriptingComponentHelper.engineQ.offer(engine)
         }
     }
 

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/AccessibleScriptingComponentHelper.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/AccessibleScriptingComponentHelper.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.script;
+
+/**
+ * An interface for retrieving the scripting component helper for a scripting processor. Aids in testing (for setting the Script Engine descriptor, for example).
+ */
+public interface AccessibleScriptingComponentHelper {
+    ScriptingComponentHelper getScriptingComponentHelper();
+}

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/BaseScriptTest.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/BaseScriptTest.java
@@ -35,8 +35,8 @@ public abstract class BaseScriptTest {
 
     public final String TEST_RESOURCE_LOCATION = "target/test/resources/";
 
-
     protected TestRunner runner;
+    protected AccessibleScriptingComponentHelper scriptingComponent;
 
     /**
      * Copies all scripts to the target directory because when they are compiled they can leave unwanted .class files.
@@ -49,17 +49,19 @@ public abstract class BaseScriptTest {
     }
 
     public void setupExecuteScript() throws Exception {
-        final ExecuteScript executeScript = new ExecuteScript();
+        final ExecuteScript executeScript = new AccessibleExecuteScript();
         // Need to do something to initialize the properties, like retrieve the list of properties
         assertNotNull(executeScript.getSupportedPropertyDescriptors());
         runner = TestRunners.newTestRunner(executeScript);
+        scriptingComponent = (AccessibleScriptingComponentHelper) executeScript;
     }
 
     public void setupInvokeScriptProcessor() throws Exception {
-        final InvokeScriptedProcessor invokeScriptedProcessor = new InvokeScriptedProcessor();
+        final InvokeScriptedProcessor invokeScriptedProcessor = new AccessibleInvokeScriptedProcessor();
         // Need to do something to initialize the properties, like retrieve the list of properties
         assertNotNull(invokeScriptedProcessor.getSupportedPropertyDescriptors());
         runner = TestRunners.newTestRunner(invokeScriptedProcessor);
+        scriptingComponent = (AccessibleScriptingComponentHelper) invokeScriptedProcessor;
     }
 
     public String getFileContentsAsString(String path) {
@@ -67,6 +69,20 @@ public abstract class BaseScriptTest {
             return new String(Files.readAllBytes(Paths.get(path)));
         } catch (IOException ioe) {
             return null;
+        }
+    }
+
+    class AccessibleExecuteScript extends ExecuteScript implements AccessibleScriptingComponentHelper {
+        @Override
+        public ScriptingComponentHelper getScriptingComponentHelper() {
+            return this.scriptingComponentHelper;
+        }
+    }
+
+    class AccessibleInvokeScriptedProcessor extends InvokeScriptedProcessor implements AccessibleScriptingComponentHelper {
+        @Override
+        public ScriptingComponentHelper getScriptingComponentHelper() {
+            return this.scriptingComponentHelper;
         }
     }
 }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
@@ -46,9 +46,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -67,9 +67,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testNoIncomingFlowFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.run();
@@ -86,9 +86,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testInvalidConfiguration() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, "body");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, "body");
 
         runner.assertNotValid();
     }
@@ -101,9 +101,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testCreateNewFlowFileWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
-        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
+        runner.setProperty(ScriptingComponentUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));
@@ -124,8 +124,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testCreateNewFlowFileWithNoInputFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY,
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY,
                 getFileContentsAsString(TEST_RESOURCE_LOCATION + "groovy/testCreateNewFlowFileWithNoInputFile.groovy")
         );
 
@@ -145,8 +145,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testDynamicProperties() throws Exception {
         runner.setValidateExpressionUsage(true);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_dynamicProperties.groovy");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_dynamicProperties.groovy");
         runner.setProperty("myProp", "${myAttr}");
 
         runner.assertValid();
@@ -169,9 +169,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testChangeFlowFileWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_onTrigger_changeContent.groovy");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/groovy/test_onTrigger_changeContent.groovy");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));
@@ -193,11 +193,11 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody.groovy")
         );
-        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy");
+        runner.setProperty(ScriptingComponentUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -217,8 +217,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBodyNoModules() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBodyNoModules.groovy")
         );
         runner.assertValid();
@@ -238,8 +238,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptNoTransfer() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testScriptNoTransfer.groovy")
         );
 
@@ -257,8 +257,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileCustomAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileCustomAttribute.groovy")
         );
         runner.setProperty("testprop", "test content");
@@ -281,8 +281,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptException() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, "throw new Exception()");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, "throw new Exception()");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
@@ -46,9 +46,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -67,9 +67,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testNoIncomingFlowFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.run();
@@ -86,9 +86,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testInvalidConfiguration() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, "body");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, "body");
 
         runner.assertNotValid();
     }
@@ -101,9 +101,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testCreateNewFlowFileWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
-        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
+        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));
@@ -124,8 +124,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testCreateNewFlowFileWithNoInputFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY,
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY,
                 getFileContentsAsString(TEST_RESOURCE_LOCATION + "groovy/testCreateNewFlowFileWithNoInputFile.groovy")
         );
 
@@ -145,8 +145,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testDynamicProperties() throws Exception {
         runner.setValidateExpressionUsage(true);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_dynamicProperties.groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_dynamicProperties.groovy");
         runner.setProperty("myProp", "${myAttr}");
 
         runner.assertValid();
@@ -169,9 +169,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testChangeFlowFileWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_onTrigger_changeContent.groovy");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_onTrigger_changeContent.groovy");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));
@@ -193,11 +193,11 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody.groovy")
         );
-        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy");
+        runner.setProperty(ScriptingComponentHelper.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -217,8 +217,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBodyNoModules() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBodyNoModules.groovy")
         );
         runner.assertValid();
@@ -238,8 +238,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptNoTransfer() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testScriptNoTransfer.groovy")
         );
 
@@ -257,8 +257,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileCustomAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileCustomAttribute.groovy")
         );
         runner.setProperty("testprop", "test content");
@@ -281,8 +281,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptException() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, "throw new Exception()");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, "throw new Exception()");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TestExecuteGroovy extends BaseScriptTest {
 
-    public final String TEST_CSV_DATA = "gender,title,first,last\n"
+    private final String TEST_CSV_DATA = "gender,title,first,last\n"
             + "female,miss,marlene,shaw\n"
             + "male,mr,todd,graham";
 
@@ -46,9 +46,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -67,9 +67,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testNoIncomingFlowFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.run();
@@ -86,9 +86,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testInvalidConfiguration() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, "body");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, "body");
 
         runner.assertNotValid();
     }
@@ -101,9 +101,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testCreateNewFlowFileWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
-        runner.setProperty(ExecuteScript.MODULES, TEST_RESOURCE_LOCATION + "groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger_newFlowFile.groovy");
+        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));
@@ -124,8 +124,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testCreateNewFlowFileWithNoInputFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY,
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY,
                 getFileContentsAsString(TEST_RESOURCE_LOCATION + "groovy/testCreateNewFlowFileWithNoInputFile.groovy")
         );
 
@@ -145,8 +145,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testDynamicProperties() throws Exception {
         runner.setValidateExpressionUsage(true);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_dynamicProperties.groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_dynamicProperties.groovy");
         runner.setProperty("myProp", "${myAttr}");
 
         runner.assertValid();
@@ -169,9 +169,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testChangeFlowFileWithScriptFile() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, "target/test/resources/groovy/test_onTrigger_changeContent.groovy");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_onTrigger_changeContent.groovy");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue(TEST_CSV_DATA.getBytes(StandardCharsets.UTF_8));
@@ -193,11 +193,11 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody.groovy")
         );
-        runner.setProperty(ExecuteScript.MODULES, TEST_RESOURCE_LOCATION + "groovy");
+        runner.setProperty(ScriptUtils.MODULES, TEST_RESOURCE_LOCATION + "groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -217,8 +217,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBodyNoModules() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBodyNoModules.groovy")
         );
         runner.assertValid();
@@ -238,8 +238,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptNoTransfer() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testScriptNoTransfer.groovy")
         );
 
@@ -257,8 +257,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileCustomAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testReadFlowFileContentAndStoreInFlowFileCustomAttribute.groovy")
         );
         runner.setProperty("testprop", "test content");
@@ -281,8 +281,8 @@ public class TestExecuteGroovy extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptException() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, "throw new Exception()");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, "throw new Exception()");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJRuby.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJRuby.java
@@ -43,9 +43,9 @@ public class TestExecuteJRuby extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "ruby");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jruby/test_onTrigger.rb");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jruby");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ruby");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jruby/test_onTrigger.rb");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/jruby");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJRuby.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJRuby.java
@@ -43,9 +43,9 @@ public class TestExecuteJRuby extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "ruby");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, "target/test/resources/jruby/test_onTrigger.rb");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/jruby");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "ruby");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jruby/test_onTrigger.rb");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/jruby");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJRuby.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJRuby.java
@@ -43,9 +43,9 @@ public class TestExecuteJRuby extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "ruby");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jruby/test_onTrigger.rb");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/jruby");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "ruby");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jruby/test_onTrigger.rb");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jruby");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJavascript.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJavascript.java
@@ -42,9 +42,9 @@ public class TestExecuteJavascript extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "ECMAScript");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, "target/test/resources/javascript/test_onTrigger.js");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/javascript");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "ECMAScript");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/javascript/test_onTrigger.js");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/javascript");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJavascript.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJavascript.java
@@ -42,9 +42,9 @@ public class TestExecuteJavascript extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "ECMAScript");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/javascript/test_onTrigger.js");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/javascript");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "ECMAScript");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/javascript/test_onTrigger.js");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/javascript");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJavascript.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJavascript.java
@@ -42,9 +42,9 @@ public class TestExecuteJavascript extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "ECMAScript");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/javascript/test_onTrigger.js");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/javascript");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ECMAScript");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/javascript/test_onTrigger.js");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/javascript");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJython.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
- * Created by mburgess on 1/25/16.
+ * Unit tests for ExecuteScript with Jython.
  */
 public class TestExecuteJython extends BaseScriptTest {
 
@@ -41,8 +41,8 @@ public class TestExecuteJython extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY,
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY,
                 "from org.apache.nifi.processors.script import ExecuteScript\n"
                         + "flowFile = session.get()\n"
                         + "flowFile = session.putAttribute(flowFile, \"from-content\", \"test content\")\n"
@@ -65,8 +65,8 @@ public class TestExecuteJython extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptNoTransfer() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY,
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY,
                 "flowFile = session.putAttribute(flowFile, \"from-content\", \"test content\")\n");
 
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJython.java
@@ -41,8 +41,8 @@ public class TestExecuteJython extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY,
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY,
                 "from org.apache.nifi.processors.script import ExecuteScript\n"
                         + "flowFile = session.get()\n"
                         + "flowFile = session.putAttribute(flowFile, \"from-content\", \"test content\")\n"
@@ -65,8 +65,8 @@ public class TestExecuteJython extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptNoTransfer() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY,
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY,
                 "flowFile = session.putAttribute(flowFile, \"from-content\", \"test content\")\n");
 
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteJython.java
@@ -41,8 +41,8 @@ public class TestExecuteJython extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptBody() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "python");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY,
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY,
                 "from org.apache.nifi.processors.script import ExecuteScript\n"
                         + "flowFile = session.get()\n"
                         + "flowFile = session.putAttribute(flowFile, \"from-content\", \"test content\")\n"
@@ -65,8 +65,8 @@ public class TestExecuteJython extends BaseScriptTest {
     @Test(expected = AssertionError.class)
     public void testScriptNoTransfer() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "python");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY,
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY,
                 "flowFile = session.putAttribute(flowFile, \"from-content\", \"test content\")\n");
 
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteLua.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteLua.java
@@ -43,9 +43,9 @@ public class TestExecuteLua extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "lua");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/lua/test_onTrigger.lua");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/lua");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "lua");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/lua/test_onTrigger.lua");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/lua");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteLua.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteLua.java
@@ -43,9 +43,9 @@ public class TestExecuteLua extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "lua");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, "target/test/resources/lua/test_onTrigger.lua");
-        runner.setProperty(ExecuteScript.MODULES, "target/test/resources/lua");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "lua");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/lua/test_onTrigger.lua");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/lua");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteLua.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteLua.java
@@ -43,9 +43,9 @@ public class TestExecuteLua extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExecuteScript());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "lua");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/lua/test_onTrigger.lua");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/lua");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "lua");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/lua/test_onTrigger.lua");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/lua");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
@@ -50,9 +50,9 @@ public class TestInvokeGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -77,9 +77,9 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        context.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
-        context.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
+        context.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        context.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        context.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/groovy");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -111,8 +111,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        context.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        context.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        context.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -140,8 +140,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
     public void testInvokeScriptCausesException() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testInvokeScriptCausesException.groovy")
         );
         runner.assertValid();
@@ -158,8 +158,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
     @Test
     public void testScriptRoutesToFailure() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testScriptRoutesToFailure.groovy")
         );
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
@@ -50,9 +50,9 @@ public class TestInvokeGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
-        runner.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -77,9 +77,9 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "Groovy");
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
-        context.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/groovy");
+        context.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        context.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        context.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -111,8 +111,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "Groovy");
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        context.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        context.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -140,8 +140,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
     public void testInvokeScriptCausesException() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testInvokeScriptCausesException.groovy")
         );
         runner.assertValid();
@@ -158,8 +158,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
     @Test
     public void testScriptRoutesToFailure() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testScriptRoutesToFailure.groovy")
         );
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
@@ -50,9 +50,9 @@ public class TestInvokeGroovy extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -77,9 +77,9 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        context.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
-        context.setProperty(ScriptUtils.MODULES, "target/test/resources/groovy");
+        context.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        context.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        context.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/groovy");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -111,8 +111,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        context.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
+        context.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        context.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/groovy/test_reader.groovy");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -140,8 +140,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
     public void testInvokeScriptCausesException() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testInvokeScriptCausesException.groovy")
         );
         runner.assertValid();
@@ -158,8 +158,8 @@ public class TestInvokeGroovy extends BaseScriptTest {
     @Test
     public void testScriptRoutesToFailure() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "Groovy");
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "Groovy");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "groovy/testScriptRoutesToFailure.groovy")
         );
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJavascript.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJavascript.java
@@ -52,9 +52,9 @@ public class TestInvokeJavascript extends BaseScriptTest {
     @Test
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "ECMAScript");
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/javascript/test_reader.js");
-        runner.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/javascript");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ECMAScript");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/javascript/test_reader.js");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/javascript");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -80,9 +80,9 @@ public class TestInvokeJavascript extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "ECMAScript");
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/javascript/test_reader.js");
-        context.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/javascript");
+        context.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ECMAScript");
+        context.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/javascript/test_reader.js");
+        context.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/javascript");
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
         processor.setup(context);
@@ -115,9 +115,9 @@ public class TestInvokeJavascript extends BaseScriptTest {
 
         processor.initialize(initContext);
 
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "ECMAScript");
-        context.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/javascript/test_reader.js");
-        context.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/javascript");
+        context.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ECMAScript");
+        context.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/javascript/test_reader.js");
+        context.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/javascript");
 
         // State Manger is unused, and a null reference is specified
         processor.customValidate(new MockValidationContext(context));
@@ -146,8 +146,8 @@ public class TestInvokeJavascript extends BaseScriptTest {
     public void testInvokeScriptCausesException() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "ECMAScript");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ECMAScript");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "javascript/testInvokeScriptCausesException.js")
         );
         runner.assertValid();
@@ -164,8 +164,8 @@ public class TestInvokeJavascript extends BaseScriptTest {
     @Test
     public void testScriptRoutesToFailure() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "ECMAScript");
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, getFileContentsAsString(
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "ECMAScript");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, getFileContentsAsString(
                 TEST_RESOURCE_LOCATION + "javascript/testScriptRoutesToFailure.js")
         );
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
@@ -52,8 +52,8 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testAlwaysInvalid() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "python");
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
 
         final Collection<ValidationResult> results = ((MockProcessContext) runner.getProcessContext()).validate();
         Assert.assertEquals(1L, results.size());
@@ -72,8 +72,8 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testUpdateAttributeFromProcessorPropertyAndFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "python");
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
         runner.setProperty("for-attributes", "value-1");
 
         final Map<String, String> attributes = new HashMap<>();
@@ -102,9 +102,9 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "python");
-        runner.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/jython/test_reader.py");
-        runner.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/jython");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_reader.py");
+        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/jython");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -124,9 +124,9 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testCompressor() throws Exception {
         final TestRunner one = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         one.setValidateExpressionUsage(false);
-        one.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "python");
-        one.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
-        one.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/jython");
+        one.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        one.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
+        one.setProperty(ScriptUtils.MODULES, "target/test/resources/jython");
         one.setProperty("mode", "compress");
 
         one.assertValid();
@@ -138,9 +138,9 @@ public class TestInvokeJython extends BaseScriptTest {
 
         final TestRunner two = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         two.setValidateExpressionUsage(false);
-        two.setProperty(InvokeScriptedProcessor.SCRIPT_ENGINE, "python");
-        two.setProperty(InvokeScriptedProcessor.MODULES, "target/test/resources/jython");
-        two.setProperty(InvokeScriptedProcessor.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
+        two.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        two.setProperty(ScriptUtils.MODULES, "target/test/resources/jython");
+        two.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
         two.setProperty("mode", "decompress");
 
         two.assertValid();
@@ -160,9 +160,9 @@ public class TestInvokeJython extends BaseScriptTest {
     @Test
     public void testInvalidConfiguration() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ExecuteScript.SCRIPT_ENGINE, "python");
-        runner.setProperty(ExecuteScript.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
-        runner.setProperty(ExecuteScript.SCRIPT_BODY, "body");
+        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
+        runner.setProperty(ScriptUtils.SCRIPT_BODY, "body");
 
         runner.assertNotValid();
     }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
@@ -52,8 +52,8 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testAlwaysInvalid() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
 
         final Collection<ValidationResult> results = ((MockProcessContext) runner.getProcessContext()).validate();
         Assert.assertEquals(1L, results.size());
@@ -72,8 +72,8 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testUpdateAttributeFromProcessorPropertyAndFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
         runner.setProperty("for-attributes", "value-1");
 
         final Map<String, String> attributes = new HashMap<>();
@@ -102,9 +102,9 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_reader.py");
-        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jython");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_reader.py");
+        runner.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/jython");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -124,9 +124,9 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testCompressor() throws Exception {
         final TestRunner one = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         one.setValidateExpressionUsage(false);
-        one.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        one.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
-        one.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jython");
+        one.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        one.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
+        one.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/jython");
         one.setProperty("mode", "compress");
 
         one.assertValid();
@@ -138,9 +138,9 @@ public class TestInvokeJython extends BaseScriptTest {
 
         final TestRunner two = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         two.setValidateExpressionUsage(false);
-        two.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        two.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jython");
-        two.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
+        two.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        two.setProperty(ScriptingComponentUtils.MODULES, "target/test/resources/jython");
+        two.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
         two.setProperty("mode", "decompress");
 
         two.assertValid();
@@ -160,9 +160,9 @@ public class TestInvokeJython extends BaseScriptTest {
     @Test
     public void testInvalidConfiguration() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
-        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, "body");
+        runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
+        runner.setProperty(ScriptingComponentUtils.SCRIPT_BODY, "body");
 
         runner.assertNotValid();
     }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
@@ -52,8 +52,8 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testAlwaysInvalid() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
 
         final Collection<ValidationResult> results = ((MockProcessContext) runner.getProcessContext()).validate();
         Assert.assertEquals(1L, results.size());
@@ -72,8 +72,8 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testUpdateAttributeFromProcessorPropertyAndFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
         runner.setProperty("for-attributes", "value-1");
 
         final Map<String, String> attributes = new HashMap<>();
@@ -102,9 +102,9 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testReadFlowFileContentAndStoreInFlowFileAttribute() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_reader.py");
-        runner.setProperty(ScriptUtils.MODULES, "target/test/resources/jython");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_reader.py");
+        runner.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jython");
 
         runner.assertValid();
         runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
@@ -124,9 +124,9 @@ public class TestInvokeJython extends BaseScriptTest {
     public void testCompressor() throws Exception {
         final TestRunner one = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         one.setValidateExpressionUsage(false);
-        one.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        one.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
-        one.setProperty(ScriptUtils.MODULES, "target/test/resources/jython");
+        one.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        one.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
+        one.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jython");
         one.setProperty("mode", "compress");
 
         one.assertValid();
@@ -138,9 +138,9 @@ public class TestInvokeJython extends BaseScriptTest {
 
         final TestRunner two = TestRunners.newTestRunner(new InvokeScriptedProcessor());
         two.setValidateExpressionUsage(false);
-        two.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        two.setProperty(ScriptUtils.MODULES, "target/test/resources/jython");
-        two.setProperty(ScriptUtils.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
+        two.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        two.setProperty(ScriptingComponentHelper.MODULES, "target/test/resources/jython");
+        two.setProperty(ScriptingComponentHelper.SCRIPT_FILE, "target/test/resources/jython/test_compress.py");
         two.setProperty("mode", "decompress");
 
         two.assertValid();
@@ -160,9 +160,9 @@ public class TestInvokeJython extends BaseScriptTest {
     @Test
     public void testInvalidConfiguration() throws Exception {
         runner.setValidateExpressionUsage(false);
-        runner.setProperty(ScriptUtils.SCRIPT_ENGINE, "python");
-        runner.setProperty(ScriptUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
-        runner.setProperty(ScriptUtils.SCRIPT_BODY, "body");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_ENGINE, "python");
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_FILE, TEST_RESOURCE_LOCATION);
+        runner.setProperty(ScriptingComponentHelper.SCRIPT_BODY, "body");
 
         runner.assertNotValid();
     }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_log_provenance_events.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_log_provenance_events.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def events = context.eventAccess.getProvenanceEvents(1,5)
+events.eachWithIndex { event, i ->
+    log.info("Event[$i] ID = ${event.eventId}")
+}
+x = events.size()
+e = events[0]
+
+

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_log_vm_stats.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_log_vm_stats.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+x = [
+        'uptime'             : vmMetrics.uptime(),
+        'heapUsed'           : vmMetrics.heapUsed(),
+        'heapUsage'          : vmMetrics.heapUsage(),
+        'nonHeapUsage'       : vmMetrics.nonHeapUsage(),
+        'threadCount'        : vmMetrics.threadCount(),
+        'daemonThreadCount'  : vmMetrics.daemonThreadCount(),
+        'fileDescriptorUsage': vmMetrics.fileDescriptorUsage()
+]
+
+


### PR DESCRIPTION
I refactored AbstractScriptProcessor into ScriptUtils, so the functionality could be shared between scripting processors and scripting reporting tasks. I admit the use of ScriptUtils is not pure OO (public members, e.g.) but I wanted to keep the spirit of what the processors did when this was part of its parent class (since we don't have traits or multiple inheritance).
