### PR TITLE
[NIFI-2813] Fix for invalid M2_HOME directory in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ install:
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.1.1\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.1.1
+  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%%
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
 build_script:


### PR DESCRIPTION
Appveyor was given the following error:
**ERROR: M2_HOME is set to an invalid directory.

M2_HOME = "C:\Program Files (x86)\Apache\Maven"

Please set the M2_HOME variable in your environment to match the location of the Maven installation**

Fixed by explicitly defining it.