### PR TITLE
NIFI-2803 The pagination of GenerateTableFetch has a sort bug

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -230,7 +230,7 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
 
                 Integer limit = partitionSize == 0 ? null : partitionSize;
                 Integer offset = partitionSize == 0 ? null : i * partitionSize;
-                final String query = dbAdapter.getSelectStatement(tableName, columnNames, StringUtils.join(maxValueClauses, " AND "), null, limit, offset);
+                final String query = dbAdapter.getSelectStatement(tableName, columnNames, whereClause, StringUtils.join(maxValueColumnNameList, ", "), limit, offset);
                 sqlFlowFile = session.create();
                 sqlFlowFile = session.write(sqlFlowFile, out -> {
                     out.write(query.getBytes());


### PR DESCRIPTION
When data is coming to the ingested table, the pagination SQL needs the ORDER BY statement with maxValueClauses.
If maxValueClauses are not the primary keys, incoming data usually inserts using primary keys. So when ExecuteSQL executes, some data may be lost.