### PR TITLE
NIFI-2822 - Provide the JWT Authorization token 

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -31,6 +31,8 @@
 <script type="text/javascript" src="../nifi/js/codemirror/addon/lint/lint.js"></script>
 <script type="text/javascript" src="../nifi/js/codemirror/addon/lint/json-lint.js"></script>
 <script type="text/javascript" src="../nifi/js/jsonlint/jsonlint.min.js"></script>
+<script type="text/javascript" src="../nifi/js/nf/nf-namespace.js"></script>
+<script type="text/javascript" src="../nifi/js/nf/nf-storage.js"></script>
 <script type="text/javascript" src="../nifi/assets/angular/angular.min.js"></script>
 <script type="text/javascript" src="../nifi/assets/angular-animate/angular-animate.min.js"></script>
 <script type="text/javascript" src="../nifi/assets/angular-aria/angular-aria.min.js"></script>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/webapp/app/app.js
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/webapp/app/app.js
@@ -17,7 +17,12 @@
 
 'use strict';
 
-var AppRun =  function($rootScope,$state){
+var AppRun =  function($rootScope,$state,$http){
+
+    if (nf.Storage.hasItem('jwt')) {
+        var token = nf.Storage.getItem('jwt');
+        $http.defaults.headers.common.Authorization = 'Bearer ' + token;
+    }
 
     $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error){
         event.preventDefault();
@@ -35,7 +40,7 @@ var AppConfig = function ($urlRouterProvider) {
 
 };
 
-AppRun.$inject = ['$rootScope','$state'];
+AppRun.$inject = ['$rootScope','$state','$http'];
 
 AppConfig.$inject = ['$urlRouterProvider'];
 


### PR DESCRIPTION
This change ensures that the JWT token used for authorization is added to headers when using the $http service.  Testing requires a secured server.

The Jolt Transform Advanced UI should appear, and validate/format/transform operation  should work. However a separate JIRA was filed (NIFI-2824) in order to handle a separate problem related to saving that was found during testing:

https://issues.apache.org/jira/browse/NIFI-2824

This problem also impacts saving the UpdateAttributes processor. It does not appear related to the token issue.