### PR TITLE
Not showing View Configuration context menu option for Process Groups

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
@@ -967,9 +967,6 @@ nf.CanvasUtils = (function () {
                 return false;
             }
 
-            if (nf.CanvasUtils.isProcessGroup(selection)) {
-                return true;
-            }
             if (nf.CanvasUtils.canRead(selection) === false) {
                 return false;
             }


### PR DESCRIPTION
NIFI-2843:
- Removing the View Configuration menu item from the context menu on Process Groups.