### PR TITLE
NIFI-2858 getSystemLoadAverage of OperatingSystemMXBean sometimes

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -573,7 +573,14 @@ public class StatusMerger {
         target.setFreeNonHeapBytes(target.getFreeNonHeapBytes() + toMerge.getFreeNonHeapBytes());
         target.setMaxHeapBytes(target.getMaxHeapBytes() + toMerge.getMaxHeapBytes());
         target.setMaxNonHeapBytes(target.getMaxNonHeapBytes() + toMerge.getMaxNonHeapBytes());
-        target.setProcessorLoadAverage(target.getProcessorLoadAverage() + toMerge.getProcessorLoadAverage());
+        double systemLoad = target.getProcessorLoadAverage();
+        double toMergeSystemLoad = toMerge.getProcessorLoadAverage();
+        if (systemLoad > 0 && toMergeSystemLoad > 0) {
+            systemLoad += toMergeSystemLoad;
+        } else if (systemLoad < 0 && toMergeSystemLoad > 0) {
+            systemLoad = toMergeSystemLoad;
+        }
+        target.setProcessorLoadAverage(systemLoad);
         target.setTotalHeapBytes(target.getTotalHeapBytes() + toMerge.getTotalHeapBytes());
         target.setTotalNonHeapBytes(target.getTotalNonHeapBytes() + toMerge.getTotalNonHeapBytes());
         target.setTotalThreads(target.getTotalThreads() + toMerge.getTotalThreads());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -575,9 +575,9 @@ public class StatusMerger {
         target.setMaxNonHeapBytes(target.getMaxNonHeapBytes() + toMerge.getMaxNonHeapBytes());
         double systemLoad = target.getProcessorLoadAverage();
         double toMergeSystemLoad = toMerge.getProcessorLoadAverage();
-        if (systemLoad > 0 && toMergeSystemLoad > 0) {
+        if (systemLoad >= 0 && toMergeSystemLoad >= 0) {
             systemLoad += toMergeSystemLoad;
-        } else if (systemLoad < 0 && toMergeSystemLoad > 0) {
+        } else if (systemLoad < 0 && toMergeSystemLoad >= 0) {
             systemLoad = toMergeSystemLoad;
         }
         target.setProcessorLoadAverage(systemLoad);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
@@ -69,6 +69,8 @@ public class SystemDiagnosticsFactory {
         final double systemLoad = os.getSystemLoadAverage();
         if (systemLoad > 0) {
             systemDiagnostics.setProcessorLoadAverage(systemLoad);
+        } else {
+            systemDiagnostics.setProcessorLoadAverage(1.0);
         }
 
         // get the database disk usage

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
@@ -70,7 +70,7 @@ public class SystemDiagnosticsFactory {
         if (systemLoad > 0) {
             systemDiagnostics.setProcessorLoadAverage(systemLoad);
         } else {
-            systemDiagnostics.setProcessorLoadAverage(1.0);
+            systemDiagnostics.setProcessorLoadAverage(-1.0);
         }
 
         // get the database disk usage

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
@@ -67,7 +67,7 @@ public class SystemDiagnosticsFactory {
         systemDiagnostics.setAvailableProcessors(os.getAvailableProcessors());
 
         final double systemLoad = os.getSystemLoadAverage();
-        if (systemLoad > 0) {
+        if (systemLoad >= 0) {
             systemDiagnostics.setProcessorLoadAverage(systemLoad);
         } else {
             systemDiagnostics.setProcessorLoadAverage(-1.0);


### PR DESCRIPTION
returns zero or a negative value.

When getSystemLoadAverage returns a negative value, ProcessorLoadAverage sets -1.0.