### PR TITLE
Fixes NIFI-2199 nifi.sh hangs on restart through ssh

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
@@ -267,7 +267,7 @@ run() {
     RUN_NIFI_CMD="cd "\""${NIFI_HOME}"\"" && ${sudo_cmd_prefix} "\""${JAVA}"\"" -cp "\""${BOOTSTRAP_CLASSPATH}"\"" -Xms12m -Xmx24m ${BOOTSTRAP_DIR_PARAMS}  org.apache.nifi.bootstrap.RunNiFi"
 
     if [ "$1" = "start" ]; then
-        (eval $RUN_NIFI_CMD $@ &)
+        (eval $RUN_NIFI_CMD $@ &)> /dev/null 2>&1 < /dev/null
     else
         (eval $RUN_NIFI_CMD $@)
     fi


### PR DESCRIPTION
When nifi.sh is executed remotely through ssh:
```
ssh root@example.com /etc/init.d/nifi restart
```
SSH session hang forever, due to unclosed STDIN/OUT/ERR streams in nifi process. Redirecting these streams from and to `/dev/null` fixes the problem.
