### PR TITLE
Cluster - Merging response when the node is the Cluster Coordinator

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/HttpResponseMapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/HttpResponseMapper.java
@@ -17,10 +17,10 @@
 
 package org.apache.nifi.cluster.coordination.http;
 
+import org.apache.nifi.cluster.manager.NodeResponse;
+
 import java.net.URI;
 import java.util.Set;
-
-import org.apache.nifi.cluster.manager.NodeResponse;
 
 /**
  * <p>
@@ -29,7 +29,7 @@ import org.apache.nifi.cluster.manager.NodeResponse;
  * user/client who made the original web requests.
  * </p>
  */
-public interface HttpResponseMerger {
+public interface HttpResponseMapper {
 
     /**
      * Maps the responses from all nodes in the cluster to a single NodeResponse object that
@@ -41,7 +41,7 @@ public interface HttpResponseMerger {
      *
      * @return a single NodeResponse that represents the response that should be returned to the user/client
      */
-    NodeResponse mergeResponses(URI uri, String httpMethod, Set<NodeResponse> nodeResponses);
+    NodeResponse mapResponses(URI uri, String httpMethod, Set<NodeResponse> nodeResponses, boolean merge);
 
     /**
      * Returns a subset (or equal set) of the given Node Responses, such that all of those returned are the responses

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
@@ -16,27 +16,12 @@
  */
 package org.apache.nifi.cluster.coordination.node;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
 import org.apache.nifi.cluster.coordination.flow.FlowElection;
-import org.apache.nifi.cluster.coordination.http.HttpResponseMerger;
-import org.apache.nifi.cluster.coordination.http.StandardHttpResponseMerger;
+import org.apache.nifi.cluster.coordination.http.HttpResponseMapper;
+import org.apache.nifi.cluster.coordination.http.StandardHttpResponseMapper;
 import org.apache.nifi.cluster.coordination.http.replication.RequestCompletionCallback;
 import org.apache.nifi.cluster.event.Event;
 import org.apache.nifi.cluster.event.NodeEvent;
@@ -72,6 +57,22 @@ import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.revision.RevisionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandler, RequestCompletionCallback {
 
@@ -974,7 +975,7 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
          * state even if they had problems handling the request.
          */
         if (mutableRequest) {
-            final HttpResponseMerger responseMerger = new StandardHttpResponseMerger(nifiProperties);
+            final HttpResponseMapper responseMerger = new StandardHttpResponseMapper(nifiProperties);
             final Set<NodeResponse> problematicNodeResponses = responseMerger.getProblematicNodeResponses(nodeResponses);
 
             // all nodes failed

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/PropertyDescriptorDtoMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/PropertyDescriptorDtoMerger.java
@@ -33,7 +33,7 @@ public class PropertyDescriptorDtoMerger {
         for (final Map.Entry<NodeIdentifier, PropertyDescriptorDTO> nodeEntry : dtoMap.entrySet()) {
             final PropertyDescriptorDTO nodePropertyDescriptor = nodeEntry.getValue();
             final List<AllowableValueEntity> nodePropertyDescriptorAllowableValues = nodePropertyDescriptor.getAllowableValues();
-            if (clientPropertyDescriptor != nodePropertyDescriptor && nodePropertyDescriptorAllowableValues != null) {
+            if (nodePropertyDescriptorAllowableValues != null) {
                 nodePropertyDescriptorAllowableValues.stream().forEach(allowableValueEntity -> {
                     allowableValueMap.computeIfAbsent(nodePropertyDescriptorAllowableValues.indexOf(allowableValueEntity), propertyDescriptorToAllowableValue -> new ArrayList<>())
                             .add(allowableValueEntity);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapperSpec.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapperSpec.groovy
@@ -20,7 +20,6 @@ import com.sun.jersey.api.client.ClientResponse
 import org.apache.nifi.cluster.manager.NodeResponse
 import org.apache.nifi.cluster.protocol.NodeIdentifier
 import org.apache.nifi.util.NiFiProperties
-import org.apache.nifi.web.api.dto.AccessPolicyDTO
 import org.apache.nifi.web.api.dto.ConnectionDTO
 import org.apache.nifi.web.api.dto.ControllerConfigurationDTO
 import org.apache.nifi.web.api.dto.FunnelDTO
@@ -43,10 +42,10 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
-class StandardHttpResponseMergerSpec extends Specification {
+class StandardHttpResponseMapperSpec extends Specification {
 
     def setup() {
-        def propFile = StandardHttpResponseMergerSpec.class.getResource("/conf/nifi.properties").getFile()
+        def propFile = StandardHttpResponseMapperSpec.class.getResource("/conf/nifi.properties").getFile()
         System.setProperty NiFiProperties.PROPERTIES_FILE_PATH, propFile
     }
 
@@ -56,7 +55,7 @@ class StandardHttpResponseMergerSpec extends Specification {
 
     def "MergeResponses: mixed HTTP GET response statuses, expecting #expectedStatus"() {
         given:
-        def responseMerger = new StandardHttpResponseMerger(NiFiProperties.createBasicNiFiProperties(null,null))
+        def responseMapper = new StandardHttpResponseMapper(NiFiProperties.createBasicNiFiProperties(null,null))
         def requestUri = new URI('http://server/resource')
         def requestId = UUID.randomUUID().toString()
         def Map<ClientResponse, Map<String, Integer>> mockToRequestEntity = [:]
@@ -68,7 +67,7 @@ class StandardHttpResponseMergerSpec extends Specification {
         } as Set
 
         when:
-        def returnedResponse = responseMerger.mergeResponses(requestUri, 'get', nodeResponseSet).getStatus()
+        def returnedResponse = responseMapper.mapResponses(requestUri, 'get', nodeResponseSet, true).getStatus()
 
         then:
         mockToRequestEntity.entrySet().forEach {
@@ -94,7 +93,7 @@ class StandardHttpResponseMergerSpec extends Specification {
         mapper.setSerializationConfig(serializationConfig.withSerializationInclusion(JsonSerialize.Inclusion.NON_NULL).withAnnotationIntrospector(jaxbIntrospector));
 
         and: "setup of the data to be used in the test"
-        def responseMerger = new StandardHttpResponseMerger(NiFiProperties.createBasicNiFiProperties(null,null))
+        def responseMerger = new StandardHttpResponseMapper(NiFiProperties.createBasicNiFiProperties(null,null))
         def requestUri = new URI("http://server/$requestUriPart")
         def requestId = UUID.randomUUID().toString()
         def Map<ClientResponse, Object> mockToRequestEntity = [:]
@@ -107,7 +106,7 @@ class StandardHttpResponseMergerSpec extends Specification {
         } as Set
 
         when:
-        def returnedResponse = responseMerger.mergeResponses(requestUri, httpMethod, nodeResponseSet)
+        def returnedResponse = responseMerger.mapResponses(requestUri, httpMethod, nodeResponseSet, true)
 
         then:
         mockToRequestEntity.entrySet().forEach {


### PR DESCRIPTION
NIFI-2777:
NIFI-2856:
- Only performing response merging when the node is the cluster cooridinator even if there is a single response.
- Fixing PropertyDescriptor merging to ensure the 'chosen' descriptor is included in map of all responses.