### PR TITLE
minor typo in expression-language-guide.doc

### DIFF
--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -741,7 +741,7 @@ then the following Expressions will result in the following values:
 | `${line:getDelimitedField(2):trim()}` | 32
 | `${line:getDelimitedField(1)}` | "Jacobson, John"
 | `${line:getDelimitedField(1, ',', '"', '\\', true)}` | Jacobson, John
-| `${altLine:getDelimitedField(1, '|')} | Jacobson, John
+| `${altLine:getDelimitedField(1, '\|')}` | Jacobson, John
 |======================================================================
 
 


### PR DESCRIPTION
delimiter in example was asciidoc syntax