### PR TITLE
NIFI-2855: Site-to-Site with port forwarding.

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -147,8 +147,10 @@ public abstract class NiFiProperties {
     // web properties
     public static final String WEB_WAR_DIR = "nifi.web.war.directory";
     public static final String WEB_HTTP_PORT = "nifi.web.http.port";
+    public static final String WEB_HTTP_PORT_FORWARDING = "nifi.web.http.port.forwarding";
     public static final String WEB_HTTP_HOST = "nifi.web.http.host";
     public static final String WEB_HTTPS_PORT = "nifi.web.https.port";
+    public static final String WEB_HTTPS_PORT_FORWARDING = "nifi.web.https.port.forwarding";
     public static final String WEB_HTTPS_HOST = "nifi.web.https.host";
     public static final String WEB_WORKING_DIR = "nifi.web.jetty.working.directory";
     public static final String WEB_THREADS = "nifi.web.jetty.threads";
@@ -403,9 +405,23 @@ public abstract class NiFiProperties {
             return null;
         }
 
-        String propertyKey = isSiteToSiteSecure() ? NiFiProperties.WEB_HTTPS_PORT : NiFiProperties.WEB_HTTP_PORT;
-        Integer port = getIntegerProperty(propertyKey, 0);
-        if (port == 0) {
+        final String propertyKey;
+        if (isSiteToSiteSecure()) {
+            if (StringUtils.isBlank(getProperty(NiFiProperties.WEB_HTTPS_PORT_FORWARDING))) {
+                propertyKey = WEB_HTTPS_PORT;
+            } else {
+                propertyKey = WEB_HTTPS_PORT_FORWARDING;
+            }
+        } else {
+            if (StringUtils.isBlank(getProperty(NiFiProperties.WEB_HTTP_PORT_FORWARDING))) {
+                propertyKey = WEB_HTTP_PORT;
+            } else {
+                propertyKey = WEB_HTTP_PORT_FORWARDING;
+            }
+        }
+
+        final Integer port = getIntegerProperty(propertyKey, null);
+        if (port == null) {
             throw new RuntimeException("Remote input HTTP" + (isSiteToSiteSecure() ? "S" : "")
                     + " is enabled but " + propertyKey + " is not specified.");
         }

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -1981,8 +1981,10 @@ These properties pertain to the web-based User Interface.
 |nifi.web.war.directory|This is the location of the web war directory. The default value is ./lib.
 |nifi.web.http.host|The HTTP host. It is blank by default.
 |nifi.web.http.port|The HTTP port. The default value is 8080.
+|nifi.web.http.port.forwarding|The port which forwards incoming HTTP requests to nifi.web.http.host. This property is designed to be used with 'port forwarding', when NiFi has to be started by a non-root user for better security, yet it needs to be accessed via low port to go through a firewall. For example, to expose NiFi via HTTP protocol on port 80, but actually listening on port 8080, you need to configure OS level port forwarding such as `iptables` (Linux/Unix) or `pfctl` (OS X) that redirects requests from 80 to 8080. Then set `nifi.web.http.port` as 8080, and `nifi.web.http.port.forwarding` as 80. It is blank by default.
 |nifi.web.https.host|The HTTPS host. It is blank by default.
 |nifi.web.https.port|The HTTPS port. It is blank by default. When configuring NiFi to run securely, this port should be configured.
+|nifi.web.https.port.forwarding|Same as `nifi.web.http.port.forwarding`, but with HTTPS for secure communication. It is blank by default.
 |nif.web.jetty.working.directory|The location of the Jetty working directory. The default value is ./work/jetty.
 |nifi.web.jetty.threads|The number of Jetty threads. The default value is 200.
 |====


### PR DESCRIPTION
This change allows user to run NiFi without root privilege but with low port (80 or 443) using port forwarding together.

- Added following properties:
  - nifi.web.http.port.forwarding
  - nifi.web.https.port.forwarding

Please refer the admin guide for detail.

Tested with:
- Local and Cloud Site-to-Site with only either one of 80 or 443 port is accessible
- Enabling port forwarding, or without it (direct access)
- Clustered/Standalone
- With proxy
- RAW transport protocol (works as it was)

Any comments are appreciated!