### PR TITLE
NIFI-2866 The Initial Max Value of QueryDatabaseTable won't be case

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
@@ -200,8 +200,8 @@ public class QueryDatabaseTable extends AbstractDatabaseFetchProcessor {
 
         //If an initial max value for column(s) has been specified using properties, and this column is not in the state manager, sync them to the state property map
         for(final Map.Entry<String,String> maxProp : maxValueProperties.entrySet()){
-            if(!statePropertyMap.containsKey(maxProp.getKey())){
-                statePropertyMap.put(maxProp.getKey(), maxProp.getValue());
+            if (!statePropertyMap.containsKey(maxProp.getKey().toLowerCase())) {
+                statePropertyMap.put(maxProp.getKey().toLowerCase(), maxProp.getValue());
             }
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableTest.java
@@ -635,7 +635,7 @@ public class QueryDatabaseTableTest {
 
         cal.setTimeInMillis(0);
         cal.add(Calendar.MINUTE, 5);
-        runner.setProperty("initial.maxvalue.created_on", dateFormat.format(cal.getTime().getTime()));
+        runner.setProperty("initial.maxvalue.CREATED_ON", dateFormat.format(cal.getTime().getTime()));
         // Initial run with no previous state. Should get only last 4 records
         runner.run();
         runner.assertAllFlowFilesTransferred(QueryDatabaseTable.REL_SUCCESS, 1);


### PR DESCRIPTION
sensitive

Now, the Initial Max Value of QueryDatabaseTable is allowed the only lowercase so I think to change the below code, it added .toLowerCase() method.
for(final Map.Entry<String,String> maxProp : maxValueProperties.entrySet()){
if (!statePropertyMap.containsKey(maxProp.getKey().toLowerCase()))
{ statePropertyMap.put(maxProp.getKey().toLowerCase(), maxProp.getValue()); }
}
When I set the property that is initial.maxvalue.UPDATE_TIME, QueryDatabaseTable doesn't have WHERE clause with UPDATE_TIME.
Thanks.
