### PR TITLE
NIFI-2867 The ColumnSize of datetime type is 19 length in MySQL JDBC

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java
@@ -25,6 +25,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -427,7 +428,7 @@ public class ConvertJSONToSQL extends AbstractProcessor {
                 final JsonNode fieldNode = rootNode.get(fieldName);
                 if (!fieldNode.isNull()) {
                     String fieldValue = fieldNode.asText();
-                    if (colSize != null && fieldValue.length() > colSize) {
+                    if (colSize != null && fieldValue.length() > colSize && Types.TIMESTAMP != sqlType) {
                         fieldValue = fieldValue.substring(0, colSize);
                     }
                     attributes.put("sql.args." + fieldCount + ".value", fieldValue);


### PR DESCRIPTION
When I use the ConvertJSONToSQL, it changes the field value for data capacity of source datastore.

/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java: 430 line
`
                    if (colSize != null && fieldValue.length() > colSize) {
                        fieldValue = fieldValue.substring(0, colSize);
                    }
`

But the type of field is datetime in MySQL DB, JDBC driver returns 19 column size. So above code truncate field value to 2016-10-05 12:00:00 from 2016-10-05 12:00:00.0.
PutSQL only resolve the TIMESTAMP type using yyyy-MM-dd HH:mm:ss.SSS SimpleDateFormat. So it throws below exception.

`
2016-10-05 13:05:56,526 ERROR [Timer-Driven Process Thread-14] o.apache.nifi.processors.standard.PutSQL
org.apache.nifi.processor.exception.ProcessException: The value of the sql.args.7.value is '2016-10-05 13:05:43', which cannot be converted to a timestamp
        at org.apache.nifi.processors.standard.PutSQL.setParameters(PutSQL.java:630) ~[nifi-standard-processors-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.processors.standard.PutSQL.onTrigger(PutSQL.java:241) ~[nifi-standard-processors-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.processor.AbstractProcessor.onTrigger(AbstractProcessor.java:27) [nifi-api-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.controller.StandardProcessorNode.onTrigger(StandardProcessorNode.java:1064) [nifi-framework-core-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.controller.tasks.ContinuallyRunProcessorTask.call(ContinuallyRunProcessorTask.java:136) [nifi-framework-core-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.controller.tasks.ContinuallyRunProcessorTask.call(ContinuallyRunProcessorTask.java:47) [nifi-framework-core-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.controller.scheduling.TimerDrivenSchedulingAgent$1.run(TimerDrivenSchedulingAgent.java:132) [nifi-framework-core-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_51]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_51]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_51]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_51]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_51]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_51]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_51]
Caused by: java.text.ParseException: Unparseable date: "2016-10-05 13:05:43"
        at java.text.DateFormat.parse(DateFormat.java:366) ~[na:1.8.0_51]
        at org.apache.nifi.processors.standard.PutSQL.setParameter(PutSQL.java:798) ~[nifi-standard-processors-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        at org.apache.nifi.processors.standard.PutSQL.setParameters(PutSQL.java:626) ~[nifi-standard-processors-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
        ... 13 common frames omitted
`

Thank you.
