### PR TITLE
NIFI-2873: Nifi throws UnknownHostException with HA NameNode

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/PutHiveStreaming.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/PutHiveStreaming.java
@@ -27,6 +27,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.hcatalog.streaming.ConnectionError;
 import org.apache.hive.hcatalog.streaming.HiveEndPoint;
@@ -322,6 +323,8 @@ public class PutHiveStreaming extends AbstractProcessor {
                 .withAutoCreatePartitions(autoCreatePartitions)
                 .withMaxOpenConnections(maxConnections)
                 .withHeartBeatInterval(heartbeatInterval);
+
+        hiveConfigurator.preload(hiveConfig);
 
         if (SecurityUtil.isSecurityEnabled(hiveConfig)) {
             final String principal = context.getProperty(kerberosProperties.getKerberosPrincipal()).getValue();

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/util/hive/HiveConfigurator.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/util/hive/HiveConfigurator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.util.hive;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -69,6 +70,14 @@ public class HiveConfigurator {
             }
         }
         return hiveConfig;
+    }
+
+    public void preload(Configuration configuration) {
+        try {
+            FileSystem.get(configuration);
+        }catch(IOException ioe) {
+            // Suppress exception as future uses of this configuration will fail
+        }
     }
 
     public UserGroupInformation authenticate(final Configuration hiveConfig, String principal, String keyTab, long ticketRenewalPeriod, ComponentLog log) throws AuthenticationFailedException {


### PR DESCRIPTION
The fix is to attempt to "preload" the configuration during the setup phase.