### PR TITLE
NIFI-2863: S2S to allow cluster URL more leniently

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteInfoProvider.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteInfoProvider.java
@@ -59,7 +59,7 @@ public class SiteInfoProvider {
         final ControllerDTO controller;
 
         try (final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, proxy, EventReporter.NO_OP)) {
-            apiClient.resolveBaseUrl(clusterUrl);
+            apiClient.setBaseUrl(SiteToSiteRestApiClient.resolveBaseUrl(clusterUrl));
             apiClient.setConnectTimeoutMillis(connectTimeoutMillis);
             apiClient.setReadTimeoutMillis(readTimeoutMillis);
             controller = apiClient.getController();

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
@@ -107,7 +107,7 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
         // Each node should has the same URL structure and network reach-ability with the proxy configuration.
         try (final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(config.getSslContext(), config.getHttpProxy(), config.getEventReporter())) {
             final String scheme = peerDescription.isSecure() ? "https" : "http";
-            final String clusterApiUrl = apiClient.resolveBaseUrl(scheme, peerDescription.getHostname(), peerDescription.getPort());
+            apiClient.setBaseUrl(scheme, peerDescription.getHostname(), peerDescription.getPort());
 
             final int timeoutMillis = (int) config.getTimeout(TimeUnit.MILLISECONDS);
             apiClient.setConnectTimeoutMillis(timeoutMillis);
@@ -115,7 +115,7 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
 
             final Collection<PeerDTO> peers = apiClient.getPeers();
             if(peers == null || peers.size() == 0){
-                throw new IOException("Couldn't get any peer to communicate with. " + clusterApiUrl + " returned zero peers.");
+                throw new IOException("Couldn't get any peer to communicate with. " + apiClient.getBaseUrl() + " returned zero peers.");
             }
 
             // Convert the PeerDTO's to PeerStatus objects. Use 'true' for the query-peer-for-peers flag because Site-to-Site over HTTP

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
@@ -107,6 +107,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -1129,8 +1130,9 @@ public class SiteToSiteRestApiClient implements Closeable {
         try {
             return mapper.readValue(responseMessage, entityClass);
         } catch (JsonParseException e) {
-            logger.warn("Failed to parse Json, response={}", responseMessage);
-            throw e;
+            final String msg = "Failed to parse Json. The specified URL " + baseUrl + " is not a proper remote NiFi endpoint for Site-to-Site communication.";
+            logger.warn("{} requestedUrl={}, response={}", msg, get.getURI(), responseMessage);
+            throw new IOException(msg, e);
         }
     }
 
@@ -1138,6 +1140,12 @@ public class SiteToSiteRestApiClient implements Closeable {
         return baseUrl;
     }
 
+    /**
+     * Set the baseUrl as it is, without altering or adjusting the specified url string.
+     * If the url is specified by user input, and if it needs to be resolved with leniency,
+     * then use {@link #resolveBaseUrl(String)} method before passing it to this method.
+     * @param baseUrl url to set
+     */
     public void setBaseUrl(final String baseUrl) {
         this.baseUrl = baseUrl;
     }
@@ -1150,29 +1158,54 @@ public class SiteToSiteRestApiClient implements Closeable {
         this.readTimeoutMillis = readTimeoutMillis;
     }
 
-    public String resolveBaseUrl(final String clusterUrl) {
+    public static String resolveBaseUrl(final String clusterUrl) {
+        Objects.requireNonNull(clusterUrl, "clusterUrl cannot be null.");
         URI clusterUri;
         try {
-            clusterUri = new URI(clusterUrl);
+            clusterUri = new URI(clusterUrl.trim());
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException("Specified clusterUrl was: " + clusterUrl, e);
         }
-        return this.resolveBaseUrl(clusterUri);
+        return resolveBaseUrl(clusterUri);
     }
 
-    public String resolveBaseUrl(final URI clusterUrl) {
-        String urlPath = clusterUrl.getPath();
-        if (urlPath.endsWith("/")) {
-            urlPath = urlPath.substring(0, urlPath.length() - 1);
+    /**
+     * Resolve NiFi API url with leniency. This method does following conversion on uri path:
+     * <ul>
+     * <li>/ to /nifi-api</li>
+     * <li>/nifi to /nifi-api</li>
+     * <li>/some/path/ to /some/path/nifi-api</li>
+     * </ul>
+     * @param clusterUrl url to be resolved
+     * @return resolved url
+     */
+    public static String resolveBaseUrl(final URI clusterUrl) {
+        String uriPath = clusterUrl.getPath().trim();
+
+        if (StringUtils.isEmpty(uriPath) || uriPath.equals("/")) {
+            uriPath = "/nifi";
+        } else if (uriPath.endsWith("/")) {
+            uriPath = uriPath.substring(0, uriPath.length() - 1);
         }
-        return resolveBaseUrl(clusterUrl.getScheme(), clusterUrl.getHost(), clusterUrl.getPort(), urlPath + "-api");
+
+        if (uriPath.endsWith("/nifi")) {
+            uriPath += "-api";
+        } else if (!uriPath.endsWith("/nifi-api")) {
+            uriPath += "/nifi-api";
+        }
+
+        try {
+            return new URL(clusterUrl.getScheme(), clusterUrl.getHost(), clusterUrl.getPort(), uriPath).toURI().toString();
+        } catch (MalformedURLException|URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
-    public String resolveBaseUrl(final String scheme, final String host, final int port) {
-        return resolveBaseUrl(scheme, host, port, "/nifi-api");
+    public void setBaseUrl(final String scheme, final String host, final int port) {
+        setBaseUrl(scheme, host, port, "/nifi-api");
     }
 
-    private String resolveBaseUrl(final String scheme, final String host, final int port, final String path) {
+    private void setBaseUrl(final String scheme, final String host, final int port, final String path) {
         final String baseUri;
         try {
             baseUri = new URL(scheme, host, port, path).toURI().toString();
@@ -1180,7 +1213,6 @@ public class SiteToSiteRestApiClient implements Closeable {
             throw new IllegalArgumentException(e);
         }
         this.setBaseUrl(baseUri);
-        return baseUri;
     }
 
     public void setCompress(final boolean compress) {

--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/util/TestSiteToSiteRestApiClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/util/TestSiteToSiteRestApiClient.java
@@ -20,6 +20,8 @@ import org.apache.nifi.events.EventReporter;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class TestSiteToSiteRestApiClient {
 
     @Test
@@ -63,6 +65,70 @@ public class TestSiteToSiteRestApiClient {
 
         final String baseUrl = apiClient.resolveBaseUrl("https://nifi.example.com:8443/nifi");
         Assert.assertEquals("https://nifi.example.com:8443/nifi-api", baseUrl);
+    }
+
+    @Test
+    public void testResolveBaseUrlLeniency() {
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
+
+        String expectedUri = "http://localhost:8080/nifi-api";
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080 "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl(" http://localhost:8080 "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/nifi"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/nifi/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/nifi/ "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl(" http://localhost:8080/nifi/ "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/nifi-api"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/nifi-api/"));
+
+        expectedUri = "http://localhost/nifi-api";
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost/nifi"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost/nifi-api"));
+
+        expectedUri = "http://localhost:8080/some/path/nifi-api";
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/some/path"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl(" http://localhost:8080/some/path"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/some/path "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/some/path/nifi"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/some/path/nifi/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/some/path/nifi-api"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("http://localhost:8080/some/path/nifi-api/"));
+    }
+
+    @Test
+    public void testResolveBaseUrlLeniencyHttps() {
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(null, null, EventReporter.NO_OP);
+
+        String expectedUri = "https://localhost:8443/nifi-api";
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443 "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl(" https://localhost:8443 "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/nifi"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/nifi/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/nifi/ "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl(" https://localhost:8443/nifi/ "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/nifi-api"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/nifi-api/"));
+
+        expectedUri = "https://localhost/nifi-api";
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost/nifi"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost/nifi-api"));
+
+        expectedUri = "https://localhost:8443/some/path/nifi-api";
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/some/path"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl(" https://localhost:8443/some/path"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/some/path "));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/some/path/nifi"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/some/path/nifi/"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/some/path/nifi-api"));
+        assertEquals(expectedUri, apiClient.resolveBaseUrl("https://localhost:8443/some/path/nifi-api/"));
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -147,15 +147,8 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
         try {
             uri = new URI(requireNonNull(targetUri.trim()));
 
-            // Trim the trailing /
-            String uriPath = uri.getPath();
-            if (uriPath == null || uriPath.equals("/") || uriPath.trim().isEmpty()) {
-                uriPath = "/nifi";
-            } else if (uriPath.endsWith("/")) {
-                uriPath = uriPath.substring(0, uriPath.length() - 1);
-            }
+            final String apiPath = SiteToSiteRestApiClient.resolveBaseUrl(uri);
 
-            final String apiPath = uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + uriPath.trim() + "-api";
             apiUri = new URI(apiPath);
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException(e);


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

- Consolidated the target cluster URL resolving logic into
  SiteToSiteRestApiClient's as a common method
- Added more unit test cases