### PR TITLE
NIFI-2861 ControlRate should accept more than one flow file per execution (0.x)

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ControlRate.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ControlRate.java
@@ -77,6 +77,9 @@ public class ControlRate extends AbstractProcessor {
     public static final AllowableValue ATTRIBUTE_RATE_VALUE = new AllowableValue(ATTRIBUTE_RATE, ATTRIBUTE_RATE,
             "Rate is controlled by accumulating the value of a specified attribute that is transferred per time duration");
 
+    // based on testing to balance commits and 10,000 FF swap limit
+    public static final int MAX_FLOW_FILES_PER_BATCH = 1000;
+
     public static final PropertyDescriptor RATE_CONTROL_CRITERIA = new PropertyDescriptor.Builder()
             .name("Rate Control Criteria")
             .description("Indicates the criteria that is used to control the throughput rate. Changing this value resets the rate counters.")
@@ -115,14 +118,6 @@ public class ControlRate extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(false)
             .build();
-    public static final PropertyDescriptor MAX_FF_PER_BATCH = new PropertyDescriptor.Builder()
-            .name("Max FlowFiles per processing batch")
-            .description("Maximum number of FlowFiles to accept per processing batch, even if Maximum Rate isn't reached.")
-            .displayName("Max FlowFiles per batch")
-            .required(false)
-            .addValidator(StandardValidators.INTEGER_VALIDATOR)
-            .expressionLanguageSupported(false)
-            .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
@@ -145,7 +140,6 @@ public class ControlRate extends AbstractProcessor {
     private volatile String rateControlAttribute = null;
     private volatile String maximumRateStr = null;
     private volatile String groupingAttributeName = null;
-    private volatile int maxFlowFilesPerBatch = 1;
     private volatile int timePeriodSeconds = 1;
 
     @Override
@@ -156,7 +150,6 @@ public class ControlRate extends AbstractProcessor {
         properties.add(RATE_CONTROL_ATTRIBUTE_NAME);
         properties.add(TIME_PERIOD);
         properties.add(GROUPING_ATTRIBUTE_NAME);
-        properties.add(MAX_FF_PER_BATCH);
         this.properties = Collections.unmodifiableList(properties);
 
         final Set<Relationship> relationships = new HashSet<>();
@@ -215,7 +208,6 @@ public class ControlRate extends AbstractProcessor {
         if (descriptor.equals(RATE_CONTROL_CRITERIA)
                 || descriptor.equals(RATE_CONTROL_ATTRIBUTE_NAME)
                 || descriptor.equals(GROUPING_ATTRIBUTE_NAME)
-                || descriptor.equals(MAX_FF_PER_BATCH)
                 || descriptor.equals(TIME_PERIOD)) {
             // if the criteria that is being used to determine limits/throttles is changed, we must clear our throttle map.
             throttleMap.clear();
@@ -239,17 +231,12 @@ public class ControlRate extends AbstractProcessor {
         rateControlAttribute = context.getProperty(RATE_CONTROL_ATTRIBUTE_NAME).getValue();
         maximumRateStr = context.getProperty(MAX_RATE).getValue().toUpperCase();
         groupingAttributeName = context.getProperty(GROUPING_ATTRIBUTE_NAME).getValue();
-        if (context.getProperty(MAX_FF_PER_BATCH).isSet()) {
-            maxFlowFilesPerBatch = context.getProperty(MAX_FF_PER_BATCH).asInteger();
-        } else {
-            maxFlowFilesPerBatch = 1;
-        }
         timePeriodSeconds = context.getProperty(TIME_PERIOD).asTimePeriod(TimeUnit.SECONDS).intValue();
     }
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
-        List<FlowFile> flowFiles = session.get(new ThrottleFilter(maxFlowFilesPerBatch));
+        List<FlowFile> flowFiles = session.get(new ThrottleFilter(MAX_FLOW_FILES_PER_BATCH));
         if (flowFiles.isEmpty()) {
             context.yield();
             return;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestControlRate.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestControlRate.java
@@ -175,6 +175,65 @@ public class TestControlRate {
         runner.assertQueueEmpty();
     }
 
+    @Test
+    public void testBatchSizeDefaultOne() throws InterruptedException {
+        final TestRunner runner = TestRunners.newTestRunner(new ControlRate());
+        runner.setProperty(ControlRate.RATE_CONTROL_CRITERIA, ControlRate.FLOWFILE_RATE);
+        runner.setProperty(ControlRate.MAX_RATE, "5555");
+        runner.setProperty(ControlRate.TIME_PERIOD, "1 sec");
+
+        runner.enqueue("test data 0");
+        runner.enqueue("test data 1");
+        runner.enqueue("test data 2");
+        runner.enqueue("test data 3");
+        runner.enqueue("test data 4");
+        runner.enqueue("test data 5");
+        runner.enqueue("test data 6");
+        runner.enqueue("test data 7");
+        runner.enqueue("test data 8");
+        runner.enqueue("test data 9");
+
+        runner.run(4, false);
+
+        // we've run 4 times and should have 4 files with 6 in the queue
+        runner.assertAllFlowFilesTransferred(ControlRate.REL_SUCCESS, 4);
+        runner.assertTransferCount(ControlRate.REL_FAILURE, 0);
+        runner.assertQueueNotEmpty();
+        runner.clearTransferState();
+
+        runner.run(8, false);
+        runner.assertAllFlowFilesTransferred(ControlRate.REL_SUCCESS, 6);
+        runner.assertTransferCount(ControlRate.REL_FAILURE, 0);
+        runner.assertQueueEmpty();
+    }
+
+    @Test
+    public void testBatchSizeOneHundred() throws InterruptedException {
+        final TestRunner runner = TestRunners.newTestRunner(new ControlRate());
+        runner.setProperty(ControlRate.RATE_CONTROL_CRITERIA, ControlRate.FLOWFILE_RATE);
+        runner.setProperty(ControlRate.MAX_RATE, "5555");
+        runner.setProperty(ControlRate.TIME_PERIOD, "1 sec");
+        runner.setProperty(ControlRate.MAX_FF_PER_BATCH, "100");
+
+        runner.enqueue("test data 0");
+        runner.enqueue("test data 1");
+        runner.enqueue("test data 2");
+        runner.enqueue("test data 3");
+        runner.enqueue("test data 4");
+        runner.enqueue("test data 5");
+        runner.enqueue("test data 6");
+        runner.enqueue("test data 7");
+        runner.enqueue("test data 8");
+        runner.enqueue("test data 9");
+
+        runner.run(1, false);
+
+        // we've run 1 time and should have all 10 files with 0 in the queue
+        runner.assertAllFlowFilesTransferred(ControlRate.REL_SUCCESS, 10);
+        runner.assertTransferCount(ControlRate.REL_FAILURE, 0);
+        runner.assertQueueEmpty();
+    }
+
     private void createFlowFile(final TestRunner runner, final int value) {
         final Map<String, String> attributeMap = new HashMap<>();
         attributeMap.put("count", String.valueOf(value));


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:
### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
   in the commit message?
- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Is your initial contribution a single, squashed commit?
### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?
### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
### Note:

Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
- Support multiple files per onTrigger call. (0.x branch)
