### PR TITLE
NIFI-2897: Fixed SelectHiveQL for CSV output of complex types

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
@@ -339,6 +339,16 @@ public class HiveJdbcCommon {
                             rowValues.add("");
                         }
                         break;
+                    case ARRAY:
+                    case STRUCT:
+                    case JAVA_OBJECT:
+                        String complexValueString = rs.getString(i);
+                        if (complexValueString != null) {
+                            rowValues.add(StringEscapeUtils.escapeCsv(complexValueString));
+                        } else {
+                            rowValues.add("");
+                        }
+                        break;
                     default:
                         if (value != null) {
                             rowValues.add(value.toString());


### PR DESCRIPTION
The lack of unit tests is due to the fact that we use Derby. When we get integration tests in place using MiniHS2, we can automate this kind of testing. In the meantime, here are some helpful HiveDDL statements you can use to populate a table with the different types, along with some queries that will illustrate the problem and solution:

Create a table with a field that is an array of structs:

`create table arraytest (a ARRAY<STRUCT<name:STRING, age:INT>>)`


Insert two elements (this assumes you have a table named "dummy" with at least one row):

`insert into arraytest select array(named_struct("name","Joe","age",42),named_struct("name","Mary","age",24)) from dummy limit 1`

Select the whole array (as one field):

`SELECT * FROM arraytest`

Select the structs as individual columns:

`SELECT a[0], a[1] FROM arraytest`

Select a struct and a field from the other struct:

`SELECT a[0], a[1].name FROM arraytest`

The first SELECT should generate a single field/column in CSV, the other two should have two columns, all properly escaped to give valid CSV. 