### PR TITLE
[NIFI-2899] Updated swagger-maven-plugin to 3.0.1

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>com.github.kongchen</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>3.0-M1</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>


### PR DESCRIPTION
Incorporates the fix from https://github.com/kongchen/swagger-maven-plugin/issues/141 
Ensures the new swagger.json is spec 2.0 compliant, see https://github.com/swagger-api/swagger-codegen/issues/3976