### PR TITLE
NIFI-2909 and NIFI-1712 Per-Instance ClassLoading

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/RequiresInstanceClassLoading.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/RequiresInstanceClassLoading.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.annotation.behavior;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *  Marker annotation a component can use to indicate that the framework should create a new ClassLoader
+ *  for each instance of the component, copying all resources from the component's NARClassLoader to a
+ *  new ClassLoader which will only be used by a given instance of the component.
+ *
+ *  This annotation is typically used when a component has one or more PropertyDescriptors which set
+ *  dynamicallyModifiesClasspath(boolean) to true.
+ *
+ *  When this annotation is used it is important to note that each added instance of the component will increase
+ *  the overall memory footprint more than that of a component without this annotation.
+ */
+@Documented
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface RequiresInstanceClassLoading {
+}

--- a/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
@@ -79,6 +79,11 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
      * Language
      */
     private final boolean expressionLanguageSupported;
+    /**
+     * indicates whether or not this property represents resources that should be added
+     * to the classpath for this instance of the component
+     */
+    private final boolean dynamicallyModifiesClasspath;
 
     /**
      * the interface of the {@link ControllerService} that this Property refers
@@ -102,6 +107,7 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
         this.required = builder.required;
         this.sensitive = builder.sensitive;
         this.dynamic = builder.dynamic;
+        this.dynamicallyModifiesClasspath = builder.dynamicallyModifiesClasspath;
         this.expressionLanguageSupported = builder.expressionLanguageSupported;
         this.controllerServiceDefinition = builder.controllerServiceDefinition;
         this.validators = new ArrayList<>(builder.validators);
@@ -232,6 +238,7 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
         private boolean sensitive = false;
         private boolean expressionLanguageSupported = false;
         private boolean dynamic = false;
+        private boolean dynamicallyModifiesClasspath = false;
         private Class<? extends ControllerService> controllerServiceDefinition;
         private List<Validator> validators = new ArrayList<>();
 
@@ -244,6 +251,7 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
             this.required = specDescriptor.required;
             this.sensitive = specDescriptor.sensitive;
             this.dynamic = specDescriptor.dynamic;
+            this.dynamicallyModifiesClasspath = specDescriptor.dynamicallyModifiesClasspath;
             this.expressionLanguageSupported = specDescriptor.expressionLanguageSupported;
             this.controllerServiceDefinition = specDescriptor.getControllerServiceDefinition();
             this.validators = new ArrayList<>(specDescriptor.validators);
@@ -328,6 +336,22 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
 
         public Builder dynamic(final boolean dynamic) {
             this.dynamic = dynamic;
+            return this;
+        }
+
+        /**
+         * Specifies that the value of this property represents one or more resources that the
+         * framework should add to the classpath of the given component.
+         *
+         * NOTE: If a component contains a PropertyDescriptor where dynamicallyModifiesClasspath is set to true,
+         *  the component must also be annotated with @RequiresInstanceClassloading, otherwise the component will be
+         *  considered invalid.
+         *
+         * @param dynamicallyModifiesClasspath whether or not this property should be used by the framework to modify the classpath
+         * @return the builder
+         */
+        public Builder dynamicallyModifiesClasspath(final boolean dynamicallyModifiesClasspath) {
+            this.dynamicallyModifiesClasspath = dynamicallyModifiesClasspath;
             return this;
         }
 
@@ -490,6 +514,10 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
 
     public boolean isExpressionLanguageSupported() {
         return expressionLanguageSupported;
+    }
+
+    public boolean isDynamicClasspathModifier() {
+        return dynamicallyModifiesClasspath;
     }
 
     public Class<? extends ControllerService> getControllerServiceDefinition() {

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
@@ -591,4 +591,5 @@ public class FileUtils {
 
         return digest.digest();
     }
+
 }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
@@ -18,9 +18,13 @@ package org.apache.nifi.util.file.classloader;
 
 import java.io.FilenameFilter;
 import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -77,6 +81,43 @@ public class TestClassLoaderUtils {
 
         jarFilePath = ",src/test/resources/TestClassLoaderUtils/TestSuccess.jar, ";
         assertNotNull(ClassLoaderUtils.getCustomClassLoader(jarFilePath, this.getClass().getClassLoader(), getJarFilenameFilter()));
+    }
+
+    @Test
+    public void testGetURLsForClasspathWithDirectory() throws MalformedURLException {
+        final String jarFilePath = "src/test/resources/TestClassLoaderUtils";
+        URL[] urls = ClassLoaderUtils.getURLsForClasspath(jarFilePath, null, false);
+        assertEquals(2, urls.length);
+    }
+
+    @Test
+    public void testGetURLsForClasspathWithSingleJAR() throws MalformedURLException {
+        final String jarFilePath = "src/test/resources/TestClassLoaderUtils/TestSuccess.jar";
+        URL[] urls = ClassLoaderUtils.getURLsForClasspath(jarFilePath, null, false);
+        assertEquals(1, urls.length);
+    }
+
+    @Test(expected = MalformedURLException.class)
+    public void testGetURLsForClasspathWithSomeNonExistentAndNoSuppression() throws MalformedURLException {
+        final String jarFilePath = "src/test/resources/TestClassLoaderUtils/TestSuccess.jar,src/test/resources/TestClassLoaderUtils/FakeTest.jar";
+        ClassLoaderUtils.getURLsForClasspath(jarFilePath, null, false);
+    }
+
+    @Test
+    public void testGetURLsForClasspathWithSomeNonExistentAndSuppression() throws MalformedURLException {
+        final String jarFilePath = "src/test/resources/TestClassLoaderUtils/TestSuccess.jar,src/test/resources/TestClassLoaderUtils/FakeTest.jar";
+        URL[] urls = ClassLoaderUtils.getURLsForClasspath(jarFilePath, null, true);
+        assertEquals(1, urls.length);
+    }
+
+    @Test
+    public void testGetURLsForClasspathWithSetAndSomeNonExistentAndSuppression() throws MalformedURLException {
+        final Set<String> modules = new HashSet<>();
+        modules.add("src/test/resources/TestClassLoaderUtils/TestSuccess.jar,src/test/resources/TestClassLoaderUtils/FakeTest1.jar");
+        modules.add("src/test/resources/TestClassLoaderUtils/FakeTest2.jar,src/test/resources/TestClassLoaderUtils/FakeTest3.jar");
+
+        URL[] urls = ClassLoaderUtils.getURLsForClasspath(modules, null, true);
+        assertEquals(1, urls.length);
     }
 
     protected FilenameFilter getJarFilenameFilter(){

--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2269,6 +2269,58 @@ API artifacts into the same NAR is often acceptable.
 
 
 
+[[per-instance-classloading]]
+== Per-Instance ClassLoading
+
+A component developer may wish to add additional resources to the component’s classpath at runtime.
+For example, you may want to provide the location of a JDBC driver to a processor that interacts with a
+relational database, thus allowing the processor to work with any driver rather than trying to bundle a
+driver into the NAR.
+
+This may be accomplished by declaring one or more PropertyDescriptor instances with
+`dynamicallyModifiesClasspath` set to true. For example:
+
+
+[source,java]
+----
+PropertyDescriptor EXTRA_RESOURCE = new PropertyDescriptor.Builder()
+   .name("Extra Resources")
+   .description("The path to one or more resources to add to the classpath.")
+   .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+   .expressionLanguageSupported(true)
+   .dynamicallyModifiesClasspath(true)
+   .build();
+----
+
+When these properties are set on a component, the framework identifies all properties where
+`dynamicallyModifiesClasspath` is set to true. For each of these properties, the framework
+attempts to resolve filesystem resources from the value of the property. The value may be a
+comma-separated list of one or more directories or files, where any paths that do not exist are
+skipped. If the resource represents a directory, the directory is listed, and all of the files
+in that directory are added to the classpath individually.
+
+Each property may impose further restrictions on the format of the value through the validators.
+For example, using StandardValidators.FILE_EXISTS_VALIDATOR restricts the property to accepting a
+single file. Using StandardValidators.NON_EMPTY_VALIDATOR allows any combination of comma-separated
+files or directories.
+
+Resources are added to the instance ClassLoader by adding them to an inner ClassLoader that is always
+checked first. Anytime the value of these properties change, the inner ClassLoader is closed and
+re-created with the new resources.
+
+NiFi provides the `@RequiresInstanceClassLoading` annotation to further expand and isolate the libraries
+available on a component’s classpath. You can annotate a component with `@RequiresInstanceClassLoading`
+to indicate that the instance ClassLoader for the component requires a copy of all the resources in the
+component's NAR ClassLoader. When `@RequiresInstanceClassLoading` is not present, the
+instance ClassLoader simply has it's parent ClassLoader set to the NAR ClassLoader, rather than
+copying resources.
+
+Because @RequiresInstanceClassLoading copies resources from the NAR ClassLoader for each instance of the
+component, use this capability judiciously. If ten instances of one component are created, all classes
+from the component's NAR ClassLoader are loaded into memory ten times. This could eventually increase the
+memory footprint significantly when enough instances of the component are created.
+
+
 
 == How to contribute to Apache NiFi
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/init/ControllerServiceInitializer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/init/ControllerServiceInitializer.java
@@ -19,6 +19,7 @@ package org.apache.nifi.documentation.init;
 import org.apache.nifi.annotation.lifecycle.OnShutdown;
 import org.apache.nifi.components.ConfigurableComponent;
 import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.documentation.ConfigurableComponentInitializer;
 import org.apache.nifi.documentation.mock.MockConfigurationContext;
 import org.apache.nifi.documentation.mock.MockControllerServiceInitializationContext;
@@ -38,15 +39,15 @@ public class ControllerServiceInitializer implements ConfigurableComponentInitia
     @Override
     public void initialize(ConfigurableComponent component) throws InitializationException {
         ControllerService controllerService = (ControllerService) component;
-
-        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass())) {
-            controllerService.initialize(new MockControllerServiceInitializationContext());
+        ControllerServiceInitializationContext context = new MockControllerServiceInitializationContext();
+        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass(), context.getIdentifier())) {
+            controllerService.initialize(context);
         }
     }
 
     @Override
     public void teardown(ConfigurableComponent component) {
-        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass())) {
+        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass(), component.getIdentifier())) {
             ControllerService controllerService = (ControllerService) component;
 
             final ComponentLog logger = new MockComponentLogger();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/init/ProcessorInitializer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/init/ProcessorInitializer.java
@@ -26,6 +26,7 @@ import org.apache.nifi.documentation.util.ReflectionUtils;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.nar.NarCloseable;
 import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.ProcessorInitializationContext;
 
 /**
  * Initializes a Procesor using a MockProcessorInitializationContext
@@ -37,15 +38,16 @@ public class ProcessorInitializer implements ConfigurableComponentInitializer {
     @Override
     public void initialize(ConfigurableComponent component) {
         Processor processor = (Processor) component;
-        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass())) {
-            processor.initialize(new MockProcessorInitializationContext());
+        ProcessorInitializationContext initializationContext = new MockProcessorInitializationContext();
+        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass(), initializationContext.getIdentifier())) {
+            processor.initialize(initializationContext);
         }
     }
 
     @Override
     public void teardown(ConfigurableComponent component) {
         Processor processor = (Processor) component;
-        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass())) {
+        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass(), component.getIdentifier())) {
 
             final ComponentLog logger = new MockComponentLogger();
             final MockProcessContext context = new MockProcessContext();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/init/ReportingTaskingInitializer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/init/ReportingTaskingInitializer.java
@@ -25,6 +25,7 @@ import org.apache.nifi.documentation.mock.MockReportingInitializationContext;
 import org.apache.nifi.documentation.util.ReflectionUtils;
 import org.apache.nifi.nar.NarCloseable;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.reporting.ReportingInitializationContext;
 import org.apache.nifi.reporting.ReportingTask;
 
 /**
@@ -37,15 +38,16 @@ public class ReportingTaskingInitializer implements ConfigurableComponentInitial
     @Override
     public void initialize(ConfigurableComponent component) throws InitializationException {
         ReportingTask reportingTask = (ReportingTask) component;
-        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass())) {
-            reportingTask.initialize(new MockReportingInitializationContext());
+        ReportingInitializationContext context = new MockReportingInitializationContext();
+        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass(), context.getIdentifier())) {
+            reportingTask.initialize(context);
         }
     }
 
     @Override
     public void teardown(ConfigurableComponent component) {
         ReportingTask reportingTask = (ReportingTask) component;
-        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass())) {
+        try (NarCloseable narCloseable = NarCloseable.withComponentNarLoader(component.getClass(), component.getIdentifier())) {
 
             final MockConfigurationContext context = new MockConfigurationContext();
             ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnShutdown.class, reportingTask, new MockComponentLogger(), context);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ConfiguredComponent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ConfiguredComponent.java
@@ -35,25 +35,7 @@ public interface ConfiguredComponent extends Authorizable {
 
     public void setAnnotationData(String data);
 
-    /**
-     * Sets the property with the given name to the given value
-     *
-     * @param name the name of the property to update
-     * @param value the value to update the property to
-     */
-    public void setProperty(String name, String value);
-
-    /**
-     * Removes the property and value for the given property name if a
-     * descriptor and value exists for the given name. If the property is
-     * optional its value might be reset to default or will be removed entirely
-     * if was a dynamic property.
-     *
-     * @param name the property to remove
-     * @return true if removed; false otherwise
-     * @throws java.lang.IllegalArgumentException if the name is null
-     */
-    public boolean removeProperty(String name);
+    public void setProperties(Map<String, String> properties);
 
     public Map<PropertyDescriptor, String> getProperties();
 
@@ -75,4 +57,5 @@ public interface ConfiguredComponent extends Authorizable {
      * @return the Canonical Class Name of the component
      */
     String getCanonicalClassName();
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ProcessorNode.java
@@ -28,10 +28,12 @@ import org.apache.nifi.controller.scheduling.ScheduleState;
 import org.apache.nifi.controller.scheduling.SchedulingAgent;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.logging.LogLevel;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,9 +45,10 @@ public abstract class ProcessorNode extends AbstractConfiguredComponent implemen
     protected final AtomicReference<ScheduledState> scheduledState;
 
     public ProcessorNode(final Processor processor, final String id,
-        final ValidationContextFactory validationContextFactory, final ControllerServiceProvider serviceProvider,
-        final String componentType, final String componentCanonicalClass) {
-        super(processor, id, validationContextFactory, serviceProvider, componentType, componentCanonicalClass);
+                         final ValidationContextFactory validationContextFactory, final ControllerServiceProvider serviceProvider,
+                         final String componentType, final String componentCanonicalClass, final VariableRegistry variableRegistry,
+                         final ComponentLog logger) {
+        super(processor, id, validationContextFactory, serviceProvider, componentType, componentCanonicalClass, variableRegistry, logger);
         this.scheduledState = new AtomicReference<>(ScheduledState.STOPPED);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
@@ -408,11 +408,15 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
                         .filter(e -> controllerServiceMapping.containsKey(e.getValue()))
                         .collect(Collectors.toSet());
 
+                final Map<String,String> controllerServiceProps = new HashMap<>();
+
                 for (Map.Entry<PropertyDescriptor, String> propEntry : propertyDescriptors) {
                     final PropertyDescriptor propertyDescriptor = propEntry.getKey();
                     final ControllerServiceNode clone = controllerServiceMapping.get(propEntry.getValue());
-                    reportingTask.setProperty(propertyDescriptor.getName(), clone.getIdentifier());
+                    controllerServiceProps.put(propertyDescriptor.getName(), clone.getIdentifier());
                 }
+
+                reportingTask.setProperties(controllerServiceProps);
             }
         }
     }
@@ -514,14 +518,7 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
             reportingTask.setSchedulingStrategy(SchedulingStrategy.valueOf(dto.getSchedulingStrategy()));
 
             reportingTask.setAnnotationData(dto.getAnnotationData());
-
-            for (final Map.Entry<String, String> entry : dto.getProperties().entrySet()) {
-                if (entry.getValue() == null) {
-                    reportingTask.removeProperty(entry.getKey());
-                } else {
-                    reportingTask.setProperty(entry.getKey(), entry.getValue());
-                }
-            }
+            reportingTask.setProperties(dto.getProperties());
 
             final ComponentLog componentLog = new SimpleProcessLogger(dto.getId(), reportingTask.getReportingTask());
             final ReportingInitializationContext config = new StandardReportingInitializationContext(dto.getId(), dto.getName(),
@@ -922,13 +919,7 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
             procNode.setAutoTerminatedRelationships(relationships);
         }
 
-        for (final Map.Entry<String, String> entry : config.getProperties().entrySet()) {
-            if (entry.getValue() == null) {
-                procNode.removeProperty(entry.getKey());
-            } else {
-                procNode.setProperty(entry.getKey(), entry.getValue());
-            }
-        }
+        procNode.setProperties(config.getProperties());
 
         final ScheduledState scheduledState = ScheduledState.valueOf(processorDTO.getState());
         if (ScheduledState.RUNNING.equals(scheduledState)) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingTaskNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingTaskNode.java
@@ -33,6 +33,7 @@ import org.apache.nifi.controller.ValidationContextFactory;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
 import org.apache.nifi.controller.service.StandardConfigurationContext;
+import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.reporting.ReportingTask;
 import org.apache.nifi.scheduling.SchedulingStrategy;
@@ -50,27 +51,26 @@ public abstract class AbstractReportingTaskNode extends AbstractConfiguredCompon
     private volatile String comment;
     private volatile ScheduledState scheduledState = ScheduledState.STOPPED;
 
-    protected final VariableRegistry variableRegistry;
-
     public AbstractReportingTaskNode(final ReportingTask reportingTask, final String id,
-        final ControllerServiceProvider controllerServiceProvider, final ProcessScheduler processScheduler,
-        final ValidationContextFactory validationContextFactory, final VariableRegistry variableRegistry) {
+                                     final ControllerServiceProvider controllerServiceProvider, final ProcessScheduler processScheduler,
+                                     final ValidationContextFactory validationContextFactory, final VariableRegistry variableRegistry,
+                                     final ComponentLog logger) {
 
         this(reportingTask, id, controllerServiceProvider, processScheduler, validationContextFactory,
-            reportingTask.getClass().getSimpleName(), reportingTask.getClass().getCanonicalName(),variableRegistry);
+            reportingTask.getClass().getSimpleName(), reportingTask.getClass().getCanonicalName(),variableRegistry, logger);
     }
 
 
     public AbstractReportingTaskNode(final ReportingTask reportingTask, final String id,
-            final ControllerServiceProvider controllerServiceProvider, final ProcessScheduler processScheduler,
-        final ValidationContextFactory validationContextFactory,
-        final String componentType, final String componentCanonicalClass, VariableRegistry variableRegistry) {
+                                     final ControllerServiceProvider controllerServiceProvider, final ProcessScheduler processScheduler,
+                                     final ValidationContextFactory validationContextFactory,
+                                     final String componentType, final String componentCanonicalClass, final VariableRegistry variableRegistry,
+                                     final ComponentLog logger) {
 
-        super(reportingTask, id, validationContextFactory, controllerServiceProvider, componentType, componentCanonicalClass);
+        super(reportingTask, id, validationContextFactory, controllerServiceProvider, componentType, componentCanonicalClass, variableRegistry, logger);
         this.reportingTask = reportingTask;
         this.processScheduler = processScheduler;
         this.serviceLookup = controllerServiceProvider;
-        this.variableRegistry = variableRegistry;
     }
 
     @Override
@@ -115,7 +115,7 @@ public abstract class AbstractReportingTaskNode extends AbstractConfiguredCompon
 
     @Override
     public ConfigurationContext getConfigurationContext() {
-        return new StandardConfigurationContext(this, serviceLookup, getSchedulingPeriod(), variableRegistry);
+        return new StandardConfigurationContext(this, serviceLookup, getSchedulingPeriod(), getVariableRegistry());
     }
 
     @Override
@@ -134,17 +134,6 @@ public abstract class AbstractReportingTaskNode extends AbstractConfiguredCompon
     public void setScheduledState(final ScheduledState state) {
         this.scheduledState = state;
     }
-
-    @Override
-    public void setProperty(final String name, final String value) {
-        super.setProperty(name, value);
-    }
-
-    @Override
-    public boolean removeProperty(String name) {
-        return super.removeProperty(name);
-    }
-
 
     public boolean isDisabled() {
         return scheduledState == ScheduledState.DISABLED;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingTaskNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingTaskNode.java
@@ -24,6 +24,7 @@ import org.apache.nifi.controller.FlowController;
 import org.apache.nifi.controller.ProcessScheduler;
 import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.ValidationContextFactory;
+import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.reporting.ReportingContext;
 import org.apache.nifi.reporting.ReportingTask;
@@ -34,15 +35,15 @@ public class StandardReportingTaskNode extends AbstractReportingTaskNode impleme
 
     public StandardReportingTaskNode(final ReportingTask reportingTask, final String id, final FlowController controller,
                                      final ProcessScheduler processScheduler, final ValidationContextFactory validationContextFactory,
-                                     final VariableRegistry variableRegistry) {
-        super(reportingTask, id, controller, processScheduler, validationContextFactory, variableRegistry);
+                                     final VariableRegistry variableRegistry, final ComponentLog logger) {
+        super(reportingTask, id, controller, processScheduler, validationContextFactory, variableRegistry, logger);
         this.flowController = controller;
     }
 
     public StandardReportingTaskNode(final ReportingTask reportingTask, final String id, final FlowController controller,
         final ProcessScheduler processScheduler, final ValidationContextFactory validationContextFactory,
-        final String componentType, final String canonicalClassName, VariableRegistry variableRegistry) {
-        super(reportingTask, id, controller, processScheduler, validationContextFactory, componentType, canonicalClassName,variableRegistry);
+        final String componentType, final String canonicalClassName, final VariableRegistry variableRegistry, final ComponentLog logger) {
+        super(reportingTask, id, controller, processScheduler, validationContextFactory, componentType, canonicalClassName,variableRegistry, logger);
         this.flowController = controller;
     }
 
@@ -58,6 +59,6 @@ public class StandardReportingTaskNode extends AbstractReportingTaskNode impleme
 
     @Override
     public ReportingContext getReportingContext() {
-        return new StandardReportingContext(flowController, flowController.getBulletinRepository(), getProperties(), flowController, getReportingTask(), variableRegistry);
+        return new StandardReportingContext(flowController, flowController.getBulletinRepository(), getProperties(), flowController, getReportingTask(), getVariableRegistry());
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/EventDrivenSchedulingAgent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/EventDrivenSchedulingAgent.java
@@ -287,7 +287,7 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
             }
 
             try {
-                try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(worker.getClass())) {
+                try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(worker.getClass(), worker.getIdentifier())) {
                     worker.onTrigger(processContext, sessionFactory);
                 } catch (final ProcessException pe) {
                     logger.error("{} failed to process session due to {}", worker, pe.toString());
@@ -305,7 +305,7 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
                 }
             } finally {
                 if (!scheduleState.isScheduled() && scheduleState.getActiveThreadCount() == 1 && scheduleState.mustCallOnStoppedMethods()) {
-                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(worker.getClass())) {
+                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(worker.getClass(), worker.getIdentifier())) {
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, worker, processContext);
                     }
                 }
@@ -328,7 +328,7 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
             }
 
             try {
-                try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(worker.getProcessor().getClass())) {
+                try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(worker.getProcessor().getClass(), worker.getIdentifier())) {
                     worker.onTrigger(processContext, sessionFactory);
                 } catch (final ProcessException pe) {
                     final ComponentLog procLog = new SimpleProcessLogger(worker.getIdentifier(), worker.getProcessor());
@@ -347,7 +347,7 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
                 // if the processor is no longer scheduled to run and this is the last thread,
                 // invoke the OnStopped methods
                 if (!scheduleState.isScheduled() && scheduleState.getActiveThreadCount() == 1 && scheduleState.mustCallOnStoppedMethods()) {
-                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(worker.getProcessor().getClass())) {
+                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(worker.getProcessor().getClass(), worker.getIdentifier())) {
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, worker.getProcessor(), processContext);
                     }
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -209,7 +209,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                                 return;
                             }
 
-                            try (final NarCloseable x = NarCloseable.withComponentNarLoader(reportingTask.getClass())) {
+                            try (final NarCloseable x = NarCloseable.withComponentNarLoader(reportingTask.getClass(), reportingTask.getIdentifier())) {
                                 ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, reportingTask, taskNode.getConfigurationContext());
                             }
 
@@ -262,7 +262,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
                     scheduleState.setScheduled(false);
 
                     try {
-                        try (final NarCloseable x = NarCloseable.withComponentNarLoader(reportingTask.getClass())) {
+                        try (final NarCloseable x = NarCloseable.withComponentNarLoader(reportingTask.getClass(), reportingTask.getIdentifier())) {
                             ReflectionUtils.invokeMethodsWithAnnotation(OnUnscheduled.class, reportingTask, configurationContext);
                         }
                     } catch (final Exception e) {
@@ -436,7 +436,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
 
         if (!state.isScheduled() && state.getActiveThreadCount() == 0 && state.mustCallOnStoppedMethods()) {
             final ConnectableProcessContext processContext = new ConnectableProcessContext(connectable, encryptor, getStateManager(connectable.getIdentifier()));
-            try (final NarCloseable x = NarCloseable.withComponentNarLoader(connectable.getClass())) {
+            try (final NarCloseable x = NarCloseable.withComponentNarLoader(connectable.getClass(), connectable.getIdentifier())) {
                 ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, connectable, processContext);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ControllerServiceLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ControllerServiceLoader.java
@@ -166,11 +166,11 @@ public class ControllerServiceLoader {
         clone.setComments(controllerService.getComments());
 
         if (controllerService.getProperties() != null) {
+            Map<String,String> properties = new HashMap<>();
             for (Map.Entry<PropertyDescriptor, String> propEntry : controllerService.getProperties().entrySet()) {
-                if (propEntry.getValue() != null) {
-                    clone.setProperty(propEntry.getKey().getName(), propEntry.getValue());
-                }
+                properties.put(propEntry.getKey().getName(), propEntry.getValue());
             }
+            clone.setProperties(properties);
         }
 
         return clone;
@@ -188,14 +188,7 @@ public class ControllerServiceLoader {
     private static void configureControllerService(final ControllerServiceNode node, final Element controllerServiceElement, final StringEncryptor encryptor) {
         final ControllerServiceDTO dto = FlowFromDOMFactory.getControllerService(controllerServiceElement, encryptor);
         node.setAnnotationData(dto.getAnnotationData());
-
-        for (final Map.Entry<String, String> entry : dto.getProperties().entrySet()) {
-            if (entry.getValue() == null) {
-                node.removeProperty(entry.getKey());
-            } else {
-                node.setProperty(entry.getKey(), entry.getValue());
-            }
-        }
+        node.setProperties(dto.getProperties());
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceProvider.java
@@ -131,7 +131,7 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
 
         final ClassLoader currentContextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
-            final ClassLoader cl = ExtensionManager.getClassLoader(type);
+            final ClassLoader cl = ExtensionManager.getClassLoader(type, id);
             final Class<?> rawClass;
 
             try {
@@ -165,7 +165,7 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
                     final boolean disabled = state != ControllerServiceState.ENABLED; // only allow method call if service state is ENABLED.
                     if (disabled && !validDisabledMethods.contains(method)) {
                         // Use nar class loader here because we are implicitly calling toString() on the original implementation.
-                        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(originalService.getClass())) {
+                        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(originalService.getClass(), originalService.getIdentifier())) {
                             throw new IllegalStateException("Cannot invoke method " + method + " on Controller Service " + originalService.getIdentifier()
                                     + " because the Controller Service is disabled");
                         } catch (final Throwable e) {
@@ -173,7 +173,7 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
                         }
                     }
 
-                    try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(originalService.getClass())) {
+                    try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(originalService.getClass(), originalService.getIdentifier())) {
                         return method.invoke(originalService, args);
                     } catch (final InvocationTargetException e) {
                         // If the ControllerService throws an Exception, it'll be wrapped in an InvocationTargetException. We want
@@ -194,14 +194,15 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
             final ComponentLog serviceLogger = new SimpleProcessLogger(id, originalService);
             originalService.initialize(new StandardControllerServiceInitializationContext(id, serviceLogger, this, getStateManager(id), nifiProperties));
 
+            final ComponentLog logger = new SimpleProcessLogger(id, originalService);
             final ValidationContextFactory validationContextFactory = new StandardValidationContextFactory(this, variableRegistry);
 
-            final ControllerServiceNode serviceNode = new StandardControllerServiceNode(proxiedService, originalService, id, validationContextFactory, this, variableRegistry);
+            final ControllerServiceNode serviceNode = new StandardControllerServiceNode(proxiedService, originalService, id, validationContextFactory, this, variableRegistry, logger);
             serviceNodeHolder.set(serviceNode);
             serviceNode.setName(rawClass.getSimpleName());
 
             if (firstTimeAdded) {
-                try (final NarCloseable x = NarCloseable.withComponentNarLoader(originalService.getClass())) {
+                try (final NarCloseable x = NarCloseable.withComponentNarLoader(originalService.getClass(), originalService.getIdentifier())) {
                     ReflectionUtils.invokeMethodsWithAnnotation(OnAdded.class, originalService);
                 } catch (final Exception e) {
                     throw new ComponentLifeCycleException("Failed to invoke On-Added Lifecycle methods of " + originalService, e);
@@ -264,8 +265,10 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
         final String simpleClassName = type.contains(".") ? StringUtils.substringAfterLast(type, ".") : type;
         final String componentType = "(Missing) " + simpleClassName;
 
+        final ComponentLog logger = new SimpleProcessLogger(id, proxiedService);
+
         final ControllerServiceNode serviceNode = new StandardControllerServiceNode(proxiedService, proxiedService, id,
-                new StandardValidationContextFactory(this, variableRegistry), this, componentType, type, variableRegistry);
+                new StandardValidationContextFactory(this, variableRegistry), this, componentType, type, variableRegistry, logger);
         return serviceNode;
     }
 
@@ -585,6 +588,7 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
         }
 
         group.removeControllerService(serviceNode);
+        ExtensionManager.removeInstanceClassLoaderIfExists(serviceNode.getIdentifier());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ContinuallyRunConnectableTask.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ContinuallyRunConnectableTask.java
@@ -76,7 +76,7 @@ public class ContinuallyRunConnectableTask implements Callable<Boolean> {
         if (shouldRun) {
             scheduleState.incrementActiveThreadCount();
             try {
-                try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(connectable.getClass())) {
+                try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(connectable.getClass(), connectable.getIdentifier())) {
                     connectable.onTrigger(processContext, sessionFactory);
                 } catch (final ProcessException pe) {
                     logger.error("{} failed to process session due to {}", connectable, pe.toString());
@@ -93,7 +93,7 @@ public class ContinuallyRunConnectableTask implements Callable<Boolean> {
                 }
             } finally {
                 if (!scheduleState.isScheduled() && scheduleState.getActiveThreadCount() == 1 && scheduleState.mustCallOnStoppedMethods()) {
-                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(connectable.getClass())) {
+                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(connectable.getClass(), connectable.getIdentifier())) {
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, connectable, processContext);
                     }
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ContinuallyRunProcessorTask.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ContinuallyRunProcessorTask.java
@@ -130,7 +130,7 @@ public class ContinuallyRunProcessorTask implements Callable<Boolean> {
         final long finishNanos = startNanos + batchNanos;
         int invocationCount = 0;
         try {
-            try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(procNode.getProcessor().getClass())) {
+            try (final AutoCloseable ncl = NarCloseable.withComponentNarLoader(procNode.getProcessor().getClass(), procNode.getIdentifier())) {
                 boolean shouldRun = true;
                 while (shouldRun) {
                     procNode.onTrigger(processContext, sessionFactory);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ReportingTaskWrapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ReportingTaskWrapper.java
@@ -37,7 +37,7 @@ public class ReportingTaskWrapper implements Runnable {
     @Override
     public synchronized void run() {
         scheduleState.incrementActiveThreadCount();
-        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(taskNode.getReportingTask().getClass())) {
+        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(taskNode.getReportingTask().getClass(), taskNode.getIdentifier())) {
             taskNode.getReportingTask().onTrigger(taskNode.getReportingContext());
         } catch (final Throwable t) {
             final ComponentLog componentLog = new SimpleProcessLogger(taskNode.getIdentifier(), taskNode.getReportingTask());
@@ -50,7 +50,7 @@ public class ReportingTaskWrapper implements Runnable {
                 // if the reporting task is no longer scheduled to run and this is the last thread,
                 // invoke the OnStopped methods
                 if (!scheduleState.isScheduled() && scheduleState.getActiveThreadCount() == 1 && scheduleState.mustCallOnStoppedMethods()) {
-                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(taskNode.getReportingTask().getClass())) {
+                    try (final NarCloseable x = NarCloseable.withComponentNarLoader(taskNode.getReportingTask().getClass(), taskNode.getIdentifier())) {
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, taskNode.getReportingTask(), taskNode.getConfigurationContext());
                     }
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardProcessorNode.java
@@ -17,16 +17,6 @@
 
 package org.apache.nifi.controller;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
@@ -35,17 +25,59 @@ import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.engine.FlowEngine;
 import org.apache.nifi.expression.ExpressionLanguageCompiler;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.nar.ExtensionManager;
+import org.apache.nifi.nar.InstanceClassLoader;
+import org.apache.nifi.nar.NarCloseable;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.StandardProcessContext;
+import org.apache.nifi.processor.StandardProcessorInitializationContext;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.registry.VariableDescriptor;
+import org.apache.nifi.registry.VariableRegistry;
+import org.apache.nifi.test.processors.ModifiesClasspathNoAnnotationProcessor;
+import org.apache.nifi.test.processors.ModifiesClasspathProcessor;
 import org.apache.nifi.util.MockPropertyValue;
+import org.apache.nifi.util.MockVariableRegistry;
 import org.apache.nifi.util.NiFiProperties;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestStandardProcessorNode {
+
+    private MockVariableRegistry variableRegistry;
+
+    @Before
+    public void setup() {
+        variableRegistry = new MockVariableRegistry();
+    }
 
     @Test(timeout = 10000)
     public void testStart() throws InterruptedException {
@@ -53,8 +85,12 @@ public class TestStandardProcessorNode {
         final ProcessorThatThrowsExceptionOnScheduled processor = new ProcessorThatThrowsExceptionOnScheduled();
         final String uuid = UUID.randomUUID().toString();
 
-        final StandardProcessorNode procNode = new StandardProcessorNode(processor, uuid, createValidationContextFactory(), null, null, NiFiProperties.createBasicNiFiProperties(null, null));
-        final ScheduledExecutorService taskScheduler = new FlowEngine(2, "TestStandardProcessorNode", true);
+        ProcessorInitializationContext initContext = new StandardProcessorInitializationContext(uuid, null, null, null, null);
+        processor.initialize(initContext);
+
+        final StandardProcessorNode procNode = new StandardProcessorNode(processor, uuid, createValidationContextFactory(), null, null,
+                NiFiProperties.createBasicNiFiProperties(null, null), VariableRegistry.EMPTY_REGISTRY, Mockito.mock(ComponentLog.class));
+        final ScheduledExecutorService taskScheduler = new FlowEngine(2, "TestClasspathResources", true);
 
         final StandardProcessContext processContext = new StandardProcessContext(procNode, null, null, null, null);
         final SchedulingAgentCallback schedulingAgentCallback = new SchedulingAgentCallback() {
@@ -79,6 +115,220 @@ public class TestStandardProcessorNode {
         assertEquals(1, processor.onScheduledCount);
         assertEquals(1, processor.onUnscheduledCount);
         assertEquals(1, processor.onStoppedCount);
+    }
+
+    @Test
+    public void testSinglePropertyDynamicallyModifiesClasspath() throws MalformedURLException {
+        final PropertyDescriptor classpathProp = new PropertyDescriptor.Builder().name("Classpath Resources")
+                .dynamicallyModifiesClasspath(true).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
+        final ModifiesClasspathProcessor processor = new ModifiesClasspathProcessor(Arrays.asList(classpathProp));
+        final StandardProcessorNode procNode = createProcessorNode(processor);
+
+        final Set<ClassLoader> classLoaders = new HashSet<>();
+        classLoaders.add(procNode.getProcessor().getClass().getClassLoader());
+
+        // Load all of the extensions in src/test/java of this project
+        ExtensionManager.discoverExtensions(classLoaders);
+
+        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(procNode.getProcessor().getClass(), procNode.getIdentifier())){
+            // Should have an InstanceClassLoader here
+            final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            assertTrue(contextClassLoader instanceof InstanceClassLoader);
+
+            final InstanceClassLoader instanceClassLoader = (InstanceClassLoader) contextClassLoader;
+
+            // Should not have any of the test resources loaded at this point
+            final URL[] testResources = getTestResources();
+            for (URL testResource : testResources) {
+                if (containsResource(instanceClassLoader.getInstanceResources(), testResource)) {
+                    fail("found resource that should not have been loaded");
+                }
+            }
+
+            // Simulate setting the properties of the processor to point to the test resources directory
+            final Map<String, String> properties = new HashMap<>();
+            properties.put(classpathProp.getName(), "src/test/resources/TestClasspathResources");
+            procNode.setProperties(properties);
+
+            // Should have all of the resources loaded into the InstanceClassLoader now
+            for (URL testResource : testResources) {
+                assertTrue(containsResource(instanceClassLoader.getInstanceResources(), testResource));
+            }
+
+            // Should pass validation
+            assertTrue(procNode.isValid());
+        } finally {
+            ExtensionManager.removeInstanceClassLoaderIfExists(procNode.getIdentifier());
+        }
+    }
+
+    @Test
+    public void testMultiplePropertiesDynamicallyModifyClasspathWithExpressionLanguage() throws MalformedURLException {
+        final PropertyDescriptor classpathProp1 = new PropertyDescriptor.Builder().name("Classpath Resource 1")
+                .dynamicallyModifiesClasspath(true).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
+        final PropertyDescriptor classpathProp2 = new PropertyDescriptor.Builder().name("Classpath Resource 2")
+                .dynamicallyModifiesClasspath(true).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
+
+        final ModifiesClasspathProcessor processor = new ModifiesClasspathProcessor(Arrays.asList(classpathProp1, classpathProp2));
+        final StandardProcessorNode procNode = createProcessorNode(processor);
+
+        final Set<ClassLoader> classLoaders = new HashSet<>();
+        classLoaders.add(procNode.getProcessor().getClass().getClassLoader());
+
+        // Load all of the extensions in src/test/java of this project
+        ExtensionManager.discoverExtensions(classLoaders);
+
+        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(procNode.getProcessor().getClass(), procNode.getIdentifier())){
+            // Should have an InstanceClassLoader here
+            final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            assertTrue(contextClassLoader instanceof InstanceClassLoader);
+
+            final InstanceClassLoader instanceClassLoader = (InstanceClassLoader) contextClassLoader;
+
+            // Should not have any of the test resources loaded at this point
+            final URL[] testResources = getTestResources();
+            for (URL testResource : testResources) {
+                if (containsResource(instanceClassLoader.getInstanceResources(), testResource)) {
+                    fail("found resource that should not have been loaded");
+                }
+            }
+
+            // Simulate setting the properties pointing to two of the resources
+            final Map<String, String> properties = new HashMap<>();
+            properties.put(classpathProp1.getName(), "src/test/resources/TestClasspathResources/resource1.txt");
+            properties.put(classpathProp2.getName(), "src/test/resources/TestClasspathResources/${myResource}");
+
+            variableRegistry.setVariable(new VariableDescriptor("myResource"), "resource3.txt");
+
+            procNode.setProperties(properties);
+
+            // Should have resources 1 and 3 loaded into the InstanceClassLoader now
+            assertTrue(containsResource(instanceClassLoader.getInstanceResources(), testResources[0]));
+            assertTrue(containsResource(instanceClassLoader.getInstanceResources(), testResources[2]));
+            assertFalse(containsResource(instanceClassLoader.getInstanceResources(), testResources[1]));
+
+            // Should pass validation
+            assertTrue(procNode.isValid());
+        } finally {
+            ExtensionManager.removeInstanceClassLoaderIfExists(procNode.getIdentifier());
+        }
+    }
+
+    @Test
+    public void testSomeNonExistentPropertiesDynamicallyModifyClasspath() throws MalformedURLException {
+        final PropertyDescriptor classpathProp1 = new PropertyDescriptor.Builder().name("Classpath Resource 1")
+                .dynamicallyModifiesClasspath(true).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
+        final PropertyDescriptor classpathProp2 = new PropertyDescriptor.Builder().name("Classpath Resource 2")
+                .dynamicallyModifiesClasspath(true).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
+
+        final ModifiesClasspathProcessor processor = new ModifiesClasspathProcessor(Arrays.asList(classpathProp1, classpathProp2));
+        final StandardProcessorNode procNode = createProcessorNode(processor);
+
+        final Set<ClassLoader> classLoaders = new HashSet<>();
+        classLoaders.add(procNode.getProcessor().getClass().getClassLoader());
+
+        // Load all of the extensions in src/test/java of this project
+        ExtensionManager.discoverExtensions(classLoaders);
+
+        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(procNode.getProcessor().getClass(), procNode.getIdentifier())){
+            // Should have an InstanceClassLoader here
+            final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            assertTrue(contextClassLoader instanceof InstanceClassLoader);
+
+            final InstanceClassLoader instanceClassLoader = (InstanceClassLoader) contextClassLoader;
+
+            // Should not have any of the test resources loaded at this point
+            final URL[] testResources = getTestResources();
+            for (URL testResource : testResources) {
+                if (containsResource(instanceClassLoader.getInstanceResources(), testResource)) {
+                    fail("found resource that should not have been loaded");
+                }
+            }
+
+            // Simulate setting the properties pointing to two of the resources
+            final Map<String, String> properties = new HashMap<>();
+            properties.put(classpathProp1.getName(), "src/test/resources/TestClasspathResources/resource1.txt");
+            properties.put(classpathProp2.getName(), "src/test/resources/TestClasspathResources/DoesNotExist.txt");
+            procNode.setProperties(properties);
+
+            // Should have resources 1 and 3 loaded into the InstanceClassLoader now
+            assertTrue(containsResource(instanceClassLoader.getInstanceResources(), testResources[0]));
+            assertFalse(containsResource(instanceClassLoader.getInstanceResources(), testResources[1]));
+            assertFalse(containsResource(instanceClassLoader.getInstanceResources(), testResources[2]));
+
+            // Should pass validation
+            assertTrue(procNode.isValid());
+        } finally {
+            ExtensionManager.removeInstanceClassLoaderIfExists(procNode.getIdentifier());
+        }
+    }
+
+    @Test
+    public void testPropertyModifiesClasspathWhenProcessorMissingAnnotation() throws MalformedURLException {
+        final ModifiesClasspathNoAnnotationProcessor processor = new ModifiesClasspathNoAnnotationProcessor();
+        final StandardProcessorNode procNode = createProcessorNode(processor);
+
+        final Set<ClassLoader> classLoaders = new HashSet<>();
+        classLoaders.add(procNode.getProcessor().getClass().getClassLoader());
+
+        // Load all of the extensions in src/test/java of this project
+        ExtensionManager.discoverExtensions(classLoaders);
+
+        try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(procNode.getProcessor().getClass(), procNode.getIdentifier())){
+            // Can't validate the ClassLoader here b/c the class is missing the annotation
+
+            // Simulate setting the properties pointing to two of the resources
+            final Map<String, String> properties = new HashMap<>();
+            properties.put(ModifiesClasspathNoAnnotationProcessor.CLASSPATH_RESOURCE.getName(),
+                    "src/test/resources/TestClasspathResources/resource1.txt");
+            procNode.setProperties(properties);
+
+            // Should not have loaded any of the resources
+            final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            assertTrue(classLoader instanceof URLClassLoader);
+
+            final URL[] testResources = getTestResources();
+            final URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
+            assertFalse(containsResource(urlClassLoader.getURLs(), testResources[0]));
+            assertFalse(containsResource(urlClassLoader.getURLs(), testResources[1]));
+            assertFalse(containsResource(urlClassLoader.getURLs(), testResources[2]));
+
+            // Should pass validation
+            assertTrue(procNode.isValid());
+
+        } finally {
+            ExtensionManager.removeInstanceClassLoaderIfExists(procNode.getIdentifier());
+        }
+    }
+
+    private StandardProcessorNode createProcessorNode(Processor processor) {
+        final String uuid = UUID.randomUUID().toString();
+        final ValidationContextFactory validationContextFactory = createValidationContextFactory();
+        final NiFiProperties niFiProperties = NiFiProperties.createBasicNiFiProperties(null, null);
+        final ProcessScheduler processScheduler = Mockito.mock(ProcessScheduler.class);
+        final ComponentLog componentLog = Mockito.mock(ComponentLog.class);
+
+        ProcessorInitializationContext initContext = new StandardProcessorInitializationContext(uuid, componentLog, null, null, null);
+        processor.initialize(initContext);
+
+        return new StandardProcessorNode(processor, uuid, validationContextFactory, processScheduler, null,
+                niFiProperties, variableRegistry, componentLog);
+    }
+
+    private boolean containsResource(URL[] resources, URL resourceToFind) {
+        for (URL resource : resources) {
+            if (resourceToFind.getPath().equals(resource.getPath())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private URL[] getTestResources() throws MalformedURLException {
+        URL resource1 = new File("src/test/resources/TestClasspathResources/resource1.txt").toURI().toURL();
+        URL resource2 = new File("src/test/resources/TestClasspathResources/resource2.txt").toURI().toURL();
+        URL resource3 = new File("src/test/resources/TestClasspathResources/resource3.txt").toURI().toURL();
+        return new URL[] { resource1, resource2, resource3 };
     }
 
 
@@ -180,4 +430,5 @@ public class TestStandardProcessorNode {
             onStoppedCount++;
         }
     }
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestProcessorLifecycle.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestProcessorLifecycle.java
@@ -83,10 +83,12 @@ public class TestProcessorLifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(TestProcessorLifecycle.class);
     private FlowController fc;
+    private Map<String,String> properties = new HashMap<>();
 
     @Before
     public void before() throws Exception {
         System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestProcessorLifecycle.class.getResource("/nifi.properties").getFile());
+        properties.put("P", "hello");
     }
 
     @After
@@ -124,7 +126,7 @@ public class TestProcessorLifecycle {
         this.setControllerRootGroup(fc, testGroup);
         final ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(),
                 UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         assertEquals(ScheduledState.STOPPED, testProcNode.getScheduledState());
         assertEquals(ScheduledState.STOPPED, testProcNode.getPhysicalScheduledState());
         // validates idempotency
@@ -149,7 +151,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         final ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -175,7 +177,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         final ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
         assertTrue(testProcNode.getScheduledState() == ScheduledState.STOPPED);
         // sets the scenario for the processor to run
@@ -198,7 +200,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -241,7 +243,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         final ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -297,7 +299,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -333,7 +335,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -365,7 +367,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -396,7 +398,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
         // sets the scenario for the processor to run
         this.blockingInterruptableOnUnschedule(testProcessor);
@@ -424,7 +426,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
         // sets the scenario for the processor to run
         this.blockingUninterruptableOnUnschedule(testProcessor);
@@ -457,7 +459,7 @@ public class TestProcessorLifecycle {
         ProcessGroup testGroup = fc.createProcessGroup(UUID.randomUUID().toString());
         this.setControllerRootGroup(fc, testGroup);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNode.setProperty("P", "hello");
+        testProcNode.setProperties(properties);
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
 
         // sets the scenario for the processor to run
@@ -504,8 +506,8 @@ public class TestProcessorLifecycle {
         ControllerServiceNode testServiceNode = fc.createControllerService(TestService.class.getName(), "serv", true);
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
 
-        testProcNode.setProperty("P", "hello");
-        testProcNode.setProperty("S", testServiceNode.getIdentifier());
+        properties.put("S", testServiceNode.getIdentifier());
+        testProcNode.setProperties(properties);
 
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
         testProcessor.withService = true;
@@ -529,8 +531,9 @@ public class TestProcessorLifecycle {
 
         ProcessorNode testProcNode = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
         testGroup.addProcessor(testProcNode);
-        testProcNode.setProperty("P", "hello");
-        testProcNode.setProperty("S", testServiceNode.getIdentifier());
+
+        properties.put("S", testServiceNode.getIdentifier());
+        testProcNode.setProperties(properties);
 
         TestProcessor testProcessor = (TestProcessor) testProcNode.getProcessor();
         testProcessor.withService = true;
@@ -556,11 +559,11 @@ public class TestProcessorLifecycle {
         this.setControllerRootGroup(fc, testGroup);
 
         ProcessorNode testProcNodeA = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNodeA.setProperty("P", "hello");
+        testProcNodeA.setProperties(properties);
         testGroup.addProcessor(testProcNodeA);
 
         ProcessorNode testProcNodeB = fc.createProcessor(TestProcessor.class.getName(), UUID.randomUUID().toString());
-        testProcNodeB.setProperty("P", "hello");
+        testProcNodeB.setProperties(properties);
         testGroup.addProcessor(testProcNodeB);
 
         Collection<String> relationNames = new ArrayList<String>();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/util/TestControllerService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/util/TestControllerService.java
@@ -50,7 +50,7 @@ public class TestControllerService implements ControllerService {
 
     @Override
     public String getIdentifier() {
-        return null;
+        return "id";
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/ModifiesClasspathNoAnnotationProcessor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/ModifiesClasspathNoAnnotationProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.test.processors;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A processor with a property descriptor that attempts to modify the classpath, but the processor
+ * does not have @RequiresInstanceClassLoading.
+ */
+public class ModifiesClasspathNoAnnotationProcessor extends AbstractProcessor {
+
+    public static final PropertyDescriptor CLASSPATH_RESOURCE = new PropertyDescriptor.Builder()
+            .name("Classpath Resource")
+            .dynamicallyModifiesClasspath(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Collections.singletonList(CLASSPATH_RESOURCE);
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/ModifiesClasspathProcessor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/ModifiesClasspathProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.test.processors;
+
+import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+
+import java.util.List;
+
+@RequiresInstanceClassLoading
+public class ModifiesClasspathProcessor extends AbstractProcessor {
+
+    private List<PropertyDescriptor> properties;
+
+    public ModifiesClasspathProcessor() {
+
+    }
+
+    public ModifiesClasspathProcessor(List<PropertyDescriptor> properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.test.processors.ModifiesClasspathProcessor
+org.apache.nifi.test.processors.ModifiesClasspathNoAnnotationProcessor

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestClasspathResources/resource1.txt
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestClasspathResources/resource1.txt
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+resource1

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestClasspathResources/resource2.txt
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestClasspathResources/resource2.txt
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+resource2

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestClasspathResources/resource3.txt
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestClasspathResources/resource3.txt
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+resource3

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/logback-test.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/logback-test.xml
@@ -30,9 +30,12 @@
     
     
     <logger name="org.apache.nifi" level="INFO"/>
+    <logger name="org.apache.nifi.controller.service.mock" level="ERROR"/>
+
+    <logger name="StandardProcessSession.claims" level="INFO" />
+
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
-    
-    <logger name="StandardProcessSession.claims" level="DEBUG" />
+
 </configuration>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/InstanceClassLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/InstanceClassLoader.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.nar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * A ClassLoader created for an instance of a component which lets a client add resources to an intermediary ClassLoader
+ * that will be checked first when loading/finding classes.
+ *
+ * Typically an instance of this ClassLoader will be created by passing in the URLs and parent from a NARClassLoader in
+ * order to create a copy of the NARClassLoader without modifying it.
+ */
+public class InstanceClassLoader extends URLClassLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(InstanceClassLoader.class);
+
+    private final String identifier;
+    private ShimClassLoader shimClassLoader;
+
+    /**
+     * @param identifier the id of the component this ClassLoader was created for
+     * @param urls the URLs for the ClassLoader
+     * @param parent the parent ClassLoader
+     */
+    public InstanceClassLoader(final String identifier, final URL[] urls, final ClassLoader parent) {
+        super(urls, parent);
+        this.identifier = identifier;
+    }
+
+    /**
+     * Initializes a new ShimClassLoader for the provided resources, closing the previous ShimClassLoader if one existed.
+     *
+     * @param urls the URLs for the ShimClassLoader
+     * @throws IOException if the previous ShimClassLoader existed and couldn't be closed
+     */
+    public synchronized void setInstanceResources(final URL[] urls) {
+        if (shimClassLoader != null) {
+            try {
+                shimClassLoader.close();
+            } catch (IOException e) {
+                logger.warn("Unable to close URLClassLoader for " + identifier);
+            }
+        }
+
+        // don't set a parent here b/c otherwise it will create an infinite loop
+        shimClassLoader = new ShimClassLoader(urls, null);
+    }
+
+    /**
+     * @return the URLs for the instance resources that have been set
+     */
+    public synchronized URL[] getInstanceResources() {
+        if (shimClassLoader != null) {
+            return shimClassLoader.getURLs();
+        }
+        return new URL[0];
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return this.loadClass(name, false);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> c = null;
+        // first try the shim
+        if (shimClassLoader != null) {
+            try {
+                c = shimClassLoader.loadClass(name, resolve);
+            } catch (ClassNotFoundException cnf) {
+                c = null;
+            }
+        }
+        // if it wasn't in the shim try our self
+        if (c == null) {
+            return super.loadClass(name, resolve);
+        } else {
+            return c;
+        }
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        Class<?> c = null;
+        // first try the shim
+        if (shimClassLoader != null) {
+            try {
+                c = shimClassLoader.findClass(name);
+            } catch (ClassNotFoundException cnf) {
+                c = null;
+            }
+        }
+        // if it wasn't in the shim try our self
+        if (c == null) {
+            return super.findClass(name);
+        } else {
+            return c;
+        }
+    }
+
+    /**
+     * Extend URLClassLoader to increase visibility of protected methods so that InstanceClassLoader can delegate.
+     */
+    private static class ShimClassLoader extends URLClassLoader {
+
+        public ShimClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        public ShimClassLoader(URL[] urls) {
+            super(urls);
+        }
+
+        @Override
+        public Class<?> findClass(String name) throws ClassNotFoundException {
+            return super.findClass(name);
+        }
+
+        @Override
+        public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            return super.loadClass(name, resolve);
+        }
+
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarCloseable.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarCloseable.java
@@ -35,18 +35,20 @@ public class NarCloseable implements Closeable {
     }
 
     /**
-     * Sets the current thread context class loader to the specific appropriate
-     * Nar class loader for the given configurable component. Restores to the
-     * previous classloader once complete. If the given class is not assignable
-     * from ConfigurableComponent then the NarThreadContextClassLoader is used.
+     * Sets the current thread context class loader to the specific appropriate class loader for the given
+     * component. If the component requires per-instance class loading then the class loader will be the
+     * specific class loader for instance with the given identifier, otherwise the class loader will be
+     * the NARClassLoader.
      *
-     * @param componentClass componentClass
-     * @return NarCloseable with current thread context classloader jailed to
-     * the nar of the component
+     * @param componentClass the component class
+     * @param componentIdentifier the identifier of the component
+     * @return NarCloseable with the current thread context classloader jailed to the Nar
+     *              or instance class loader of the component
      */
-    public static NarCloseable withComponentNarLoader(final Class componentClass) {
+    public static NarCloseable withComponentNarLoader(final Class componentClass, final String componentIdentifier) {
         final ClassLoader current = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(componentClass.getClassLoader());
+        final ClassLoader instanceClassLoader = ExtensionManager.getClassLoader(componentClass.getName(), componentIdentifier);
+        Thread.currentThread().setContextClassLoader(instanceClassLoader);
         return new NarCloseable(current);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -1647,7 +1647,7 @@ public class ControllerFacade implements Authorizable {
             final SearchContext context = new StandardSearchContext(searchStr, procNode, flowController, variableRegistry);
 
             // search the processor using the appropriate thread context classloader
-            try (final NarCloseable x = NarCloseable.withComponentNarLoader(processor.getClass())) {
+            try (final NarCloseable x = NarCloseable.withComponentNarLoader(processor.getClass(), processor.getIdentifier())) {
                 final Collection<SearchResult> searchResults = searchable.search(context);
                 if (CollectionUtils.isNotEmpty(searchResults)) {
                     for (final SearchResult searchResult : searchResults) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
@@ -275,15 +275,7 @@ public class StandardControllerServiceDAO extends ComponentDAO implements Contro
             controllerService.setComments(comments);
         }
         if (isNotNull(properties)) {
-            for (final Map.Entry<String, String> entry : properties.entrySet()) {
-                final String propName = entry.getKey();
-                final String propVal = entry.getValue();
-                if (isNotNull(propName) && propVal == null) {
-                    controllerService.removeProperty(propName);
-                } else if (isNotNull(propName)) {
-                    controllerService.setProperty(propName, propVal);
-                }
-            }
+            controllerService.setProperties(properties);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -161,15 +161,7 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                 processor.setLossTolerant(config.isLossTolerant());
             }
             if (isNotNull(configProperties)) {
-                for (final Map.Entry<String, String> entry : configProperties.entrySet()) {
-                    final String propName = entry.getKey();
-                    final String propVal = entry.getValue();
-                    if (isNotNull(propName) && propVal == null) {
-                        processor.removeProperty(propName);
-                    } else if (isNotNull(propName)) {
-                        processor.setProperty(propName, propVal);
-                    }
-                }
+                processor.setProperties(configProperties);
             }
 
             if (isNotNull(undefinedRelationshipsToTerminate)) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
@@ -285,15 +285,7 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
             reportingTask.setComments(comments);
         }
         if (isNotNull(properties)) {
-            for (final Map.Entry<String, String> entry : properties.entrySet()) {
-                final String propName = entry.getKey();
-                final String propVal = entry.getValue();
-                if (isNotNull(propName) && propVal == null) {
-                    reportingTask.removeProperty(propName);
-                } else if (isNotNull(propName)) {
-                    reportingTask.setProperty(propName, propVal);
-                }
-            }
+            reportingTask.setProperties(properties);
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/MonitorMemoryTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/MonitorMemoryTest.java
@@ -62,7 +62,10 @@ public class MonitorMemoryTest {
     @Test(expected = IllegalStateException.class)
     public void validatevalidationKicksInOnWrongPoolNames() throws Exception {
         ReportingTaskNode reportingTask = fc.createReportingTask(MonitorMemory.class.getName());
-        reportingTask.setProperty(MonitorMemory.MEMORY_POOL_PROPERTY.getName(), "foo");
+
+        Map<String,String> props = new HashMap<>();
+        props.put(MonitorMemory.MEMORY_POOL_PROPERTY.getName(), "foo");
+        reportingTask.setProperties(props);
         ProcessScheduler ps = fc.getProcessScheduler();
         ps.schedule(reportingTask);
     }
@@ -91,9 +94,12 @@ public class MonitorMemoryTest {
         CapturingLogger capturingLogger = this.wrapAndReturnCapturingLogger();
         ReportingTaskNode reportingTask = fc.createReportingTask(MonitorMemory.class.getName());
         reportingTask.setSchedulingPeriod("1 sec");
-        reportingTask.setProperty(MonitorMemory.MEMORY_POOL_PROPERTY.getName(), "PS Old Gen");
-        reportingTask.setProperty(MonitorMemory.REPORTING_INTERVAL.getName(), "100 millis");
-        reportingTask.setProperty(MonitorMemory.THRESHOLD_PROPERTY.getName(), threshold);
+
+        Map<String,String> props = new HashMap<>();
+        props.put(MonitorMemory.MEMORY_POOL_PROPERTY.getName(), "PS Old Gen");
+        props.put(MonitorMemory.REPORTING_INTERVAL.getName(), "100 millis");
+        props.put(MonitorMemory.THRESHOLD_PROPERTY.getName(), threshold);
+        reportingTask.setProperties(props);
 
         ProcessScheduler ps = fc.getProcessScheduler();
         ps.schedule(reportingTask);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
@@ -67,6 +67,14 @@ public interface HBaseClientService extends ControllerService {
             .defaultValue("1")
             .build();
 
+    PropertyDescriptor PHOENIX_CLIENT_JAR_LOCATION = new PropertyDescriptor.Builder()
+            .name("Phoenix Client JAR Location")
+            .description("The full path to the Phoenix client JAR. Required if Phoenix is installed on top of HBase.")
+            .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+            .expressionLanguageSupported(true)
+            .dynamicallyModifiesClasspath(true)
+            .build();
+
     /**
      * Puts a batch of mutations to the given table.
      *

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.hbase;
 
-import java.io.File;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -36,6 +35,7 @@ import org.apache.hadoop.hbase.filter.ParseFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
@@ -57,6 +57,7 @@ import org.apache.nifi.hbase.scan.ResultHandler;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.reporting.InitializationException;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
@@ -68,6 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+@RequiresInstanceClassLoading
 @Tags({ "hbase", "client"})
 @CapabilityDescription("Implementation of HBaseClientService for HBase 1.1.2. This service can be configured by providing " +
         "a comma-separated list of configuration files, or by specifying values for the other properties. If configuration files " +
@@ -109,6 +111,7 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
         props.add(ZOOKEEPER_CLIENT_PORT);
         props.add(ZOOKEEPER_ZNODE_PARENT);
         props.add(HBASE_CLIENT_RETRIES);
+        props.add(PHOENIX_CLIENT_JAR_LOCATION);
         this.properties = Collections.unmodifiableList(props);
     }
 


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:
### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
   in the commit message?
- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [X] Is your initial contribution a single, squashed commit?
### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?
### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
### Note:

Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
## Summary of Changes
- Introduced a new annotation for processors, reporting tasks, controller services - @RequiresInstanceClassLoading
- Added new builder method to PropertyDescriptor dynamicallyModifiesClasspath(boolean)
- Created a new InstanceClassLoader that maintains a child-first internal ClassLoader where classpath resources can be set, only used when component has @RequiresInstanceClassLoading
- Added support to ExtensionManager to obtain ClassLoaders based on type + id, before we only had by type
- If the type being requested supports instance class loading (the annotation described above) it will create an InstanceClassLoader which starts as a copy of the NAR ClassLoader for that type
- When properties are set on a component, the framework will identify the properties that are classpath modifiers and add those resources to the InstanceClassLoader's child resources
