### PR TITLE
NIFI-2936: Fix TestExecuteProcess error on Travis.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
@@ -221,9 +221,24 @@ public class TestExecuteProcess {
 
         processor.onTrigger(processContext, runner.getProcessSessionFactory());
 
+        if (isCommandFailed(runner)) return;
+
+        // ExecuteProcess doesn't wait for finishing to drain error stream if it's configure NOT to redirect stream.
+        // This causes test failure when draining the error stream didn't finish
+        // fast enough before the thread of this test case method checks the warn msg count.
+        // So, this loop wait for a while until the log msg count becomes expected number, otherwise let it fail.
+        final int expectedWarningMessages = 1;
+        final int maxRetry = 5;
+        for (int i = 0; i < maxRetry
+            && (runner.getLogger().getWarnMessages().size() < expectedWarningMessages); i++) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+            }
+        }
         final List<LogMessage> warnMessages = runner.getLogger().getWarnMessages();
         assertEquals("If redirect error stream is false, " +
-                "the output should be logged as a warning so that user can notice on bulletin.", 1, warnMessages.size());
+                "the output should be logged as a warning so that user can notice on bulletin.", expectedWarningMessages, warnMessages.size());
         final List<MockFlowFile> succeeded = runner.getFlowFilesForRelationship(ExecuteProcess.REL_SUCCESS);
         assertEquals(0, succeeded.size());
     }
@@ -244,11 +259,26 @@ public class TestExecuteProcess {
 
         processor.onTrigger(processContext, runner.getProcessSessionFactory());
 
+        if (isCommandFailed(runner)) return;
+
         final List<LogMessage> warnMessages = runner.getLogger().getWarnMessages();
         assertEquals("If redirect error stream is true " +
                 "the output should be sent as a content of flow-file.", 0, warnMessages.size());
         final List<MockFlowFile> succeeded = runner.getFlowFilesForRelationship(ExecuteProcess.REL_SUCCESS);
         assertEquals(1, succeeded.size());
+    }
+
+    /**
+     * On some environment, the test command immediately fail with an IOException
+     * because of the native UnixProcess.init method implementation difference.
+     *
+     * @return true, if the command fails
+     */
+    private boolean isCommandFailed(final TestRunner runner) {
+        final List<LogMessage> errorMessages = runner.getLogger().getErrorMessages();
+        return (errorMessages.size() > 0
+                && errorMessages.stream()
+                    .anyMatch(m -> m.getMsg().contains("Failed to create process due to")));
     }
 
 }


### PR DESCRIPTION
I added a wait loop up to 5 seconds, so that the test case can wait until ExecuteProcess processor finishes draining error stream.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

