### PR TITLE
UI - Policy go to Group selection issue

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
@@ -295,6 +295,9 @@ nf.Actions = (function () {
                 // select only the component/connection in question
                 selection.classed('selected', true);
                 nf.Actions.center(selection);
+
+                // inform Angular app that values have changed
+                nf.ng.Bridge.digest();
             }
         },
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
@@ -785,8 +785,16 @@ nf.PolicyManagement = (function () {
 
             // build the mark up
             return $('<span>Showing effective policy inherited from Process Group </span>').append($('<span class="link"></span>').text(processGroupName).on('click', function () {
+                // close the shell
                 $('#shell-close-button').click();
-                nf.CanvasUtils.enterGroup(processGroupId);
+
+                // load the correct group and unselect everything if necessary
+                nf.CanvasUtils.enterGroup(processGroupId).done(function () {
+                    nf.CanvasUtils.getSelection().classed('selected', false);
+
+                    // inform Angular app that values have changed
+                    nf.ng.Bridge.digest();
+                });
             })).append('<span>.</span>');
         }
     };


### PR DESCRIPTION
NIFI-2965:
- Ensuring the selection is cleared when going to the Process Group where the selected component policy is defined.
- Ensure that the selection context is updated when going to a component or group.