### PR TITLE
UI - Updating the text and header of the delete policy dialog

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
@@ -667,8 +667,10 @@ nf.PolicyManagement = (function () {
      */
     var promptToDeletePolicy = function () {
         nf.Dialog.showYesNoDialog({
-            headerText: 'Update Policy',
-            dialogContent: 'Are you sure you want to delete this policy?',
+            headerText: 'Delete Policy',
+            dialogContent: 'By deleting this policy, the permissions for this component will revert to the inherited policy.',
+            yesText: 'Delete',
+            noText: 'Cancel',
             yesHandler: function () {
                 deletePolicy();
             }
@@ -695,7 +697,7 @@ nf.PolicyManagement = (function () {
             });
         } else {
             nf.Dialog.showOkDialog({
-                headerText: 'Update Policy',
+                headerText: 'Delete Policy',
                 dialogContent: 'No policy selected'
             });
         }


### PR DESCRIPTION
NIFI-2989:
- Updating the content of the delete policy dialog to make it a little more clear that the permissions for the component will revert back to the inherit policy.