### PR TITLE
NIFI-401: Decouple Scheduling Strategy from Execution Node

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/scheduling/ExecutionNode.java
+++ b/nifi-api/src/main/java/org/apache/nifi/scheduling/ExecutionNode.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.scheduling;
+
+public enum ExecutionNode {
+    ALL,
+    PRIMARY;
+}

--- a/nifi-api/src/main/java/org/apache/nifi/scheduling/ExecutionNode.java
+++ b/nifi-api/src/main/java/org/apache/nifi/scheduling/ExecutionNode.java
@@ -16,7 +16,16 @@
  */
 package org.apache.nifi.scheduling;
 
+/**
+ * Defines the Nodes where a given Component will be scheduled to run.
+ */
 public enum ExecutionNode {
+    /**
+     * A Component will be scheduled to run on all nodes.
+     */
     ALL,
+    /**
+     * A Component will be scheduled to run on the primary node only.
+     */
     PRIMARY;
 }

--- a/nifi-api/src/main/java/org/apache/nifi/scheduling/SchedulingStrategy.java
+++ b/nifi-api/src/main/java/org/apache/nifi/scheduling/SchedulingStrategy.java
@@ -65,6 +65,7 @@ public enum SchedulingStrategy {
      * Scheduling Strategy is used, the component will be scheduled in the same
      * manner as if {@link TIMER_DRIVEN} were used.
      */
+    @Deprecated
     PRIMARY_NODE_ONLY(1, "0 sec"),
     /**
      * Indicates that the component will be scheduled to run according to a

--- a/nifi-api/src/main/java/org/apache/nifi/scheduling/SchedulingStrategy.java
+++ b/nifi-api/src/main/java/org/apache/nifi/scheduling/SchedulingStrategy.java
@@ -56,6 +56,10 @@ public enum SchedulingStrategy {
      */
     TIMER_DRIVEN(1, "0 sec"),
     /**
+     * NOTE: This option has been deprecated with the addition of the
+     * execution-node combo box.  It still exists for backward compatibility
+     * with existing flows that still have this value for schedulingStrategy.
+     **
      * Indicates that the component will be scheduled via timer only on the
      * Primary Node. If the instance is not part of a cluster and this
      * Scheduling Strategy is used, the component will be scheduled in the same

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -529,6 +529,10 @@ The default value of `0 sec` means that the Processor should run as often as pos
 for any time duration of 0, regardless of the time unit (i.e., `0 sec`, `0 mins`, `0 days`). For an explanation of values that are
 applicable for the CRON driven Scheduling Strategy, see the description of the CRON driven Scheduling Strategy itself.
 
+When configured for clustering, an Execution setting will be available. This setting is used determine which node(s) the Processor will be
+scheduled to execute. Selecting 'All Nodes' will result in this Processor being scheduled on every node in the cluster. Selecting
+'Primary Node' will result in this Processor being scheduled on the Primary Node only.
+
 The right-hand side of the tab contains a slider for choosing the `Run duration.' This controls how long the Processor should be scheduled
 to run each time that it is triggered. On the left-hand side of the slider, it is marked `Lower latency' while the right-hand side
 is marked `Higher throughput.' When a Processor finishes running, it must update the repository in order to transfer the FlowFiles to

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorConfigDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorConfigDTO.java
@@ -34,6 +34,7 @@ public class ProcessorConfigDTO {
     // settings
     private String schedulingPeriod;
     private String schedulingStrategy;
+    private String executionNode;
     private String penaltyDuration;
     private String yieldDuration;
     private String bulletinLevel;
@@ -84,6 +85,22 @@ public class ProcessorConfigDTO {
 
     public void setSchedulingStrategy(String schedulingStrategy) {
         this.schedulingStrategy = schedulingStrategy;
+    }
+
+    /**
+     * Indicates which node the process should run on
+     *
+     * @return execution node
+     */
+    @ApiModelProperty(
+            value = "Indicates the node where the process will execute."
+    )
+    public String getExecutionNode() {
+        return executionNode;
+    }
+
+    public void setExecutionNode(String executionNode) {
+        this.executionNode = executionNode;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ProcessorNode.java
@@ -33,6 +33,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,10 @@ public abstract class ProcessorNode extends AbstractConfiguredComponent implemen
 
     @Override
     public abstract SchedulingStrategy getSchedulingStrategy();
+
+    public abstract void setExecutionNode(ExecutionNode executionNode);
+
+    public abstract ExecutionNode getExecutionNode();
 
     public abstract void setRunDuration(long duration, TimeUnit timeUnit);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -16,35 +16,7 @@
  */
 package org.apache.nifi.controller;
 
-import static java.util.Objects.requireNonNull;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import javax.net.ssl.SSLContext;
-
+import com.sun.jersey.api.client.ClientHandlerException;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.action.Action;
@@ -206,8 +178,8 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.reporting.ReportingInitializationContext;
 import org.apache.nifi.reporting.ReportingTask;
 import org.apache.nifi.reporting.Severity;
-import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.scheduling.ExecutionNode;
+import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.stream.io.LimitingInputStream;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.ComponentIdGenerator;
@@ -235,7 +207,33 @@ import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jersey.api.client.ClientHandlerException;
+import javax.net.ssl.SSLContext;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static java.util.Objects.requireNonNull;
 
 public class FlowController implements EventAccess, ControllerServiceProvider, ReportingTaskProvider, QueueProvider, Authorizable, ProvenanceAuthorizableFactory, NodeTypeProvider {
 
@@ -482,8 +480,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
         final QuartzSchedulingAgent quartzSchedulingAgent = new QuartzSchedulingAgent(this, timerDrivenEngineRef.get(), contextFactory, encryptor, this.variableRegistry);
         final TimerDrivenSchedulingAgent timerDrivenAgent = new TimerDrivenSchedulingAgent(this, timerDrivenEngineRef.get(), contextFactory, encryptor, this.variableRegistry, this.nifiProperties);
         processScheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, timerDrivenAgent);
-        // PRIMARY_NODE_ONLY is deprecated, but still exists to handle processors that are still defined with it (they haven't been
-        // re-configured with executeNode = PRIMARY).
+        // PRIMARY_NODE_ONLY is deprecated, but still exists to handle processors that are still defined with it (they haven't been re-configured with executeNode = PRIMARY).
         processScheduler.setSchedulingAgent(SchedulingStrategy.PRIMARY_NODE_ONLY, timerDrivenAgent);
         processScheduler.setSchedulingAgent(SchedulingStrategy.CRON_DRIVEN, quartzSchedulingAgent);
         processScheduler.scheduleFrameworkTask(new ExpireFlowFiles(this, contextFactory), "Expire FlowFiles", 30L, 30L, TimeUnit.SECONDS);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -207,6 +207,7 @@ import org.apache.nifi.reporting.ReportingInitializationContext;
 import org.apache.nifi.reporting.ReportingTask;
 import org.apache.nifi.reporting.Severity;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.stream.io.LimitingInputStream;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.ComponentIdGenerator;
@@ -481,6 +482,8 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
         final QuartzSchedulingAgent quartzSchedulingAgent = new QuartzSchedulingAgent(this, timerDrivenEngineRef.get(), contextFactory, encryptor, this.variableRegistry);
         final TimerDrivenSchedulingAgent timerDrivenAgent = new TimerDrivenSchedulingAgent(this, timerDrivenEngineRef.get(), contextFactory, encryptor, this.variableRegistry, this.nifiProperties);
         processScheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, timerDrivenAgent);
+        // PRIMARY_NODE_ONLY is deprecated, but still exists to handle processors that are still defined with it (they haven't been
+        // re-configured with executeNode = PRIMARY).
         processScheduler.setSchedulingAgent(SchedulingStrategy.PRIMARY_NODE_ONLY, timerDrivenAgent);
         processScheduler.setSchedulingAgent(SchedulingStrategy.CRON_DRIVEN, quartzSchedulingAgent);
         processScheduler.scheduleFrameworkTask(new ExpireFlowFiles(this, contextFactory), "Expire FlowFiles", 30L, 30L, TimeUnit.SECONDS);
@@ -1711,6 +1714,10 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
 
                 if (config.getSchedulingStrategy() != null) {
                     procNode.setSchedulingStrategy(SchedulingStrategy.valueOf(config.getSchedulingStrategy()));
+                }
+
+                if (config.getExecutionNode() != null) {
+                    procNode.setExecutionNode(ExecutionNode.valueOf(config.getExecutionNode()));
                 }
 
                 // ensure that the scheduling strategy is set prior to these values

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
@@ -88,6 +88,7 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.reporting.ReportingInitializationContext;
 import org.apache.nifi.reporting.Severity;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.util.DomUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.file.FileUtils;
@@ -903,6 +904,10 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
 
         if (config.getSchedulingStrategy() != null) {
             procNode.setSchedulingStrategy(SchedulingStrategy.valueOf(config.getSchedulingStrategy()));
+        }
+
+        if (config.getExecutionNode() != null) {
+            procNode.setExecutionNode(ExecutionNode.valueOf(config.getExecutionNode()));
         }
 
         // must set scheduling strategy before these two

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -55,6 +55,7 @@ import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.SimpleProcessLogger;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.ReflectionUtils;
@@ -133,6 +134,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
     private SchedulingStrategy schedulingStrategy; // guarded by read/write lock
                                                    // ??????? NOT any more
+    private ExecutionNode executionNode;
 
     public StandardProcessorNode(final Processor processor, final String uuid,
         final ValidationContextFactory validationContextFactory, final ProcessScheduler scheduler,
@@ -187,6 +189,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         }
 
         schedulingStrategy = SchedulingStrategy.TIMER_DRIVEN;
+        executionNode = ExecutionNode.ALL;
     }
 
     /**
@@ -423,6 +426,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         }
 
         this.schedulingStrategy = schedulingStrategy;
+        // PRIMARY_NODE_ONLY is deprecated.  Isolated is also set when executionNode == PRIMARY
         setIsolated(schedulingStrategy == SchedulingStrategy.PRIMARY_NODE_ONLY);
     }
 
@@ -471,6 +475,17 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         }
 
         this.schedulingPeriod.set(schedulingPeriod);
+    }
+
+    @Override
+    public void setExecutionNode(final ExecutionNode executionNode) {
+        this.executionNode = executionNode;
+        setIsolated(executionNode == ExecutionNode.PRIMARY);
+    }
+
+    @Override
+    public ExecutionNode getExecutionNode() {
+        return this.executionNode;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -110,7 +110,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
     private final Map<Relationship, Set<Connection>> connections;
     private final AtomicReference<Set<Relationship>> undefinedRelationshipsToTerminate;
     private final AtomicReference<List<Connection>> incomingConnectionsRef;
-    private final AtomicBoolean isolated;
     private final AtomicBoolean lossTolerant;
     private final AtomicReference<String> comments;
     private final AtomicReference<Position> position;
@@ -169,7 +168,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         style = new AtomicReference<>(Collections.unmodifiableMap(new HashMap<String, String>()));
         this.processGroup = new AtomicReference<>();
         processScheduler = scheduler;
-        isolated = new AtomicBoolean(false);
         penalizationPeriod = new AtomicReference<>(DEFAULT_PENALIZATION_PERIOD);
         this.nifiProperties = nifiProperties;
 
@@ -263,7 +261,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
     @Override
     public boolean isIsolated() {
-        return isolated.get();
+        return schedulingStrategy == SchedulingStrategy.PRIMARY_NODE_ONLY || executionNode == ExecutionNode.PRIMARY;
     }
 
     /**
@@ -312,19 +310,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             throw new IllegalStateException("Cannot modify Processor configuration while the Processor is running");
         }
         this.lossTolerant.set(lossTolerant);
-    }
-
-    /**
-     * Indicates whether the processor runs on only the primary node.
-     *
-     * @param isolated
-     *            isolated
-     */
-    public void setIsolated(final boolean isolated) {
-        if (isRunning()) {
-            throw new IllegalStateException("Cannot modify Processor configuration while the Processor is running");
-        }
-        this.isolated.set(isolated);
     }
 
     @Override
@@ -426,8 +411,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         }
 
         this.schedulingStrategy = schedulingStrategy;
-        // PRIMARY_NODE_ONLY is deprecated.  Isolated is also set when executionNode == PRIMARY
-        setIsolated(schedulingStrategy == SchedulingStrategy.PRIMARY_NODE_ONLY);
     }
 
     /**
@@ -480,7 +463,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
     @Override
     public void setExecutionNode(final ExecutionNode executionNode) {
         this.executionNode = executionNode;
-        setIsolated(executionNode == ExecutionNode.PRIMARY);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/FlowFromDOMFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/FlowFromDOMFactory.java
@@ -32,6 +32,7 @@ import org.apache.nifi.encrypt.StringEncryptor;
 import org.apache.nifi.groups.RemoteProcessGroupPortDescriptor;
 import org.apache.nifi.remote.StandardRemoteProcessGroupPortDescriptor;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.util.DomUtils;
 import org.apache.nifi.web.api.dto.ConnectableDTO;
 import org.apache.nifi.web.api.dto.ConnectionDTO;
@@ -372,6 +373,14 @@ public class FlowFromDOMFactory {
             configDto.setSchedulingStrategy(SchedulingStrategy.TIMER_DRIVEN.name());
         } else {
             configDto.setSchedulingStrategy(schedulingStrategyName.trim());
+        }
+
+        // handle execution node
+        final String executionNode = getString(element, "executionNode");
+        if (executionNode == null || executionNode.trim().isEmpty()) {
+            configDto.setExecutionNode(ExecutionNode.ALL.name());
+        } else {
+            configDto.setExecutionNode(executionNode.trim());
         }
 
         final Long runDurationNanos = getOptionalLong(element, "runDurationNanos");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/StandardFlowSerializer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/StandardFlowSerializer.java
@@ -344,6 +344,7 @@ public class StandardFlowSerializer implements FlowSerializer {
         addTextElement(element, "lossTolerant", String.valueOf(processor.isLossTolerant()));
         addTextElement(element, "scheduledState", processor.getScheduledState().name());
         addTextElement(element, "schedulingStrategy", processor.getSchedulingStrategy().name());
+        addTextElement(element, "executionNode", processor.getExecutionNode().name());
         addTextElement(element, "runDurationNanos", processor.getRunDuration(TimeUnit.NANOSECONDS));
 
         addConfiguration(element, processor.getProperties(), processor.getAnnotationData(), encryptor);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/fingerprint/FingerprintFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/fingerprint/FingerprintFactory.java
@@ -519,6 +519,7 @@ public class FingerprintFactory {
         builder.append(config.getComments());
         builder.append(config.getSchedulingPeriod());
         builder.append(config.getSchedulingStrategy());
+        builder.append(config.getExecutionNode());
         builder.append(config.getYieldDuration());
         builder.append(config.getConcurrentlySchedulableTaskCount());
         builder.append(config.getPenaltyDuration());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/FlowConfiguration.xsd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/FlowConfiguration.xsd
@@ -87,6 +87,8 @@
 
             <xs:element name="schedulingStrategy" type="SchedulingStrategy" minOccurs="0" maxOccurs="1" />
 
+            <xs:element name="executionNode" type="ExecutionNode" minOccurs="0" maxOccurs="1" />
+
             <xs:element name="runDurationNanos" type="xs:long" minOccurs="0" maxOccurs="1" />
 
             <!-- properties that must be valid for the processor to execute.
@@ -337,6 +339,13 @@
         </xs:restriction>
     </xs:simpleType>
     
+    <xs:simpleType name="ExecutionNode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ALL"></xs:enumeration>
+            <xs:enumeration value="PRIMARY"></xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:complexType name="ControllerServicesType">
         <xs:sequence>
             <xs:element name="controllerService" type="ControllerServiceType" minOccurs="0" maxOccurs="unbounded" />

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
@@ -68,6 +68,7 @@ public class ProcessorAuditor extends NiFiAuditor {
     private static final String AUTO_TERMINATED_RELATIONSHIPS = "Auto Terminated Relationships";
     private static final String SCHEDULING_PERIOD = "Run Schedule";
     private static final String SCHEDULING_STRATEGY = "Scheduling Strategy";
+    private static final String EXECUTION_NODE = "Execution Node";
 
     /**
      * Audits the creation of processors via createProcessor().
@@ -368,6 +369,9 @@ public class ProcessorAuditor extends NiFiAuditor {
             }
             if (newConfig.getSchedulingStrategy() != null) {
                 values.put(SCHEDULING_STRATEGY, processor.getSchedulingStrategy().toString());
+            }
+            if (newConfig.getExecutionNode() != null) {
+                values.put(EXECUTION_NODE, processor.getExecutionNode().name());
             }
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
@@ -368,7 +368,7 @@ public class ProcessorAuditor extends NiFiAuditor {
                 values.put(COMMENTS, processor.getComments());
             }
             if (newConfig.getSchedulingStrategy() != null) {
-                values.put(SCHEDULING_STRATEGY, processor.getSchedulingStrategy().toString());
+                values.put(SCHEDULING_STRATEGY, processor.getSchedulingStrategy().name());
             }
             if (newConfig.getExecutionNode() != null) {
                 values.put(EXECUTION_NODE, processor.getExecutionNode().name());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -2492,6 +2492,7 @@ public final class DtoFactory {
         dto.setComments(procNode.getComments());
         dto.setBulletinLevel(procNode.getBulletinLevel().name());
         dto.setSchedulingStrategy(procNode.getSchedulingStrategy().name());
+        dto.setExecutionNode(procNode.getExecutionNode().name());
         dto.setAnnotationData(procNode.getAnnotationData());
 
         // set up the default values for concurrent tasks and scheduling period
@@ -2670,6 +2671,7 @@ public final class DtoFactory {
         copy.setAutoTerminatedRelationships(copy(original.getAutoTerminatedRelationships()));
         copy.setComments(original.getComments());
         copy.setSchedulingStrategy(original.getSchedulingStrategy());
+        copy.setExecutionNode(original.getExecutionNode());
         copy.setConcurrentlySchedulableTaskCount(original.getConcurrentlySchedulableTaskCount());
         copy.setCustomUiUrl(original.getCustomUiUrl());
         copy.setDescriptors(copy(original.getDescriptors()));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -82,6 +82,7 @@ import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.remote.RootGroupPort;
 import org.apache.nifi.reporting.ReportingTask;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.search.SearchContext;
 import org.apache.nifi.search.SearchResult;
 import org.apache.nifi.search.Searchable;
@@ -1589,7 +1590,13 @@ public class ControllerFacade implements Authorizable {
         } else if (SchedulingStrategy.TIMER_DRIVEN.equals(procNode.getSchedulingStrategy()) && StringUtils.containsIgnoreCase("timer", searchStr)) {
             matches.add("Scheduling strategy: Timer driven");
         } else if (SchedulingStrategy.PRIMARY_NODE_ONLY.equals(procNode.getSchedulingStrategy()) && StringUtils.containsIgnoreCase("primary", searchStr)) {
+            // PRIMARY_NODE_ONLY has been deprecated as a SchedulingStrategy and replaced by PRIMARY as an ExecutionNode.
             matches.add("Scheduling strategy: On primary node");
+        }
+
+        // consider execution node
+        if (ExecutionNode.PRIMARY.equals(procNode.getExecutionNode()) && StringUtils.containsIgnoreCase("primary", searchStr)) {
+            matches.add("Execution node: primary");
         }
 
         // consider scheduled state

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -31,6 +31,7 @@ import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.logging.LogLevel;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.web.NiFiCoreException;
 import org.apache.nifi.web.ResourceNotFoundException;
@@ -117,6 +118,7 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
         if (isNotNull(config)) {
             // perform the configuration
             final String schedulingStrategy = config.getSchedulingStrategy();
+            final String executionNode = config.getExecutionNode();
             final String comments = config.getComments();
             final String annotationData = config.getAnnotationData();
             final Integer maxTasks = config.getConcurrentlySchedulableTaskCount();
@@ -133,6 +135,9 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                 processor.setSchedulingStrategy(SchedulingStrategy.valueOf(schedulingStrategy));
             }
 
+            if (isNotNull(executionNode)) {
+                processor.setExecutionNode(ExecutionNode.valueOf(executionNode));
+            }
             if (isNotNull(comments)) {
                 processor.setComments(comments);
             }
@@ -217,6 +222,13 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                 LogLevel.valueOf(config.getBulletinLevel());
             } catch (IllegalArgumentException iae) {
                 validationErrors.add(String.format("Bulletin level: Value must be one of [%s]", StringUtils.join(LogLevel.values(), ", ")));
+            }
+        }
+        if (isNotNull(config.getExecutionNode())) {
+            try {
+                ExecutionNode.valueOf(config.getExecutionNode());
+            } catch (IllegalArgumentException iae) {
+                validationErrors.add(String.format("Execution node: Value must be one of [%s]", StringUtils.join(ExecutionNode.values(), ", ")));
             }
         }
 
@@ -353,6 +365,7 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                     configDTO.getProperties(),
                     configDTO.getSchedulingPeriod(),
                     configDTO.getSchedulingStrategy(),
+                    configDTO.getExecutionNode(),
                     configDTO.getYieldDuration())) {
 
                 modificationRequest = true;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/processor-configuration.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/processor-configuration.jsp
@@ -108,18 +108,6 @@
                         </div>
                         <div class="clear"></div>
                     </div>
-                    <div class="setting">
-                        <div id="execution-node-container" class="execution-node-setting">
-                            <div class="setting-name">
-                                Execution node
-                                <img class="setting-icon icon-info" src="images/iconInfo.png" alt="Info" title="The node(s) that will run this processor."/>
-                            </div>
-                            <div class="setting-field">
-                                <div id="execution-node-combo"></div>
-                            </div>
-                        </div>
-                        <div class="clear"></div>
-                    </div>
                     <div id="timer-driven-options" class="setting">
                         <div class="concurrently-schedulable-tasks-setting">
                             <div class="setting-name">
@@ -170,6 +158,18 @@
                             </div>
                             <div class="setting-field">
                                 <input type="text" id="cron-driven-scheduling-period" name="cron-driven-scheduling-period" class="small-setting-input"/>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+                    </div>
+                    <div id="execution-node-options" class="setting">
+                        <div class="execution-node-setting">
+                            <div class="setting-name">
+                                Execution
+                                <div class="fa fa-question-circle" alt="Info" title="The node(s) that this processor will be scheduled to run on."></div>
+                            </div>
+                            <div class="setting-field">
+                                <div id="execution-node-combo"></div>
                             </div>
                         </div>
                         <div class="clear"></div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/processor-configuration.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/processor-configuration.jsp
@@ -108,6 +108,18 @@
                         </div>
                         <div class="clear"></div>
                     </div>
+                    <div class="setting">
+                        <div id="execution-node-container" class="execution-node-setting">
+                            <div class="setting-name">
+                                Execution node
+                                <img class="setting-icon icon-info" src="images/iconInfo.png" alt="Info" title="The node(s) that will run this processor."/>
+                            </div>
+                            <div class="setting-field">
+                                <div id="execution-node-combo"></div>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+                    </div>
                     <div id="timer-driven-options" class="setting">
                         <div class="concurrently-schedulable-tasks-setting">
                             <div class="setting-name">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/processor-details.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/processor-details.jsp
@@ -103,6 +103,18 @@
                         <div class="clear"></div>
                     </div>
                     <div class="setting">
+                        <div id="details-execution-node-container" class="execution-node-setting">
+                            <div class="setting-name">
+                                Execution node
+                                <img class="setting-icon icon-info" src="images/iconInfo.png" alt="Info" title="The node(s) that will run this processor."/>
+                            </div>
+                            <div class="setting-field">
+                                <span id="read-only-execution-node"></span>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+                    </div>
+                    <div class="setting">
                         <div class="concurrently-schedulable-tasks-setting">
                             <div class="setting-name">
                                 Concurrent tasks

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/processor-details.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/processor-details.jsp
@@ -103,18 +103,6 @@
                         <div class="clear"></div>
                     </div>
                     <div class="setting">
-                        <div id="details-execution-node-container" class="execution-node-setting">
-                            <div class="setting-name">
-                                Execution node
-                                <img class="setting-icon icon-info" src="images/iconInfo.png" alt="Info" title="The node(s) that will run this processor."/>
-                            </div>
-                            <div class="setting-field">
-                                <span id="read-only-execution-node"></span>
-                            </div>
-                        </div>
-                        <div class="clear"></div>
-                    </div>
-                    <div class="setting">
                         <div class="concurrently-schedulable-tasks-setting">
                             <div class="setting-name">
                                 Concurrent tasks
@@ -131,6 +119,18 @@
                             </div>
                             <div class="setting-field">
                                 <span id="read-only-scheduling-period"></span>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+                    </div>
+                    <div id="read-only-execution-node-options" class="setting">
+                        <div class="execution-node-setting">
+                            <div class="setting-name">
+                                Execution
+                                <div class="fa fa-question-circle" alt="Info" title="The node(s) that this processor will be scheduled to run on."></div>
+                            </div>
+                            <div class="setting-field">
+                                <span id="read-only-execution-node"></span>
                             </div>
                         </div>
                         <div class="clear"></div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/processor-configuration.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/processor-configuration.css
@@ -55,12 +55,6 @@ div.processor-enabled-container {
     width: 20%;
 }
 
-#execution-node-combo {
-    width: 130px;
-    height: 18px;
-    line-height: 18px;
-}
-
 #event-driven-warning {
     padding-top: 22px;
     color: #f00;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/processor-configuration.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/processor-configuration.css
@@ -55,6 +55,12 @@ div.processor-enabled-container {
     width: 20%;
 }
 
+#execution-node-combo {
+    width: 130px;
+    height: 18px;
+    line-height: 18px;
+}
+
 #event-driven-warning {
     padding-top: 22px;
     color: #f00;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/processor-details.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/processor-details.css
@@ -50,7 +50,7 @@
     width: 340px;
 }
 
-div.concurrently-schedulable-tasks-setting, div.scheduling-period-setting, div.penalty-duration-setting, div.yield-duration-setting, div.scheduling-strategy-setting, div.bulletin-setting {
+div.concurrently-schedulable-tasks-setting, div.scheduling-period-setting, div.penalty-duration-setting, div.yield-duration-setting, div.scheduling-strategy-setting, div.execution-node-setting, div.bulletin-setting {
     float: left;
     width: 40%;
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -57,7 +57,7 @@ nf.ProcessorConfiguration = (function () {
             strategies.push({
                 text: 'On primary node',
                 value: 'PRIMARY_NODE_ONLY',
-                description: 'Processor will be scheduled on the primary node on an interval defined by the run schedule. This option has been deprecated, please use the Execution Node below.',
+                description: 'Processor will be scheduled on the primary node on an interval defined by the run schedule. This option has been deprecated, please use the Execution setting below.',
                 disabled: true
             });
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -25,7 +25,7 @@ nf.ProcessorConfiguration = (function () {
     /**
      * Gets the available scheduling strategies based on the specified processor.
      *
-     * @param {type} processor
+     * @param {object} processor
      * @returns {Array}
      */
     var getSchedulingStrategies = function (processor) {
@@ -52,6 +52,16 @@ nf.ProcessorConfiguration = (function () {
             });
         }
 
+        // conditionally support event driven
+        if (processor.config['schedulingStrategy'] === 'PRIMARY_NODE_ONLY') {
+            strategies.push({
+                text: 'On primary node',
+                value: 'PRIMARY_NODE_ONLY',
+                description: 'Processor will be scheduled on the primary node on an interval defined by the run schedule. This option has been deprecated, please use the Execution Node below.',
+                disabled: true
+            });
+        }
+
         // add an option for cron driven
         strategies.push({
             text: 'CRON driven',
@@ -60,6 +70,25 @@ nf.ProcessorConfiguration = (function () {
         });
 
         return strategies;
+    };
+
+    /**
+     * Gets the available execution nodes based on the specified processor.
+     *
+     * @param {object} processor
+     * @returns {Array}
+     */
+    var getExecutionNodeOptions = function (processor) {
+        return [{
+            text: 'All nodes',
+            value: 'ALL',
+            description: 'Processor will be scheduled to run on all nodes'
+        }, {
+            text: 'Primary node',
+            value: 'PRIMARY',
+            description: 'Processor will be scheduled to run only on the primary node',
+            disabled: !nf.Canvas.isClustered() && processor.config['executionNode'] === 'PRIMARY'
+        }];
     };
 
     /**
@@ -516,19 +545,6 @@ nf.ProcessorConfiguration = (function () {
                 }]
             });
 
-            // initialize the execution node combo
-            $('#execution-node-combo').combo({
-                options: [{
-                        text: 'All nodes',
-                        value: 'ALL',
-                        description: 'Processor will be configured to run on all nodes'
-                    }, {
-                        text: 'Primary node only',
-                        value: 'PRIMARY',
-                        description: 'Processor will be configured to run only on the primary node'
-                    }]
-            });
-
             // initialize the run duration slider
             $('#run-duration-slider').slider({
                 min: 0,
@@ -630,16 +646,7 @@ nf.ProcessorConfiguration = (function () {
                         value: processor.config['bulletinLevel']
                     });
 
-                    // If the scheduling strategy is PRIMARY_NODE_ONLY (deprecated),
-                    // then set the execution node to PRIMARY and the scheduling
-                    // strategy to TIMER.  These new values will be saved when/if
-                    // the dialog is applied.
                     var schedulingStrategy = processor.config['schedulingStrategy'];
-                    var executionNode = processor.config['executionNode'];
-                    if (schedulingStrategy === 'PRIMARY_NODE_ONLY') {
-                        executionNode = 'PRIMARY';
-                        schedulingStrategy = 'TIMER_DRIVEN';
-                    }
 
                     // initialize the scheduling strategy
                     $('#scheduling-strategy-combo').combo({
@@ -671,14 +678,21 @@ nf.ProcessorConfiguration = (function () {
                         }
                     });
 
-                    // select the execution node
-                    $('#execution-node-combo').combo('setSelectedOption', {
-                        value: executionNode
+                    var executionNode = processor.config['executionNode'];
+
+                    // initialize the execution node combo
+                    $('#execution-node-combo').combo({
+                        options: getExecutionNodeOptions(processor),
+                        selectedOption: {
+                            value: executionNode
+                        }
                     });
-                    if (nf.Canvas.isClustered()) {
-                        $('#execution-node-container').show();
+
+                    // show the execution node option if we're cluster or we're currently configured to run on the primary node only
+                    if (nf.Canvas.isClustered() || executionNode === 'PRIMARY') {
+                        $('#execution-node-options').show();
                     } else {
-                        $('#execution-node-container').hide();
+                        $('#execution-node-options').hide();
                     }
 
                     // initialize the concurrentTasks

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -560,9 +560,9 @@ nf.Common = (function () {
          */
         populateField: function (target, value) {
             if (nf.Common.isUndefined(value) || nf.Common.isNull(value)) {
-                return $('#' + target).addClass('unset').text('No value previously set');
+                return $('#' + target).addClass('unset').text('No value set');
             } else if (value === '') {
-                return $('#' + target).addClass('blank').text('Empty string previously set');
+                return $('#' + target).addClass('blank').text('Empty string set');
             } else {
                 return $('#' + target).text(value);
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
@@ -104,6 +104,7 @@ nf.ProcessorDetails = (function () {
                         nf.Common.clearField('read-only-yield-duration');
                         nf.Common.clearField('read-only-run-duration');
                         nf.Common.clearField('read-only-bulletin-level');
+                        nf.Common.clearField('read-only-execution-node');
                         nf.Common.clearField('read-only-execution-status');
                         nf.Common.clearField('read-only-processor-comments');
 
@@ -159,6 +160,7 @@ nf.ProcessorDetails = (function () {
 
                     // make the scheduling strategy human readable
                     var schedulingStrategy = details.config['schedulingStrategy'];
+                    var executionNode = details.config['executionNode'];
                     if (schedulingStrategy === 'EVENT_DRIVEN') {
                         showRunSchedule = false;
                         schedulingStrategy = 'Event driven';
@@ -166,8 +168,12 @@ nf.ProcessorDetails = (function () {
                         schedulingStrategy = 'CRON driven';
                     } else if (schedulingStrategy === 'TIMER_DRIVEN') {
                         schedulingStrategy = "Timer driven";
-                    } else {
-                        schedulingStrategy = "On primary node";
+                    } else if (schedulingStrategy === 'PRIMARY_NODE_ONLY') {
+                        // PRIMARY_NODE_ONLY has been deprecated as a
+                        // schedulingStrategy option, and is now an
+                        // executionNode option instead.
+                        schedulingStrategy = "Timer driven";
+                        executionNode = 'PRIMARY'
                     }
                     nf.Common.populateField('read-only-scheduling-strategy', schedulingStrategy);
 
@@ -176,6 +182,19 @@ nf.ProcessorDetails = (function () {
                         $('#read-only-run-schedule').show();
                     } else {
                         $('#read-only-run-schedule').hide();
+                    }
+
+                    // only show the execution-node when applicable
+                    if (executionNode === 'ALL') {
+                        executionNode = "All nodes";
+                    } else if (executionNode === 'PRIMARY') {
+                        executionNode = "Primary node only";
+                    }
+                    nf.Common.populateField('read-only-execution-node', executionNode);
+                    if (nf.Canvas.isClustered()) {
+                        $('#details-execution-node-container').show();
+                    } else {
+                        $('#details-execution-node-container').hide();
                     }
 
                     // load the relationship list

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
@@ -158,9 +158,9 @@ nf.ProcessorDetails = (function () {
 
                     var showRunSchedule = true;
 
-                    // make the scheduling strategy human readable
                     var schedulingStrategy = details.config['schedulingStrategy'];
-                    var executionNode = details.config['executionNode'];
+
+                    // make the scheduling strategy human readable
                     if (schedulingStrategy === 'EVENT_DRIVEN') {
                         showRunSchedule = false;
                         schedulingStrategy = 'Event driven';
@@ -168,12 +168,8 @@ nf.ProcessorDetails = (function () {
                         schedulingStrategy = 'CRON driven';
                     } else if (schedulingStrategy === 'TIMER_DRIVEN') {
                         schedulingStrategy = "Timer driven";
-                    } else if (schedulingStrategy === 'PRIMARY_NODE_ONLY') {
-                        // PRIMARY_NODE_ONLY has been deprecated as a
-                        // schedulingStrategy option, and is now an
-                        // executionNode option instead.
-                        schedulingStrategy = "Timer driven";
-                        executionNode = 'PRIMARY'
+                    } else {
+                        schedulingStrategy = "On primary node";
                     }
                     nf.Common.populateField('read-only-scheduling-strategy', schedulingStrategy);
 
@@ -184,17 +180,20 @@ nf.ProcessorDetails = (function () {
                         $('#read-only-run-schedule').hide();
                     }
 
+                    var executionNode = details.config['executionNode'];
+
                     // only show the execution-node when applicable
-                    if (executionNode === 'ALL') {
-                        executionNode = "All nodes";
-                    } else if (executionNode === 'PRIMARY') {
-                        executionNode = "Primary node only";
-                    }
-                    nf.Common.populateField('read-only-execution-node', executionNode);
-                    if (nf.Canvas.isClustered()) {
-                        $('#details-execution-node-container').show();
+                    if (nf.Canvas.isClustered() || executionNode === 'PRIMARY') {
+                        if (executionNode === 'ALL') {
+                            executionNode = "All nodes";
+                        } else if (executionNode === 'PRIMARY') {
+                            executionNode = "Primary node only";
+                        }
+                        nf.Common.populateField('read-only-execution-node', executionNode);
+
+                        $('#read-only-execution-node-options').show();
                     } else {
-                        $('#details-execution-node-container').hide();
+                        $('#read-only-execution-node-options').hide();
                     }
 
                     // load the relationship list


### PR DESCRIPTION
NIFI-401:
- Decoupling  scheduling strategy from execution node.
- Ensuring existing configuration is retained and shown until the user explicitly changes it.
- Retaining, but disabling, deprecated options.

This is a continuation of #1117. Once this PR is closed/merged, please close that one as well.