### PR TITLE
Remove legacy site to site code to ensure port availability is accurate

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -106,8 +106,6 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
     private final AtomicBoolean transmitting = new AtomicBoolean(false);
     private final FlowController flowController;
     private final SSLContext sslContext;
-    private final AtomicReference<Boolean> pointsToCluster = new AtomicReference<>(null);
-    private final AtomicBoolean targetIsUnreachable = new AtomicBoolean(false);
 
     private volatile String communicationsTimeout = "30 sec";
     private volatile String targetId;
@@ -184,7 +182,6 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
 
     @Override
     public void reinitialize(boolean isClustered) {
-        this.pointsToCluster.set(null);
         backgroundThreadExecutor.submit(new InitializationTask());
     }
 
@@ -767,38 +764,6 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
         return parent == null ? context : getRootGroup(parent);
     }
 
-    private void refreshFlowContentsFromLocal() {
-        final ProcessGroup rootGroup = getRootGroup();
-        setName(rootGroup.getName());
-        setTargetId(rootGroup.getIdentifier());
-        setComments(rootGroup.getComments());
-        setCounts(rootGroup.getCounts());
-
-        final Set<RemoteProcessGroupPortDescriptor> convertedInputPorts = new HashSet<>();
-        for (final Port port : rootGroup.getInputPorts()) {
-            convertedInputPorts.add(convertPortToRemotePortDescriptor(port));
-        }
-
-        final Set<RemoteProcessGroupPortDescriptor> convertedOutputPorts = new HashSet<>();
-        for (final Port port : rootGroup.getOutputPorts()) {
-            convertedOutputPorts.add(convertPortToRemotePortDescriptor(port));
-        }
-
-        setInputPorts(convertedInputPorts);
-        setOutputPorts(convertedOutputPorts);
-
-        writeLock.lock();
-        try {
-            this.destinationSecure = nifiProperties.isSiteToSiteSecure();
-            this.listeningPort = nifiProperties.getRemoteInputPort();
-            this.listeningHttpPort = nifiProperties.getRemoteInputHttpPort();
-
-            refreshContentsTimestamp = System.currentTimeMillis();
-        } finally {
-            writeLock.unlock();
-        }
-    }
-
     @Override
     public Date getLastRefreshTime() {
         readLock.lock();
@@ -811,22 +776,6 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
 
     @Override
     public void refreshFlowContents() throws CommunicationsException {
-        // check to see if we know whether we pointing to a local cluster or not -
-        // we must know this before we attempt to update since querying the cluster
-        // will cause a deadlock if we are in the context of another replicated request
-        if (pointsToCluster.get() == null) {
-            return;
-        }
-
-        if (pointsToCluster.get()) {
-            refreshFlowContentsFromLocal();
-            return;
-        }
-
-        if (targetIsUnreachable.get()) {
-            return;
-        }
-
         try {
             // perform the request
             final ControllerDTO dto;
@@ -1180,11 +1129,6 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
                     } finally {
                         writeLock.unlock();
                     }
-
-                    final String remoteInstanceId = dto.getInstanceId();
-                    final boolean isPointingToCluster = flowController.getInstanceId().equals(remoteInstanceId);
-                    pointsToCluster.set(isPointingToCluster);
-
                 } catch (SiteToSiteRestApiClient.HttpGetFailedException e) {
 
                     if (e.getResponseCode() == UNAUTHORIZED_STATUS_CODE) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -2529,7 +2529,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         controllerDTO.setInstanceId(controllerFacade.getInstanceId());
         controllerDTO.setInputPorts(inputPortDtos);
         controllerDTO.setOutputPorts(outputPortDtos);
-        controllerDTO.setInputPortCount(inputPorts.size());
+        controllerDTO.setInputPortCount(inputPortDtos.size());
         controllerDTO.setOutputPortCount(outputPortDtos.size());
         controllerDTO.setRunningCount(counts.getRunningCount());
         controllerDTO.setStoppedCount(counts.getStoppedCount());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-connection.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-connection.js
@@ -863,17 +863,17 @@ nf.Connection = (function () {
                                     }
                                 })
                                 .classed('running', function () {
-                                    if (d.component.source.exists === true) {
-                                        return d.component.source.running;
-                                    } else {
+                                    if (d.component.source.exists === false) {
                                         return false;
+                                    } else {
+                                        return d.component.source.running;
                                     }
                                 })
                                 .classed('stopped', function () {
-                                    if (d.component.source.exists === true) {
-                                        return !d.component.source.running;
-                                    } else {
+                                    if (d.component.source.exists === false) {
                                         return false;
+                                    } else {
+                                        return !d.component.source.running;
                                     }
                                 })
                                 .classed('is-missing-port', function () {
@@ -972,17 +972,17 @@ nf.Connection = (function () {
                                     }
                                 })
                                 .classed('running', function () {
-                                    if (d.component.destination.running === true) {
-                                        return d.component.destination.running;
-                                    } else {
+                                    if (d.component.destination.exists === false) {
                                         return false;
+                                    } else {
+                                        return d.component.destination.running;
                                     }
                                 })
                                 .classed('stopped', function () {
-                                    if (d.component.destination.running !== true) {
-                                        return !d.component.destination.running;
-                                    } else {
+                                    if (d.component.destination.exists === false) {
                                         return false;
+                                    } else {
+                                        return !d.component.destination.running;
                                     }
                                 })
                                 .classed('is-missing-port', function () {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
@@ -668,7 +668,7 @@ nf.PolicyManagement = (function () {
     var promptToDeletePolicy = function () {
         nf.Dialog.showYesNoDialog({
             headerText: 'Delete Policy',
-            dialogContent: 'By deleting this policy, the permissions for this component will revert to the inherited policy.',
+            dialogContent: 'By deleting this policy, the permissions for this component will revert to the inherited policy if applicable.',
             yesText: 'Delete',
             noText: 'Cancel',
             yesHandler: function () {


### PR DESCRIPTION
NIFI-3002:
- Removing legacy code when retrieving site to site details when the target instance is this local NiFi.
- Ensures the UI accurately reflects available remote ports.
NIFI-2603:
- Fixing color of remote input/output port status in connection label.