### PR TITLE
Ensuring DROP events are accessible after manually emptying a queue

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -3998,19 +3998,28 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
         final String rootGroupId = getRootGroupId();
 
         // Provenance Events are generated only by connectable components, with the exception of DOWNLOAD events,
-        // which have the root process group's identifier assigned as the component ID. So, we check if the component ID
-        // is set to the root group and otherwise assume that the ID is that of a component.
+        // which have the root process group's identifier assigned as the component ID, and DROP events, which
+        // could have the connection identifier assigned as the component ID. So, we check if the component ID
+        // is set to the root group and otherwise assume that the ID is that of a connectable or connection.
         final DataAuthorizable authorizable;
         if (rootGroupId.equals(componentId)) {
             authorizable = new DataAuthorizable(getRootGroup());
         } else {
+            // check if the component is a connectable, this should be the case most often
             final Connectable connectable = getRootGroup().findConnectable(componentId);
-
             if (connectable == null) {
-                throw new ResourceNotFoundException("The component that generated this event is no longer part of the data flow.");
-            }
+                // if the component id is not a connectable then consider a connection
+                final Connection connection = getRootGroup().findConnection(componentId);
 
-            authorizable = new DataAuthorizable(connectable);
+                if (connection == null) {
+                    throw new ResourceNotFoundException("The component that generated this event is no longer part of the data flow.");
+                } else {
+                    // authorizable for connection data is associated with the source connectable
+                    authorizable = new DataAuthorizable(connection.getSource());
+                }
+            } else {
+                authorizable = new DataAuthorizable(connectable);
+            }
         }
 
         return authorizable;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -81,8 +81,8 @@ import org.apache.nifi.provenance.search.SearchableField;
 import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.remote.RootGroupPort;
 import org.apache.nifi.reporting.ReportingTask;
-import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.scheduling.ExecutionNode;
+import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.search.SearchContext;
 import org.apache.nifi.search.SearchResult;
 import org.apache.nifi.search.Searchable;
@@ -132,6 +132,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.apache.nifi.controller.FlowController.ROOT_GROUP_ID_ALIAS;
 
@@ -1434,6 +1435,21 @@ public class ControllerFacade implements Authorizable {
         if (connectable != null) {
             dto.setGroupId(connectable.getProcessGroup().getIdentifier());
             dto.setComponentName(connectable.getName());
+            return;
+        }
+
+        final Connection connection = root.findConnection(dto.getComponentId());
+        if (connection != null) {
+            dto.setGroupId(connection.getProcessGroup().getIdentifier());
+
+            String name = connection.getName();
+            final Collection<Relationship> relationships = connection.getRelationships();
+            if (StringUtils.isBlank(name) && CollectionUtils.isNotEmpty(relationships)) {
+                name = StringUtils.join(relationships.stream().map(relationship -> relationship.getName()).collect(Collectors.toSet()), ", ");
+            }
+            dto.setComponentName(name);
+
+            return;
         }
     }
 


### PR DESCRIPTION
NIFI-3022:
- Returning the appropriate authorizable when accessing provenance events for a manual DROP event by emptying a queue.
- Populating the component details of a provenance event when the source is a connection.