### PR TITLE
NIFI-2909 Fix logic in AbstractConfiguredComponent setProperties()

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarCloseable.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarCloseable.java
@@ -47,8 +47,13 @@ public class NarCloseable implements Closeable {
      */
     public static NarCloseable withComponentNarLoader(final Class componentClass, final String componentIdentifier) {
         final ClassLoader current = Thread.currentThread().getContextClassLoader();
-        final ClassLoader instanceClassLoader = ExtensionManager.getClassLoader(componentClass.getName(), componentIdentifier);
-        Thread.currentThread().setContextClassLoader(instanceClassLoader);
+
+        ClassLoader componentClassLoader = ExtensionManager.getClassLoader(componentClass.getName(), componentIdentifier);
+        if (componentClassLoader == null) {
+            componentClassLoader = componentClass.getClassLoader();
+        }
+
+        Thread.currentThread().setContextClassLoader(componentClassLoader);
         return new NarCloseable(current);
     }
 


### PR DESCRIPTION
for setting classpath resources in the InstanceClassLoader.

Before if you updated other properties that were not classpath properties, it would end up resetting the classpath resources to an empty set, now it will only set the classpath resources when at least one classpath property is part of the setProperties call, so in the case where other properties are updated the class loader will not change.