### PR TITLE
NIFI-3061 PutAzureEventHub blocks after network interruption

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>azure-eventhubs</artifactId>
-			<version>0.7.1</version>
+			<version>0.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.nifi</groupId>


### PR DESCRIPTION
This change maintains status quo and does not enable the existing unit tests. The change was tested against [NIFI-3061.xml](https://gist.github.com/jfrazee/6820ec854974df88519f99b3388a0874) though. As mentioned in [NIFI-3070](https://issues.apache.org/jira/browse/NIFI-3070), there isn't a good way to provide meaningful unit tests so integration tests should be added as a new improvement.

- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?
- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [X] Is your initial contribution a single, squashed commit?
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?