### PR TITLE
NIFI-3082: Fixed status code handling in PutElasticsearchHttp

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttp.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttp.java
@@ -358,9 +358,15 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
                     session.transfer(flowFilesToTransfer, REL_FAILURE);
                     context.yield();
                 }
-            } else {
-                // Something went wrong during the bulk update, throw a ProcessException to indicate rollback
-                throw new ProcessException("Received error code " + statusCode + " from Elasticsearch API");
+            } else if (statusCode / 100 == 5) {
+                // 5xx -> RETRY, but a server error might last a while, so yield
+                logger.warn("Elasticsearch returned code {} with message {}, transferring flow file to retry. This is likely a server problem, yielding...",
+                        new Object[]{statusCode, getResponse.message()});
+                session.transfer(flowFilesToTransfer, REL_RETRY);
+                context.yield();
+            } else {  // 1xx, 3xx, 4xx, etc. -> NO RETRY
+                logger.warn("Elasticsearch returned code {} with message {}, transferring flow file to failure", new Object[]{statusCode, getResponse.message()});
+                session.transfer(flowFilesToTransfer, REL_FAILURE);
             }
         }
     }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttp.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttp.java
@@ -167,7 +167,7 @@ public class TestPutElasticsearchHttp {
         runner.assertNotValid();
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void testPutElasticSearchOnTriggerWithFailures() throws IOException {
         PutElasticsearchTestProcessor processor = new PutElasticsearchTestProcessor(true);
         processor.setStatus(100, "Should fail");
@@ -183,6 +183,15 @@ public class TestPutElasticsearchHttp {
             put("doc_id", "28039652140");
         }});
         runner.run(1, true, true);
+        runner.assertAllFlowFilesTransferred(PutElasticsearchHttp.REL_FAILURE, 1);
+        runner.clearTransferState();
+
+        processor.setStatus(500, "Should retry");
+        runner.enqueue(docExample, new HashMap<String, String>() {{
+            put("doc_id", "28039652140");
+        }});
+        runner.run(1, true, true);
+        runner.assertAllFlowFilesTransferred(PutElasticsearchHttp.REL_RETRY, 1);
     }
 
     @Test


### PR DESCRIPTION
For consistency, the status code handling is now the same as FetchElasticsearchHttp with respect to status codes and transfer relationships.
