### PR TITLE
NIFI-3101: Improve Get/Modify/PutHTMLElement URL

### DIFF
--- a/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/GetHTMLElement.java
+++ b/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/GetHTMLElement.java
@@ -92,7 +92,9 @@ public class GetHTMLElement
             .Builder().name("Attribute Name")
             .description(("When getting the value of a HTML element attribute this value is used as the key to determine" +
                     " which attribute on the selected element should be retrieved. This value is used when the \"Output Type\"" +
-                    " is set to \"" + ELEMENT_ATTRIBUTE + "\""))
+                    " is set to \"" + ELEMENT_ATTRIBUTE + "\"." +
+                    " If this value is prefixed with 'abs:', then the extracted attribute value will be converted into" +
+                    " an absolute URL form using the specified base URL."))
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(true)
@@ -238,4 +240,8 @@ public class GetHTMLElement
         }
     }
 
+    @Override
+    protected String getBaseUrl(FlowFile inputFlowFile, ProcessContext context) {
+        return context.getProperty(URL).evaluateAttributeExpressions(inputFlowFile).getValue();
+    }
 }

--- a/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/ModifyHTMLElement.java
+++ b/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/ModifyHTMLElement.java
@@ -98,7 +98,6 @@ public class ModifyHTMLElement extends AbstractHTMLProcessor {
     @Override
     protected void init(final ProcessorInitializationContext context) {
         final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(URL);
         descriptors.add(CSS_SELECTOR);
         descriptors.add(HTML_CHARSET);
         descriptors.add(OUTPUT_TYPE);
@@ -122,6 +121,16 @@ public class ModifyHTMLElement extends AbstractHTMLProcessor {
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return descriptors;
+    }
+
+    /**
+     * This processor used to support URL property, but it has been removed
+     * since it's not required when altering HTML elements.
+     * Support URL as dynamic property so that existing data flow can stay in valid state without modification.
+     */
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return URL;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/PutHTMLElement.java
+++ b/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/PutHTMLElement.java
@@ -88,7 +88,6 @@ public class PutHTMLElement extends AbstractHTMLProcessor {
     @Override
     protected void init(final ProcessorInitializationContext context) {
         final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
-        descriptors.add(URL);
         descriptors.add(CSS_SELECTOR);
         descriptors.add(HTML_CHARSET);
         descriptors.add(PUT_LOCATION_TYPE);
@@ -111,6 +110,16 @@ public class PutHTMLElement extends AbstractHTMLProcessor {
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return descriptors;
+    }
+
+    /**
+     * This processor used to support URL property, but it has been removed
+     * since it's not required when altering HTML elements.
+     * Support URL as dynamic property so that existing data flow can stay in valid state without modification.
+     */
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return URL;
     }
 
     @Override


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

- Added detailed description about how the URL property works with
  GetHTMLElement
- Added Expression support with URL
- Made URL property dynamic with ModifyHTMLElement and PutHTMLElement,
  since it won't be used to alter HTML element and need not to be
  specified. Making it a dynamic property let existing processor configuration stays valid