### PR TITLE
NIFI-3093 HIVE Support for QueryDatabaseTable

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -244,8 +244,10 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
             try (final Connection con = dbcpService.getConnection();
                 final Statement st = con.createStatement()) {
 
-                final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions(fileToProcess).asTimePeriod(TimeUnit.SECONDS).intValue();
-                st.setQueryTimeout(queryTimeout); // timeout in seconds
+                if(dbAdapter.getSupportsStatementTimeout()) {
+                    final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).asTimePeriod(TimeUnit.SECONDS).intValue();
+                    st.setQueryTimeout(queryTimeout); // timeout in seconds
+                }
 
                 logger.debug("Executing {}", new Object[]{selectQuery});
                 ResultSet resultSet;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
@@ -26,6 +26,27 @@ public interface DatabaseAdapter {
     String getDescription();
 
     /**
+     * Indicates whether this JDBC driver supports statement level execution timeouts
+     *
+     * @return <code>true</code> if so; <code>false</code> otherwise
+     */
+    boolean getSupportsStatementTimeout();
+
+    /**
+     * Indicates whether this JDBC driver supports retrieving the table name associated with a result set
+     *
+     * @return <code>true</code> if so; <code>false</code> otherwise
+     */
+    boolean getSupportsGetTableName();
+
+    /**
+     * Indicates whether this JDBC driver supports retrieving column sign information for numeric types
+     *
+     * @return <code>true</code> if so; <code>false</code> otherwise
+     */
+    boolean getSupportsMetaDataColumnIsSigned();
+
+    /**
      * Returns a SQL SELECT statement with the given clauses applied.
      *
      * @param tableName     The name of the table to fetch rows from

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/GenericDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/GenericDatabaseAdapter.java
@@ -34,6 +34,21 @@ public class GenericDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
+    public boolean getSupportsStatementTimeout() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsGetTableName() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsMetaDataColumnIsSigned() {
+        return true;
+    }
+
+    @Override
     public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Long limit, Long offset) {
         if (StringUtils.isEmpty(tableName)) {
             throw new IllegalArgumentException("Table name cannot be null or empty");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MSSQL2008DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MSSQL2008DatabaseAdapter.java
@@ -34,6 +34,21 @@ public class MSSQL2008DatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
+    public boolean getSupportsStatementTimeout() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsGetTableName() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsMetaDataColumnIsSigned() {
+        return true;
+    }
+
+    @Override
     public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Long limit, Long offset) {
         if (StringUtils.isEmpty(tableName)) {
             throw new IllegalArgumentException("Table name cannot be null or empty");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MSSQLDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MSSQLDatabaseAdapter.java
@@ -34,6 +34,21 @@ public class MSSQLDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
+    public boolean getSupportsStatementTimeout() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsGetTableName() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsMetaDataColumnIsSigned() {
+        return true;
+    }
+
+    @Override
     public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Long limit, Long offset) {
         if (StringUtils.isEmpty(tableName)) {
             throw new IllegalArgumentException("Table name cannot be null or empty");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
@@ -34,6 +34,21 @@ public class OracleDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
+    public boolean getSupportsStatementTimeout() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsGetTableName() {
+        return true;
+    }
+
+    @Override
+    public boolean getSupportsMetaDataColumnIsSigned() {
+        return true;
+    }
+
+    @Override
     public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause, Long limit, Long offset) {
         if (StringUtils.isEmpty(tableName)) {
             throw new IllegalArgumentException("Table name cannot be null or empty");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processors.standard.db.DatabaseAdapter
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processors.standard.db.DatabaseAdapter
@@ -16,3 +16,4 @@ org.apache.nifi.processors.standard.db.impl.GenericDatabaseAdapter
 org.apache.nifi.processors.standard.db.impl.OracleDatabaseAdapter
 org.apache.nifi.processors.standard.db.impl.MSSQLDatabaseAdapter
 org.apache.nifi.processors.standard.db.impl.MSSQL2008DatabaseAdapter
+org.apache.nifi.processors.standard.db.impl.HiveDatabaseAdapter

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestHiveDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestHiveDatabaseAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.db.impl;
+
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHiveDatabaseAdapter {
+    final DatabaseAdapter db = new HiveDatabaseAdapter();
+
+    @Test
+    public void testGeneration() throws Exception {
+        String sql1 = db.getSelectStatement("database.tablename", "some(set),of(columns),that,might,contain,methods,a.*","","",null,null);
+        String expected1 = "SELECT some(set),of(columns),that,might,contain,methods,a.* FROM database.tablename";
+        Assert.assertEquals(sql1,expected1);
+
+        String sql2 = db.getSelectStatement("database.tablename", "some(set),of(columns),that,might,contain,methods,a.*","that=\'some\"\' value\'","",null,null);
+        String expected2 = "SELECT some(set),of(columns),that,might,contain,methods,a.* FROM database.tablename WHERE that=\'some\"\' value\'";
+        Assert.assertEquals(sql2,expected2);
+
+        String sql3 = db.getSelectStatement("database.tablename", "some(set),of(columns),that,might,contain,methods,a.*","that=\'some\"\' value\'","might DESC",null,null);
+        String expected3 = "SELECT some(set),of(columns),that,might,contain,methods,a.* FROM database.tablename WHERE that=\'some\"\' value\' ORDER BY might DESC";
+        Assert.assertEquals(sql3,expected3);
+
+        String sql4 = db.getSelectStatement("database.tablename", "","that=\'some\"\' value\'","might DESC",null,null);
+        String expected4 = "SELECT * FROM database.tablename WHERE that=\'some\"\' value\' ORDER BY might DESC";
+        Assert.assertEquals(sql4,expected4);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoTableName() throws Exception {
+        db.getSelectStatement("", "some(set),of(columns),that,might,contain,methods,a.*","","",null,null);
+    }
+
+    @Test
+    public void testPagingQuery() throws Exception {
+        String sql1 = db.getSelectStatement("database.tablename", "some(set),of(columns),that,might,contain,methods,a.*","","contain",100L,0L);
+        String expected1 = "SELECT * FROM (SELECT some(set),of(columns),that,might,contain,methods,a.*, ROW_NUMBER() OVER(ORDER BY contain ASC) rnum FROM database.tablename ORDER BY contain) A WHERE rnum > 0 AND rnum <= 100";
+        Assert.assertEquals(expected1,sql1);
+
+        String sql2 = db.getSelectStatement("database.tablename", "some(set),of(columns),that,might,contain,methods,a.*","","contain",10000L,123456L);
+        String expected2 = "SELECT * FROM (SELECT some(set),of(columns),that,might,contain,methods,a.*, ROW_NUMBER() OVER(ORDER BY contain ASC) rnum FROM database.tablename ORDER BY contain) A WHERE rnum > 123456 AND rnum <= 133456";
+        Assert.assertEquals(expected2,sql2);
+
+        String sql3 = db.getSelectStatement("database.tablename", "some(set),of(columns),that,might,contain,methods,a.*","methods='strange'","contain",10000L,123456L);
+        String expected3 = "SELECT * FROM (SELECT some(set),of(columns),that,might,contain,methods,a.*, ROW_NUMBER() OVER(ORDER BY contain ASC) rnum FROM database.tablename WHERE methods='strange' ORDER BY contain) A WHERE rnum > 123456 AND rnum <= 133456";
+        Assert.assertEquals(expected3,sql3);
+    }
+}


### PR DESCRIPTION
This update adds HIVE support to `QueryDatabaseTable`.

I included a few changes to `GenerateTableFetch`, but these were only for compatability with the new properties added to the DB Adapter interface. This does NOT add support to `GenerateTableFetch` for HIVE (as I don't think paging HIVE is possible).

I'm expecting this will need a few tweaks, just let me know.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

