### PR TITLE
NIFI-3141: Fixed TailFile ArrayIndexOutOfBounds.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -345,6 +345,25 @@ public class TailFile extends AbstractProcessor {
 
         Map<String, String> statesMap = stateMap.toMap();
 
+        if (statesMap.containsKey(TailFileState.StateKeys.FILENAME)
+                && !statesMap.keySet().stream().anyMatch(key -> key.startsWith(MAP_PREFIX))) {
+            // If statesMap contains "filename" key without "file.0." prefix,
+            // and there's no key with "file." prefix, then
+            // it indicates that the statesMap is created with earlier version of NiFi.
+            // In this case, we need to migrate the state by adding prefix indexed with 0.
+            final Map<String, String> migratedStatesMap = new HashMap<>(statesMap.size());
+            for (String key : statesMap.keySet()) {
+                migratedStatesMap.put(MAP_PREFIX + "0." + key, statesMap.get(key));
+            }
+
+            // LENGTH is added from NiFi 1.1.0. Set the value with using the last position so that we can use existing state
+            // to avoid sending duplicated log data after updating NiFi.
+            migratedStatesMap.put(MAP_PREFIX + "0." + TailFileState.StateKeys.LENGTH, statesMap.get(TailFileState.StateKeys.POSITION));
+            statesMap = Collections.unmodifiableMap(migratedStatesMap);
+
+            getLogger().info("statesMap has been migrated. {}", new Object[]{migratedStatesMap});
+        }
+
         initStates(filesToTail, statesMap, false);
         recoverState(context, filesToTail, statesMap);
     }
@@ -931,6 +950,15 @@ public class TailFile extends AbstractProcessor {
             Map<String, String> updatedState = new HashMap<String, String>();
 
             for(String key : oldState.toMap().keySet()) {
+                // These states are stored by older version of NiFi, and won't be used anymore.
+                // New states have 'file.<index>.' prefix.
+                if (TailFileState.StateKeys.CHECKSUM.equals(key)
+                        || TailFileState.StateKeys.FILENAME.equals(key)
+                        || TailFileState.StateKeys.POSITION.equals(key)
+                        || TailFileState.StateKeys.TIMESTAMP.equals(key)) {
+                    getLogger().info("Removed state {}={} stored by older version of NiFi.", new Object[]{key, oldState.get(key)});
+                    continue;
+                }
                 updatedState.put(key, oldState.get(key));
             }
 


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

- Added unit test cases to simulate NiFi version update which fails without this fix.
- Added state object migration code, add file.0. prefix to state keys,
  and add length from stored position.