### PR TITLE
Fix NIFI-3142: ExtractHL7Attribute processor: Route a flowfile to REL_FAILURE if processing the flow…

### DIFF
--- a/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
+++ b/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
@@ -196,8 +196,8 @@ public class ExtractHL7Attributes extends AbstractProcessor {
             final Map<String, String> attributes = getAttributes(message, useSegmentNames, parseSegmentFields);
             flowFile = session.putAllAttributes(flowFile, attributes);
             getLogger().debug("Added the following attributes for {}: {}", new Object[]{flowFile, attributes});
-        } catch (final HL7Exception e) {
-            getLogger().error("Failed to extract attributes from {} due to {}", new Object[]{flowFile, e});
+        } catch (final Throwable t) {
+            getLogger().error("Failed to extract attributes from {} due to {}", new Object[]{flowFile, t}, t);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [n/a] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [n/a] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [n/a] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [n/a] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

… file throws an exception that is not an HL7Exception for the ExtractHL7Attribute processor.

Fixed by changing the catch block to catch a throwable object instead of an HL7Exception object in the onTrigger method.