### PR TITLE
NIFI-3196 Provide MiNiFi FlowStatus Insights processor that integrates MiNiFi Flow Status Report with Azure Application Insights

### DIFF
--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-nar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-minififlowstatus-insights-bundle</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-minififlowstatus-insights-nar</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-minififlowstatus-insights-processors</artifactId>
+            <version>1.2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,232 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses. 
+
+This product bundles 'ApplicationInsights-Java' which is available under the MIT License.
+For details see https://github.com/Microsoft/ApplicationInsights-Java
+
+	ApplicationInsights-Java
+    Copyright (c) Microsoft Corporation
+    All rights reserved.
+
+    MIT License
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this
+    software and associated documentation files (the ""Software""), to deal in the Software
+    without restriction, including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+    persons to whom the Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+    PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+    FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,35 @@
+nifi-minififlowstatus-insights-nar
+Copyright 2015-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+******************
+Apache Software License v2
+******************
+
+The following binary components are provided under the Apache Software License v2
+
+  (ASLv2) Jackson JSON processor
+      The following NOTICE information applies:
+        # Jackson JSON processor
+
+        Jackson is a high-performance, Free/Open Source JSON processing library.
+        It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+        been in development since 2007.
+        It is currently developed by a community of developers, as well as supported
+        commercially by FasterXML.com.
+
+        ## Licensing
+
+        Jackson core and extension components may licensed under different licenses.
+        To find the details that apply to this artifact see the accompanying LICENSE file.
+        For more information, including possible other licensing options, contact
+        FasterXML.com (http://fasterxml.com).
+
+        ## Credits
+
+        A list of contributors may be found from CREDITS file, which is included
+        in some artifacts (usually source distributions); but is always available
+        from the source code management (SCM) system project uses.
+

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-minififlowstatus-insights-bundle</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-minififlowstatus-insights-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <azure.applicationinsights.version>1.0.6</azure.applicationinsights.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.microsoft.azure/applicationinsights-core -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>applicationinsights-core</artifactId>
+            <version>${azure.applicationinsights.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <!--- Test related -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/MiNiFiFlowStatus.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/MiNiFiFlowStatus.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.minififlowstatus.minifi;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.nifi.processors.minififlowstatus.minifi.connection.ConnectionStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.instance.InstanceStatus;
+import org.apache.nifi.processors.minififlowstatus.minifi.processor.ProcessorStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.rpg.RemoteProcessGroupStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.system.SystemDiagnosticsStatus;
+
+import java.util.List;
+
+@JsonIgnoreProperties({ "controllerServiceStatusList", "reportingTaskStatusList","errorsGeneratingReport" })
+public final class MiNiFiFlowStatus {
+
+    public List<ProcessorStatusBean> processorStatusList;
+    public List<ConnectionStatusBean> connectionStatusList;
+    public List<RemoteProcessGroupStatusBean> remoteProcessGroupStatusList;
+    public InstanceStatus instanceStatus;
+    public SystemDiagnosticsStatus systemDiagnosticsStatus;
+}
+

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/connection/ConnectionStats.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/connection/ConnectionStats.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.connection;
+
+public class ConnectionStats  {
+    public int inputCount;
+    public long inputBytes;
+    public int outputCount;
+    public long outputBytes;
+
+    public ConnectionStats() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/connection/ConnectionStatusBean.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/connection/ConnectionStatusBean.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.connection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties({ "connectionHealth"})
+public class ConnectionStatusBean  {
+    public String name;
+    public ConnectionStats connectionStats;
+
+    public ConnectionStatusBean() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/instance/InstanceStats.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/instance/InstanceStats.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.instance;
+
+public class InstanceStats {
+    public long bytesRead;
+    public long bytesWritten;
+    public long bytesSent;
+    public int flowfilesSent;
+    public long bytesTransferred;
+    public int flowfilesTransferred;
+    public long bytesReceived;
+    public int flowfilesReceived;
+
+    public InstanceStats() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/instance/InstanceStatus.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/instance/InstanceStatus.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.instance;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+@JsonIgnoreProperties({ "instanceHealth,bulletinList"})
+public class InstanceStatus  {
+
+    public InstanceStats instanceStats;
+
+    public InstanceStatus() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/processor/ProcessorStats.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/processor/ProcessorStats.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.processor;
+
+public class ProcessorStats  {
+
+    public int activeThreads;
+    public int flowfilesReceived;
+    public long bytesRead;
+    public long bytesWritten;
+    public int flowfilesSent;
+    public int invocations;
+    public long processingNanos;
+
+    public ProcessorStats() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/processor/ProcessorStatusBean.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/processor/ProcessorStatusBean.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.processor;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties({ "processorHealth,bulletinList"})
+public class ProcessorStatusBean  {
+
+    public String name;
+    public ProcessorStats processorStats;
+
+    public ProcessorStatusBean() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/rpg/RemoteProcessGroupStats.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/rpg/RemoteProcessGroupStats.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.rpg;
+
+public class RemoteProcessGroupStats  {
+    public int activeThreads;
+    public int sentCount;
+    public long sentContentSize;
+
+    public RemoteProcessGroupStats() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/rpg/RemoteProcessGroupStatusBean.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/rpg/RemoteProcessGroupStatusBean.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.rpg;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties({ "remoteProcessGroupHealth,inputPortStatusList,bulletinList"})
+public class RemoteProcessGroupStatusBean  {
+    public String name;
+    public RemoteProcessGroupStats remoteProcessGroupStats;
+
+    public RemoteProcessGroupStatusBean() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/ContentRepositoryUsage.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/ContentRepositoryUsage.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.system;
+
+public class ContentRepositoryUsage  {
+
+    public String name;
+    public long freeSpace;
+    public long totalSpace;
+    public long usedSpace;
+    public int diskUtilization;
+
+    public ContentRepositoryUsage() {
+
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/FlowfileRepositoryUsage.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/FlowfileRepositoryUsage.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.system;
+
+public class FlowfileRepositoryUsage  {
+
+    public long freeSpace;
+    public long totalSpace;
+    public long usedSpace;
+    public int diskUtilization;
+
+    public FlowfileRepositoryUsage() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/HeapStatus.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/HeapStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.system;
+
+public class HeapStatus  {
+
+    public long totalHeap;
+    public long maxHeap;
+    public long freeHeap;
+    public long usedHeap;
+    public int heapUtilization;
+    public long totalNonHeap;
+    public long maxNonHeap;
+    public long freeNonHeap;
+    public long usedNonHeap;
+    public int nonHeapUtilization;
+
+    public HeapStatus() {
+    }
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/SystemDiagnosticsStatus.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/minifi/system/SystemDiagnosticsStatus.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.minififlowstatus.minifi.system;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties({ "garbageCollectionStatusList,processorStatus"})
+public class SystemDiagnosticsStatus  {
+    public HeapStatus heapStatus;
+    public List<ContentRepositoryUsage> contentRepositoryUsageList;
+    public FlowfileRepositoryUsage flowfileRepositoryUsage;
+
+    public SystemDiagnosticsStatus() {
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/reporting/azure/AzureApplicationInsights.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/java/org/apache/nifi/processors/minififlowstatus/reporting/azure/AzureApplicationInsights.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.minififlowstatus.reporting.azure;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.applicationinsights.TelemetryClient;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.lifecycle.OnShutdown;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.minififlowstatus.minifi.MiNiFiFlowStatus;
+import org.apache.nifi.processors.minififlowstatus.minifi.connection.ConnectionStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.processor.ProcessorStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.rpg.RemoteProcessGroupStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.system.ContentRepositoryUsage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Tags({"insights metrics"})
+@CapabilityDescription("This processor will take the flow file, which is assumed to be JSON representing the FlowStatus" +
+        " report from MiNiFi and send it to Azure Application Insights. Every field in the JSON will be sent as a" +
+        " metric to Azure. The hierarchy will be represented with '.' between field names. This processor does not send" +
+        " health or bulletin related information")
+@SeeAlso({})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@ReadsAttribute(attribute = "minifi.hostname", description = "The minifi hostname to use as the basename " +
+        "for all metrics that are sent to a metrics endpoint")
+@SupportsBatching
+public class AzureApplicationInsights extends AbstractProcessor {
+
+    public static final String TRUE = "True";
+    public static final String FALSE = "False";
+
+    public static final PropertyDescriptor AZURE_INSTRUMENTATION_KEY = new PropertyDescriptor
+            .Builder().name("Azure InstrumentationKey")
+            .displayName("Azure InstrumentationKey")
+            .description("The instrumentation key used when sending data to Azure. ")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor BASE_METRIC_NAME = new PropertyDescriptor
+            .Builder().name("Base Metric Name")
+            .displayName("Base Metric Name")
+            .description("This is the base name to use, if this is not populated, then it will look for the property " +
+                    "minifi.hostname to use as the base name. If neither of these are populated, then it will default to " +
+                    " unkown-minifi-host")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor SEND_PROCESSOR_STATUS_PROP = new PropertyDescriptor
+            .Builder().name("Send Processor Status")
+            .displayName("Send Processor Status")
+            .description("If send is chosen then all processor statuses will be sent.")
+            .required(true)
+            .defaultValue(TRUE)
+            .allowableValues(TRUE, FALSE)
+            .build();
+
+    public static final PropertyDescriptor SEND_CONNECTION_STATUS_PROP = new PropertyDescriptor
+            .Builder().name("Send Connection Status")
+            .displayName("Send Connection Status")
+            .description("If send is chosen then all connection statuses will be sent.")
+            .required(true)
+            .defaultValue(TRUE)
+            .allowableValues(TRUE, FALSE)
+            .build();
+
+    public static final PropertyDescriptor SEND_RPG_STATUS_PROP = new PropertyDescriptor
+            .Builder().name("Send Remote Processor Group Status")
+            .displayName("Send Remote Processor Group Status")
+            .description("If send is chosen then all report processor group statuses will be sent.")
+            .required(true)
+            .defaultValue(TRUE)
+            .allowableValues(TRUE, FALSE)
+            .build();
+
+    public static final PropertyDescriptor SEND_INSTANCE_STATUS_PROP = new PropertyDescriptor
+            .Builder().name("Send Instance Status")
+            .displayName("Send Instance Status")
+            .description("If send is chosen then all instance statuses will be sent.")
+            .required(true)
+            .defaultValue(TRUE)
+            .allowableValues(TRUE, FALSE)
+            .build();
+    public static final PropertyDescriptor SEND_SYS_DIAG_STATUS_PROP = new PropertyDescriptor
+            .Builder().name("Send System Diagnostic Status")
+            .displayName("Send System Diagnostic Status")
+            .description("If send is chosen then all system diagnostic statuses will be sent.")
+            .required(true)
+            .defaultValue(TRUE)
+            .allowableValues(TRUE, FALSE)
+            .build();
+
+    public static final Relationship SUCCESS_REL = new Relationship.Builder()
+            .name("Success")
+            .description("Success Relationship")
+            .build();
+
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private TelemetryClient telemetryClient = createTelemetryClient();
+
+    protected TelemetryClient createTelemetryClient() {
+        return new TelemetryClient();
+    }
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        descriptors.add(AZURE_INSTRUMENTATION_KEY);
+        descriptors.add(BASE_METRIC_NAME);
+        descriptors.add(SEND_PROCESSOR_STATUS_PROP);
+        descriptors.add(SEND_CONNECTION_STATUS_PROP);
+        descriptors.add(SEND_RPG_STATUS_PROP);
+        descriptors.add(SEND_INSTANCE_STATUS_PROP);
+        descriptors.add(SEND_SYS_DIAG_STATUS_PROP);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<Relationship>();
+        relationships.add(SUCCESS_REL);
+        this.relationships = Collections.unmodifiableSet(relationships);
+
+        //ensure we do not fail parsing the JSON if MiNiFi FlowStatus changes
+        //before this get's updated.
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+
+    @Override
+    public void onPropertyModified(PropertyDescriptor descriptor, String oldValue, String newValue) {
+        if (descriptor.equals(AZURE_INSTRUMENTATION_KEY)) {
+            if (null != newValue) {
+                telemetryClient.getContext().setInstrumentationKey(newValue);
+            }
+        }
+    }
+
+    @OnStopped
+    @OnShutdown
+    public void drainTelemtryClient() {
+        try {
+            telemetryClient.flush();
+        } catch (Exception ex) {
+            //not much we can do here.....
+            getLogger().error("Caught exception trying to flush Azure Telemetry Client");
+        }
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (null != flowFile) {
+
+            if (null == telemetryClient.getContext().getInstrumentationKey()) {
+                final String intstrumentationKey = context.getProperty(AZURE_INSTRUMENTATION_KEY).getValue();
+                telemetryClient.getContext().setInstrumentationKey(intstrumentationKey);
+            }
+
+
+            session.read(flowFile, new InputStreamCallback() {
+
+                @Override
+                public void process(InputStream inputStream) throws IOException {
+
+                    String hostBaseName = "unkown-minifi-host";
+                    if (context.getProperty(BASE_METRIC_NAME).isSet()) {
+                        hostBaseName = context.getProperty(BASE_METRIC_NAME).getValue();
+                    }
+                    String minifiHost = flowFile.getAttribute("minifi.hostname");
+
+                    if (null != minifiHost) {
+                        hostBaseName = minifiHost;
+                    }
+
+                    MiNiFiFlowStatus flowStatus = objectMapper.readValue(inputStream, MiNiFiFlowStatus.class);
+
+                    if (context.getProperty(SEND_CONNECTION_STATUS_PROP).asBoolean()) {
+                        sendConnectionStatus(hostBaseName, flowStatus);
+                    }
+
+                    if (context.getProperty(SEND_INSTANCE_STATUS_PROP).asBoolean()) {
+                        sendInstanceStatus(hostBaseName, flowStatus);
+                    }
+
+                    if (context.getProperty(SEND_PROCESSOR_STATUS_PROP).asBoolean()) {
+                        sendProcessorStatus(hostBaseName, flowStatus);
+                    }
+
+                    if (context.getProperty(SEND_RPG_STATUS_PROP).asBoolean()) {
+                        sendRPGStatus(hostBaseName, flowStatus);
+                    }
+                    if (context.getProperty(SEND_SYS_DIAG_STATUS_PROP).asBoolean()) {
+                        sendSystemDiagnosticStatus(hostBaseName, flowStatus);
+                    }
+                }
+            });
+
+            session.transfer(flowFile, SUCCESS_REL);
+        }
+
+
+    }
+
+    private void sendSystemDiagnosticStatus(String hostBaseName, MiNiFiFlowStatus flowStatus) {
+        if (null != flowStatus.systemDiagnosticsStatus) {
+
+            for (final ContentRepositoryUsage contentRepositoryUsage : flowStatus.systemDiagnosticsStatus.contentRepositoryUsageList) {
+
+                final String baseName = hostBaseName + ".system.content.repository." + contentRepositoryUsage.name + ".";
+                telemetryClient.trackMetric(baseName + "freeSpace", contentRepositoryUsage.freeSpace);
+                telemetryClient.trackMetric(baseName + "totalSpace", contentRepositoryUsage.totalSpace);
+                telemetryClient.trackMetric(baseName + "usedSpace", contentRepositoryUsage.usedSpace);
+                telemetryClient.trackMetric(baseName + "diskUtilization", contentRepositoryUsage.diskUtilization);
+            }
+
+            if (null != flowStatus.systemDiagnosticsStatus.flowfileRepositoryUsage) {
+                final String baseName = hostBaseName + ".system.flowfile.repository.";
+                telemetryClient.trackMetric(baseName + "freeSpace", flowStatus.systemDiagnosticsStatus.flowfileRepositoryUsage.freeSpace);
+                telemetryClient.trackMetric(baseName + "totalSpace", flowStatus.systemDiagnosticsStatus.flowfileRepositoryUsage.totalSpace);
+                telemetryClient.trackMetric(baseName + "usedSpace", flowStatus.systemDiagnosticsStatus.flowfileRepositoryUsage.usedSpace);
+                telemetryClient.trackMetric(baseName + "diskUtilization", flowStatus.systemDiagnosticsStatus.flowfileRepositoryUsage.diskUtilization);
+            }
+            if (null != flowStatus.systemDiagnosticsStatus.heapStatus) {
+                final String baseName = hostBaseName + ".system.heap.";
+                telemetryClient.trackMetric(baseName + "totalHeap", flowStatus.systemDiagnosticsStatus.heapStatus.totalHeap);
+                telemetryClient.trackMetric(baseName + "maxHeap", flowStatus.systemDiagnosticsStatus.heapStatus.maxHeap);
+                telemetryClient.trackMetric(baseName + "freeHeap", flowStatus.systemDiagnosticsStatus.heapStatus.freeHeap);
+                telemetryClient.trackMetric(baseName + "usedHeap", flowStatus.systemDiagnosticsStatus.heapStatus.usedHeap);
+                telemetryClient.trackMetric(baseName + "heapUtilization", flowStatus.systemDiagnosticsStatus.heapStatus.heapUtilization);
+                telemetryClient.trackMetric(baseName + "totalNonHeap", flowStatus.systemDiagnosticsStatus.heapStatus.totalNonHeap);
+                telemetryClient.trackMetric(baseName + "maxNonHeap", flowStatus.systemDiagnosticsStatus.heapStatus.maxNonHeap);
+                telemetryClient.trackMetric(baseName + "freeNonHeap", flowStatus.systemDiagnosticsStatus.heapStatus.freeNonHeap);
+                telemetryClient.trackMetric(baseName + "usedNonHeap", flowStatus.systemDiagnosticsStatus.heapStatus.usedNonHeap);
+                telemetryClient.trackMetric(baseName + "nonHeapUtilization", flowStatus.systemDiagnosticsStatus.heapStatus.nonHeapUtilization);
+
+            }
+        }
+    }
+
+    private void sendRPGStatus(String hostBaseName, MiNiFiFlowStatus flowStatus) {
+        if (null != flowStatus.remoteProcessGroupStatusList) {
+            for (final RemoteProcessGroupStatusBean remoteProcessGroupStatusBean : flowStatus.remoteProcessGroupStatusList) {
+
+                final String baseName = hostBaseName + ".rpg." + URI.create(remoteProcessGroupStatusBean.name).getHost() + ".";
+                if (null != remoteProcessGroupStatusBean.remoteProcessGroupStats) {
+                    telemetryClient.trackMetric(baseName + "activeThreads", remoteProcessGroupStatusBean.remoteProcessGroupStats.activeThreads);
+                    telemetryClient.trackMetric(baseName + "sentCount", remoteProcessGroupStatusBean.remoteProcessGroupStats.sentCount);
+                    telemetryClient.trackMetric(baseName + "sentContentSize", remoteProcessGroupStatusBean.remoteProcessGroupStats.sentContentSize);
+                }
+            }
+
+        }
+    }
+
+    private void sendProcessorStatus(String hostBaseName, MiNiFiFlowStatus flowStatus) {
+        if (null != flowStatus.processorStatusList) {
+            for (final ProcessorStatusBean processorStatus : flowStatus.processorStatusList) {
+
+                final String baseName = hostBaseName + ".processor." + processorStatus.name.replace('/', '-') + ".";
+                telemetryClient.trackMetric(baseName + "activeThreads", processorStatus.processorStats.activeThreads);
+                telemetryClient.trackMetric(baseName + "flowfilesReceived", processorStatus.processorStats.flowfilesReceived);
+                telemetryClient.trackMetric(baseName + "flowfilesSent", processorStatus.processorStats.flowfilesSent);
+                telemetryClient.trackMetric(baseName + "bytesRead", processorStatus.processorStats.bytesRead);
+                telemetryClient.trackMetric(baseName + "bytesWritten", processorStatus.processorStats.bytesWritten);
+                telemetryClient.trackMetric(baseName + "invocations", processorStatus.processorStats.invocations);
+                telemetryClient.trackMetric(baseName + "processingNanos", processorStatus.processorStats.processingNanos);
+
+            }
+
+        }
+    }
+
+    private void sendInstanceStatus(String hostBaseName, MiNiFiFlowStatus flowStatus) {
+        if (null != flowStatus.instanceStatus) {
+            if (null != flowStatus.instanceStatus.instanceStats) {
+                final String baseName = hostBaseName + ".instance.";
+                telemetryClient.trackMetric(baseName + "bytesRead", flowStatus.instanceStatus.instanceStats.bytesRead);
+                telemetryClient.trackMetric(baseName + "bytesWritten", flowStatus.instanceStatus.instanceStats.bytesWritten);
+                telemetryClient.trackMetric(baseName + "bytesSent", flowStatus.instanceStatus.instanceStats.bytesSent);
+                telemetryClient.trackMetric(baseName + "flowfilesSent", flowStatus.instanceStatus.instanceStats.flowfilesSent);
+                telemetryClient.trackMetric(baseName + "bytesTransferred", flowStatus.instanceStatus.instanceStats.bytesTransferred);
+                telemetryClient.trackMetric(baseName + "flowfilesTransferred", flowStatus.instanceStatus.instanceStats.flowfilesTransferred);
+                telemetryClient.trackMetric(baseName + "bytesReceived", flowStatus.instanceStatus.instanceStats.bytesReceived);
+                telemetryClient.trackMetric(baseName + "flowfilesReceived", flowStatus.instanceStatus.instanceStats.flowfilesReceived);
+            }
+        }
+    }
+
+    private void sendConnectionStatus(String hostBaseName, MiNiFiFlowStatus flowStatus) {
+
+        if (null != flowStatus.connectionStatusList) {
+            for (final ConnectionStatusBean connectionStatus : flowStatus.connectionStatusList) {
+
+                final String baseName = hostBaseName + ".connection." + connectionStatus.name.replace('/', '-') + ".";
+                telemetryClient.trackMetric(baseName + "inputCount", connectionStatus.connectionStats.inputCount);
+                telemetryClient.trackMetric(baseName + "inputBytes", connectionStatus.connectionStats.inputBytes);
+                telemetryClient.trackMetric(baseName + "outputCount", connectionStatus.connectionStats.outputCount);
+                telemetryClient.trackMetric(baseName + "outputBytes", connectionStatus.connectionStats.outputBytes);
+            }
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.minififlowstatus.reporting.azure.AzureApplicationInsights

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/test/java/org/apache/nifi/processors/minififlowstatus/reporting/azure/AzureApplicationInsightsProcessorTest.java
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/nifi-minififlowstatus-insights-processors/src/test/java/org/apache/nifi/processors/minififlowstatus/reporting/azure/AzureApplicationInsightsProcessorTest.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.minififlowstatus.reporting.azure;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.applicationinsights.TelemetryClient;
+import org.apache.nifi.processors.minififlowstatus.minifi.MiNiFiFlowStatus;
+import org.apache.nifi.processors.minififlowstatus.minifi.connection.ConnectionStats;
+import org.apache.nifi.processors.minififlowstatus.minifi.connection.ConnectionStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.instance.InstanceStats;
+import org.apache.nifi.processors.minififlowstatus.minifi.instance.InstanceStatus;
+import org.apache.nifi.processors.minififlowstatus.minifi.processor.ProcessorStats;
+import org.apache.nifi.processors.minififlowstatus.minifi.processor.ProcessorStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.rpg.RemoteProcessGroupStats;
+import org.apache.nifi.processors.minififlowstatus.minifi.rpg.RemoteProcessGroupStatusBean;
+import org.apache.nifi.processors.minififlowstatus.minifi.system.ContentRepositoryUsage;
+import org.apache.nifi.processors.minififlowstatus.minifi.system.FlowfileRepositoryUsage;
+import org.apache.nifi.processors.minififlowstatus.minifi.system.HeapStatus;
+import org.apache.nifi.processors.minififlowstatus.minifi.system.SystemDiagnosticsStatus;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+public class AzureApplicationInsightsProcessorTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String TEST_KEY = "agp_test_key";
+    private static final String MINIFI_HOSTNAME = "minifi.hostname";
+
+    private TelemetryClient telemetryClient = new TelemetryClient();
+    private TelemetryClient mockTelemetryClient = spy(telemetryClient);
+
+
+    @Before
+    public void init() {
+
+        doNothing().when(mockTelemetryClient).trackMetric(anyString(), anyDouble());
+    }
+
+    @Test
+    public void testConnectionStatus() throws JsonProcessingException {
+
+
+        final TestRunner testRunner = TestRunners.newTestRunner(new MockAzureApplicaitonInsights() {
+        });
+
+        MiNiFiFlowStatus miNiFiFlowStatus = new MiNiFiFlowStatus();
+        ConnectionStatusBean connectionStatusBean = new ConnectionStatusBean();
+        connectionStatusBean.name = "testConnectionStatus";
+        connectionStatusBean.connectionStats = new ConnectionStats();
+        connectionStatusBean.connectionStats.inputBytes = 100L;
+        connectionStatusBean.connectionStats.inputCount = 10;
+        connectionStatusBean.connectionStats.outputBytes = 200L;
+        connectionStatusBean.connectionStats.outputCount = 20;
+        miNiFiFlowStatus.connectionStatusList = new ArrayList<>();
+        miNiFiFlowStatus.connectionStatusList.add(connectionStatusBean);
+
+        testRunner.enqueue(objectMapper.writeValueAsBytes(miNiFiFlowStatus));
+        testRunner.setProperty(AzureApplicationInsights.SEND_CONNECTION_STATUS_PROP, AzureApplicationInsights.TRUE);
+        testRunner.setProperty(AzureApplicationInsights.BASE_METRIC_NAME, MINIFI_HOSTNAME);
+        testRunner.setProperty(AzureApplicationInsights.AZURE_INSTRUMENTATION_KEY, TEST_KEY);
+        testRunner.run();
+
+        final String baseName = MINIFI_HOSTNAME + ".connection." + connectionStatusBean.name + ".";
+
+        verify(mockTelemetryClient).trackMetric(baseName + "inputCount", connectionStatusBean.connectionStats.inputCount);
+        verify(mockTelemetryClient).trackMetric(baseName + "inputBytes", connectionStatusBean.connectionStats.inputBytes);
+        verify(mockTelemetryClient).trackMetric(baseName + "outputCount", connectionStatusBean.connectionStats.outputCount);
+        verify(mockTelemetryClient).trackMetric(baseName + "outputBytes", connectionStatusBean.connectionStats.outputBytes);
+        verify(mockTelemetryClient, times(2)).getContext();
+        verify(mockTelemetryClient).flush();
+    }
+
+    @Test
+    public void testInstanceStatus() throws JsonProcessingException {
+
+        final TestRunner testRunner = TestRunners.newTestRunner(new MockAzureApplicaitonInsights() {
+        });
+
+        MiNiFiFlowStatus miNiFiFlowStatus = new MiNiFiFlowStatus();
+        InstanceStats instanceStats = new InstanceStats();
+        instanceStats.bytesRead = 100L;
+        instanceStats.bytesWritten = 100L;
+        instanceStats.bytesSent = 100L;
+        instanceStats.flowfilesSent = 1;
+        instanceStats.bytesTransferred = 100L;
+        instanceStats.flowfilesTransferred = 1;
+        instanceStats.bytesReceived = 100L;
+        instanceStats.flowfilesReceived = 1;
+
+        miNiFiFlowStatus.instanceStatus = new InstanceStatus();
+        miNiFiFlowStatus.instanceStatus.instanceStats = instanceStats;
+
+        testRunner.enqueue(objectMapper.writeValueAsBytes(miNiFiFlowStatus));
+        testRunner.setProperty(AzureApplicationInsights.SEND_INSTANCE_STATUS_PROP, AzureApplicationInsights.TRUE);
+        testRunner.setProperty(AzureApplicationInsights.BASE_METRIC_NAME, MINIFI_HOSTNAME);
+        testRunner.setProperty(AzureApplicationInsights.AZURE_INSTRUMENTATION_KEY, TEST_KEY);
+        testRunner.run();
+
+        final String baseName = MINIFI_HOSTNAME + ".instance.";
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesRead", instanceStats.bytesRead);
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesWritten", instanceStats.bytesWritten);
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesSent", instanceStats.bytesSent);
+        verify(mockTelemetryClient).trackMetric(baseName + "flowfilesSent", instanceStats.flowfilesSent);
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesTransferred", instanceStats.bytesTransferred);
+        verify(mockTelemetryClient).trackMetric(baseName + "flowfilesTransferred", instanceStats.flowfilesTransferred);
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesReceived", instanceStats.bytesReceived);
+        verify(mockTelemetryClient).trackMetric(baseName + "flowfilesReceived", instanceStats.flowfilesReceived);
+        verify(mockTelemetryClient, times(2)).getContext();
+        verify(mockTelemetryClient).flush();
+    }
+
+    @Test
+    public void testProcessorStatus() throws JsonProcessingException {
+
+        final TestRunner testRunner = TestRunners.newTestRunner(new MockAzureApplicaitonInsights() {
+        });
+
+        MiNiFiFlowStatus miNiFiFlowStatus = new MiNiFiFlowStatus();
+        ProcessorStatusBean processorStatusBean = new ProcessorStatusBean();
+        ProcessorStats processorStats = new ProcessorStats();
+        processorStats.bytesRead = 100L;
+        processorStats.bytesWritten = 100L;
+        processorStats.activeThreads = 1;
+        processorStats.flowfilesSent = 1;
+        processorStats.invocations = 1;
+        processorStats.processingNanos = 100L;
+        processorStats.flowfilesReceived = 1;
+        processorStatusBean.name = "my_processor";
+        processorStatusBean.processorStats = processorStats;
+
+        miNiFiFlowStatus.processorStatusList = Collections.singletonList(processorStatusBean);
+
+
+        testRunner.enqueue(objectMapper.writeValueAsBytes(miNiFiFlowStatus));
+
+        testRunner.setProperty(AzureApplicationInsights.SEND_INSTANCE_STATUS_PROP, AzureApplicationInsights.TRUE);
+        testRunner.setProperty(AzureApplicationInsights.BASE_METRIC_NAME, MINIFI_HOSTNAME);
+        testRunner.setProperty(AzureApplicationInsights.AZURE_INSTRUMENTATION_KEY, TEST_KEY);
+
+        testRunner.run();
+
+        final String baseName = MINIFI_HOSTNAME + ".processor." + processorStatusBean.name.replace('/', '-') + ".";
+        verify(mockTelemetryClient).trackMetric(baseName + "activeThreads", processorStats.activeThreads);
+        verify(mockTelemetryClient).trackMetric(baseName + "flowfilesReceived", processorStats.flowfilesReceived);
+        verify(mockTelemetryClient).trackMetric(baseName + "flowfilesSent", processorStats.flowfilesSent);
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesRead", processorStats.bytesRead);
+        verify(mockTelemetryClient).trackMetric(baseName + "bytesWritten", processorStats.bytesWritten);
+        verify(mockTelemetryClient).trackMetric(baseName + "invocations", processorStats.invocations);
+        verify(mockTelemetryClient).trackMetric(baseName + "processingNanos", processorStats.processingNanos);
+
+        verify(mockTelemetryClient, times(2)).getContext();
+        verify(mockTelemetryClient).flush();
+    }
+
+    @Test
+    public void testRPGStatus() throws JsonProcessingException {
+
+        final TestRunner testRunner = TestRunners.newTestRunner(new MockAzureApplicaitonInsights() {
+        });
+
+        MiNiFiFlowStatus miNiFiFlowStatus = new MiNiFiFlowStatus();
+        RemoteProcessGroupStatusBean remoteProcessGroupStatusBean = new RemoteProcessGroupStatusBean();
+        RemoteProcessGroupStats remoteProcessGroupStats = new RemoteProcessGroupStats();
+        remoteProcessGroupStats.sentCount = 100;
+        remoteProcessGroupStats.sentContentSize = 100L;
+        remoteProcessGroupStats.activeThreads = 1;
+
+        remoteProcessGroupStatusBean.name = "http://localhost/nifi";
+        remoteProcessGroupStatusBean.remoteProcessGroupStats = remoteProcessGroupStats;
+
+        miNiFiFlowStatus.remoteProcessGroupStatusList = Collections.singletonList(remoteProcessGroupStatusBean);
+
+
+        testRunner.enqueue(objectMapper.writeValueAsBytes(miNiFiFlowStatus));
+
+        testRunner.setProperty(AzureApplicationInsights.SEND_INSTANCE_STATUS_PROP, AzureApplicationInsights.TRUE);
+        testRunner.setProperty(AzureApplicationInsights.BASE_METRIC_NAME, MINIFI_HOSTNAME);
+        testRunner.setProperty(AzureApplicationInsights.AZURE_INSTRUMENTATION_KEY, TEST_KEY);
+
+        testRunner.run();
+
+
+        final String baseName = MINIFI_HOSTNAME + ".rpg." + URI.create(remoteProcessGroupStatusBean.name).getHost() + ".";
+        verify(mockTelemetryClient).trackMetric(baseName + "activeThreads", remoteProcessGroupStatusBean.remoteProcessGroupStats.activeThreads);
+        verify(mockTelemetryClient).trackMetric(baseName + "sentCount", remoteProcessGroupStatusBean.remoteProcessGroupStats.sentCount);
+        verify(mockTelemetryClient).trackMetric(baseName + "sentContentSize", remoteProcessGroupStatusBean.remoteProcessGroupStats.sentContentSize);
+        verify(mockTelemetryClient, times(2)).getContext();
+        verify(mockTelemetryClient).flush();
+    }
+
+    @Test
+    public void testSystemStatus() throws JsonProcessingException {
+
+        final TestRunner testRunner = TestRunners.newTestRunner(new MockAzureApplicaitonInsights() {
+        });
+
+        MiNiFiFlowStatus miNiFiFlowStatus = new MiNiFiFlowStatus();
+        SystemDiagnosticsStatus systemDiagnosticsStatus = new SystemDiagnosticsStatus();
+        HeapStatus heapStatus = new HeapStatus();
+        heapStatus.totalHeap = 100;
+        heapStatus.maxHeap = 100;
+        heapStatus.freeHeap = 100;
+        heapStatus.usedHeap = 100;
+        heapStatus.heapUtilization = 100;
+        heapStatus.totalNonHeap = 100;
+        heapStatus.maxNonHeap = 100;
+        heapStatus.freeNonHeap = 100;
+        heapStatus.usedNonHeap = 100;
+        heapStatus.nonHeapUtilization = 100;
+
+        ContentRepositoryUsage contentRepositoryUsage = new ContentRepositoryUsage();
+        contentRepositoryUsage.freeSpace = 100L;
+        contentRepositoryUsage.totalSpace = 100L;
+        contentRepositoryUsage.usedSpace = 100L;
+        contentRepositoryUsage.diskUtilization = 100;
+        contentRepositoryUsage.name = "contentRepo";
+
+        FlowfileRepositoryUsage flowfileRepositoryUsage = new FlowfileRepositoryUsage();
+        flowfileRepositoryUsage.freeSpace = 100L;
+        flowfileRepositoryUsage.totalSpace = 100L;
+        flowfileRepositoryUsage.usedSpace = 100L;
+        flowfileRepositoryUsage.diskUtilization = 100;
+        systemDiagnosticsStatus.heapStatus = heapStatus;
+        systemDiagnosticsStatus.contentRepositoryUsageList = Collections.singletonList(contentRepositoryUsage);
+        systemDiagnosticsStatus.flowfileRepositoryUsage = flowfileRepositoryUsage;
+
+        miNiFiFlowStatus.systemDiagnosticsStatus = systemDiagnosticsStatus;
+
+        testRunner.enqueue(objectMapper.writeValueAsBytes(miNiFiFlowStatus));
+        testRunner.setProperty(AzureApplicationInsights.SEND_INSTANCE_STATUS_PROP, AzureApplicationInsights.TRUE);
+        testRunner.setProperty(AzureApplicationInsights.BASE_METRIC_NAME, MINIFI_HOSTNAME);
+        testRunner.setProperty(AzureApplicationInsights.AZURE_INSTRUMENTATION_KEY, TEST_KEY);
+        testRunner.run();
+
+        final String contentRepobaseName = MINIFI_HOSTNAME + ".system.content.repository." + contentRepositoryUsage.name + ".";
+
+        verify(mockTelemetryClient).trackMetric(contentRepobaseName + "freeSpace", contentRepositoryUsage.freeSpace);
+        verify(mockTelemetryClient).trackMetric(contentRepobaseName + "totalSpace", contentRepositoryUsage.totalSpace);
+        verify(mockTelemetryClient).trackMetric(contentRepobaseName + "usedSpace", contentRepositoryUsage.usedSpace);
+        verify(mockTelemetryClient).trackMetric(contentRepobaseName + "diskUtilization", contentRepositoryUsage.diskUtilization);
+
+        final String flowRepoBaseName = MINIFI_HOSTNAME + ".system.flowfile.repository.";
+
+        verify(mockTelemetryClient).trackMetric(flowRepoBaseName + "freeSpace", flowfileRepositoryUsage.freeSpace);
+        verify(mockTelemetryClient).trackMetric(flowRepoBaseName + "totalSpace", flowfileRepositoryUsage.totalSpace);
+        verify(mockTelemetryClient).trackMetric(flowRepoBaseName + "usedSpace", flowfileRepositoryUsage.usedSpace);
+        verify(mockTelemetryClient).trackMetric(flowRepoBaseName + "diskUtilization", flowfileRepositoryUsage.diskUtilization);
+
+        final String heapBaseName = MINIFI_HOSTNAME + ".system.heap.";
+
+        telemetryClient.trackMetric(heapBaseName + "totalHeap", heapStatus.totalHeap);
+        telemetryClient.trackMetric(heapBaseName + "maxHeap", heapStatus.maxHeap);
+        telemetryClient.trackMetric(heapBaseName + "freeHeap", heapStatus.freeHeap);
+        telemetryClient.trackMetric(heapBaseName + "usedHeap", heapStatus.usedHeap);
+        telemetryClient.trackMetric(heapBaseName + "heapUtilization", heapStatus.heapUtilization);
+        telemetryClient.trackMetric(heapBaseName + "totalNonHeap", heapStatus.totalNonHeap);
+        telemetryClient.trackMetric(heapBaseName + "maxNonHeap", heapStatus.maxNonHeap);
+        telemetryClient.trackMetric(heapBaseName + "freeNonHeap", heapStatus.freeNonHeap);
+        telemetryClient.trackMetric(heapBaseName + "usedNonHeap", heapStatus.usedNonHeap);
+        telemetryClient.trackMetric(heapBaseName + "nonHeapUtilization", heapStatus.nonHeapUtilization);
+
+
+        verify(mockTelemetryClient, times(2)).getContext();
+        verify(mockTelemetryClient).flush();
+    }
+
+    class MockAzureApplicaitonInsights extends AzureApplicationInsights {
+
+        @Override
+        protected TelemetryClient createTelemetryClient() {
+            return mockTelemetryClient;
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-minififlowstatus-insights-bundle/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-bundles</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>nifi-minififlowstatus-insights-bundle</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>nifi-minififlowstatus-insights-processors</module>
+        <module>nifi-minififlowstatus-insights-nar</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
As a user of both NiFi and MiNiFi there are many times I would like to have an operational dashboard for MiNiFi. Although, there is a discussion and desire for Centralized management there are many times where as a user I just want to be able to use the operational tools I already have. In many cases those may be products such as: Nagios, Zenoos, Zabix, Graphite, Grafana and in cloud environments perhaps Azure Application Insights and AWS Cloudwatch.

This  P/R provides a processor that ingests the MiNiFi Flow Status report and sends it to Azure Application Insights as custom metrics. This then allows a user to set alerts in Azure Application Insights, thus providing the ability to monitor MiNiFi agents. As such, this has a dependency on the following MiNiFi JIRA: Change FlowStatusReport to be JSON ([https://github.com/apache/nifi-minifi/pull/65](url))

An example flow of how to set this up for the MiNiFi side is:

![image](https://cloud.githubusercontent.com/assets/1100275/21208171/61891462-c23a-11e6-9075-e7657653f40f.png)

And the NiFi Side looks like:
![image](https://cloud.githubusercontent.com/assets/1100275/21208215/bc114cec-c23a-11e6-8393-ee2ec50e61e7.png)

Then once this is all set in Azure Application Insights I can build a dashboard that may look like this:
![image](https://cloud.githubusercontent.com/assets/1100275/21208329/67804e02-c23b-11e6-8e7d-933c56f33d3b.png)

And explore all the various metrics, that I may want to build a dashboard from:
![image](https://cloud.githubusercontent.com/assets/1100275/21208347/913e5b76-c23b-11e6-89b6-b8895210ffff.png)

I can then also go and set alerts 
![image](https://cloud.githubusercontent.com/assets/1100275/21208458/128b653e-c23c-11e6-8737-d8665c280325.png)

In the end this type of integration can also be done with other enterprise tools.
