### PR TITLE
NIFI-3118: Inconsistent order of garbage collection statistics

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/SystemDiagnosticsSnapshotDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/SystemDiagnosticsSnapshotDTO.java
@@ -16,17 +16,15 @@
  */
 package org.apache.nifi.web.api.dto;
 
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
+import com.wordnik.swagger.annotations.ApiModelProperty;
 import org.apache.nifi.web.api.dto.util.DateTimeAdapter;
 import org.apache.nifi.web.api.dto.util.TimeAdapter;
 
-import com.wordnik.swagger.annotations.ApiModelProperty;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * The diagnostics of the system this NiFi is running on.
@@ -346,13 +344,13 @@ public class SystemDiagnosticsSnapshotDTO implements Cloneable {
 
         other.setFlowFileRepositoryStorageUsage(getFlowFileRepositoryStorageUsage().clone());
 
-        final Set<StorageUsageDTO> contentRepoStorageUsage = new HashSet<>();
+        final Set<StorageUsageDTO> contentRepoStorageUsage = new LinkedHashSet<>();
         other.setContentRepositoryStorageUsage(contentRepoStorageUsage);
         for (final StorageUsageDTO usage : getContentRepositoryStorageUsage()) {
             contentRepoStorageUsage.add(usage.clone());
         }
 
-        final Set<GarbageCollectionDTO> gcUsage = new HashSet<>();
+        final Set<GarbageCollectionDTO> gcUsage = new LinkedHashSet<>();
         other.setGarbageCollection(gcUsage);
         for (final GarbageCollectionDTO gcDto : getGarbageCollection()) {
             gcUsage.add(gcDto.clone());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/cluster/nf-cluster-table.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/cluster/nf-cluster-table.js
@@ -678,6 +678,13 @@ nf.ClusterTable = (function () {
             var jvmTableRows = [];
             systemDiagnosticsResponse.systemDiagnostics.nodeSnapshots.forEach(function (nodeSnapshot) {
                 var snapshot = nodeSnapshot.snapshot;
+
+                // sort the garbage collection
+                var garbageCollection = snapshot.garbageCollection.sort(function (a, b) {
+                    return a.name === b.name ? 0 : a.name > b.name ? 1 : -1;
+                });
+
+                // add the node jvm details
                 jvmTableRows.push({
                     id: nodeSnapshot.nodeId,
                     node: nodeSnapshot.address + ':' + nodeSnapshot.apiPort,
@@ -689,10 +696,10 @@ nf.ClusterTable = (function () {
                     maxNonHeap: snapshot.maxNonHeap,
                     totalNonHeap: snapshot.totalNonHeap,
                     usedNonHeap: snapshot.usedNonHeap,
-                    gcOldGen: snapshot.garbageCollection[0].collectionCount + ' times (' +
-                        snapshot.garbageCollection[0].collectionTime + ')',
-                    gcNewGen: snapshot.garbageCollection[1].collectionCount + ' times (' +
-                        snapshot.garbageCollection[1].collectionTime + ')'
+                    gcOldGen: garbageCollection[0].collectionCount + ' times (' +
+                        garbageCollection[0].collectionTime + ')',
+                    gcNewGen: garbageCollection[1].collectionCount + ' times (' +
+                        garbageCollection[1].collectionTime + ')'
                 });
             });
             jvmTab.rowCount = jvmTableRows.length;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/summary/nf-summary-table.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/summary/nf-summary-table.js
@@ -2260,9 +2260,16 @@ nf.SummaryTable = (function () {
 
             // garbage collection
             var garbageCollectionContainer = $('#garbage-collection-table tbody').empty();
-            $.each(aggregateSnapshot.garbageCollection, function (_, garbageCollection) {
-                addGarbageCollection(garbageCollectionContainer, garbageCollection);
-            });
+            if (nf.Common.isDefinedAndNotNull(aggregateSnapshot.garbageCollection)) {
+                // sort the garbage collections
+                var sortedGarbageCollection = aggregateSnapshot.garbageCollection.sort(function(a, b) {
+                    return a.name === b.name ? 0 : a.name > b.name ? 1 : -1;
+                });
+                // add each to the UI
+                $.each(sortedGarbageCollection, function (_, garbageCollection) {
+                    addGarbageCollection(garbageCollectionContainer, garbageCollection);
+                });
+            }
 
             // available processors
             $('#available-processors').text(aggregateSnapshot.availableProcessors);
@@ -2274,15 +2281,22 @@ nf.SummaryTable = (function () {
                 $('#processor-load-average').html(nf.Common.formatValue(aggregateSnapshot.processorLoadAverage));
             }
 
-            // database storage usage
+            // flow file storage usage
             var flowFileRepositoryStorageUsageContainer = $('#flow-file-repository-storage-usage-container').empty();
             addStorageUsage(flowFileRepositoryStorageUsageContainer, aggregateSnapshot.flowFileRepositoryStorageUsage);
 
-            // database storage usage
+            // content repo storage usage
             var contentRepositoryUsageContainer = $('#content-repository-storage-usage-container').empty();
-            $.each(aggregateSnapshot.contentRepositoryStorageUsage, function (_, contentRepository) {
-                addStorageUsage(contentRepositoryUsageContainer, contentRepository);
-            });
+            if (nf.Common.isDefinedAndNotNull(aggregateSnapshot.contentRepositoryStorageUsage)) {
+                // sort the content repos
+                var sortedContentRepositoryStorageUsage = aggregateSnapshot.contentRepositoryStorageUsage.sort(function(a, b) {
+                    return a.identifier === b.identifier ? 0 : a.identifier > b.identifier ? 1 : -1;
+                });
+                // add each to the UI
+                $.each(sortedContentRepositoryStorageUsage, function (_, contentRepository) {
+                    addStorageUsage(contentRepositoryUsageContainer, contentRepository);
+                });
+            }
 
             // Version
             var versionSpanSelectorToFieldMap = {
@@ -2318,7 +2332,7 @@ nf.SummaryTable = (function () {
      */
     var addGarbageCollection = function (container, garbageCollection) {
         var nameTr = $('<tr></tr>').appendTo(container);
-        $('<td class="setting-name"></td>').append(garbageCollection.name + ':').appendTo(nameTr);
+        $('<td class="setting-name"></td>').text(garbageCollection.name + ':').appendTo(nameTr);
         var valTr = $('<tr></tr>').appendTo(container);
         $('<td></td>').append($('<b></b>').text(garbageCollection.collectionCount + ' times (' + garbageCollection.collectionTime + ')')).appendTo(valTr);
         $('<tr></tr>').text(' ').appendTo(container);


### PR DESCRIPTION
NIFI-3118
- Sorting the garbage collection stats and content repository entries client side. Opting to not sort server side as the property of the DTO does not support deterministic order. Consequently, order would need to be implemented every time that DTO is (de)serializaed which may happen in a number of places with zero master clustering.