### PR TITLE
NIFI-2967: Disabling Add button in new component dialog when appropriate

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/header/components/nf-ng-processor-component.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/header/components/nf-ng-processor-component.js
@@ -37,6 +37,9 @@ nf.ng.ProcessorComponent = function (serviceProvider) {
             });
             processorTypesData.refresh();
 
+            // update the buttons to possibly trigger the disabled state
+            $('#new-processor-dialog').modal('refreshButtons');
+
             // update the selection if possible
             if (processorTypesData.getLength() > 0) {
                 processorTypesGrid.setSelectedRows([0]);
@@ -593,7 +596,7 @@ nf.ng.ProcessorComponent = function (serviceProvider) {
                         var item = grid.getDataItem(selected[0]);
                         return isSelectable(item) === false;
                     } else {
-                        return false;
+                        return grid.getData().getLength() === 0;
                     }
                 },
                 handler: {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
@@ -74,6 +74,9 @@ nf.ControllerServices = (function () {
             });
             controllerServiceTypesData.refresh();
 
+            // update the buttons to possibly trigger the disabled state
+            $('#new-controller-service-dialog').modal('refreshButtons');
+
             // update the selection if possible
             if (controllerServiceTypesData.getLength() > 0) {
                 controllerServiceTypesGrid.setSelectedRows([0]);
@@ -908,7 +911,7 @@ nf.ControllerServices = (function () {
                         var item = grid.getDataItem(selected[0]);
                         return isSelectable(item) === false;
                     } else {
-                        return false;
+                        return grid.getData().getLength() === 0;
                     }
                 },
                 handler: {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-settings.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-settings.js
@@ -281,6 +281,9 @@ nf.Settings = (function () {
             });
             reportingTaskTypesData.refresh();
 
+            // update the buttons to possibly trigger the disabled state
+            $('#new-reporting-task-dialog').modal('refreshButtons');
+
             // update the selection if possible
             if (reportingTaskTypesData.getLength() > 0) {
                 reportingTaskTypesGrid.setSelectedRows([0]);
@@ -598,7 +601,7 @@ nf.Settings = (function () {
                             var item = reportingTaskTypesGrid.getDataItem(selected[0]);
                             return isSelectable(item) === false;
                         } else {
-                            return false;
+                            return reportingTaskTypesGrid.getData().getLength() === 0;
                         }
                     },
                     handler: {


### PR DESCRIPTION
NIFI-2967:
- Disabling the Add button in the new Processor, Controller Service, and Reporting Task dialog when no components match the filter.
