### PR TITLE
NIFI-2585 Add attributes to track s2s host and port

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/Peer.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/Peer.java
@@ -29,8 +29,6 @@ public class Peer implements Communicant {
     private final CommunicationsSession commsSession;
     private final String url;
     private final String clusterUrl;
-    private final String host;
-    private final int port;
 
     private final Map<String, Long> penaltyExpirationMap = new HashMap<>();
     private boolean closed = false;
@@ -42,9 +40,8 @@ public class Peer implements Communicant {
         this.clusterUrl = clusterUrl;
 
         try {
-            final URI uri = new URI(peerUrl);
-            this.port = uri.getPort();
-            this.host = uri.getHost();
+            // Parse peerUrl to validate it.
+            new URI(peerUrl);
         } catch (final Exception e) {
             throw new IllegalArgumentException("Invalid URL: " + peerUrl);
         }
@@ -104,7 +101,7 @@ public class Peer implements Communicant {
 
     @Override
     public String getHost() {
-        return host;
+        return description.getHostname();
     }
 
     @Override
@@ -141,7 +138,7 @@ public class Peer implements Communicant {
 
     @Override
     public int getPort() {
-        return port;
+        return description.getPort();
     }
 
     @Override

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/flowfile/attributes/SiteToSiteAttributes.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/flowfile/attributes/SiteToSiteAttributes.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flowfile.attributes;
+
+/**
+ * FlowFile attributes used during site-to-site transfer.
+ */
+public enum SiteToSiteAttributes implements FlowFileAttributeKey {
+
+    S2S_HOST("s2s.host"),
+
+    S2S_ADDRESS("s2s.address");
+
+    private final String key;
+
+    private SiteToSiteAttributes(final String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/pom.xml
@@ -71,8 +71,8 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/SocketRemoteSiteListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/SocketRemoteSiteListener.java
@@ -137,16 +137,16 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                         public void run() {
                             LOG.debug("{} Determining URL of connection", this);
                             final InetAddress inetAddress = socket.getInetAddress();
-                            String hostname = inetAddress.getHostName();
-                            final int slashIndex = hostname.indexOf("/");
+                            String clientHostName = inetAddress.getHostName();
+                            final int slashIndex = clientHostName.indexOf("/");
                             if (slashIndex == 0) {
-                                hostname = hostname.substring(1);
+                                clientHostName = clientHostName.substring(1);
                             } else if (slashIndex > 0) {
-                                hostname = hostname.substring(0, slashIndex);
+                                clientHostName = clientHostName.substring(0, slashIndex);
                             }
 
-                            final int port = socket.getPort();
-                            final String peerUri = "nifi://" + hostname + ":" + port;
+                            final int clientPort = socket.getPort();
+                            final String peerUri = "nifi://" + clientHostName + ":" + clientPort;
                             LOG.debug("{} Connection URL is {}", this, peerUri);
 
                             final CommunicationsSession commsSession;
@@ -211,7 +211,7 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                                 protocol.setRootProcessGroup(rootGroup.get());
                                 protocol.setNodeInformant(nodeInformant);
 
-                                final PeerDescription description = new PeerDescription("localhost", getPort(), sslContext != null);
+                                final PeerDescription description = new PeerDescription(clientHostName, clientPort, sslContext != null);
                                 peer = new Peer(description, commsSession, peerUri, "nifi://localhost:" + getPort());
                                 LOG.debug("Handshaking....");
                                 protocol.handshake(peer);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,6 +39,7 @@ import org.apache.nifi.controller.ProcessScheduler;
 import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.flowfile.attributes.SiteToSiteAttributes;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.RemoteProcessGroup;
 import org.apache.nifi.processor.ProcessContext;
@@ -338,6 +341,14 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
 
             FlowFile flowFile = session.create();
             flowFile = session.putAllAttributes(flowFile, dataPacket.getAttributes());
+
+            final Map<String,String> attributes = new HashMap<>(3);
+            attributes.put(SiteToSiteAttributes.S2S_HOST.key(), transaction.getCommunicant().getHost());
+            attributes.put(SiteToSiteAttributes.S2S_ADDRESS.key(),
+                    transaction.getCommunicant().getHost() + ":" + transaction.getCommunicant().getPort());
+
+            flowFile = session.putAllAttributes(flowFile, attributes);
+
             flowFile = session.importFrom(dataPacket.getData(), flowFile);
             final long receiveNanos = System.nanoTime() - start;
             flowFilesReceived.add(flowFile);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -59,6 +59,7 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.StopWatch;
+import org.apache.nifi.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -342,10 +343,13 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
             FlowFile flowFile = session.create();
             flowFile = session.putAllAttributes(flowFile, dataPacket.getAttributes());
 
-            final Map<String,String> attributes = new HashMap<>(3);
-            attributes.put(SiteToSiteAttributes.S2S_HOST.key(), transaction.getCommunicant().getHost());
-            attributes.put(SiteToSiteAttributes.S2S_ADDRESS.key(),
-                    transaction.getCommunicant().getHost() + ":" + transaction.getCommunicant().getPort());
+            final Communicant communicant = transaction.getCommunicant();
+            final String host = StringUtils.isEmpty(communicant.getHost()) ? "unknown" : communicant.getHost();
+            final String port = communicant.getPort() < 0 ? "unknown" : String.valueOf(communicant.getPort());
+
+            final Map<String,String> attributes = new HashMap<>(2);
+            attributes.put(SiteToSiteAttributes.S2S_HOST.key(), host);
+            attributes.put(SiteToSiteAttributes.S2S_ADDRESS.key(), host + ":" + port);
 
             flowFile = session.putAllAttributes(flowFile, attributes);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
@@ -506,6 +506,12 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
                 throw new ProtocolException(this + " Received unexpected Response Code from peer " + peer + " : " + confirmTransactionResponse + "; expected 'Confirm Transaction' Response Code");
         }
 
+        // For routing purposes, downstream consumers often need to reference Flowfile's originating system
+        for (FlowFile flowFile : transaction.getFlowFilesSent()){
+          flowFile = session.putAttribute(flowFile, "remote.host", peer.getHost());
+          flowFile = session.putAttribute(flowFile, "remote.address", peer.getHost() + ":" + peer.getPort());
+        }
+
         // Commit the session so that we have persisted the data
         session.commit();
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
@@ -38,6 +38,7 @@ import org.apache.nifi.remote.io.CompressionOutputStream;
 import org.apache.nifi.remote.util.StandardDataPacket;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.StopWatch;
+import org.apache.nifi.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -451,10 +452,13 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
             final long transferMillis = TimeUnit.MILLISECONDS.convert(transferNanos, TimeUnit.NANOSECONDS);
             final String sourceSystemFlowFileUuid = dataPacket.getAttributes().get(CoreAttributes.UUID.key());
 
+            final String host = StringUtils.isEmpty(peer.getHost()) ? "unknown" : peer.getHost();
+            final String port = peer.getPort() <= 0 ? "unknown" : String.valueOf(peer.getPort());
+
             final Map<String,String> attributes = new HashMap<>(4);
             attributes.put(CoreAttributes.UUID.key(), UUID.randomUUID().toString());
-            attributes.put(SiteToSiteAttributes.S2S_HOST.key(), peer.getHost());
-            attributes.put(SiteToSiteAttributes.S2S_ADDRESS.key(), peer.getHost() + ":" + peer.getPort());
+            attributes.put(SiteToSiteAttributes.S2S_HOST.key(), host);
+            attributes.put(SiteToSiteAttributes.S2S_ADDRESS.key(), host + ":" + port);
 
             flowFile = session.putAllAttributes(flowFile, attributes);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/TestStandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/TestStandardRemoteGroupPort.java
@@ -18,15 +18,15 @@ package org.apache.nifi.remote;
 
 import org.apache.nifi.connectable.ConnectableType;
 import org.apache.nifi.controller.ProcessScheduler;
-import org.apache.nifi.controller.queue.QueueSize;
 import org.apache.nifi.events.EventReporter;
-import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.flowfile.attributes.SiteToSiteAttributes;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.RemoteProcessGroup;
-import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.provenance.ProvenanceReporter;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.remote.client.SiteToSiteClient;
 import org.apache.nifi.remote.io.http.HttpCommunicationsSession;
 import org.apache.nifi.remote.io.socket.SocketChannelCommunicationsSession;
@@ -34,22 +34,30 @@ import org.apache.nifi.remote.protocol.CommunicationsSession;
 import org.apache.nifi.remote.protocol.DataPacket;
 import org.apache.nifi.remote.protocol.SiteToSiteTransportProtocol;
 import org.apache.nifi.remote.util.StandardDataPacket;
-import org.apache.nifi.stream.io.ByteArrayInputStream;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockProcessContext;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.SharedSessionState;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.nio.channels.SocketChannel;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.nifi.util.NiFiProperties;
 
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestStandardRemoteGroupPort {
 
@@ -64,9 +72,9 @@ public class TestStandardRemoteGroupPort {
     private ProcessGroup processGroup;
     public static final String REMOTE_CLUSTER_URL = "http://node0.example.com:8080/nifi";
     private StandardRemoteGroupPort port;
-    private ProcessContext context;
-    private ProcessSession session;
-    private ProvenanceReporter provenanceReporter;
+    private SharedSessionState sessionState;
+    private MockProcessSession processSession;
+    private MockProcessContext processContext;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -112,41 +120,49 @@ public class TestStandardRemoteGroupPort {
         doReturn(transaction).when(siteToSiteClient).createTransaction(eq(direction));
         doReturn(eventReporter).when(remoteGroup).getEventReporter();
 
-        context = null;
-        session = mock(ProcessSession.class);
-        provenanceReporter = mock(ProvenanceReporter.class);
-        doReturn(provenanceReporter).when(session).getProvenanceReporter();
+    }
 
+    private void setupMockProcessSession() {
+        // Construct a RemoteGroupPort as a processor to use NiFi mock library.
+        final Processor remoteGroupPort = mock(Processor.class);
+        final Set<Relationship> relationships = new HashSet<>();
+        relationships.add(Relationship.ANONYMOUS);
+        when(remoteGroupPort.getRelationships()).thenReturn(relationships);
+        when(remoteGroupPort.getIdentifier()).thenReturn("remote-group-port-id");
+
+        sessionState = new SharedSessionState(remoteGroupPort, new AtomicLong(0));
+        processSession = new MockProcessSession(sessionState, remoteGroupPort);
+        processContext = new MockProcessContext(remoteGroupPort);
     }
 
     @Test
     public void testSendRaw() throws Exception {
 
         setupMock(SiteToSiteTransportProtocol.RAW, TransferDirection.SEND);
+        setupMockProcessSession();
 
         final String peerUrl = "nifi://node1.example.com:9090";
-        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 9090, false);
+        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 9090, true);
         try (final SocketChannel socketChannel = SocketChannel.open()) {
             final CommunicationsSession commsSession = new SocketChannelCommunicationsSession(socketChannel);
+            commsSession.setUserDn("nifi.node1.example.com");
             final Peer peer = new Peer(peerDescription, commsSession, peerUrl, REMOTE_CLUSTER_URL);
 
             doReturn(peer).when(transaction).getCommunicant();
 
-            final QueueSize queueSize = new QueueSize(1, 10);
-            final FlowFile flowFile = mock(FlowFile.class);
+            final MockFlowFile flowFile = processSession.createFlowFile("0123456789".getBytes());
+            sessionState.getFlowFileQueue().offer(flowFile);
 
-            doReturn(queueSize).when(session).getQueueSize();
-            // Return null when it gets called second time.
-            doReturn(flowFile).doReturn(null).when(session).get();
+            port.onTrigger(processContext, processSession);
 
-            final String flowFileUuid = "flowfile-uuid";
-            doReturn(flowFileUuid).when(flowFile).getAttribute(eq(CoreAttributes.UUID.key()));
+            // Assert provenance.
+            final List<ProvenanceEventRecord> provenanceEvents = sessionState.getProvenanceEvents();
+            assertEquals(1, provenanceEvents.size());
+            final ProvenanceEventRecord provenanceEvent = provenanceEvents.get(0);
+            assertEquals(ProvenanceEventType.SEND, provenanceEvent.getEventType());
+            assertEquals(peerUrl + "/" + flowFile.getAttribute(CoreAttributes.UUID.key()), provenanceEvent.getTransitUri());
+            assertEquals("Remote DN=nifi.node1.example.com", provenanceEvent.getDetails());
 
-            port.onTrigger(context, session);
-
-            // Transit uri can be customized if necessary.
-            verify(provenanceReporter).send(eq(flowFile), eq(peerUrl + "/" + flowFileUuid), any(String.class),
-                    any(Long.class), eq(false));
         }
     }
 
@@ -154,16 +170,17 @@ public class TestStandardRemoteGroupPort {
     public void testReceiveRaw() throws Exception {
 
         setupMock(SiteToSiteTransportProtocol.RAW, TransferDirection.RECEIVE);
+        setupMockProcessSession();
 
         final String peerUrl = "nifi://node1.example.com:9090";
-        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 9090, false);
+        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 9090, true);
         try (final SocketChannel socketChannel = SocketChannel.open()) {
             final CommunicationsSession commsSession = new SocketChannelCommunicationsSession(socketChannel);
+            commsSession.setUserDn("nifi.node1.example.com");
             final Peer peer = new Peer(peerDescription, commsSession, peerUrl, REMOTE_CLUSTER_URL);
 
             doReturn(peer).when(transaction).getCommunicant();
 
-            final FlowFile flowFile = mock(FlowFile.class);
             final String sourceFlowFileUuid = "flowfile-uuid";
             final Map<String, String> attributes = new HashMap<>();
             attributes.put(CoreAttributes.UUID.key(), sourceFlowFileUuid);
@@ -172,18 +189,26 @@ public class TestStandardRemoteGroupPort {
             final DataPacket dataPacket = new StandardDataPacket(attributes,
                     dataPacketInputStream, dataPacketContents.length);
 
-            doReturn(flowFile).when(session).create();
             // Return null when it gets called second time.
             doReturn(dataPacket).doReturn(null).when(this.transaction).receive();
 
-            doReturn(flowFile).doReturn(flowFile).when(session).putAllAttributes(eq(flowFile), any(Map.class));
-            doReturn(flowFile).when(session).importFrom(any(InputStream.class), eq(flowFile));
+            port.onTrigger(processContext, processSession);
 
-            port.onTrigger(context, session);
+            // Assert provenance.
+            final List<ProvenanceEventRecord> provenanceEvents = sessionState.getProvenanceEvents();
+            assertEquals(1, provenanceEvents.size());
+            final ProvenanceEventRecord provenanceEvent = provenanceEvents.get(0);
+            assertEquals(ProvenanceEventType.RECEIVE, provenanceEvent.getEventType());
+            assertEquals(peerUrl + "/" + sourceFlowFileUuid, provenanceEvent.getTransitUri());
+            assertEquals("Remote DN=nifi.node1.example.com", provenanceEvent.getDetails());
 
-            // Transit uri can be customized if necessary.
-            verify(provenanceReporter).receive(eq(flowFile), eq(peerUrl + "/" + sourceFlowFileUuid), any(String.class),
-                    any(String.class), any(Long.class));
+            // Assert received flow files.
+            processSession.assertAllFlowFilesTransferred(Relationship.ANONYMOUS);
+            final List<MockFlowFile> flowFiles = processSession.getFlowFilesForRelationship(Relationship.ANONYMOUS);
+            assertEquals(1, flowFiles.size());
+            final MockFlowFile flowFile = flowFiles.get(0);
+            flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_HOST.key(), peer.getHost());
+            flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_ADDRESS.key(), peer.getHost() + ":" + peer.getPort());
         }
 
     }
@@ -192,66 +217,76 @@ public class TestStandardRemoteGroupPort {
     public void testSendHttp() throws Exception {
 
         setupMock(SiteToSiteTransportProtocol.HTTP, TransferDirection.SEND);
+        setupMockProcessSession();
 
-        final String peerUrl = "http://node1.example.com:8080/nifi";
-        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 8080, false);
+        final String peerUrl = "https://node1.example.com:8080/nifi";
+        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 8080, true);
         final HttpCommunicationsSession commsSession = new HttpCommunicationsSession();
+        commsSession.setUserDn("nifi.node1.example.com");
         final Peer peer = new Peer(peerDescription, commsSession, peerUrl, REMOTE_CLUSTER_URL);
 
-        final String flowFileEndpointUri = "http://node1.example.com:8080/nifi-api/output-ports/port-id/transactions/transaction-id/flow-files";
+        final String flowFileEndpointUri = "https://node1.example.com:8080/nifi-api/output-ports/port-id/transactions/transaction-id/flow-files";
 
         doReturn(peer).when(transaction).getCommunicant();
         commsSession.setDataTransferUrl(flowFileEndpointUri);
 
-        final QueueSize queueSize = new QueueSize(1, 10);
-        final FlowFile flowFile = mock(FlowFile.class);
+        final MockFlowFile flowFile = processSession.createFlowFile("0123456789".getBytes());
+        sessionState.getFlowFileQueue().offer(flowFile);
 
-        doReturn(queueSize).when(session).getQueueSize();
-        // Return null when it's called second time.
-        doReturn(flowFile).doReturn(null).when(session).get();
+        port.onTrigger(processContext, processSession);
 
-        port.onTrigger(context, session);
-
-        // peerUrl should be used as the transit url.
-        verify(provenanceReporter).send(eq(flowFile), eq(flowFileEndpointUri), any(String.class),
-                any(Long.class), eq(false));
-
+        // Assert provenance.
+        final List<ProvenanceEventRecord> provenanceEvents = sessionState.getProvenanceEvents();
+        assertEquals(1, provenanceEvents.size());
+        final ProvenanceEventRecord provenanceEvent = provenanceEvents.get(0);
+        assertEquals(ProvenanceEventType.SEND, provenanceEvent.getEventType());
+        assertEquals(flowFileEndpointUri, provenanceEvent.getTransitUri());
+        assertEquals("Remote DN=nifi.node1.example.com", provenanceEvent.getDetails());
     }
 
     @Test
     public void testReceiveHttp() throws Exception {
 
         setupMock(SiteToSiteTransportProtocol.HTTP, TransferDirection.RECEIVE);
+        setupMockProcessSession();
 
-        final String peerUrl = "http://node1.example.com:8080/nifi";
-        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 8080, false);
+        final String peerUrl = "https://node1.example.com:8080/nifi";
+        final PeerDescription peerDescription = new PeerDescription("node1.example.com", 8080, true);
         final HttpCommunicationsSession commsSession = new HttpCommunicationsSession();
+        commsSession.setUserDn("nifi.node1.example.com");
         final Peer peer = new Peer(peerDescription, commsSession, peerUrl, REMOTE_CLUSTER_URL);
 
-        final String flowFileEndpointUri = "http://node1.example.com:8080/nifi-api/output-ports/port-id/transactions/transaction-id/flow-files";
+        final String flowFileEndpointUri = "https://node1.example.com:8080/nifi-api/output-ports/port-id/transactions/transaction-id/flow-files";
 
         doReturn(peer).when(transaction).getCommunicant();
         commsSession.setDataTransferUrl(flowFileEndpointUri);
 
-        final FlowFile flowFile = mock(FlowFile.class);
         final Map<String, String> attributes = new HashMap<>();
         final byte[] dataPacketContents = "DataPacket Contents".getBytes();
         final ByteArrayInputStream dataPacketInputStream = new ByteArrayInputStream(dataPacketContents);
         final DataPacket dataPacket = new StandardDataPacket(attributes,
                 dataPacketInputStream, dataPacketContents.length);
 
-        doReturn(flowFile).when(session).create();
-        // Return null when it's called second time.
+        // Return null when it gets called second time.
         doReturn(dataPacket).doReturn(null).when(transaction).receive();
 
-        doReturn(flowFile).doReturn(flowFile).when(session).putAllAttributes(eq(flowFile), any(Map.class));
-        doReturn(flowFile).when(session).importFrom(any(InputStream.class), eq(flowFile));
+        port.onTrigger(processContext, processSession);
 
-        port.onTrigger(context, session);
+        // Assert provenance.
+        final List<ProvenanceEventRecord> provenanceEvents = sessionState.getProvenanceEvents();
+        assertEquals(1, provenanceEvents.size());
+        final ProvenanceEventRecord provenanceEvent = provenanceEvents.get(0);
+        assertEquals(ProvenanceEventType.RECEIVE, provenanceEvent.getEventType());
+        assertEquals(flowFileEndpointUri, provenanceEvent.getTransitUri());
+        assertEquals("Remote DN=nifi.node1.example.com", provenanceEvent.getDetails());
 
-        // peerUrl should be used as the transit url.
-        verify(provenanceReporter).receive(eq(flowFile), eq(flowFileEndpointUri), any(String.class),
-                any(String.class), any(Long.class));
+        // Assert received flow files.
+        processSession.assertAllFlowFilesTransferred(Relationship.ANONYMOUS);
+        final List<MockFlowFile> flowFiles = processSession.getFlowFilesForRelationship(Relationship.ANONYMOUS);
+        assertEquals(1, flowFiles.size());
+        final MockFlowFile flowFile = flowFiles.get(0);
+        flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_HOST.key(), peer.getHost());
+        flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_ADDRESS.key(), peer.getHost() + ":" + peer.getPort());
 
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/TestStandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/TestStandardRemoteGroupPort.java
@@ -176,7 +176,7 @@ public class TestStandardRemoteGroupPort {
             // Return null when it gets called second time.
             doReturn(dataPacket).doReturn(null).when(this.transaction).receive();
 
-            doReturn(flowFile).when(session).putAllAttributes(eq(flowFile), eq(attributes));
+            doReturn(flowFile).doReturn(flowFile).when(session).putAllAttributes(eq(flowFile), any(Map.class));
             doReturn(flowFile).when(session).importFrom(any(InputStream.class), eq(flowFile));
 
             port.onTrigger(context, session);
@@ -244,7 +244,7 @@ public class TestStandardRemoteGroupPort {
         // Return null when it's called second time.
         doReturn(dataPacket).doReturn(null).when(transaction).receive();
 
-        doReturn(flowFile).when(session).putAllAttributes(eq(flowFile), eq(attributes));
+        doReturn(flowFile).doReturn(flowFile).when(session).putAllAttributes(eq(flowFile), any(Map.class));
         doReturn(flowFile).when(session).importFrom(any(InputStream.class), eq(flowFile));
 
         port.onTrigger(context, session);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/protocol/http/TestHttpFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/protocol/http/TestHttpFlowFileServerProtocol.java
@@ -505,7 +505,7 @@ public class TestHttpFlowFileServerProtocol {
         }).when(processSession).importFrom(any(InputStream.class), any(FlowFile.class));
         // AbstractFlowFileServerProtocol adopts builder pattern and putAttribute is the last execution
         // which returns flowFile instance used later.
-        doReturn(flowFile).when(processSession).putAttribute(any(FlowFile.class), any(String.class), any(String.class));
+        doReturn(flowFile).when(processSession).putAllAttributes(any(FlowFile.class), any(Map.class));
         doReturn(provenanceReporter).when(processSession).getProvenanceReporter();
         doAnswer(invocation -> {
             final String transitUri = (String)invocation.getArguments()[1];
@@ -567,12 +567,16 @@ public class TestHttpFlowFileServerProtocol {
             }
             return flowFile1;
         }).when(processSession).importFrom(any(InputStream.class), any(FlowFile.class));
-        // AbstractFlowFileServerProtocol adopts builder pattern and putAttribute is the last execution
-        // which returns flowFile instance used later.
+
+        // AbstractFlowFileServerProtocol adopts builder pattern and putAllAttributes is the last execution
+        // which returns flowFile instance used later, it is called twice for each flow file
         doReturn(flowFile1)
+                .doReturn(flowFile1)
                 .doReturn(flowFile2)
-                .when(processSession).putAttribute(any(FlowFile.class), any(String.class), any(String.class));
+                .doReturn(flowFile2)
+                .when(processSession).putAllAttributes(any(FlowFile.class), any(Map.class));
         doReturn(provenanceReporter).when(processSession).getProvenanceReporter();
+
         doAnswer(invocation -> {
             final String transitUri = (String)invocation.getArguments()[1];
             final String detail = (String)invocation.getArguments()[3];

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/DataTransferResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/DataTransferResource.java
@@ -77,6 +77,8 @@ import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.nifi.remote.protocol.HandshakeProperty.BATCH_COUNT;
@@ -316,7 +318,14 @@ public class DataTransferResource extends ApplicationResource {
 
     private Peer constructPeer(final HttpServletRequest req, final InputStream inputStream,
                                final OutputStream outputStream, final String portId, final String transactionId) {
-        final String clientHostName = req.getRemoteHost();
+        String clientHostName = req.getRemoteHost();
+        try {
+            // req.getRemoteHost returns IP address, try to resolve hostname to be consistent with RAW protocol.
+            final InetAddress clientAddress = InetAddress.getByName(clientHostName);
+            clientHostName = clientAddress.getHostName();
+        } catch (UnknownHostException e) {
+            logger.info("Failed to resolve client hostname {}, due to {}", clientHostName, e.getMessage());
+        }
         final int clientPort = req.getRemotePort();
 
         final PeerDescription peerDescription = new PeerDescription(clientHostName, clientPort, req.isSecure());


### PR DESCRIPTION
I left the four commits to show the history of how this evolved. We can squash Bryan's two commits when merging, but we wanted Randy to get credit for starting the work on this ticket.

While reviewing #1320, I found few concerns as shown in the table below.
Let's say there are `client.nifi` and `server.nifi` transferring files each other using S2S. This table shows how `s2s.address` attribute values are set in each case with #1320:

| Transfer Protocol | Pulled from a remote OutputPort to S2S client | Received via an InputPort at S2S server |
|-------------------|-----------------------------------------------|--------------------------------------------|
| RAW | Server's hostname and port are the one that the client gets when it received remote NiFi peers. Those values are defined in server's nifi.properties.  <br/> `nifi.remote.input.host:nifi.remote.input.socket.port` <br/> e.x. `server.nifi:8081` | Client's hostname and port is used. But due to the existing logic which parses URL string and extract hostname and port, if the URL string contains illegal character such as underscore, the result becomes null, then converted with `unknown`. This happens with Docker as container hostname often contain underscore. <br/> e.x. `client.nifi:58034`, `unknown:unknown` (if hostname contains underscore) <br/> **FIX 1** <br/> `client_nifi:58034` (even if hostname contains underscore)|
| HTTP | Same as RAW protocol, but uses `nifi.web.http(s).port`. <br/> e.x. `server.nifi:8080`| Client hostname and port are retrieved from HTTP request object.  However, it returns IP address string representation instead of hostname. Probably performance reason. <br/> e.x. `192.168.0.33:59946` <br/> **FIX 2** <br/> `client.nifi:59946`.|

## FIX 1

As reporte in [the previous PR comment](https://github.com/apache/nifi/pull/1307#issuecomment-266442657) I got 'unknown' hostname and port with Docker containers. While this can be handled as a corner case since it's not allowed by the URL specification, I think it'd be better if we can be lenient here to support Docker environment. I confirmed provenance event also failed to resolve hostname and produced provenance details with null hostname.

This can be improved by changing Peer's constructor. Currently, it parses peerUrl then use its hostname and port, but the same information should be retrieved from PeerDescriptor without parsing the URL. Also, SocketRemoteSiteListener uses server's hostname and port for PeerDescription, but it seems it's not correct, those should be client's.

This commit modifies SocketRemoteSiteListener to use PeerDescriptor instead of parsing URL string.

## FIX 2

This commit modifies DataTransferResource to resolve hostname from IP address using InetAddress  when HTTP transport protocol is used, as RAW resolves hostname from socket, using InetAddress.