### PR TITLE
NIFI-3233 Fix minor typo in developer-guide.adoc

### DIFF
--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -866,7 +866,7 @@ hardened rules.
 === Data Ingress
 
 A Processor that ingests data into NiFi has a single Relationship
-names `success`. This Processor generates
+named `success`. This Processor generates
 new FlowFiles via the ProcessSession `create` method and does not pull
 FlowFiles from incoming Connections.
 The Processor name starts with "Get" or "Listen," depending on whether


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/NIFI-3233 :  In section "Common Processor Patterns" -> "Data Ingress", the sentence "A Processor that ingests data into NiFi has a single Relationship names success" should read "...named success".
