### PR TITLE
NIFI-3294 Adjusting nifi.sh to invoke nifi-env.sh 

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
@@ -38,12 +38,12 @@ done
 
 # Compute the canonicalized name by finding the physical path
 # for the directory we're in and appending the target file.
-PHYS_DIR=`pwd -P`
+PHYS_DIR=$(pwd -P)
 
 SCRIPT_DIR=$PHYS_DIR
 PROGNAME=$(basename "$0")
 
-. "$SCRIPT_DIR"/nifi-env.sh
+. "${SCRIPT_DIR}/nifi-env.sh"
 
 
 
@@ -234,15 +234,14 @@ run() {
     BOOTSTRAP_CONF="${BOOTSTRAP_CONF_DIR}/bootstrap.conf";
     BOOTSTRAP_LIBS="${NIFI_HOME}/lib/bootstrap/*"
 
-    run_as=$(grep '^\s*run.as' "${BOOTSTRAP_CONF}" | cut -d'=' -f2)
+    run_as_user=$(grep '^\s*run.as' "${BOOTSTRAP_CONF}" | cut -d'=' -f2)
     # If the run as user is the same as that starting the process, ignore this configuration
-    if [ "$run_as" = "$(whoami)" ]; then
-        unset run_as
+    if [ "${run_as_user}" = "$(whoami)" ]; then
+        unset run_as_user
     fi
 
-    sudo_cmd_prefix=""
     if $cygwin; then
-        if [ -n "${run_as}" ]; then
+        if [ -n "${run_as_user}" ]; then
             echo "The run.as option is not supported in a Cygwin environment. Exiting."
             exit 1
         fi;
@@ -259,11 +258,9 @@ run() {
             BOOTSTRAP_CLASSPATH="${TOOLS_JAR};${BOOTSTRAP_CLASSPATH}"
         fi
     else
-        if [ -n "${run_as}" ]; then
-            if id -u "${run_as}" >/dev/null 2>&1; then
-                sudo_cmd_prefix="sudo -u ${run_as}"
-            else
-                echo "The specified run.as user ${run_as} does not exist. Exiting."
+        if [ -n "${run_as_user}" ]; then
+            if ! id -u "${run_as_user}" >/dev/null 2>&1; then
+                echo "The specified run.as user ${run_as_user} does not exist. Exiting."
                 exit 1
             fi
         fi;
@@ -284,18 +281,21 @@ run() {
     # all other commands will terminate quickly so want to just wait for them
 
     #setup directory parameters
-    BOOTSTRAP_LOG_PARAMS="-Dorg.apache.nifi.bootstrap.config.log.dir="\""${NIFI_LOG_DIR}"\"""
-    BOOTSTRAP_PID_PARAMS="-Dorg.apache.nifi.bootstrap.config.pid.dir="\""${NIFI_PID_DIR}"\"""
-    BOOTSTRAP_CONF_PARAMS="-Dorg.apache.nifi.bootstrap.config.file="\""${BOOTSTRAP_CONF}"\"""
+    BOOTSTRAP_LOG_PARAMS="-Dorg.apache.nifi.bootstrap.config.log.dir='${NIFI_LOG_DIR}'"
+    BOOTSTRAP_PID_PARAMS="-Dorg.apache.nifi.bootstrap.config.pid.dir='${NIFI_PID_DIR}'"
+    BOOTSTRAP_CONF_PARAMS="-Dorg.apache.nifi.bootstrap.config.file='${BOOTSTRAP_CONF}'"
 
     BOOTSTRAP_DIR_PARAMS="${BOOTSTRAP_LOG_PARAMS} ${BOOTSTRAP_PID_PARAMS} ${BOOTSTRAP_CONF_PARAMS}"
-
-    RUN_NIFI_CMD="cd "\""${NIFI_HOME}"\"" && exec ${sudo_cmd_prefix} "\""${JAVA}"\"" -cp "\""${BOOTSTRAP_CLASSPATH}"\"" -Xms12m -Xmx24m ${BOOTSTRAP_DIR_PARAMS}  org.apache.nifi.bootstrap.RunNiFi"
+    run_nifi_cmd="exec '${JAVA}' -cp '${BOOTSTRAP_CLASSPATH}' -Xms12m -Xmx24m ${BOOTSTRAP_DIR_PARAMS} org.apache.nifi.bootstrap.RunNiFi $@"
+    if [ -n "${run_as_user}" ]; then
+      # Provide SCRIPT_DIR and execute nifi-env for the run.as user command
+      run_nifi_cmd="sudo -u ${run_as_user} sh -c \"SCRIPT_DIR='${SCRIPT_DIR}' && . '${SCRIPT_DIR}/nifi-env.sh' && ${run_nifi_cmd}\""
+    fi
 
     if [ "$1" = "start" ]; then
-        (eval $RUN_NIFI_CMD $@ &)
+        ( eval "cd ${NIFI_HOME} && ${run_nifi_cmd}" & )
     else
-        eval $RUN_NIFI_CMD $@
+        eval "cd ${NIFI_HOME} && ${run_nifi_cmd}"
     fi
     EXIT_STATUS=$?
 


### PR DESCRIPTION
NIFI-3294 Adjusting nifi.sh to invoke nifi-env.sh when running as another user such that properties are preserved across environments.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
