### PR TITLE
NIFI-3214: Added fetch and replace to DistributedMapCache

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/AtomicDistributedMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/AtomicDistributedMapCacheClient.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.distributed.cache.client;
+
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+
+import java.io.IOException;
+
+/**
+ * <p>This interface defines an API that can be used for interacting with a
+ * Distributed Cache that functions similarly to a {@link java.util.Map Map}.
+ *
+ * <p>In addition to the API defined in {@link DistributedMapCacheClient} super class,
+ * this class provides methods for concurrent atomic updates those are added since Map Cache protocol version 2.
+ *
+ * <p>If a remote cache server doesn't support Map Cache protocol version 2, these methods throw UnsupportedOperationException.
+ */
+@Tags({"distributed", "client", "cluster", "map", "cache"})
+@CapabilityDescription("Provides the ability to communicate with a DistributedMapCacheServer. This allows "
+        + "multiple nodes to coordinate state with a single remote entity.")
+public interface AtomicDistributedMapCacheClient extends DistributedMapCacheClient {
+
+    interface CacheEntry<K, V> {
+
+        long getRevision();
+
+        K getKey();
+
+        V getValue();
+
+    }
+
+    /**
+     * Fetch a CacheEntry with a key.
+     * @param <K> the key type
+     * @param <V> the value type
+     * @param key the key to lookup in the map
+     * @param keySerializer key serializer
+     * @param valueDeserializer value deserializer
+     * @return A CacheEntry instance if one exists, otherwise <cod>null</cod>.
+     * @throws IOException if unable to communicate with the remote instance
+     */
+    <K, V> CacheEntry<K, V> fetch(K key, Serializer<K> keySerializer, Deserializer<V> valueDeserializer) throws IOException;
+
+    /**
+     * Replace an existing key with new value.
+     * @param <K> the key type
+     * @param <V> the value type
+     * @param key the key to replace
+     * @param value the new value for the key
+     * @param keySerializer key serializer
+     * @param valueSerializer value serializer
+     * @param revision a revision that was retrieved by a preceding fetch operation, if the key is already updated by other client,
+     *                 this doesn't match with the one on server, therefore the replace operation will not be performed.
+     *                 If there's no existing entry for the key, any revision can replace the key.
+     * @return true only if the key is replaced.
+     * @throws IOException if unable to communicate with the remote instance
+     */
+    <K, V> boolean replace(K key, V value, Serializer<K> keySerializer, Serializer<V> valueSerializer, long revision) throws IOException;
+
+}

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CommsSession.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CommsSession.java
@@ -43,4 +43,8 @@ public interface CommsSession extends Closeable {
     long getTimeout(TimeUnit timeUnit);
 
     SSLContext getSSLContext();
+
+    int getProtocolVersion();
+
+    void setProtocolVersion(final int protocolVersion);
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
@@ -127,6 +127,7 @@ public class DistributedSetCacheClientService extends AbstractControllerService 
         final VersionNegotiator versionNegotiator = new StandardVersionNegotiator(1);
         try {
             ProtocolHandshake.initiateHandshake(session.getInputStream(), session.getOutputStream(), versionNegotiator);
+            session.setProtocolVersion(versionNegotiator.getVersion());
         } catch (final HandshakeException e) {
             IOUtils.closeQuietly(session);
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SSLCommsSession.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SSLCommsSession.java
@@ -42,6 +42,8 @@ public class SSLCommsSession implements CommsSession {
     private final SSLSocketChannelOutputStream out;
     private final BufferedOutputStream bufferedOut;
 
+    private int protocolVersion;
+
     public SSLCommsSession(final SSLContext sslContext, final String hostname, final int port) throws IOException {
         sslSocketChannel = new SSLSocketChannel(sslContext, hostname, port, true);
 
@@ -106,4 +108,13 @@ public class SSLCommsSession implements CommsSession {
         return timeUnit.convert(sslSocketChannel.getTimeout(), TimeUnit.MILLISECONDS);
     }
 
+    @Override
+    public int getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    @Override
+    public void setProtocolVersion(final int protocolVersion) {
+        this.protocolVersion = protocolVersion;
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/StandardCacheEntry.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/StandardCacheEntry.java
@@ -14,35 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.distributed.cache.server.map;
+package org.apache.nifi.distributed.cache.client;
 
-public class MapPutResult {
+public class StandardCacheEntry<K,V> implements AtomicDistributedMapCacheClient.CacheEntry<K,V> {
 
-    private final boolean successful;
-    private final MapCacheRecord record;
-    private final MapCacheRecord existing;
-    private final MapCacheRecord evicted;
+    private final K key;
+    private final V value;
+    private final long revision;
 
-    public MapPutResult(boolean successful, MapCacheRecord record, MapCacheRecord existing, MapCacheRecord evicted) {
-        this.successful = successful;
-        this.record = record;
-        this.existing = existing;
-        this.evicted = evicted;
+
+    public StandardCacheEntry(final K key, final V value, final long revision) {
+        this.key = key;
+        this.value = value;
+        this.revision = revision;
     }
 
-    public boolean isSuccessful() {
-        return successful;
+    @Override
+    public long getRevision() {
+        return revision;
     }
 
-    public MapCacheRecord getRecord() {
-        return record;
+    @Override
+    public K getKey() {
+        return key;
     }
 
-    public MapCacheRecord getExisting() {
-        return existing;
-    }
-
-    public MapCacheRecord getEvicted() {
-        return evicted;
+    @Override
+    public V getValue() {
+        return value;
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/StandardCommsSession.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/StandardCommsSession.java
@@ -45,6 +45,8 @@ public class StandardCommsSession implements CommsSession {
     private final SocketChannelOutputStream out;
     private final InterruptableOutputStream bufferedOut;
 
+    private int protocolVersion;
+
     public StandardCommsSession(final String hostname, final int port) throws IOException {
         socketChannel = SocketChannel.open(new InetSocketAddress(hostname, port));
         socketChannel.configureBlocking(false);
@@ -122,4 +124,15 @@ public class StandardCommsSession implements CommsSession {
     public long getTimeout(final TimeUnit timeUnit) {
         return timeUnit.convert(timeoutMillis, TimeUnit.MILLISECONDS);
     }
+
+    @Override
+    public int getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    @Override
+    public void setProtocolVersion(final int protocolVersion) {
+        this.protocolVersion = protocolVersion;
+    }
+
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-protocol/src/main/java/org/apache/nifi/distributed/cache/protocol/ProtocolHandshake.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-protocol/src/main/java/org/apache/nifi/distributed/cache/protocol/ProtocolHandshake.java
@@ -33,6 +33,19 @@ public class ProtocolHandshake {
     public static final int DIFFERENT_RESOURCE_VERSION = 21;
     public static final int ABORT = 255;
 
+    /**
+     * <p>Initiate handshake to ensure client and server can communicate with the same protocol.
+     * If the server doesn't support requested protocol version, HandshakeException will be thrown.</p>
+     *
+     * <p>DistributedMapCache version histories:<ul>
+     *     <li>2: Added atomic update operations (fetch and replace) using optimistic lock with revision number.</li>
+     *     <li>1: Initial version.</li>
+     * </ul></p>
+     *
+     * <p>DistributedSetCache version histories:<ul>
+     *     <li>1: Initial version.</li>
+     * </ul></p>
+     */
     public static void initiateHandshake(final InputStream in, final OutputStream out, final VersionNegotiator versionNegotiator) throws IOException, HandshakeException {
         final DataInputStream dis = new DataInputStream(in);
         final DataOutputStream dos = new DataOutputStream(out);
@@ -85,6 +98,7 @@ public class ProtocolHandshake {
 
                 // Attempt negotiation of resource based on our new preferred version.
                 initiateVersionNegotiation(negotiator, dis, dos);
+                return;
             case ABORT:
                 throw new HandshakeException("Remote destination aborted connection with message: " + dis.readUTF());
             default:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/AbstractCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/AbstractCacheServer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.distributed.cache.server;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,8 +32,6 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.nifi.distributed.cache.protocol.ProtocolHandshake;
 import org.apache.nifi.distributed.cache.protocol.exception.HandshakeException;
-import org.apache.nifi.stream.io.BufferedInputStream;
-import org.apache.nifi.stream.io.BufferedOutputStream;
 import org.apache.nifi.remote.StandardVersionNegotiator;
 import org.apache.nifi.remote.VersionNegotiator;
 import org.apache.nifi.remote.io.socket.SocketChannelInputStream;
@@ -121,9 +121,9 @@ public abstract class AbstractCacheServer implements CacheServer {
                                 return;
                             }
                             try (final InputStream in = new BufferedInputStream(rawInputStream);
-                                final OutputStream out = new BufferedOutputStream(rawOutputStream)) {
+                                 final OutputStream out = new BufferedOutputStream(rawOutputStream)) {
 
-                                final VersionNegotiator versionNegotiator = new StandardVersionNegotiator(1);
+                                final VersionNegotiator versionNegotiator = getVersionNegotiator();
 
                                 ProtocolHandshake.receiveHandshake(in, out, versionNegotiator);
 
@@ -161,6 +161,14 @@ public abstract class AbstractCacheServer implements CacheServer {
         thread.setDaemon(true);
         thread.setName("Distributed Cache Server: " + identifier);
         thread.start();
+    }
+
+    /**
+     * Refer {@link org.apache.nifi.distributed.cache.protocol.ProtocolHandshake#initiateHandshake(InputStream, OutputStream, VersionNegotiator)}
+     * for details of each version enhancements.
+     */
+    protected StandardVersionNegotiator getVersionNegotiator() {
+        return new StandardVersionNegotiator(1);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/DistributedMapCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/DistributedMapCacheServer.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.distributed.cache.server.map;
 
 import java.io.File;
+import java.io.IOException;
 
 import javax.net.ssl.SSLContext;
 
@@ -69,10 +70,14 @@ public class DistributedMapCacheServer extends DistributedCacheServer {
         try {
             final File persistenceDir = persistencePath == null ? null : new File(persistencePath);
 
-            return new MapCacheServer(getIdentifier(), sslContext, port, maxSize, evictionPolicy, persistenceDir);
+            return createMapCacheServer(port, maxSize, sslContext, evictionPolicy, persistenceDir);
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected MapCacheServer createMapCacheServer(int port, int maxSize, SSLContext sslContext, EvictionPolicy evictionPolicy, File persistenceDir) throws IOException {
+        return new MapCacheServer(getIdentifier(), sslContext, port, maxSize, evictionPolicy, persistenceDir);
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCache.java
@@ -31,5 +31,9 @@ public interface MapCache {
 
     ByteBuffer remove(ByteBuffer key) throws IOException;
 
+    MapCacheRecord fetch(ByteBuffer key) throws IOException;
+
+    MapPutResult replace(MapCacheRecord record) throws IOException;
+
     void shutdown() throws IOException;
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheRecord.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheRecord.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.distributed.cache.server.map;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.apache.nifi.distributed.cache.server.CacheRecord;
 
@@ -24,10 +25,19 @@ public class MapCacheRecord extends CacheRecord {
 
     private final ByteBuffer key;
     private final ByteBuffer value;
+    /**
+     * Revision is a number that increases every time the key is updated.
+     */
+    private final long revision;
 
     public MapCacheRecord(final ByteBuffer key, final ByteBuffer value) {
+        this(key, value, -1L);
+    }
+
+    public MapCacheRecord(final ByteBuffer key, final ByteBuffer value, final long revision) {
         this.key = key;
         this.value = value;
+        this.revision = revision;
     }
 
     public ByteBuffer getKey() {
@@ -40,7 +50,7 @@ public class MapCacheRecord extends CacheRecord {
 
     @Override
     public int hashCode() {
-        return 2938476 + key.hashCode() * value.hashCode();
+        return Arrays.hashCode(new Object[]{key, value, revision});
     }
 
     @Override
@@ -51,9 +61,13 @@ public class MapCacheRecord extends CacheRecord {
 
         if (obj instanceof MapCacheRecord) {
             final MapCacheRecord that = ((MapCacheRecord) obj);
-            return key.equals(that.key) && value.equals(that.value);
+            return key.equals(that.key) && value.equals(that.value) && revision == that.revision;
         }
 
         return false;
+    }
+
+    public long getRevision() {
+        return revision;
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
@@ -84,16 +84,7 @@ public class SimpleMapCache implements MapCache {
             final MapCacheRecord record = cache.get(key);
             if (record == null) {
                 // Record is null. We will add.
-                final MapCacheRecord evicted = evict();
-                final MapCacheRecord newRecord = new MapCacheRecord(key, value);
-                cache.put(key, newRecord);
-                inverseCacheMap.put(newRecord, key);
-
-                if (evicted == null) {
-                    return new MapPutResult(true, key, value, null, null, null);
-                } else {
-                    return new MapPutResult(true, key, value, null, evicted.getKey(), evicted.getValue());
-                }
+                return put(key, value, record);
             }
 
             // Record is not null. Increment hit count and return result indicating that record was not added.
@@ -101,29 +92,37 @@ public class SimpleMapCache implements MapCache {
             record.hit();
             inverseCacheMap.put(record, key);
 
-            return new MapPutResult(false, key, value, record.getValue(), null, null);
+            return new MapPutResult(false, record, record, null);
         } finally {
             writeLock.unlock();
         }
     }
 
+    private MapPutResult put(final ByteBuffer key, final ByteBuffer value, final MapCacheRecord existing) {
+        // evict if we need to in order to make room for a new entry.
+        final MapCacheRecord evicted = evict();
+
+        final long revision;
+        if (existing == null) {
+            revision = 0;
+        } else {
+            revision = existing.getRevision() + 1;
+            inverseCacheMap.remove(existing);
+        }
+
+        final MapCacheRecord record = new MapCacheRecord(key, value, revision);
+        cache.put(key, record);
+        inverseCacheMap.put(record, key);
+
+        return new MapPutResult(true, record, existing, evicted);
+    }
 
     @Override
-    public MapPutResult put(final ByteBuffer key, final ByteBuffer value) {
+    public MapPutResult put(final ByteBuffer key, final ByteBuffer value) throws IOException {
         writeLock.lock();
         try {
-            // evict if we need to in order to make room for a new entry.
-            final MapCacheRecord evicted = evict();
-
-            final MapCacheRecord record = new MapCacheRecord(key, value);
-            final MapCacheRecord existing = cache.put(key, record);
-            inverseCacheMap.put(record, key);
-
-            final ByteBuffer existingValue = (existing == null) ? null : existing.getValue();
-            final ByteBuffer evictedKey = (evicted == null) ? null : evicted.getKey();
-            final ByteBuffer evictedValue = (evicted == null) ? null : evicted.getValue();
-
-            return new MapPutResult(true, key, value, existingValue, evictedKey, evictedValue);
+            final MapCacheRecord existing = cache.get(key);
+            return put(key, value, existing);
         } finally {
             writeLock.unlock();
         }
@@ -177,6 +176,43 @@ public class SimpleMapCache implements MapCache {
             }
             inverseCacheMap.remove(record);
             return record.getValue();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public MapCacheRecord fetch(ByteBuffer key) throws IOException {
+        readLock.lock();
+        try {
+            final MapCacheRecord record = cache.get(key);
+            if (record == null) {
+                return null;
+            }
+
+            inverseCacheMap.remove(record);
+            record.hit();
+            inverseCacheMap.put(record, key);
+
+            return record;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public MapPutResult replace(MapCacheRecord inputRecord) throws IOException {
+        writeLock.lock();
+        try {
+            final ByteBuffer key = inputRecord.getKey();
+            final ByteBuffer value = inputRecord.getValue();
+            final MapCacheRecord existing = fetch(key);
+            if (existing != null && inputRecord.getRevision() != existing.getRevision()) {
+                // The key has been updated by other operation.
+                return new MapPutResult(false, inputRecord, existing, null);
+            }
+
+            return put(key, value, existing);
         } finally {
             writeLock.unlock();
         }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/test/java/org/apache/nifi/distributed/cache/server/map/TestSimpleMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/test/java/org/apache/nifi/distributed/cache/server/map/TestSimpleMapCache.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.distributed.cache.server.map;
+
+import org.apache.nifi.distributed.cache.server.EvictionPolicy;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestSimpleMapCache {
+
+    @Test
+    public void testBasicOperations() throws Exception {
+        final SimpleMapCache cache = new SimpleMapCache("service-id", 2, EvictionPolicy.FIFO);
+
+        final ByteBuffer key1 = ByteBuffer.wrap("key1".getBytes());
+        final ByteBuffer key2 = ByteBuffer.wrap("key2".getBytes());
+        final ByteBuffer key3 = ByteBuffer.wrap("key3".getBytes());
+        ByteBuffer value1 = ByteBuffer.wrap("value1-0".getBytes());
+        ByteBuffer value2 = ByteBuffer.wrap("value2-0".getBytes());
+        ByteBuffer value3 = ByteBuffer.wrap("value3-0".getBytes());
+
+        // Initial state.
+        assertNull(cache.get(key1));
+        assertNull(cache.fetch(key1));
+
+        // Put the 1st key.
+        MapPutResult putResult = cache.put(key1, value1);
+        assertTrue(putResult.isSuccessful());
+        assertNull(putResult.getExisting());
+        assertNull(putResult.getEvicted());
+        assertEquals(0, putResult.getRecord().getRevision());
+
+        // Update the same key.
+        value1 = ByteBuffer.wrap("value1-1".getBytes());
+        putResult = cache.put(key1, value1);
+        assertTrue(putResult.isSuccessful());
+        assertNotNull(putResult.getExisting());
+        assertEquals(1, putResult.getRecord().getRevision());
+        assertEquals(key1, putResult.getExisting().getKey());
+        assertEquals("value1-0", new String(putResult.getExisting().getValue().array()));
+        assertNull(putResult.getEvicted());
+
+        // Put the 2nd key.
+        putResult = cache.put(key2, value2);
+        assertTrue(putResult.isSuccessful());
+        assertNull(putResult.getExisting());
+        assertNull(putResult.getEvicted());
+        assertEquals(0, putResult.getRecord().getRevision());
+
+        // Put the 3rd key.
+        putResult = cache.put(key3, value3);
+        assertTrue(putResult.isSuccessful());
+        assertNull(putResult.getExisting());
+        assertNotNull("The first key should be evicted", putResult.getEvicted());
+        assertEquals("key1", new String(putResult.getEvicted().getKey().array()));
+        assertEquals("value1-1", new String(putResult.getEvicted().getValue().array()));
+        assertEquals(0, putResult.getRecord().getRevision());
+
+        // Delete 2nd key.
+        ByteBuffer removed = cache.remove(key2);
+        assertNotNull(removed);
+        assertEquals("value2-0", new String(removed.array()));
+
+        // Put the 2nd key again.
+        putResult = cache.put(key2, value2);
+        assertTrue(putResult.isSuccessful());
+        assertNull(putResult.getExisting());
+        assertNull(putResult.getEvicted());
+        assertEquals("Revision should start from 0", 0, putResult.getRecord().getRevision());
+
+    }
+
+    @Test
+    public void testOptimisticLock() throws Exception {
+
+        final SimpleMapCache cache = new SimpleMapCache("service-id", 2, EvictionPolicy.FIFO);
+
+        final ByteBuffer key = ByteBuffer.wrap("key1".getBytes());
+        ByteBuffer valueC1 = ByteBuffer.wrap("valueC1-0".getBytes());
+        ByteBuffer valueC2 = ByteBuffer.wrap("valueC2-0".getBytes());
+
+        assertNull("If there's no existing key, fetch should return null.", cache.fetch(key));
+
+        // Client 1 inserts the key.
+        MapCacheRecord c1 = new MapCacheRecord(key, valueC1);
+        MapPutResult putResult = cache.replace(c1);
+        assertTrue("Replace should succeed if there's no existing key.", putResult.isSuccessful());
+
+        MapCacheRecord c2 = new MapCacheRecord(key, valueC2);
+        putResult = cache.replace(c2);
+        assertFalse("Replace should fail.", putResult.isSuccessful());
+
+        // Client 1 and 2 fetch the key
+        c1 = cache.fetch(key);
+        c2 = cache.fetch(key);
+        assertEquals(0, c1.getRevision());
+        assertEquals(0, c2.getRevision());
+
+        // Client 1 replace
+        valueC1 = ByteBuffer.wrap("valueC1-1".getBytes());
+        putResult = cache.replace(new MapCacheRecord(key, valueC1, c1.getRevision()));
+        assertTrue("Replace should succeed since revision matched.", putResult.isSuccessful());
+        assertEquals(1, putResult.getRecord().getRevision());
+
+        // Client 2 replace with the old revision
+        valueC2 = ByteBuffer.wrap("valueC2-1".getBytes());
+        putResult = cache.replace(new MapCacheRecord(key, valueC2, c2.getRevision()));
+        assertFalse("Replace should fail.", putResult.isSuccessful());
+    }
+
+}


### PR DESCRIPTION
There's no Processor that utilizes these new cache operations yet, but will be added by [JIRA-3216](https://issues.apache.org/jira/browse/NIFI-3216). To test client and server communication, please use `org.apache.nifi.distributed.cache.server.TestServerAndClient` test class in `nifi-distributed-cache-server` project. If you need to test it on Mac OS X, then you also have to comment out these lines. Sometime it fails due to JVM issue but sometime it works:

```
Assume.assumeFalse("test is skipped due to build environment being OS X with JDK 1.8. See https://issues.apache.org/jira/browse/NIFI-437",
    SystemUtils.IS_OS_MAC && SystemUtils.IS_JAVA_1_8);
```

- Using fetch and replace together can provide optimistic locking for  concurrency control.
- Added fetch to get cache entry with its meta data such as revision number.
- Added replace to update cache only if it has not been updated.
- Added Map Cache protocol version 2 for those new operations.
- Existing operations such as get or put can work with protocol version  1.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
