### PR TITLE
NIFI-3330 Replaced two instances of multiple calls to getter methods …

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -512,8 +513,9 @@ public class HandleHttpRequest extends AbstractProcessor {
             putAttribute(attributes, "http.method", request.getMethod());
             putAttribute(attributes, "http.local.addr", request.getLocalAddr());
             putAttribute(attributes, HTTPUtils.HTTP_LOCAL_NAME, request.getLocalName());
-            if (request.getQueryString() != null) {
-                putAttribute(attributes, "http.query.string", URLDecoder.decode(request.getQueryString(), charset));
+            final String queryString = request.getQueryString();
+            if (queryString != null) {
+                putAttribute(attributes, "http.query.string", URLDecoder.decode(queryString, charset));
             }
             putAttribute(attributes, HTTPUtils.HTTP_REMOTE_HOST, request.getRemoteHost());
             putAttribute(attributes, "http.remote.addr", request.getRemoteAddr());
@@ -523,8 +525,9 @@ public class HandleHttpRequest extends AbstractProcessor {
             putAttribute(attributes, "http.auth.type", request.getAuthType());
 
             putAttribute(attributes, "http.requested.session.id", request.getRequestedSessionId());
-            if (request.getDispatcherType() != null) {
-                putAttribute(attributes, "http.dispatcher.type", request.getDispatcherType().name());
+            final DispatcherType dispatcherType = request.getDispatcherType();
+            if (dispatcherType != null) {
+                putAttribute(attributes, "http.dispatcher.type", dispatcherType.name());
             }
             putAttribute(attributes, "http.character.encoding", request.getCharacterEncoding());
             putAttribute(attributes, "http.locale", request.getLocale());
@@ -552,7 +555,6 @@ public class HandleHttpRequest extends AbstractProcessor {
                 }
             }
 
-            final String queryString = request.getQueryString();
             if (queryString != null) {
                 final String[] params = URL_QUERY_PARAM_DELIMITER.split(queryString);
                 for (final String keyValueString : params) {


### PR DESCRIPTION
…during request attribute retrieval with a single call saved to a local variable to prevent null pointer exceptions during multiple invocations of a getter method.
