### PR TITLE
NIFI-3314 Adjusting Dockerfile for Docker Hub to use defaults for ARGs

### DIFF
--- a/nifi-docker/dockerhub/Dockerfile
+++ b/nifi-docker/dockerhub/Dockerfile
@@ -16,12 +16,12 @@
 # under the License.
 #
 
-FROM java:8
+FROM openjdk:8
 MAINTAINER Apache NiFi <dev@nifi.apache.org>
 
-ARG UID
-ARG GID
-ARG NIFI_VERSION
+ARG UID=1000
+ARG GID=50
+ARG NIFI_VERSION=1.2.0
 
 ENV NIFI_BASE_DIR /opt/nifi
 ENV NIFI_HOME $NIFI_BASE_DIR/nifi-$NIFI_VERSION

--- a/nifi-docker/dockermaven/Dockerfile
+++ b/nifi-docker/dockermaven/Dockerfile
@@ -16,11 +16,11 @@
 # under the License.
 #
 
-FROM java:8
+FROM openjdk:8
 MAINTAINER Apache NiFi <dev@nifi.apache.org>
 
-ARG UID
-ARG GID
+ARG UID=1000
+ARG GID=50
 ARG NIFI_VERSION
 ARG NIFI_BINARY
 


### PR DESCRIPTION
NIFI-3314 Adjusting Dockerfile for Docker Hub to use defaults for ARGs such that it does not need supporting build script.  Making use of openjdk base image as the java image has been deprecated.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [-] Have you written or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [-] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [-] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
