### PR TITLE
NIFI-2615 Adding GetTCP processor

### DIFF
--- a/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/AbstractSocketHandler.java
+++ b/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/AbstractSocketHandler.java
@@ -56,6 +56,8 @@ abstract class AbstractSocketHandler {
     protected final byte endOfMessageByte;
 
     /**
+     * This constructor configures the address to bind to, the size of the buffer to use for reading and
+     * the byte pattern to use for demarcating the end of a message.
      *
      * @param address the socket address
      * @param readingBufferSize the buffer size
@@ -70,7 +72,10 @@ abstract class AbstractSocketHandler {
     }
 
     /**
+     * Once the handler is constructed this should be called to start the handler. Although,
+     * this method is safe to be called by multiple threads, it should only be called once.
      *
+     * @throws IllegalStateException if it fails to start listening on the port that is configured.
      *
      */
     public void start() {
@@ -96,7 +101,9 @@ abstract class AbstractSocketHandler {
     }
 
     /**
-     *
+     * This should be called to stop the handler from listening on the socket. Although it is reccommended
+     * that this is called once, by a single thread. This method does protect itself from being called by more
+     * than one thread and more than one time.
      *
      */
     public void stop() {
@@ -135,6 +142,7 @@ abstract class AbstractSocketHandler {
     }
 
     /**
+     * This must be overriden by an implementing class and should establish the socket connection.
      *
      * @throws Exception if an exception occurs
      */
@@ -149,6 +157,8 @@ abstract class AbstractSocketHandler {
     abstract void processData(SelectionKey selectionKey, ByteBuffer buffer) throws IOException;
 
     /**
+     * This does not perform any work at this time as all current implementations of this class
+     * provide the client side of the connection and thus do not accept connections.
      *
      * @param selectionKey the selection key
      * @throws IOException if there is a problem
@@ -193,14 +203,21 @@ abstract class AbstractSocketHandler {
         }
 
         /**
+         * Accept the selectable channel
          *
+         * @throws IOException in the event that something goes wrong accepting it.
          */
         private void accept(SelectionKey selectionKey) throws IOException {
             AbstractSocketHandler.this.doAccept(selectionKey);
         }
 
         /**
+         * This will connect the channel, if it is in a pending state then this will finish
+         * establishing the connection. Finally the sockethandler is registered with this
+         * channel.
          *
+         * @throws IOException if anyhting goes wrong during the connection establishment
+         * or registering of the handler.
          */
         private void connect(SelectionKey selectionKey) throws IOException {
             SocketChannel clientChannel = (SocketChannel) selectionKey.channel();

--- a/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/GetTCP.java
+++ b/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/GetTCP.java
@@ -269,7 +269,9 @@ public class GetTCP extends AbstractSessionFactoryProcessor {
     }
 
     /**
-     *
+     * This handles the taking the message that has been received off the wire and writing it to the
+     * content of a flow file. If only a partial message is received then the flow file is sent to
+     * the Partial Relationship. If a full message is received then it is sent to the Success relationship.
      */
     private class NiFiDelegatingMessageHandler implements MessageHandler {
         private final ProcessSessionFactory sessionFactory;

--- a/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/ReceivingClient.java
+++ b/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/ReceivingClient.java
@@ -59,7 +59,9 @@ class ReceivingClient extends AbstractSocketHandler {
     }
 
     /**
-     *
+     * Connects to the endpoint specified and it that fails will attempt to connect to the
+     * secondary endpoint up to the number of reconnection attempts inclusively using the
+     * configured delayed between attempts.
      */
     @Override
     InetSocketAddress connect() throws Exception {
@@ -119,7 +121,7 @@ class ReceivingClient extends AbstractSocketHandler {
     }
 
     /**
-     *
+     * Process the message that has arrived off the wire.
      */
     @Override
     void processData(SelectionKey selectionKey, ByteBuffer messageBuffer) throws IOException {


### PR DESCRIPTION
This P/R is to address the code documentation issues that caused checkstyle failures and the build to fail after the changes from #1433 were merged. I have run a build with this using the -Pcontrib-check profile and will run all future contributions with this profile enabled prior to P/R submission. Thanks you @alopresto for catching these violations and starting the fixes. 

This nar provides a GetTCP processor in a generic TCP bundle. This is an update based on the previous P/R [1] feedback for this nar.

[1] #1433
[2] #1434 

