### PR TITLE
NIFI-3424: NIFI-3040: Fixed bug where we were generating a …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -3628,7 +3628,8 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
         provenanceEventRepository.registerEvent(replayEvent);
 
         // Update the FlowFile Repository to indicate that we have added the FlowFile to the flow
-        final StandardRepositoryRecord record = new StandardRepositoryRecord(queue, flowFileRecord);
+        final StandardRepositoryRecord record = new StandardRepositoryRecord(queue);
+        record.setWorking(flowFileRecord);
         record.setDestination(queue);
         flowFileRepository.updateRepository(Collections.<RepositoryRecord> singleton(record));
 


### PR DESCRIPTION
…RepositoryRecord with an 'UPDATE' type instead of a 'CREATE' time for Replay of FlowFiles. This caused FlowFile to have no attributes when restored from the FlowFile Repository.
