### PR TITLE
NIFI-3426: Add dynamic property support to DBCPConnectionPool

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/groovy/org/apache/nifi/dbcp/GroovyDBCPServiceTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/groovy/org/apache/nifi/dbcp/GroovyDBCPServiceTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.dbcp
+
+import org.apache.nifi.reporting.InitializationException
+import org.apache.nifi.util.TestRunner
+import org.apache.nifi.util.TestRunners
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+
+import java.sql.Connection
+import java.sql.SQLException
+
+import static org.apache.nifi.dbcp.DBCPConnectionPool.*
+
+/**
+ * Groovy unit tests for the DBCPService module.
+ */
+class GroovyDBCPServiceTest {
+
+    final static String DB_LOCATION = "target/db"
+
+    @BeforeClass
+    static void setup() {
+        System.setProperty("derby.stream.error.file", "target/derby.log")
+    }
+
+    /**
+     * Test dynamic connection properties.
+     */
+    @Test
+    void testDynamicProperties() throws InitializationException, SQLException {
+        final TestRunner runner = TestRunners.newTestRunner(TestProcessor)
+        final DBCPConnectionPool service = new DBCPConnectionPool()
+        runner.addControllerService("test-dynamic-properties", service)
+
+        // remove previous test database, if any
+        final File dbLocation = new File(DB_LOCATION)
+        dbLocation.deleteDir()
+
+        // set embedded Derby database connection url
+        runner.setProperty(service, DATABASE_URL, "jdbc:derby:" + DB_LOCATION)
+        runner.setProperty(service, DB_USER, "tester")
+        runner.setProperty(service, DB_PASSWORD, "testerp")
+        runner.setProperty(service, DB_DRIVERNAME, "org.apache.derby.jdbc.EmbeddedDriver")
+        runner.setProperty(service, "create", "true")
+
+        runner.enableControllerService(service)
+
+        runner.assertValid(service)
+        final DBCPService dbcpService = (DBCPService) runner.processContext.controllerServiceLookup.getControllerService("test-dynamic-properties")
+        Assert.assertNotNull(dbcpService)
+
+        2.times {
+            final Connection connection = dbcpService.getConnection()
+            Assert.assertNotNull(connection)
+            connection.close() // will return connection to pool
+        }
+    }
+}


### PR DESCRIPTION
Unit test adds "create=true" as a Derby property (instead of via the URL), written in Groovy to leverage the recursive deleteDir() method. If the create property is not set, the test fails.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
