### PR TITLE
NIFI-3427 Fix Provenance DateTime Sorting

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -1040,14 +1040,20 @@
             if (date.length !== 3 || time.length !== 3) {
                 return new Date();
             }
+            var year = parseInt(date[2], 10);
+            var month = parseInt(date[0], 10) - 1; // new Date() accepts months 0 - 11
+            var day = parseInt(date[1], 10);
+            var hours = parseInt(time[0], 10);
+            var minutes = parseInt(time[1], 10);
 
             // detect if there is millis
-            var seconds = time[2].split(/\./);
-            if (seconds.length === 2) {
-                return new Date(parseInt(date[2], 10), parseInt(date[0], 10), parseInt(date[1], 10), parseInt(time[0], 10), parseInt(time[1], 10), parseInt(seconds[0], 10), parseInt(seconds[1], 10));
-            } else {
-                return new Date(parseInt(date[2], 10), parseInt(date[0], 10), parseInt(date[1], 10), parseInt(time[0], 10), parseInt(time[1], 10), parseInt(time[2], 10), 0);
+            var secondsSpec = time[2].split(/\./);
+            var seconds = parseInt(secondsSpec[0], 10);
+            var milliseconds = 0;
+            if (secondsSpec.length === 2) {
+                milliseconds = parseInt(secondsSpec[1], 10);
             }
+            return new Date(year, month, day, hours, minutes, seconds, milliseconds);
         },
 
         /**


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

---

Fixing nf.Common.parseDateTime to use month 0 - 11 instead of 1 - 12. Although dates produced by parseDateTime are used for sorting, getting the month off by one results in inconsistent relative sorting when the months are not of the same length (January 31st becomes March 3rd).   parseDateTime is used beyond the provenance table that started the ticket, it is also used in Templates dialog sorting, Add Template dialog sorting, and Cluster dialog sorting.
