### PR TITLE
NIFI-3408 Add exception class when InvokeHTTP fails

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -104,6 +104,8 @@ import org.joda.time.format.DateTimeFormatter;
     @WritesAttribute(attribute = "invokehttp.request.url", description = "The request URL"),
     @WritesAttribute(attribute = "invokehttp.tx.id", description = "The transaction ID that is returned after reading the response"),
     @WritesAttribute(attribute = "invokehttp.remote.dn", description = "The DN of the remote server"),
+    @WritesAttribute(attribute = "invokehttp.java.exception.class", description = "The Java exception class raised when the processor fails"),
+    @WritesAttribute(attribute = "invokehttp.java.exception.message", description = "The Java exception message raised when the processor fails"),
     @WritesAttribute(attribute = "user-defined", description = "If the 'Put Response Body In Attribute' property is set then whatever it is set to "
         + "will become the attribute key and the value would be the body of the HTTP response.")})
 @DynamicProperty(name = "Header Name", value = "Attribute Expression Language", supportsExpressionLanguage = true, description = "Send request header "
@@ -118,6 +120,9 @@ public final class InvokeHTTP extends AbstractProcessor {
     public final static String REQUEST_URL = "invokehttp.request.url";
     public final static String TRANSACTION_ID = "invokehttp.tx.id";
     public final static String REMOTE_DN = "invokehttp.remote.dn";
+    public final static String EXCEPTION_CLASS = "invokehttp.java.exception.class";
+    public final static String EXCEPTION_MESSAGE = "invokehttp.java.exception.message";
+
 
     public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
@@ -127,6 +132,7 @@ public final class InvokeHTTP extends AbstractProcessor {
     // attributes.
     public static final Set<String> IGNORED_ATTRIBUTES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             STATUS_CODE, STATUS_MESSAGE, RESPONSE_BODY, REQUEST_URL, TRANSACTION_ID, REMOTE_DN,
+            EXCEPTION_CLASS, EXCEPTION_MESSAGE,
             "uuid", "filename", "path")));
 
     // properties
@@ -753,6 +759,8 @@ public final class InvokeHTTP extends AbstractProcessor {
             if (requestFlowFile != null) {
                 logger.error("Routing to {} due to exception: {}", new Object[]{REL_FAILURE.getName(), e}, e);
                 requestFlowFile = session.penalize(requestFlowFile);
+                requestFlowFile = session.putAttribute(requestFlowFile, EXCEPTION_CLASS, e.getClass().getName());
+                requestFlowFile = session.putAttribute(requestFlowFile, EXCEPTION_MESSAGE, e.getMessage());
                 // transfer original to failure
                 session.transfer(requestFlowFile, REL_FAILURE);
             } else {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
@@ -184,6 +184,31 @@ public class TestInvokeHTTP extends TestInvokeHttpCommon {
         bundle1.assertAttributeEquals("Content-Type", "text/plain;charset=iso-8859-1");
     }
 
+    @Test
+    public void testFailingHttpRequest() throws Exception {
+
+        runner = TestRunners.newTestRunner(InvokeHTTP.class);
+
+        // Remember: we expect that connecting to the following URL should raise a Java exception
+        runner.setProperty(InvokeHTTP.PROP_URL, "http://127.0.0.1:0");
+
+        createFlowFiles(runner);
+
+        runner.run();
+
+        runner.assertTransferCount(InvokeHTTP.REL_SUCCESS_REQ, 0);
+        runner.assertTransferCount(InvokeHTTP.REL_RESPONSE, 0);
+        runner.assertTransferCount(InvokeHTTP.REL_RETRY, 0);
+        runner.assertTransferCount(InvokeHTTP.REL_NO_RETRY, 0);
+        runner.assertTransferCount(InvokeHTTP.REL_FAILURE, 1);
+        runner.assertPenalizeCount(1);
+
+        // expected in request java.exception
+        final MockFlowFile bundle = runner.getFlowFilesForRelationship(InvokeHTTP.REL_FAILURE).get(0);
+        bundle.assertAttributeEquals(InvokeHTTP.EXCEPTION_CLASS, "java.lang.IllegalArgumentException");
+
+    }
+
     public static class MyProxyHandler extends AbstractHandler {
 
         @Override


### PR DESCRIPTION
Hi, 

I think this closes the Jira ticket. I couldn't execute (all) the tests as an SMTP tests fails on Windows (in my machine at least), but it fails on the master branch and on release 1.1.0 and 1.0.0 so I guess it's not due to the changes below.

I also have not added tests related to this. The test suite in nifi-standard-processors seemed quite thin, I'm probably missing something.

Disclaimer: I'm a data scientist that writes Python. I'm more than willing to learn (and help!) if things are not how they should be.