### PR TITLE
NIFI-3055 StandardRecordWriter Can Throw UTFDataFormatException (1.x)

### DIFF
--- a/nifi-commons/nifi-schema-utils/pom.xml
+++ b/nifi-commons/nifi-schema-utils/pom.xml
@@ -21,6 +21,11 @@
     </parent>
     <artifactId>nifi-schema-utils</artifactId>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/nifi-commons/nifi-schema-utils/src/main/java/org/apache/nifi/repository/schema/SchemaRecordWriter.java
+++ b/nifi-commons/nifi-schema-utils/src/main/java/org/apache/nifi/repository/schema/SchemaRecordWriter.java
@@ -150,8 +150,8 @@ public class SchemaRecordWriter {
             out.writeUTF(utfString);
         } catch (UTFDataFormatException e) {
             final String truncated = utfString.substring(0, getCharsInUTFLength(utfString, MAX_ALLOWED_UTF_LENGTH));
-            logger.warn("Truncating UTF value!  Attempted to write string with char length {} and UTF length greater than "
-                            + "supported maximum allowed ({}), truncating to char length {}.",
+            logger.warn("Truncating repository record value!  Attempted to write {} chars that encode to a UTF byte length greater than "
+                            + "supported maximum ({}), truncating to {} chars.",
                     utfString.length(), MAX_ALLOWED_UTF_LENGTH, truncated.length());
             if (logger.isDebugEnabled()) {
                 logger.warn("String value was:\n{}", truncated);

--- a/nifi-commons/nifi-schema-utils/src/main/java/org/apache/nifi/repository/schema/SchemaRecordWriter.java
+++ b/nifi-commons/nifi-schema-utils/src/main/java/org/apache/nifi/repository/schema/SchemaRecordWriter.java
@@ -17,15 +17,23 @@
 
 package org.apache.nifi.repository.schema;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UTFDataFormatException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public class SchemaRecordWriter {
+
+    public static final int MAX_ALLOWED_UTF_LENGTH = 65_535;
+
+    private static final Logger logger = LoggerFactory.getLogger(SchemaRecordWriter.class);
 
     public void writeRecord(final Record record, final OutputStream out) throws IOException {
         // write sentinel value to indicate that there is a record. This allows the reader to then read one
@@ -105,7 +113,7 @@ public class SchemaRecordWriter {
                 out.writeLong((Long) value);
                 break;
             case STRING:
-                out.writeUTF((String) value);
+                writeUTFLimited(out, (String) value);
                 break;
             case LONG_STRING:
                 final byte[] charArray = ((String) value).getBytes(StandardCharsets.UTF_8);
@@ -126,7 +134,7 @@ public class SchemaRecordWriter {
                 break;
             case UNION:
                 final NamedValue namedValue = (NamedValue) value;
-                out.writeUTF(namedValue.getName());
+                writeUTFLimited(out, namedValue.getName());
                 final Record childRecord = (Record) namedValue.getValue();
                 writeRecordFields(childRecord, out);
                 break;
@@ -136,4 +144,44 @@ public class SchemaRecordWriter {
                 break;
         }
     }
+
+    private void writeUTFLimited(final DataOutputStream out, final String utfString) throws IOException {
+        try {
+            out.writeUTF(utfString);
+        } catch (UTFDataFormatException e) {
+            final String truncated = utfString.substring(0, getCharsInUTFLength(utfString, MAX_ALLOWED_UTF_LENGTH));
+            logger.warn("Truncating UTF value!  Attempted to write string with char length {} and UTF length greater than "
+                            + "supported maximum allowed ({}), truncating to char length {}.",
+                    utfString.length(), MAX_ALLOWED_UTF_LENGTH, truncated.length());
+            if (logger.isDebugEnabled()) {
+                logger.warn("String value was:\n{}", truncated);
+            }
+            out.writeUTF(truncated);
+        }
+    }
+
+
+    static int getCharsInUTFLength(final String str, final int utfLimit) {
+        // see java.io.DataOutputStream.writeUTF()
+        int strlen = str.length();
+        int utflen = 0;
+        int c;
+
+        /* use charAt instead of copying String to Char array */
+        for (int i = 0; i < strlen; i++) {
+            c = str.charAt(i);
+            if ((c >= 0x0001) & (c <= 0x007F)) {
+                utflen++;
+            } else if (c > 0x07FF) {
+                utflen += 3;
+            } else {
+                utflen += 2;
+            }
+            if (utflen > utfLimit) {
+                return i;
+            }
+        }
+        return strlen;
+    }
+
 }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
@@ -58,5 +58,10 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/StandardRecordWriter.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/StandardRecordWriter.java
@@ -204,8 +204,8 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
             out.writeUTF(utfString);
         } catch (UTFDataFormatException e) {
             final String truncated = utfString.substring(0, getCharsInUTFLength(utfString, MAX_ALLOWED_UTF_LENGTH));
-            logger.warn("Truncating UTF value!  Attempted to write string with char length {} and UTF length greater than "
-                            + "supported maximum allowed ({}), truncating to char length {}.",
+            logger.warn("Truncating repository record value!  Attempted to write {} chars that encode to a UTF byte length greater than "
+                            + "supported maximum ({}), truncating to {} chars.",
                     utfString.length(), MAX_ALLOWED_UTF_LENGTH, truncated.length());
             if (logger.isDebugEnabled()) {
                 logger.warn("String value was:\n{}", truncated);

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/StandardRecordWriter.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/StandardRecordWriter.java
@@ -19,6 +19,7 @@ package org.apache.nifi.provenance;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UTFDataFormatException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -34,6 +35,9 @@ import org.slf4j.LoggerFactory;
  */
 @Deprecated
 public class StandardRecordWriter extends CompressableRecordWriter implements RecordWriter {
+
+    public static final int MAX_ALLOWED_UTF_LENGTH = 65_535;
+
     private static final Logger logger = LoggerFactory.getLogger(StandardRecordWriter.class);
     public static final int SERIALIZATION_VERISON = 9;
     public static final String SERIALIZATION_NAME = "org.apache.nifi.provenance.PersistentProvenanceRepository";
@@ -72,7 +76,7 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
         final ProvenanceEventType recordType = record.getEventType();
 
         out.writeLong(recordIdentifier);
-        out.writeUTF(record.getEventType().name());
+        writeUTFLimited(out, record.getEventType().name());
         out.writeLong(record.getEventTime());
         out.writeLong(record.getFlowFileEntryDate());
         out.writeLong(record.getEventDuration());
@@ -101,9 +105,9 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
         // If Content Claim Info is present, write out a 'TRUE' followed by claim info. Else, write out 'false'.
         if (record.getContentClaimSection() != null && record.getContentClaimContainer() != null && record.getContentClaimIdentifier() != null) {
             out.writeBoolean(true);
-            out.writeUTF(record.getContentClaimContainer());
-            out.writeUTF(record.getContentClaimSection());
-            out.writeUTF(record.getContentClaimIdentifier());
+            writeUTFLimited(out, record.getContentClaimContainer());
+            writeUTFLimited(out, record.getContentClaimSection());
+            writeUTFLimited(out, record.getContentClaimIdentifier());
             if (record.getContentClaimOffset() == null) {
                 out.writeLong(0L);
             } else {
@@ -117,9 +121,9 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
         // If Previous Content Claim Info is present, write out a 'TRUE' followed by claim info. Else, write out 'false'.
         if (record.getPreviousContentClaimSection() != null && record.getPreviousContentClaimContainer() != null && record.getPreviousContentClaimIdentifier() != null) {
             out.writeBoolean(true);
-            out.writeUTF(record.getPreviousContentClaimContainer());
-            out.writeUTF(record.getPreviousContentClaimSection());
-            out.writeUTF(record.getPreviousContentClaimIdentifier());
+            writeUTFLimited(out, record.getPreviousContentClaimContainer());
+            writeUTFLimited(out, record.getPreviousContentClaimSection());
+            writeUTFLimited(out, record.getPreviousContentClaimIdentifier());
             if (record.getPreviousContentClaimOffset() == null) {
                 out.writeLong(0L);
             } else {
@@ -157,7 +161,7 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
     }
 
     protected void writeUUID(final DataOutputStream out, final String uuid) throws IOException {
-        out.writeUTF(uuid);
+        writeUTFLimited(out, uuid);
     }
 
     protected void writeUUIDs(final DataOutputStream out, final Collection<String> list) throws IOException {
@@ -176,7 +180,7 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(toWrite);
+            writeUTFLimited(out, toWrite);
         }
     }
 
@@ -194,6 +198,45 @@ public class StandardRecordWriter extends CompressableRecordWriter implements Re
         out.writeInt(bytes.length);
         out.write(bytes);
     }
+
+    private void writeUTFLimited(final java.io.DataOutputStream out, final String utfString) throws IOException {
+        try {
+            out.writeUTF(utfString);
+        } catch (UTFDataFormatException e) {
+            final String truncated = utfString.substring(0, getCharsInUTFLength(utfString, MAX_ALLOWED_UTF_LENGTH));
+            logger.warn("Truncating UTF value!  Attempted to write string with char length {} and UTF length greater than "
+                            + "supported maximum allowed ({}), truncating to char length {}.",
+                    utfString.length(), MAX_ALLOWED_UTF_LENGTH, truncated.length());
+            if (logger.isDebugEnabled()) {
+                logger.warn("String value was:\n{}", truncated);
+            }
+            out.writeUTF(truncated);
+        }
+    }
+
+    static int getCharsInUTFLength(final String str, final int utfLimit) {
+        // see java.io.DataOutputStream.writeUTF()
+        int strlen = str.length();
+        int utflen = 0;
+        int c;
+
+        /* use charAt instead of copying String to Char array */
+        for (int i = 0; i < strlen; i++) {
+            c = str.charAt(i);
+            if ((c >= 0x0001) & (c <= 0x007F)) {
+                utflen++;
+            } else if (c > 0x07FF) {
+                utflen += 3;
+            } else {
+                utflen += 2;
+            }
+            if (utflen > utfLimit) {
+                return i;
+            }
+        }
+        return strlen;
+    }
+
 
 
     @Override


### PR DESCRIPTION
* Updated StandardRecordWriter, even though it is now deprecated to consider the encoding behavior of java.io.DataOutputStream.writeUTF() and truncate string values such that the UTF representation will not be longer than that DataOutputStream's 64K UTF format limit.
* Updated the new SchemaRecordWriter class to similarly truncate long Strings that will be written as UTF.
* Add tests to confirm handling of large UTF strings and various edge conditions of UTF string handling.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
