### PR TITLE
NIFI-1125 InvokeHTTP throws NullPointerException

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -460,7 +460,7 @@ public final class InvokeHTTP extends AbstractProcessor {
         } else {
             // compile the attributes-to-send filter pattern
             if (PROP_ATTRIBUTES_TO_SEND.getName().equalsIgnoreCase(descriptor.getName())) {
-                if (newValue.isEmpty()) {
+                if (newValue == null || newValue.isEmpty()) {
                     regexAttributesToSend = null;
                 } else {
                     final String trimmedValue = StringUtils.trimToEmpty(newValue);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHTTP.java
@@ -34,9 +34,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 
 public class TestInvokeHTTP extends TestInvokeHttpCommon {
@@ -206,5 +210,31 @@ public class TestInvokeHTTP extends TestInvokeHttpCommon {
                 response.setContentLength(0);
             }
         }
+    }
+
+    @Test
+    public void testOnPropertyModified() throws Exception {
+        final InvokeHTTP processor = new InvokeHTTP();
+        final Field regexAttributesToSendField = InvokeHTTP.class.getDeclaredField("regexAttributesToSend");
+        regexAttributesToSendField.setAccessible(true);
+
+        assertNull(regexAttributesToSendField.get(processor));
+
+        // Set Attributes to Send.
+        processor.onPropertyModified(InvokeHTTP.PROP_ATTRIBUTES_TO_SEND, null, "uuid");
+        assertNotNull(regexAttributesToSendField.get(processor));
+
+        // Null clear Attributes to Send. NIFI-1125: Throws NullPointerException.
+        processor.onPropertyModified(InvokeHTTP.PROP_ATTRIBUTES_TO_SEND, "uuid", null);
+        assertNull(regexAttributesToSendField.get(processor));
+
+        // Set Attributes to Send.
+        processor.onPropertyModified(InvokeHTTP.PROP_ATTRIBUTES_TO_SEND, null, "uuid");
+        assertNotNull(regexAttributesToSendField.get(processor));
+
+        // Clear Attributes to Send with empty string.
+        processor.onPropertyModified(InvokeHTTP.PROP_ATTRIBUTES_TO_SEND, "uuid", "");
+        assertNull(regexAttributesToSendField.get(processor));
+
     }
 }


### PR DESCRIPTION
Added null check in onPropertyModified to avoid NPE.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
