### PR TITLE
NIFI-3251: Addressing JS error preventing CS table loading

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
@@ -678,10 +678,10 @@ nf.ControllerServices = (function () {
                 if (dataContext.component.persistsState === true) {
                     markup += '<div title="View State" class="pointer view-state-controller-service fa fa-tasks" style="margin-top: 2px; margin-right: 3px;" ></div>';
                 }
-            }
 
-            if (dataContext.permissions.canWrite && canWriteControllerServiceParent(dataContext)) {
-                markup += '<div class="pointer delete-controller-service fa fa-trash" title="Remove" style="margin-top: 2px; margin-right: 3px;" ></div>';
+                if (canWriteControllerServiceParent(dataContext)) {
+                    markup += '<div class="pointer delete-controller-service fa fa-trash" title="Remove" style="margin-top: 2px; margin-right: 3px;" ></div>';
+                }
             }
 
             // allow policy configuration conditionally


### PR DESCRIPTION
NIFI-3251:
- Ensuring read permissions to the ControllerService before attempting to check permissions to parent.