### PR TITLE
NIFI-3454 Tests should consistently use the FileNameFilter when reading file names from directories

### DIFF
--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
@@ -86,7 +86,7 @@ public class TestClassLoaderUtils {
     @Test
     public void testGetURLsForClasspathWithDirectory() throws MalformedURLException {
         final String jarFilePath = "src/test/resources/TestClassLoaderUtils";
-        URL[] urls = ClassLoaderUtils.getURLsForClasspath(jarFilePath, null, false);
+        URL[] urls = ClassLoaderUtils.getURLsForClasspath(jarFilePath, getJarFilenameFilter(), false);
         assertEquals(2, urls.length);
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
@@ -38,7 +38,7 @@ public class TestIdentifyMimeType {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
         final File dir = new File("src/test/resources/TestIdentifyMimeType");
-        final File[] files = dir.listFiles();
+        final File[] files = dir.listFiles((ldir,name)-> name != null && !name.startsWith("."));
         int fileCount = 0;
         for (final File file : files) {
             if (file.isDirectory()) {


### PR DESCRIPTION
Tests that work with getting files from directories ( either doing listings or building URLs for the classloader ) should use the FileNameFilter to ensure unwanted files don't fowl the tests.

As an example, on Mac OS .DS_Store files will break some tests if present

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.