### PR TITLE
NIFI-2565 - Add Elastic copyright to notice due to the use of grok patterns during test

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/src/main/resources/META-INF/NOTICE
@@ -5,6 +5,10 @@ This includes derived works from the Apache Software License V2 library Jolt (ht
 Copyright 2013-2014 Bazaarvoice, Inc
 The derived work is adapted from com.bazaarvoice.jolt.chainr.ChainrBuilder.java, com.bazaarvoice.jolt.chainr.spec.ChainrSpec.java, com.bazaarvoice.jolt.chainr.spec.ChainrEntry.java and can be found in the org.apache.nifi.processors.standard.util.jolt.TransformFactory.java class.
 
+This includes derived works from Elastic Logstash (https://github.com/elastic/logstash/tree/v1.4.0/) and modified by Anthony Corbacho, and contributors.
+Copyright 2009-2013 Jordan Sissel, Pete Fritchman, and contributors.
+Copyright 2014 Anthony Corbacho, and contributors.
+The derived work consists in modifications from patterns/grok-patterns and found in the file nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestExtractGrok/patterns
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
since the patterns used during testing were originally defined here

https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/grok-patterns

I also added the notice to the bundle - which is sort of ironic given the patterns are scoped for test only and not bundled (Code is released under ASLv2)

Happy to close the PR if you think it is not necessary