### PR TITLE
NIFI-3362 update FlowConfiguration.xsd to allow all current time period units

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -35,8 +35,8 @@ public class FormatUtils {
     private static final double BYTES_IN_TERABYTE = BYTES_IN_GIGABYTE * 1024;
 
     // for Time Durations
-    private static final String NANOS = join(UNION, "ns", "nano", "nanos", "nanoseconds");
-    private static final String MILLIS = join(UNION, "ms", "milli", "millis", "milliseconds");
+    private static final String NANOS = join(UNION, "ns", "nano", "nanos", "nanosecond", "nanoseconds");
+    private static final String MILLIS = join(UNION, "ms", "milli", "millis", "millisecond", "milliseconds");
     private static final String SECS = join(UNION, "s", "sec", "secs", "second", "seconds");
     private static final String MINS = join(UNION, "m", "min", "mins", "minute", "minutes");
     private static final String HOURS = join(UNION, "h", "hr", "hrs", "hour", "hours");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/FlowConfiguration.xsd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/FlowConfiguration.xsd
@@ -302,7 +302,7 @@
 
     <xs:simpleType name="TimePeriod">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\d+\s*(ns|nano|nanos|nanoseconds|ms|milli|millis|milliseconds|s|sec|secs|seconds|m|min|mins|minutes|h|hr|hrs|hours|d|day|days)"></xs:pattern>
+            <xs:pattern value="\d+\s*(ns|nano|nanos|nanosecond|nanoseconds|ms|milli|millis|millisecond|milliseconds|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|wk|wks|week|weeks)"></xs:pattern>
         </xs:restriction>
     </xs:simpleType>
 	


### PR DESCRIPTION
@apiri I pulled out the new unit test that was in master from this 0.x PR.  I would have needed a new flow.xml for the unit test to validate.  I didn't feel it was critical to include the test in 0.x considering that we have it in master, moving forward.  Please let me know if you disagree, and I will amend this PR.  Thanks!