### PR TITLE
NIFI-2714 Added regex support to ConsumeKafka_0_10

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -25,7 +25,7 @@
     <properties>
       <kafka8.version>0.8.2.2</kafka8.version>
       <kafka9.version>0.9.0.1</kafka9.version>
-      <kafka10.version>0.10.0.1</kafka10.version>
+      <kafka10.version>0.10.1.1</kafka10.version>
     </properties>
 
     <modules>
@@ -54,5 +54,5 @@
                 <version>1.2.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
-    </dependencyManagement> 
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
Enabled the ability to specify topics as a regular expression as natively supported in the Kafka client.  The current ConsumeKafka* modules only support the topic name as a single string or list of strings.  The regex (Pattern object) format is much more flexible.

This is implemented with a new PropertyDescriptor to differentiate between string name(s) and patterns, defaulting to the existing string(s).  It might be possible to automatically identify strings or patterns, but since some strings are also valid regex patterns with slightly different meanings it seems safer to set a property -- as @joewitt commented on this ticket in Aug. 2016.

Updated Kafka client from 0.10.0.1 to 0.10.1.1

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
