### PR TITLE
NIFI-3517 If HandleHttpResponse cannot write response remove entry from HttpContextMap

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
@@ -165,6 +165,11 @@ public class HandleHttpResponse extends AbstractProcessor {
         try {
             session.exportTo(flowFile, response.getOutputStream());
             response.flushBuffer();
+        } catch (final ProcessException e) {
+            session.transfer(flowFile, REL_FAILURE);
+            getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, e});
+            contextMap.complete(contextIdentifier);
+            return;
         } catch (final Exception e) {
             session.transfer(flowFile, REL_FAILURE);
             getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, e});

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHandleHttpResponse.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHandleHttpResponse.java
@@ -39,6 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.http.HttpContextMap;
 import org.apache.nifi.processor.exception.FlowFileAccessException;
+import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.standard.util.HTTPUtils;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.reporting.InitializationException;
@@ -56,7 +57,7 @@ public class TestHandleHttpResponse {
     public void testEnsureCompleted() throws InitializationException {
         final TestRunner runner = TestRunners.newTestRunner(HandleHttpResponse.class);
 
-        final MockHttpContextMap contextMap = new MockHttpContextMap("my-id", false);
+        final MockHttpContextMap contextMap = new MockHttpContextMap("my-id", "");
         runner.addControllerService("http-context-map", contextMap);
         runner.enableControllerService(contextMap);
         runner.setProperty(HandleHttpResponse.HTTP_CONTEXT_MAP, "http-context-map");
@@ -95,7 +96,7 @@ public class TestHandleHttpResponse {
     public void testWithExceptionThrown() throws InitializationException {
         final TestRunner runner = TestRunners.newTestRunner(HandleHttpResponse.class);
 
-        final MockHttpContextMap contextMap = new MockHttpContextMap("my-id", true);
+        final MockHttpContextMap contextMap = new MockHttpContextMap("my-id", "FlowFileAccessException");
         runner.addControllerService("http-context-map", contextMap);
         runner.enableControllerService(contextMap);
         runner.setProperty(HandleHttpResponse.HTTP_CONTEXT_MAP, "http-context-map");
@@ -113,6 +114,32 @@ public class TestHandleHttpResponse {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(HandleHttpResponse.REL_FAILURE, 1);
+        assertEquals(0, contextMap.getCompletionCount());
+    }
+
+    @Test
+    public void testCannotWriteResponse() throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(HandleHttpResponse.class);
+
+        final MockHttpContextMap contextMap = new MockHttpContextMap("my-id", "ProcessException");
+        runner.addControllerService("http-context-map", contextMap);
+        runner.enableControllerService(contextMap);
+        runner.setProperty(HandleHttpResponse.HTTP_CONTEXT_MAP, "http-context-map");
+        runner.setProperty(HandleHttpResponse.STATUS_CODE, "${status.code}");
+        runner.setProperty("my-attr", "${my-attr}");
+        runner.setProperty("no-valid-attr", "${no-valid-attr}");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(HTTPUtils.HTTP_CONTEXT_ID, "my-id");
+        attributes.put("my-attr", "hello");
+        attributes.put("status.code", "201");
+
+        runner.enqueue("hello".getBytes(), attributes);
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(HandleHttpResponse.REL_FAILURE, 1);
+        assertEquals(1, contextMap.getCompletionCount());
     }
 
     private static class MockHttpContextMap extends AbstractControllerService implements HttpContextMap {
@@ -121,14 +148,14 @@ public class TestHandleHttpResponse {
         private final AtomicInteger completedCount = new AtomicInteger(0);
         private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         private final ConcurrentMap<String, String> headersSent = new ConcurrentHashMap<>();
-        private final boolean shouldThrowException;
+        private final String shouldThrowExceptionClass;
         private volatile int statusCode = -1;
 
         private final List<String> headersWithNoValue = new CopyOnWriteArrayList<>();
 
-        public MockHttpContextMap(final String expectedIdentifier, final boolean shouldThrowException) {
+        public MockHttpContextMap(final String expectedIdentifier, final String shouldThrowExceptionClass) {
             this.id = expectedIdentifier;
-            this.shouldThrowException = shouldThrowException;
+            this.shouldThrowExceptionClass = shouldThrowExceptionClass;
         }
 
         @Override
@@ -144,8 +171,10 @@ public class TestHandleHttpResponse {
 
             try {
                 final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-                if(shouldThrowException) {
+                if(shouldThrowExceptionClass != null && shouldThrowExceptionClass.equals("FlowFileAccessException")) {
                     Mockito.when(response.getOutputStream()).thenThrow(new FlowFileAccessException("exception"));
+                } else if(shouldThrowExceptionClass != null && shouldThrowExceptionClass.equals("ProcessException")) {
+                        Mockito.when(response.getOutputStream()).thenThrow(new ProcessException("exception"));
                 } else {
                     Mockito.when(response.getOutputStream()).thenReturn(new ServletOutputStream() {
                         @Override


### PR DESCRIPTION
* Add test for failure not clear context map.
* Add handler to remove context map entry if ProcessException occurs during while exporting response.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
