### PR TITLE
NIFI-3246: Prevent editing of inherited Controller Services

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/process-group-configuration.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/process-group-configuration.jsp
@@ -28,6 +28,7 @@
                 <div id="general-process-group-configuration">
                     <div class="setting">
                         <div class="setting-name">Process group name</div>
+                        <span id="process-group-id" class="hidden"></span>
                         <div class="editable setting-field">
                             <input type="text" id="process-group-name" class="setting-input"/>
                         </div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-process-group-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-process-group-configuration.js
@@ -151,6 +151,23 @@
             }
         };
 
+        // record the group id
+        $('#process-group-id').text(groupId);
+
+        // update the click listener
+        $('#process-group-configuration-refresh-button').off('click').on('click', function () {
+            loadConfiguration(groupId);
+        });
+
+        // update the new controller service click listener
+        $('#add-process-group-configuration-controller-service').off('click').on('click', function () {
+            var selectedTab = $('#process-group-configuration-tabs li.selected-tab').text();
+            if (selectedTab === 'Controller Services') {
+                var controllerServicesUri = config.urls.api + '/process-groups/' + encodeURIComponent(groupId) + '/controller-services';
+                nfControllerServices.promptNewControllerService(controllerServicesUri, getControllerServicesTable());
+            }
+        });
+
         var processGroup = $.Deferred(function (deferred) {
             $.ajax({
                 type: 'GET',
@@ -164,7 +181,6 @@
                     var processGroup = response.component;
 
                     // populate the process group settings
-                    $('#process-group-id').text(processGroup.id);
                     $('#process-group-name').removeClass('unset').val(processGroup.name);
                     $('#process-group-comments').removeClass('unset').val(processGroup.comments);
 
@@ -253,6 +269,7 @@
         $('#process-group-configuration-save').mouseout();
 
         // reset the fields
+        $('#process-group-id').text('');
         $('#process-group-name').val('');
         $('#process-group-comments').val('');
 
@@ -330,21 +347,6 @@
          * Shows the settings dialog.
          */
         showConfiguration: function (groupId) {
-            // update the click listener
-            $('#process-group-configuration-refresh-button').off('click').on('click', function () {
-                loadConfiguration(groupId);
-            });
-
-            // update the new controller service click listener
-            $('#add-process-group-configuration-controller-service').off('click').on('click', function () {
-                var selectedTab = $('#process-group-configuration-tabs li.selected-tab').text();
-                if (selectedTab === 'Controller Services') {
-                    var controllerServicesUri = config.urls.api + '/process-groups/' + encodeURIComponent(groupId) + '/controller-services';
-                    nfControllerServices.promptNewControllerService(controllerServicesUri, getControllerServicesTable());
-                }
-            });
-
-            // load the configuration
             return loadConfiguration(groupId).done(showConfiguration);
         },
 


### PR DESCRIPTION
NIFI-3246:
- Preventing the editing of controller services that are defined in an ancestor process group.
- Adding a go to link for users to easily navigate to where services are actually defined.