### PR TITLE
NIFI-3609: ConnectWebSocket auto session recovery

### DIFF
--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/AbstractWebSocketService.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/AbstractWebSocketService.java
@@ -45,9 +45,4 @@ public abstract class AbstractWebSocketService extends AbstractControllerService
         routers.sendMessage(endpointId, sessionId, sendMessage);
     }
 
-    @Override
-    public void disconnect(final String endpointId, final String sessionId, final String reason) throws IOException, WebSocketConfigurationException {
-        routers.disconnect(endpointId, sessionId, reason);
-    }
-
 }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketMessageRouter.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketMessageRouter.java
@@ -124,4 +124,8 @@ public class WebSocketMessageRouter {
         sessions.remove(sessionId);
     }
 
+    public boolean containsSession(final String sessionId) {
+        return sessions.containsKey(sessionId);
+    }
+
 }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketMessageRouters.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketMessageRouters.java
@@ -59,17 +59,13 @@ public class WebSocketMessageRouters {
 
     public synchronized void deregisterProcessor(final String endpointId, final Processor processor) throws WebSocketConfigurationException {
         final WebSocketMessageRouter router = getRouterOrFail(endpointId);
+        routers.remove(endpointId);
         router.deregisterProcessor(processor);
     }
 
     public void sendMessage(final String endpointId, final String sessionId, final SendMessage sendMessage) throws IOException, WebSocketConfigurationException {
         final WebSocketMessageRouter router = getRouterOrFail(endpointId);
         router.sendMessage(sessionId, sendMessage);
-    }
-
-    public void disconnect(final String endpointId, final String sessionId, final String reason) throws IOException, WebSocketConfigurationException {
-        final WebSocketMessageRouter router = getRouterOrFail(endpointId);
-        router.disconnect(sessionId, reason);
     }
 
 }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketService.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketService.java
@@ -45,6 +45,4 @@ public interface WebSocketService extends ControllerService {
 
     void sendMessage(final String endpointId, final String sessionId, final SendMessage sendMessage) throws IOException, WebSocketConfigurationException;
 
-    void disconnect(final String endpointId, final String sessionId, final String reason) throws Exception;
-
 }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
@@ -90,7 +90,12 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
     public static final PropertyDescriptor SESSION_MAINTENANCE_INTERVAL = new PropertyDescriptor.Builder()
             .name("session-maintenance-interval")
             .displayName("Session Maintenance Interval")
-            .description("The interval between session maintenance activities.")
+            .description("The interval between session maintenance activities." +
+                    " A WebSocket session established with a WebSocket server can be terminated due to different reasons" +
+                    " including restarting the WebSocket server or timing out inactive sessions." +
+                    " This session maintenance activity is periodically executed in order to reconnect those lost sessions," +
+                    " so that a WebSocket client can reuse the same session id transparently after it reconnects successfully. " +
+                    " The maintenance activity is executed until corresponding processors or this controller service is stopped.")
             .required(true)
             .expressionLanguageSupported(true)
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
@@ -238,10 +243,11 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
                 }
 
                 final String sessionId = activeSessions.get(clientId);
-                // If this session is stil alive, do nothing.
+                // If this session is still alive, do nothing.
                 if (!router.containsSession(sessionId)) {
                     // This session is no longer active, reconnect it.
                     // If it fails, the sessionId will remain in activeSessions, and retries later.
+                    // This reconnect attempt is continued until user explicitly stops a processor or this controller service.
                     connect(clientId, sessionId);
                 }
             }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/RoutingWebSocketListener.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/RoutingWebSocketListener.java
@@ -33,7 +33,11 @@ public class RoutingWebSocketListener extends WebSocketAdapter {
     @Override
     public void onWebSocketConnect(final Session session) {
         super.onWebSocketConnect(session);
-        sessionId = UUID.randomUUID().toString();
+        if (sessionId == null || sessionId.isEmpty()) {
+            // If sessionId is already assigned to this instance, don't publish new one.
+            // So that existing sesionId can be reused when reconnecting.
+            sessionId = UUID.randomUUID().toString();
+        }
         final JettyWebSocketSession webSocketSession = new JettyWebSocketSession(sessionId, session);
         router.captureSession(webSocketSession);
     }
@@ -52,5 +56,13 @@ public class RoutingWebSocketListener extends WebSocketAdapter {
     @Override
     public void onWebSocketBinary(final byte[] payload, final int offset, final int len) {
         router.onWebSocketBinary(sessionId, payload, offset, len);
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
     }
 }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/ControllerServiceTestContext.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/ControllerServiceTestContext.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.websocket;
+package org.apache.nifi.websocket.jetty;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketClient.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketClient.java
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.websocket;
+package org.apache.nifi.websocket.jetty;
 
 import org.apache.nifi.components.ValidationResult;
-import org.apache.nifi.websocket.jetty.JettyWebSocketServer;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -25,27 +24,39 @@ import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 
 
-public class TestJettyWebSocketServer {
+public class TestJettyWebSocketClient {
 
     @Test
     public void testValidationRequiredProperties() throws Exception {
-        final JettyWebSocketServer service = new JettyWebSocketServer();
+        final JettyWebSocketClient service = new JettyWebSocketClient();
         final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
         service.initialize(context.getInitializationContext());
         final Collection<ValidationResult> results = service.validate(context.getValidationContext());
         assertEquals(1, results.size());
         final ValidationResult result = results.iterator().next();
-        assertEquals(JettyWebSocketServer.LISTEN_PORT.getDisplayName(), result.getSubject());
+        assertEquals(JettyWebSocketClient.WS_URI.getDisplayName(), result.getSubject());
     }
 
     @Test
     public void testValidationSuccess() throws Exception {
-        final JettyWebSocketServer service = new JettyWebSocketServer();
+        final JettyWebSocketClient service = new JettyWebSocketClient();
         final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
-        context.setCustomValue(JettyWebSocketServer.LISTEN_PORT, "9001");
+        context.setCustomValue(JettyWebSocketClient.WS_URI, "ws://localhost:9001/test");
         service.initialize(context.getInitializationContext());
         final Collection<ValidationResult> results = service.validate(context.getValidationContext());
         assertEquals(0, results.size());
+    }
+
+    @Test
+    public void testValidationProtocol() throws Exception {
+        final JettyWebSocketClient service = new JettyWebSocketClient();
+        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
+        context.setCustomValue(JettyWebSocketClient.WS_URI, "http://localhost:9001/test");
+        service.initialize(context.getInitializationContext());
+        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
+        assertEquals(1, results.size());
+        final ValidationResult result = results.iterator().next();
+        assertEquals(JettyWebSocketClient.WS_URI.getName(), result.getSubject());
     }
 
 }

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketSecureCommunication.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketSecureCommunication.java
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.websocket;
+package org.apache.nifi.websocket.jetty;
 
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.ssl.StandardSSLContextService;
+import org.apache.nifi.websocket.WebSocketService;
 import org.junit.Test;
 
 

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.websocket;
+package org.apache.nifi.websocket.jetty;
 
 import org.apache.nifi.components.ValidationResult;
-import org.apache.nifi.websocket.jetty.JettyWebSocketClient;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -25,39 +24,27 @@ import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 
 
-public class TestJettyWebSocketClient {
+public class TestJettyWebSocketServer {
 
     @Test
     public void testValidationRequiredProperties() throws Exception {
-        final JettyWebSocketClient service = new JettyWebSocketClient();
+        final JettyWebSocketServer service = new JettyWebSocketServer();
         final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
         service.initialize(context.getInitializationContext());
         final Collection<ValidationResult> results = service.validate(context.getValidationContext());
         assertEquals(1, results.size());
         final ValidationResult result = results.iterator().next();
-        assertEquals(JettyWebSocketClient.WS_URI.getDisplayName(), result.getSubject());
+        assertEquals(JettyWebSocketServer.LISTEN_PORT.getDisplayName(), result.getSubject());
     }
 
     @Test
     public void testValidationSuccess() throws Exception {
-        final JettyWebSocketClient service = new JettyWebSocketClient();
+        final JettyWebSocketServer service = new JettyWebSocketServer();
         final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
-        context.setCustomValue(JettyWebSocketClient.WS_URI, "ws://localhost:9001/test");
+        context.setCustomValue(JettyWebSocketServer.LISTEN_PORT, "9001");
         service.initialize(context.getInitializationContext());
         final Collection<ValidationResult> results = service.validate(context.getValidationContext());
         assertEquals(0, results.size());
-    }
-
-    @Test
-    public void testValidationProtocol() throws Exception {
-        final JettyWebSocketClient service = new JettyWebSocketClient();
-        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
-        context.setCustomValue(JettyWebSocketClient.WS_URI, "http://localhost:9001/test");
-        service.initialize(context.getInitializationContext());
-        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
-        assertEquals(1, results.size());
-        final ValidationResult result = results.iterator().next();
-        assertEquals(JettyWebSocketClient.WS_URI.getName(), result.getSubject());
     }
 
 }


### PR DESCRIPTION
Before this fix, ConnectWebSocket has to be restarted manually if its target WebSocket server restarted, or session expiration if there's no communication more than certain period of time (looks 3 min). This PR adds automatic session maintenance logic so that ConnectWebSocket keeps its session alive as long as it's running. 

- Removed unused disconnect method from WebSocketService interface.
- Added session maintenance background thread at JettyWebSocketClient
  which reconnects sessions those are still referred by ConnectWebSocket
  processor but no longer active.
- Added Session Maintenance Interval property to JettyWebSocketClient.
- Allowed specifying existing session id so that it can be recovered
  transparently.
- Moved test classes to appropriate package.
- Added test cases that verify the same session id can be used after
  WebSocket server restarts.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
