### PR TITLE
NIFI-3528 Added support for keytab/principal to Kafka 0.10 processors

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-10-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-10-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaTest.java
@@ -164,4 +164,29 @@ public class ConsumeKafkaTest {
         verifyNoMoreInteractions(mockLease);
     }
 
+    @Test
+    public void testJaasConfiguration() throws Exception {
+        ConsumeKafka_0_10 consumeKafka = new ConsumeKafka_0_10();
+        TestRunner runner = TestRunners.newTestRunner(consumeKafka);
+        runner.setProperty(KafkaProcessorUtils.BOOTSTRAP_SERVERS, "okeydokey:1234");
+        runner.setProperty(ConsumeKafka_0_10.TOPICS, "foo");
+        runner.setProperty(ConsumeKafka_0_10.GROUP_ID, "foo");
+        runner.setProperty(ConsumeKafka_0_10.AUTO_OFFSET_RESET, ConsumeKafka_0_10.OFFSET_EARLIEST);
+
+        runner.setProperty(KafkaProcessorUtils.SECURITY_PROTOCOL, KafkaProcessorUtils.SEC_SASL_PLAINTEXT);
+        runner.assertNotValid();
+
+        runner.setProperty(KafkaProcessorUtils.KERBEROS_PRINCIPLE, "kafka");
+        runner.assertValid();
+
+        runner.setProperty(KafkaProcessorUtils.USER_PRINCIPAL, "nifi@APACHE.COM");
+        runner.assertNotValid();
+
+        runner.setProperty(KafkaProcessorUtils.USER_KEYTAB, "not.A.File");
+        runner.assertNotValid();
+
+        runner.setProperty(KafkaProcessorUtils.USER_KEYTAB, "src/test/resources/server.properties");
+        runner.assertValid();
+    }
+
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -25,7 +25,7 @@
     <properties>
       <kafka8.version>0.8.2.2</kafka8.version>
       <kafka9.version>0.9.0.1</kafka9.version>
-      <kafka10.version>0.10.0.1</kafka10.version>
+      <kafka10.version>0.10.2.0</kafka10.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [X] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

==================================================

At the moment, it is not possible to have multi-tenancy when using Kafka processors: a single JAAS configuration file must be set in JVM variables to allow communication with Kerberos enabled Kafka cluster. Since the release of Kafka client 0.10.2, this has been improved and it gives the possibility to define a Login Module at processor level.

Here is a summary of the tests performed: on a standalone NiFi instance, only the ``krb5.conf`` file path has been set in ``nifi.properties``. And the following workflow has been used:

<img width="1009" alt="screen shot 2017-03-21 at 4 06 44 pm" src="https://cloud.githubusercontent.com/assets/11541012/24154067/7546606a-0e50-11e7-9502-d6607fd3f3fd.png">

Each Publish/Consume is using its own pair of user keytab/principal and consume/publish from/to a queue where correct ACLs have been set for the corresponding users. By looking at the audit logs, we can confirm that the authentication on each queue is correctly performed and that we have the expected behavior.

At the moment, I used the following JAAS input as the standard:
````
    KafkaClient {
       com.sun.security.auth.module.Krb5LoginModule required
       useTicketCache=false
       renewTicket=true
       serviceName="kafka"
       useKeyTab=true
       keyTab="/path/to/keytab"
       principal="principal@EXAMPLE.COM";
    };
````
and I only exposed the keytab and principal as new properties. The other properties are not exposed but that's something we could add if necessary/useful.
