### PR TITLE
NIFI-3657: Fix HTTP S2S to use local address.

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/AbstractSiteToSiteClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/AbstractSiteToSiteClient.java
@@ -33,7 +33,7 @@ public abstract class AbstractSiteToSiteClient implements SiteToSiteClient {
         siteInfoProvider.setConnectTimeoutMillis(commsTimeout);
         siteInfoProvider.setReadTimeoutMillis(commsTimeout);
         siteInfoProvider.setProxy(config.getHttpProxy());
-
+        siteInfoProvider.setLocalAddress(config.getLocalAddress());
     }
 
     @Override

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteInfoProvider.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteInfoProvider.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.remote.client;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ public class SiteInfoProvider {
     private Boolean siteToSiteSecure;
     private long remoteRefreshTime;
     private HttpProxy proxy;
+    private InetAddress localAddress;
 
     private final Map<String, String> inputPortMap = new HashMap<>(); // map input port name to identifier
     private final Map<String, String> outputPortMap = new HashMap<>(); // map output port name to identifier
@@ -63,8 +65,6 @@ public class SiteInfoProvider {
         final ControllerDTO controller;
         final URI connectedClusterUrl;
         try (final SiteToSiteRestApiClient apiClient = createSiteToSiteRestApiClient(sslContext, proxy)) {
-            apiClient.setConnectTimeoutMillis(connectTimeoutMillis);
-            apiClient.setReadTimeoutMillis(readTimeoutMillis);
             controller = apiClient.getController(clusterUrls);
             try {
                 connectedClusterUrl = new URI(apiClient.getBaseUrl());
@@ -100,7 +100,11 @@ public class SiteInfoProvider {
     }
 
     protected SiteToSiteRestApiClient createSiteToSiteRestApiClient(final SSLContext sslContext, final HttpProxy proxy) {
-        return new SiteToSiteRestApiClient(sslContext, proxy, EventReporter.NO_OP);
+        final SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, proxy, EventReporter.NO_OP);
+        apiClient.setConnectTimeoutMillis(connectTimeoutMillis);
+        apiClient.setReadTimeoutMillis(readTimeoutMillis);
+        apiClient.setLocalAddress(localAddress);
+        return apiClient;
     }
 
     public boolean isWebInterfaceSecure() {
@@ -270,5 +274,9 @@ public class SiteInfoProvider {
 
     public void setProxy(HttpProxy proxy) {
         this.proxy = proxy;
+    }
+
+    public void setLocalAddress(InetAddress localAddress) {
+        this.localAddress = localAddress;
     }
 }

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
@@ -106,6 +106,7 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
             final int timeoutMillis = (int) config.getTimeout(TimeUnit.MILLISECONDS);
             apiClient.setConnectTimeoutMillis(timeoutMillis);
             apiClient.setReadTimeoutMillis(timeoutMillis);
+            apiClient.setLocalAddress(config.getLocalAddress());
 
             final Collection<PeerDTO> peers = apiClient.getPeers();
             if(peers == null || peers.size() == 0){
@@ -153,6 +154,7 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
             apiClient.setBaseUrl(peer.getUrl());
             apiClient.setConnectTimeoutMillis(timeoutMillis);
             apiClient.setReadTimeoutMillis(timeoutMillis);
+            apiClient.setLocalAddress(config.getLocalAddress());
 
             apiClient.setCompress(config.isUseCompression());
             apiClient.setRequestExpirationMillis(config.getIdleConnectionExpiration(TimeUnit.MILLISECONDS));

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
@@ -1206,12 +1206,10 @@ public class SiteToSiteRestApiClient implements Closeable {
 
     public void setConnectTimeoutMillis(final int connectTimeoutMillis) {
         this.connectTimeoutMillis = connectTimeoutMillis;
-        setupRequestConfig();
     }
 
     public void setReadTimeoutMillis(final int readTimeoutMillis) {
         this.readTimeoutMillis = readTimeoutMillis;
-        setupRequestConfig();
     }
 
     public static String getFirstUrl(final String clusterUrlStr) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -880,6 +880,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
         try {
             this.networkInterfaceName = interfaceName;
             if (interfaceName == null) {
+                this.localAddress = null;
                 this.nicValidationResult = null;
             } else {
                 try {
@@ -930,11 +931,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
         SiteToSiteRestApiClient apiClient = new SiteToSiteRestApiClient(sslContext, new HttpProxy(proxyHost, proxyPort, proxyUser, proxyPassword), getEventReporter());
         apiClient.setConnectTimeoutMillis(getCommunicationsTimeout(TimeUnit.MILLISECONDS));
         apiClient.setReadTimeoutMillis(getCommunicationsTimeout(TimeUnit.MILLISECONDS));
-
-        final InetAddress localAddress = getLocalAddress();
-        if (localAddress != null) {
-            apiClient.setLocalAddress(localAddress);
-        }
+        apiClient.setLocalAddress(getLocalAddress());
 
         return apiClient;
     }


### PR DESCRIPTION
- Fixed SiteInfoProvider and HttpClient to use specified local address with its SiteToSiteRestApiClient
- Removed setupRequestConfig method call from connection and read timeout setter methods at SiteToSiteRestApiClient, because it created config object before local address was set
- Null clear StandardRemoteProcessGroup localAddress when user clears Local Network Interface

Confirmed both RAW and HTTP S2S use specified network interface for all S2S related requests. I used `netstat` command to observe that the expected local address is used:

```bash
# Show connections towards 11200 or 11201
# 192.168.99.1 is the address for the specified nic in my env,
# and it can be confirmed that no other address is used for connections to remote NiFi instance.
$ netstat -an |egrep -e '.1120[01]\s+[ETL]'
tcp4       0      0  192.168.99.1.55953     192.168.11.1.11201     ESTABLISHED
tcp4       0      0  192.168.99.1.55952     192.168.11.1.11201     ESTABLISHED
tcp4       0      0  192.168.99.1.57827     192.168.2.101.11200    TIME_WAIT
tcp4       0      0  192.168.99.1.57868     192.168.2.101.11200    TIME_WAIT

# If no Local Network Interface is specified, S2S client used the default address.
$ netstat -an |egrep -e '.1120[01]\s+[ETL]'
tcp4       0      0  192.168.2.101.58041    192.168.2.101.11201    ESTABLISHED
tcp4       0      0  192.168.2.101.58040    192.168.2.101.11201    ESTABLISHED
tcp4       0      0  192.168.2.101.58096    192.168.2.101.11200    TIME_WAIT
tcp4       0      0  192.168.2.101.58135    192.168.2.101.11200    TIME_WAIT
```

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
