### PR TITLE
NIFI-3648 removed cluster message copying when not in debug mode

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/SocketProtocolListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/SocketProtocolListener.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.cluster.protocol.ProtocolContext;
@@ -45,6 +44,7 @@ import org.apache.nifi.io.socket.SocketListener;
 import org.apache.nifi.reporting.Bulletin;
 import org.apache.nifi.reporting.BulletinRepository;
 import org.apache.nifi.security.util.CertificateUtils;
+import org.apache.nifi.stream.io.ByteCountingInputStream;
 import org.apache.nifi.util.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,9 +121,7 @@ public class SocketProtocolListener extends SocketListener implements ProtocolLi
 
     @Override
     public void dispatchRequest(final Socket socket) {
-        byte[] receivedMessage = null;
         String hostname = null;
-        final int maxMsgBuffer = 1024 * 1024;   // don't buffer more than 1 MB of the message
         try {
             final StopWatch stopWatch = new StopWatch(true);
             hostname = socket.getInetAddress().getHostName();
@@ -134,15 +132,21 @@ public class SocketProtocolListener extends SocketListener implements ProtocolLi
 
             // unmarshall message
             final ProtocolMessageUnmarshaller<ProtocolMessage> unmarshaller = protocolContext.createUnmarshaller();
-            final InputStream inStream = socket.getInputStream();
-            final CopyingInputStream copyingInputStream = new CopyingInputStream(inStream, maxMsgBuffer); // don't copy more than 1 MB
+            final ByteCountingInputStream countingIn = new ByteCountingInputStream(socket.getInputStream());
+            InputStream wrappedInStream = countingIn;
+            if (logger.isDebugEnabled()) {
+                final int maxMsgBuffer = 1024 * 1024;   // don't buffer more than 1 MB of the message
+                final CopyingInputStream copyingInputStream = new CopyingInputStream(wrappedInStream, maxMsgBuffer);
+                wrappedInStream = copyingInputStream;
+            }
 
             final ProtocolMessage request;
             try {
-                request = unmarshaller.unmarshal(copyingInputStream);
+                request = unmarshaller.unmarshal(wrappedInStream);
             } finally {
-                receivedMessage = copyingInputStream.getBytesRead();
                 if (logger.isDebugEnabled()) {
+                    final CopyingInputStream copyingInputStream = (CopyingInputStream) wrappedInStream;
+                    byte[] receivedMessage = copyingInputStream.getBytesRead();
                     logger.debug("Received message: " + new String(receivedMessage));
                 }
             }
@@ -181,8 +185,8 @@ public class SocketProtocolListener extends SocketListener implements ProtocolLi
             stopWatch.stop();
             final NodeIdentifier nodeId = getNodeIdentifier(request);
             final String from = nodeId == null ? hostname : nodeId.toString();
-            logger.info("Finished processing request {} (type={}, length={} bytes) from {} in {} millis",
-                requestId, request.getType(), receivedMessage.length, from, stopWatch.getDuration(TimeUnit.MILLISECONDS));
+            logger.info("Finished processing request {} (type={}, length={} bytes) from {} in {}",
+                requestId, request.getType(), countingIn.getBytesRead(), from, stopWatch.getDuration());
         } catch (final IOException | ProtocolException e) {
             logger.warn("Failed processing protocol message from " + hostname + " due to " + e, e);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/SocketProtocolListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/SocketProtocolListener.java
@@ -144,7 +144,7 @@ public class SocketProtocolListener extends SocketListener implements ProtocolLi
             try {
                 request = unmarshaller.unmarshal(wrappedInStream);
             } finally {
-                if (logger.isDebugEnabled()) {
+                if (logger.isDebugEnabled() && wrappedInStream instanceof CopyingInputStream) {
                     final CopyingInputStream copyingInputStream = (CopyingInputStream) wrappedInStream;
                     byte[] receivedMessage = copyingInputStream.getBytesRead();
                     logger.debug("Received message: " + new String(receivedMessage));


### PR DESCRIPTION
I expect NIFI-3648 could have several PRs, and that they will not be included in 1.2.0 release, so review of this can be delayed until the rest of that ticket is PRed and reviewed.  I just wanted to get this in so I don't forget.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
