### PR TITLE
NIFI-3692 Use hbc-core instead of hbc-twitter4j in social-media bundle to resolve org.json cat-x

### DIFF
--- a/nifi-nar-bundles/nifi-social-media-bundle/nifi-social-media-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-social-media-bundle/nifi-social-media-nar/src/main/resources/META-INF/NOTICE
@@ -40,39 +40,11 @@ The following binary components are provided under the Apache Software License v
       Apache Commons Logging
       Copyright 2003-2013 The Apache Software Foundation
 
-  (ASLv2) Twitter4J
-    The following NOTICE information applies:
-      Copyright 2007 Yusuke Yamamoto
-      
-      Twitter4J includes software from JSON.org to parse JSON response from the Twitter API.
-      You can see the license term at http://www.JSON.org/license.html
-
-      Copyright (c) 2002 JSON.org
-
-      Permission is hereby granted, free of charge, to any person obtaining a copy of this 
-      software and associated documentation files (the "Software"), to deal in the Software 
-      without restriction, including without limitation the rights to use, copy, modify, 
-      merge, publish, distribute, sublicense, and/or sell copies of the Software, and to 
-      permit persons to whom the Software is furnished to do so, subject to the following
-      conditions:
-
-      The above copyright notice and this permission notice shall be included in all 
-      copies or substantial portions of the Software.
-
-      The Software shall be used for Good, not Evil.
-
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-      INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
-      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-      HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-      CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
-      OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
   (ASLv2) JOAuth
     The following NOTICE information applies:
       JOAuth
       Copyright 2010-2013 Twitter, Inc
-  
+
   (ASLv2) Hosebird Client
     The following NOTICE information applies:
       Hosebird Client (hbc)

--- a/nifi-nar-bundles/nifi-social-media-bundle/nifi-twitter-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-social-media-bundle/nifi-twitter-processors/pom.xml
@@ -36,12 +36,16 @@
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>
-            <artifactId>hbc-twitter4j</artifactId>
+            <artifactId>hbc-core</artifactId>
             <version>2.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.twitter4j</groupId>
+                    <artifactId>twitter4j-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Note: We can't remove Twitter4j from nifi-assembly/NOTICE until [NIFI-3018](https://issues.apache.org/jira/browse/NIFI-3018) is complete.

I verified the lack of Twitter4j and org.json by checking the contents of the .nar, nifi-twitter-processors-1.2.0-SNAPSHOT.jar, and hbc-core-2.2.0.jar and grepping all the .class files. Here the new contents of the .nar:

```
     0 Tue Apr 11 09:56:14 CDT 2017 META-INF/
   365 Tue Apr 11 09:56:12 CDT 2017 META-INF/MANIFEST.MF
     0 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/
284184 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/commons-codec-1.10.jar
 61829 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/commons-logging-1.2.jar
 15322 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/findbugs-annotations-1.3.9-1.jar
2256213 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/guava-18.0.jar
 66687 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/hbc-core-2.2.0.jar
720931 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/httpclient-4.4.1.jar
322234 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/httpcore-4.4.1.jar
 63214 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/joauth-6.0.2.jar
 22410 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/nifi-twitter-processors-1.2.0-SNAPSHOT.jar
150592 Tue Apr 11 09:56:14 CDT 2017 META-INF/bundled-dependencies/nifi-utils-1.2.0-SNAPSHOT.jar
  2578 Tue Apr 11 09:56:14 CDT 2017 META-INF/DEPENDENCIES
 11358 Tue Apr 11 09:56:14 CDT 2017 META-INF/LICENSE
  3296 Tue Apr 11 09:56:14 CDT 2017 META-INF/NOTICE
     0 Tue Apr 11 09:56:16 CDT 2017 META-INF/maven/
     0 Tue Apr 11 09:56:16 CDT 2017 META-INF/maven/org.apache.nifi/
     0 Tue Apr 11 09:56:16 CDT 2017 META-INF/maven/org.apache.nifi/nifi-social-media-nar/
  1694 Tue Mar 21 10:04:18 CDT 2017 META-INF/maven/org.apache.nifi/nifi-social-media-nar/pom.xml
   130 Tue Apr 11 09:56:14 CDT 2017 META-INF/maven/org.apache.nifi/nifi-social-media-nar/pom.properties
```