### PR TITLE
NIFI-3738 Fixed NPE when ListenSyslog UDP datagram has zero length.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/syslog/SyslogParser.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/syslog/SyslogParser.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.standard.syslog;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,6 +71,10 @@ public class SyslogParser {
     public static final int SYSLOG_BODY_POS = 5;
 
     private Charset charset;
+
+    public SyslogParser() {
+        this(StandardCharsets.UTF_8);
+    }
 
     public SyslogParser(final Charset charset) {
         this.charset = charset;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/syslog/SyslogParser.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/syslog/SyslogParser.java
@@ -167,4 +167,7 @@ public class SyslogParser {
         return builder.build();
     }
 
+    public String getCharsetName() {
+        return charset == null ? StandardCharsets.UTF_8.name() : charset.name();
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ListenSyslogGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ListenSyslogGroovyTest.groovy
@@ -1,0 +1,95 @@
+package org.apache.nifi.processors.standard
+
+import org.apache.nifi.processor.ProcessContext
+import org.apache.nifi.processor.ProcessSessionFactory
+import org.apache.nifi.processors.standard.syslog.SyslogParser
+import org.apache.nifi.util.TestRunner
+import org.apache.nifi.util.TestRunners
+import org.bouncycastle.util.encoders.Hex
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@RunWith(JUnit4.class)
+class ListenSyslogGroovyTest extends GroovyTestCase {
+    private static final Logger logger = LoggerFactory.getLogger(ListenSyslogGroovyTest.class)
+
+    static final String ZERO_LENGTH_MESSAGE = "     \n"
+
+    @BeforeClass
+    static void setUpOnce() throws Exception {
+        logger.metaClass.methodMissing = { String name, args ->
+            logger.info("[${name?.toUpperCase()}] ${(args as List).join(" ")}")
+        }
+    }
+
+    @Before
+    void setUp() throws Exception {
+    }
+
+    @After
+    void tearDown() throws Exception {
+    }
+
+    @Test
+    void testShouldHandleZeroLengthUDP() throws Exception {
+        // Arrange
+        final ListenSyslog proc = new ListenSyslog()
+        final TestRunner runner = TestRunners.newTestRunner(proc)
+        runner.setProperty(ListenSyslog.PROTOCOL, ListenSyslog.TCP_VALUE.getValue())
+        runner.setProperty(ListenSyslog.PORT, "0")
+
+        // schedule to start listening on a random port
+        final ProcessSessionFactory processSessionFactory = runner.getProcessSessionFactory()
+        final ProcessContext context = runner.getProcessContext()
+        proc.onScheduled(context)
+
+        // Inject a SyslogParser which will always return null
+        def nullEventParser = [parseEvent: { byte[] bytes, String sender ->
+            logger.mock("Regardless of input bytes: [${Hex.toHexString(bytes)}] and sender: [${sender}], this parser will return null")
+            return null
+        }] as SyslogParser
+        proc.parser = nullEventParser
+
+        final int numMessages = 10
+        final int port = proc.getPort()
+        Assert.assertTrue(port > 0)
+
+        // write some TCP messages to the port in the background
+        final Thread sender = new Thread(new TestListenSyslog.SingleConnectionSocketSender(port, numMessages, 100, ZERO_LENGTH_MESSAGE))
+        sender.setDaemon(true)
+        sender.start()
+
+        // Act
+
+        // call onTrigger until we read all messages, or 30 seconds passed
+        try {
+            int numFailed = 0
+            long timeout = System.currentTimeMillis() + 30000
+
+            while (numFailed < numMessages && System.currentTimeMillis() < timeout) {
+                Thread.sleep(50)
+                proc.onTrigger(context, processSessionFactory)
+                numFailed = runner.getFlowFilesForRelationship(ListenSyslog.REL_INVALID).size()
+            }
+
+            int numSuccess = runner.getFlowFilesForRelationship(ListenSyslog.REL_SUCCESS).size()
+            logger.info("Transferred " + numSuccess + " to SUCCESS and " + numFailed + " to INVALID")
+
+            // Assert
+
+            // all messages should be transferred to invalid
+            Assert.assertEquals("Did not process all the messages", numMessages, numFailed)
+
+        } finally {
+            // unschedule to close connections
+            proc.onUnscheduled()
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ListenSyslogGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ListenSyslogGroovyTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.processors.standard
 
 import org.apache.nifi.processor.ProcessContext

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ParseSyslogGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ParseSyslogGroovyTest.groovy
@@ -1,0 +1,69 @@
+package org.apache.nifi.processors.standard
+
+import org.apache.nifi.processors.standard.syslog.SyslogParser
+import org.apache.nifi.util.TestRunner
+import org.apache.nifi.util.TestRunners
+import org.bouncycastle.util.encoders.Hex
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@RunWith(JUnit4.class)
+class ParseSyslogGroovyTest extends GroovyTestCase {
+    private static final Logger logger = LoggerFactory.getLogger(ParseSyslogGroovyTest.class)
+
+    static final String ZERO_LENGTH_MESSAGE = "     \n"
+
+    @BeforeClass
+    static void setUpOnce() throws Exception {
+        logger.metaClass.methodMissing = { String name, args ->
+            logger.info("[${name?.toUpperCase()}] ${(args as List).join(" ")}")
+        }
+    }
+
+    @Before
+    void setUp() throws Exception {
+    }
+
+    @After
+    void tearDown() throws Exception {
+    }
+
+    @Test
+    void testShouldHandleZeroLengthUDP() throws Exception {
+        // Arrange
+        final ParseSyslog proc = new ParseSyslog()
+        final TestRunner runner = TestRunners.newTestRunner(proc)
+        runner.setProperty(ParseSyslog.CHARSET, ParseSyslog.CHARSET.defaultValue)
+
+        // Inject a SyslogParser which will always return null
+        def nullEventParser = [parseEvent: { byte[] bytes, String sender ->
+            logger.mock("Regardless of input bytes: [${Hex.toHexString(bytes)}] and sender: [${sender}], this parser will return null")
+            return null
+        }] as SyslogParser
+        proc.parser = nullEventParser
+
+        final int numMessages = 10
+
+        // Act
+        numMessages.times {
+            runner.enqueue("Doesn't matter what is enqueued here")
+        }
+        runner.run(numMessages)
+
+        int numFailed = runner.getFlowFilesForRelationship(ParseSyslog.REL_FAILURE).size()
+        int numSuccess = runner.getFlowFilesForRelationship(ParseSyslog.REL_SUCCESS).size()
+        logger.info("Transferred " + numSuccess + " to SUCCESS and " + numFailed + " to FAILURE")
+
+        // Assert
+
+        // all messages should be transferred to invalid
+        Assert.assertEquals("Did not process all the messages", numMessages, numFailed)
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ParseSyslogGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/ParseSyslogGroovyTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.processors.standard
 
 import org.apache.nifi.processors.standard.syslog.SyslogParser
@@ -17,8 +33,6 @@ import org.slf4j.LoggerFactory
 @RunWith(JUnit4.class)
 class ParseSyslogGroovyTest extends GroovyTestCase {
     private static final Logger logger = LoggerFactory.getLogger(ParseSyslogGroovyTest.class)
-
-    static final String ZERO_LENGTH_MESSAGE = "     \n"
 
     @BeforeClass
     static void setUpOnce() throws Exception {


### PR DESCRIPTION
Added default constructor to SyslogParser to allow map coercion for test.
Added unit test.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
