### PR TITLE
NIFI-3223 added support for expression language to PublishAMQP

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
@@ -18,9 +18,7 @@ package org.apache.nifi.amqp.processors;
 
 import java.io.IOException;
 
-import org.apache.nifi.logging.ProcessorLog;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.nifi.logging.ComponentLog;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
@@ -32,50 +30,21 @@ import com.rabbitmq.client.ReturnListener;
  */
 final class AMQPPublisher extends AMQPWorker {
 
-    private final static Logger logger = LoggerFactory.getLogger(AMQPPublisher.class);
+    private final ComponentLog processLog;
 
-    private final String exchangeName;
-
-    private final String routingKey;
-
-    private final ProcessorLog processLog;
+    private final String connectionString;
 
     /**
      * Creates an instance of this publisher
      *
      * @param connection
      *            instance of AMQP {@link Connection}
-     * @param exchangeName
-     *            the name of AMQP exchange to which messages will be published.
-     *            If not provided 'default' exchange will be used.
-     * @param routingKey
-     *            (required) the name of the routingKey to be used by AMQP-based
-     *            system to route messages to its final destination (queue).
      */
-    AMQPPublisher(Connection connection, String exchangeName, String routingKey, ProcessorLog processLog) {
+    AMQPPublisher(Connection connection, ComponentLog processLog) {
         super(connection);
         this.processLog = processLog;
-        this.validateStringProperty("routingKey", routingKey);
-        this.exchangeName = exchangeName == null ? "" : exchangeName.trim();
-        if (this.exchangeName.length() == 0) {
-            logger.info("The 'exchangeName' is not specified. Messages will be sent to default exchange");
-        }
-
-        this.routingKey = routingKey;
         this.channel.addReturnListener(new UndeliverableMessageLogger());
-        logger.info("Successfully connected AMQPPublisher to " + connection.toString() + " and '" + this.exchangeName
-                + "' exchange with '" + routingKey + "' as a routing key.");
-    }
-
-    /**
-     * Publishes message without any AMQP properties (see
-     * {@link BasicProperties}) to a pre-defined AMQP Exchange.
-     *
-     * @param bytes
-     *            bytes representing a message.
-     */
-    void publish(byte[] bytes) {
-        this.publish(bytes, null);
+        this.connectionString = connection.toString();
     }
 
     /**
@@ -86,14 +55,28 @@ final class AMQPPublisher extends AMQPWorker {
      *            bytes representing a message.
      * @param properties
      *            instance of {@link BasicProperties}
+     * @param exchange
+     *            the name of AMQP exchange to which messages will be published.
+     *            If not provided 'default' exchange will be used.
+     * @param routingKey
+     *            (required) the name of the routingKey to be used by AMQP-based
+     *            system to route messages to its final destination (queue).
      */
-    void publish(byte[] bytes, BasicProperties properties) {
+    void publish(byte[] bytes, BasicProperties properties, String routingKey, String exchange) {
+        this.validateStringProperty("routingKey", routingKey);
+        exchange = exchange == null ? "" : exchange.trim();
+        if (exchange.length() == 0) {
+            processLog.info("The 'exchangeName' is not specified. Messages will be sent to default exchange");
+        }
+        processLog.info("Successfully connected AMQPPublisher to " + this.connectionString + " and '" + exchange
+                + "' exchange with '" + routingKey + "' as a routing key.");
+
         if (this.channel.isOpen()) {
             try {
-                this.channel.basicPublish(this.exchangeName, this.routingKey, true, properties, bytes);
+                this.channel.basicPublish(exchange, routingKey, true, properties, bytes);
             } catch (Exception e) {
                 throw new IllegalStateException("Failed to publish to '" +
-                        this.exchangeName + "' with '" + this.routingKey + "'.", e);
+                        exchange + "' with '" + routingKey + "'.", e);
             }
         } else {
             throw new IllegalStateException("This instance of AMQPPublisher is invalid since "
@@ -106,7 +89,7 @@ final class AMQPPublisher extends AMQPWorker {
      */
     @Override
     public String toString() {
-        return super.toString() + ", EXCHANGE:" + this.exchangeName + ", ROUTING_KEY:" + this.routingKey;
+        return this.connectionString;
     }
 
     /**
@@ -127,7 +110,7 @@ final class AMQPPublisher extends AMQPWorker {
                 throws IOException {
             String logMessage = "Message destined for '" + exchangeName + "' exchange with '" + routingKey
                     + "' as routing key came back with replyCode=" + replyCode + " and replyText=" + replyText + ".";
-            logger.warn(logMessage);
+            processLog.warn(logMessage);
             AMQPPublisher.this.processLog.warn(logMessage);
         }
     }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPPublisherTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPPublisherTest.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.amqp.processors;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -27,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.nifi.util.MockProcessorLog;
+import org.apache.nifi.logging.ComponentLog;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -40,31 +39,24 @@ public class AMQPPublisherTest {
     @SuppressWarnings("resource")
     @Test(expected = IllegalArgumentException.class)
     public void failOnNullConnection() {
-        new AMQPPublisher(null, null, null, null);
-    }
-
-    @SuppressWarnings("resource")
-    @Test(expected = IllegalArgumentException.class)
-    public void failOnMissingRoutingKey() throws Exception {
-        Connection conn = new TestConnection(null, null);
-        new AMQPPublisher(conn, null, "", null);
+        new AMQPPublisher(null, null);
     }
 
     @Test(expected = IllegalStateException.class)
     public void failPublishIfChannelClosed() throws Exception {
         Connection conn = new TestConnection(null, null);
-        try (AMQPPublisher sender = new AMQPPublisher(conn, null, "foo", null)) {
+        try (AMQPPublisher sender = new AMQPPublisher(conn, mock(ComponentLog.class))) {
             conn.close();
-            sender.publish("oleg".getBytes());
+            sender.publish("oleg".getBytes(), null, "foo", "");
         }
     }
 
     @Test(expected = IllegalStateException.class)
     public void failPublishIfChannelFails() throws Exception {
         TestConnection conn = new TestConnection(null, null);
-        try (AMQPPublisher sender = new AMQPPublisher(conn, null, "foo", null)) {
+        try (AMQPPublisher sender = new AMQPPublisher(conn, mock(ComponentLog.class))) {
             ((TestChannel) conn.createChannel()).corruptChannel();
-            sender.publish("oleg".getBytes());
+            sender.publish("oleg".getBytes(), null, "foo", "");
         }
     }
 
@@ -77,8 +69,8 @@ public class AMQPPublisherTest {
 
         Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
 
-        try (AMQPPublisher sender = new AMQPPublisher(connection, "myExchange", "key1", null)) {
-            sender.publish("hello".getBytes());
+        try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
+            sender.publish("hello".getBytes(), null, "key1", "myExchange");
             Thread.sleep(200);
         }
 
@@ -100,9 +92,8 @@ public class AMQPPublisherTest {
         ReturnListener retListener = mock(ReturnListener.class);
         connection.createChannel().addReturnListener(retListener);
 
-        try (AMQPPublisher sender = new AMQPPublisher(connection, "myExchange", "key2",
-                new MockProcessorLog("foo", ""))) {
-            sender.publish("hello".getBytes());
+        try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
+            sender.publish("hello".getBytes(), null, "key1", "myExchange");
             Thread.sleep(1000);
         }
         Thread.sleep(200);
@@ -111,12 +102,4 @@ public class AMQPPublisherTest {
         connection.close();
     }
 
-    @Test
-    public void validateToString() throws Exception {
-        TestConnection conn = new TestConnection(null, null);
-        try (AMQPPublisher sender = new AMQPPublisher(conn, "myExchange", "key1", null)) {
-            String toString = sender.toString();
-            assertTrue(toString.contains("EXCHANGE:myExchange, ROUTING_KEY:key1"));
-        }
-    }
 }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -17,12 +17,14 @@
 package org.apache.nifi.amqp.processors;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -46,8 +48,8 @@ public class ConsumeAMQPTest {
 
         Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
 
-        try (AMQPPublisher sender = new AMQPPublisher(connection, "myExchange", "key1", null)) {
-            sender.publish("hello".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN);
+        try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
+            sender.publish("hello".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
 
             ConsumeAMQP pubProc = new LocalConsumeAMQP(connection);
             TestRunner runner = TestRunners.newTestRunner(pubProc);


### PR DESCRIPTION
properties supporting EL are EXCHANGE and ROUTING_KEY.  This is a PR for the 0.x branch, using changes from #1449. 

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
