### PR TITLE
NIFI-3796 Fixed Windows test failures due to POSIX permissions

### DIFF
--- a/nifi-commons/nifi-data-provenance-utils/src/test/groovy/org/apache/nifi/provenance/CryptoUtilsTest.groovy
+++ b/nifi-commons/nifi-data-provenance-utils/src/test/groovy/org/apache/nifi/provenance/CryptoUtilsTest.groovy
@@ -21,6 +21,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.util.encoders.Hex
 import org.junit.After
 import org.junit.AfterClass
+import org.junit.Assume
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.ClassRule
@@ -176,8 +177,27 @@ class CryptoUtilsTest {
     }
 
     @Test
-    void testShouldNotValidateUnreadableOrMissingFileBasedKeyProvider() {
+    void testShouldNotValidateMissingFileBasedKeyProvider() {
         // Arrange
+        String fileBasedProvider = FileBasedKeyProvider.class.name
+        File fileBasedProviderFile = new File(tempFolder.root, "filebased_missing.kp")
+        String providerLocation = fileBasedProviderFile.path
+        logger.info("Created (no actual file) temporary file based key provider: ${providerLocation}")
+
+        // Act
+        String missingLocation = providerLocation
+        boolean missingKeyProviderIsValid = CryptoUtils.isValidKeyProvider(fileBasedProvider, missingLocation, KEY_ID, null)
+        logger.info("Key Provider ${fileBasedProvider} with location ${missingLocation} and keyId ${KEY_ID} / ${null} is ${missingKeyProviderIsValid ? "valid" : "invalid"}")
+
+        // Assert
+        assert !missingKeyProviderIsValid
+    }
+
+    @Test
+    void testShouldNotValidateUnreadableFileBasedKeyProvider() {
+        // Arrange
+        Assume.assumeFalse("This test does not run on Windows", SystemUtils.IS_OS_WINDOWS)
+
         String fileBasedProvider = FileBasedKeyProvider.class.name
         File fileBasedProviderFile = tempFolder.newFile("filebased.kp")
         String providerLocation = fileBasedProviderFile.path
@@ -190,13 +210,8 @@ class CryptoUtilsTest {
         boolean unreadableKeyProviderIsValid = CryptoUtils.isValidKeyProvider(fileBasedProvider, providerLocation, KEY_ID, null)
         logger.info("Key Provider ${fileBasedProvider} with location ${providerLocation} and keyId ${KEY_ID} / ${null} is ${unreadableKeyProviderIsValid ? "valid" : "invalid"}")
 
-        String missingLocation = providerLocation + "_missing"
-        boolean missingKeyProviderIsValid = CryptoUtils.isValidKeyProvider(fileBasedProvider, missingLocation, KEY_ID, null)
-        logger.info("Key Provider ${fileBasedProvider} with location ${missingLocation} and keyId ${KEY_ID} / ${null} is ${missingKeyProviderIsValid ? "valid" : "invalid"}")
-
         // Assert
         assert !unreadableKeyProviderIsValid
-        assert !missingKeyProviderIsValid
 
         // Make the file deletable so cleanup can occur
         markFileReadable(fileBasedProviderFile)
@@ -448,4 +463,5 @@ class CryptoUtilsTest {
 
         Base64.encoder.encodeToString(CryptoUtils.concatByteArrays(ivBytes, cipherBytes))
     }
+
 }

--- a/nifi-commons/nifi-data-provenance-utils/src/test/groovy/org/apache/nifi/provenance/CryptoUtilsTest.groovy
+++ b/nifi-commons/nifi-data-provenance-utils/src/test/groovy/org/apache/nifi/provenance/CryptoUtilsTest.groovy
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.provenance
 
+import org.apache.commons.lang3.SystemUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.util.encoders.Hex
 import org.junit.After
@@ -183,8 +184,7 @@ class CryptoUtilsTest {
         logger.info("Created temporary file based key provider: ${providerLocation}")
 
         // Make it unreadable
-        fileBasedProviderFile.setReadable(false, false)
-        Files.setPosixFilePermissions(fileBasedProviderFile.toPath(), [] as Set<PosixFilePermission>)
+        markFileUnreadable(fileBasedProviderFile)
 
         // Act
         boolean unreadableKeyProviderIsValid = CryptoUtils.isValidKeyProvider(fileBasedProvider, providerLocation, KEY_ID, null)
@@ -199,8 +199,23 @@ class CryptoUtilsTest {
         assert !missingKeyProviderIsValid
 
         // Make the file deletable so cleanup can occur
-        fileBasedProviderFile.setReadable(true, false)
-        Files.setPosixFilePermissions(fileBasedProviderFile.toPath(), ALL_POSIX_ATTRS)
+        markFileReadable(fileBasedProviderFile)
+    }
+
+    private static void markFileReadable(File fileBasedProviderFile) {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            fileBasedProviderFile.setReadable(true, false)
+        } else {
+            Files.setPosixFilePermissions(fileBasedProviderFile.toPath(), ALL_POSIX_ATTRS)
+        }
+    }
+
+    private static void markFileUnreadable(File fileBasedProviderFile) {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            fileBasedProviderFile.setReadable(false, false)
+        } else {
+            Files.setPosixFilePermissions(fileBasedProviderFile.toPath(), [] as Set<PosixFilePermission>)
+        }
     }
 
     @Test


### PR DESCRIPTION
I separated the unit test for unreadable and missing files into two distinct tests and skipped the unreadable one for Windows. Windows is not POSIX-compliant and the `File.setReadable()` method is not working to mock the unreadable file situation. 

Confirmed this ran on Windows 10. 

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
