### PR TITLE
NIFI-2199 & NIFI-3112 - Handle propagation of stderr and allow ssh restart

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
@@ -300,7 +300,7 @@ run() {
     fi
 
     if [ "$1" = "start" ]; then
-        ( eval "cd ${NIFI_HOME} && ${run_nifi_cmd}" & )
+        ( eval "cd ${NIFI_HOME} && ${run_nifi_cmd}" & )> /dev/null 1>&-
     else
         eval "cd ${NIFI_HOME} && ${run_nifi_cmd}"
     fi


### PR DESCRIPTION
NIFI-2199
NIFI-3112
Pipe stdout to /dev/null and allow stderr to propagate through.

This correction does not make NiFi fully LSB spec compliant but does solve the two issues presented in the listed tickets.  This will allow stderr to propagate through and restart through SSH.

ssh can be tested by issuing a 
`ssh user@remote-host <path to nifi>/bin/nifi.sh restart`
from a local machine to a remote host

3112 can be verified by changing a property to bootstrap causing it to be invalid and running the above.  As listed in the prior discussion of 3112, making `graceful.shutdown.seconds` a negative number such as below:
> graceful.shutdown.seconds=-20

Will cause an error to be triggered and the appropriate contents transmitted.