### PR TITLE
NIFI-3894: Call Inflater/Deflater.end to free up memory

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/AbstractTransaction.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/AbstractTransaction.java
@@ -148,6 +148,11 @@ public abstract class AbstractTransaction implements Transaction {
                 final InputStream dataIn = compress ? new CompressionInputStream(is) : is;
                 final DataPacket packet = codec.decode(new CheckedInputStream(dataIn, crc));
 
+                if (compress) {
+                    // Close CompressionInputStream to free acquired memory, without closing underlying stream.
+                    dataIn.close();
+                }
+
                 if (packet == null) {
                     this.dataAvailable = false;
                 } else {

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/CompressionInputStream.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/CompressionInputStream.java
@@ -174,12 +174,13 @@ public class CompressionInputStream extends InputStream {
     }
 
     /**
-     * Does nothing. Does NOT close underlying InputStream
+     * Calls {@link Inflater#end()} to free acquired memory to prevent OutOfMemory error.
+     * However, does NOT close underlying InputStream.
      *
      * @throws java.io.IOException for any issues closing underlying stream
      */
     @Override
     public void close() throws IOException {
-
+        inflater.end();
     }
 }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/CompressionOutputStream.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/CompressionOutputStream.java
@@ -137,10 +137,15 @@ public class CompressionOutputStream extends OutputStream {
         super.flush();
     }
 
+    /**
+     * Flushes remaining buffer and calls {@link Deflater#end()} to free acquired memory to prevent OutOfMemory error.
+     * @throws IOException for any issues closing underlying stream
+     */
     @Override
     public void close() throws IOException {
         compressAndWrite();
         out.write(0);   // indicate that the stream is finished.
         out.flush();
+        deflater.end();
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
@@ -440,6 +440,12 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
             final CheckedInputStream checkedInputStream = new CheckedInputStream(flowFileInputStream, crc);
 
             final DataPacket dataPacket = codec.decode(checkedInputStream);
+
+            if (handshakeProperties.isUseGzip()) {
+                // Close CompressionInputStream to free acquired memory, without closing underlying stream.
+                checkedInputStream.close();
+            }
+
             if (dataPacket == null) {
                 logger.debug("{} Received null dataPacket indicating the end of transaction from {}", this, peer);
                 break;


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
