### PR TITLE
NIFI-3933: Monitor heartbeats based on connected nodes

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/HeartbeatMonitor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/HeartbeatMonitor.java
@@ -59,13 +59,6 @@ public interface HeartbeatMonitor {
     void purgeHeartbeats();
 
     /**
-     * Returns when the heartbeats were purged last.
-     *
-     * @return when the heartbeats were purged last
-     */
-    long getPurgeTimestamp();
-
-    /**
      * @return the address that heartbeats should be sent to when this node is elected coordinator.
      */
     String getHeartbeatAddress();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/HeartbeatMonitor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/HeartbeatMonitor.java
@@ -59,6 +59,13 @@ public interface HeartbeatMonitor {
     void purgeHeartbeats();
 
     /**
+     * Returns when the heartbeats were purged last.
+     *
+     * @return when the heartbeats were purged last
+     */
+    long getPurgeTimestamp();
+
+    /**
      * @return the address that heartbeats should be sent to when this node is elected coordinator.
      */
     String getHeartbeatAddress();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
@@ -282,6 +282,13 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
     protected abstract Map<NodeIdentifier, NodeHeartbeat> getLatestHeartbeats();
 
     /**
+     * Returns when the heartbeats were purged last.
+     *
+     * @return when the heartbeats were purged last
+     */
+    protected abstract long getPurgeTimestamp();
+
+    /**
      * This method does nothing in the abstract class but is meant for
      * subclasses to override in order to provide functionality when the monitor
      * is started.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/ClusterProtocolHeartbeatMonitor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/ClusterProtocolHeartbeatMonitor.java
@@ -16,18 +16,6 @@
  */
 package org.apache.nifi.cluster.coordination.heartbeat;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Unmarshaller;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
 import org.apache.nifi.cluster.coordination.node.NodeConnectionState;
 import org.apache.nifi.cluster.coordination.node.NodeConnectionStatus;
@@ -38,15 +26,28 @@ import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.cluster.protocol.ProtocolException;
 import org.apache.nifi.cluster.protocol.ProtocolHandler;
 import org.apache.nifi.cluster.protocol.ProtocolListener;
-import org.apache.nifi.cluster.protocol.message.HeartbeatMessage;
-import org.apache.nifi.cluster.protocol.message.HeartbeatResponseMessage;
 import org.apache.nifi.cluster.protocol.message.ClusterWorkloadRequestMessage;
 import org.apache.nifi.cluster.protocol.message.ClusterWorkloadResponseMessage;
+import org.apache.nifi.cluster.protocol.message.HeartbeatMessage;
+import org.apache.nifi.cluster.protocol.message.HeartbeatResponseMessage;
 import org.apache.nifi.cluster.protocol.message.ProtocolMessage;
 import org.apache.nifi.cluster.protocol.message.ProtocolMessage.MessageType;
 import org.apache.nifi.util.NiFiProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Unmarshaller;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Uses Apache ZooKeeper to advertise the address to send heartbeats to, and
@@ -59,6 +60,8 @@ public class ClusterProtocolHeartbeatMonitor extends AbstractHeartbeatMonitor im
 
     private final String heartbeatAddress;
     private final ConcurrentMap<NodeIdentifier, NodeHeartbeat> heartbeatMessages = new ConcurrentHashMap<>();
+
+    private volatile long purgeTimestamp = System.currentTimeMillis();
 
     protected static final Unmarshaller nodeIdentifierUnmarshaller;
 
@@ -136,6 +139,12 @@ public class ClusterProtocolHeartbeatMonitor extends AbstractHeartbeatMonitor im
     public synchronized void purgeHeartbeats() {
         logger.debug("Purging old heartbeats");
         heartbeatMessages.clear();
+        purgeTimestamp = System.currentTimeMillis();
+    }
+
+    @Override
+    public synchronized long getPurgeTimestamp() {
+        return purgeTimestamp;
     }
 
     @Override


### PR DESCRIPTION
NIFI-3933:
- When monitoring heartbeats use the connected nodes as the basis for the check. This addresses the case when a node is terminated and no corresponding heartbeats exist.