### PR TITLE
NIFI-3671: Ensure that we use the existing ResourceClaim (if it exist…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-flowfile-repo-serialization/src/main/java/org/apache/nifi/controller/repository/schema/ContentClaimFieldMap.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-flowfile-repo-serialization/src/main/java/org/apache/nifi/controller/repository/schema/ContentClaimFieldMap.java
@@ -112,7 +112,15 @@ public class ContentClaimFieldMap implements Record {
         final Long length = (Long) claimRecord.getFieldValue(ContentClaimSchema.CONTENT_CLAIM_LENGTH);
         final Long resourceOffset = (Long) claimRecord.getFieldValue(ContentClaimSchema.RESOURCE_CLAIM_OFFSET);
 
-        final ResourceClaim resourceClaim = resourceClaimManager.newResourceClaim(container, section, identifier, lossTolerant, false);
+        // Make sure that we preserve the existing ResourceClaim, if there is already one held by the Resource Claim Manager
+        // because we need to honor its determination of whether or not the claim is writable. If the Resource Claim Manager
+        // does not have a copy of this Resource Claim, then we can go ahead and just create one and assume that it is not
+        // writable (because if it were writable, then the Resource Claim Manager would know about it).
+        ResourceClaim resourceClaim = resourceClaimManager.getResourceClaim(container, section, identifier);
+        if (resourceClaim == null) {
+            resourceClaim = resourceClaimManager.newResourceClaim(container, section, identifier, lossTolerant, false);
+        }
+
         final StandardContentClaim contentClaim = new StandardContentClaim(resourceClaim, resourceOffset);
         contentClaim.setLength(length);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-flowfile-repo-serialization/src/main/java/org/apache/nifi/controller/repository/schema/ResourceClaimFieldMap.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-flowfile-repo-serialization/src/main/java/org/apache/nifi/controller/repository/schema/ResourceClaimFieldMap.java
@@ -58,7 +58,16 @@ public class ResourceClaimFieldMap implements Record {
         final String identifier = (String) record.getFieldValue(ContentClaimSchema.CLAIM_IDENTIFIER);
         final Boolean lossTolerant = (Boolean) record.getFieldValue(ContentClaimSchema.LOSS_TOLERANT);
 
-        return claimManager.newResourceClaim(container, section, identifier, lossTolerant, false);
+        // Make sure that we preserve the existing ResourceClaim, if there is already one held by the Resource Claim Manager
+        // because we need to honor its determination of whether or not the claim is writable. If the Resource Claim Manager
+        // does not have a copy of this Resource Claim, then we can go ahead and just create one and assume that it is not
+        // writable (because if it were writable, then the Resource Claim Manager would know about it).
+        ResourceClaim resourceClaim = claimManager.getResourceClaim(container, section, identifier);
+        if (resourceClaim == null) {
+            resourceClaim = claimManager.newResourceClaim(container, section, identifier, lossTolerant, false);
+        }
+
+        return resourceClaim;
     }
 
     @Override


### PR DESCRIPTION
…s) when swapping data in, instead of creating a new one. Otherwise, if the ResourceClaim is still writable, then we may archive the data and then write to it, which can cause a NullPointerException in FileSystemRepository

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
