### PR TITLE
NIFI-3978 Increase threadpool size for S2S HTTP tests

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
@@ -432,7 +432,7 @@ public class TestHttpClient {
         // Create embedded Jetty server
         // Use less threads to mitigate Gateway Timeout (504) with proxy test
         // Minimum thread pool size = (acceptors=2 + selectors=8 + request=1), defaults to max=200
-        final QueuedThreadPool threadPool = new QueuedThreadPool(20);
+        final QueuedThreadPool threadPool = new QueuedThreadPool(50);
         server = new Server(threadPool);
 
         final ContextHandlerCollection handlerCollection = new ContextHandlerCollection();


### PR DESCRIPTION
Increases threadpool limits for S2S HTTP tests so they'll pass on many core machines, as discussed in [NIFI-3978](https://issues.apache.org/jira/browse/NIFI-3978).