### PR TITLE
NIFI-3983 - Support ability to make JMS 2.0 durable subscriptions on …

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -79,6 +79,15 @@ abstract class AbstractJMSProcessor<T extends JMSWorker> extends AbstractProcess
             .defaultValue(QUEUE)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
+    static final PropertyDescriptor CLIENT_ID = new PropertyDescriptor.Builder()
+            .name("Connection Client ID")
+            .description("The client id to be set on the connection, if set. For durable non shared consumer this is mandatory, " +
+                         "for all others it is optional, typically with shared consumers it is undesirable to be set. " +
+                         "Please see JMS spec for further details")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(true)
+            .build();
     static final PropertyDescriptor SESSION_CACHE_SIZE = new PropertyDescriptor.Builder()
             .name("Session Cache size")
             .description("The maximum limit for the number of cached Sessions.")
@@ -86,6 +95,7 @@ abstract class AbstractJMSProcessor<T extends JMSWorker> extends AbstractProcess
             .defaultValue("1")
             .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
             .build();
+    
 
     // ConnectionFactoryProvider ControllerService
     static final PropertyDescriptor CF_SERVICE = new PropertyDescriptor.Builder()
@@ -107,6 +117,7 @@ abstract class AbstractJMSProcessor<T extends JMSWorker> extends AbstractProcess
         propertyDescriptors.add(DESTINATION_TYPE);
         propertyDescriptors.add(USER);
         propertyDescriptors.add(PASSWORD);
+        propertyDescriptors.add(CLIENT_ID);
         propertyDescriptors.add(SESSION_CACHE_SIZE);
     }
 
@@ -196,7 +207,10 @@ abstract class AbstractJMSProcessor<T extends JMSWorker> extends AbstractProcess
 
             this.cachingConnectionFactory = new CachingConnectionFactory(cfCredentialsAdapter);
             this.cachingConnectionFactory.setSessionCacheSize(Integer.parseInt(context.getProperty(SESSION_CACHE_SIZE).getValue()));
-
+            String clientId = context.getProperty(CLIENT_ID).evaluateAttributeExpressions().getValue();
+            if (clientId != null) {
+                this.cachingConnectionFactory.setClientId(clientId);
+            }
             JmsTemplate jmsTemplate = new JmsTemplate();
             jmsTemplate.setConnectionFactory(this.cachingConnectionFactory);
             jmsTemplate.setPubSubDomain(TOPIC.equals(context.getProperty(DESTINATION_TYPE).getValue()));

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerTest.java
@@ -100,7 +100,7 @@ public class JMSPublisherConsumerTest {
 
         JMSConsumer consumer = new JMSConsumer(jmsTemplate, mock(ComponentLog.class));
         try {
-            consumer.consume(destinationName, new ConsumerCallback() {
+            consumer.consume(destinationName, false, false, null, new ConsumerCallback() {
                 @Override
                 public void accept(JMSResponse response) {
                     // noop
@@ -129,7 +129,7 @@ public class JMSPublisherConsumerTest {
 
         JMSConsumer consumer = new JMSConsumer(jmsTemplate, mock(ComponentLog.class));
         final AtomicBoolean callbackInvoked = new AtomicBoolean();
-        consumer.consume(destinationName, new ConsumerCallback() {
+        consumer.consume(destinationName, false, false, null, new ConsumerCallback() {
             @Override
             public void accept(JMSResponse response) {
                 callbackInvoked.set(true);
@@ -155,7 +155,7 @@ public class JMSPublisherConsumerTest {
         JMSConsumer consumer = new JMSConsumer(jmsTemplate, mock(ComponentLog.class));
         final AtomicBoolean callbackInvoked = new AtomicBoolean();
         try {
-            consumer.consume(destinationName, new ConsumerCallback() {
+            consumer.consume(destinationName, false, false, null, new ConsumerCallback() {
                 @Override
                 public void accept(JMSResponse response) {
                     callbackInvoked.set(true);
@@ -171,7 +171,7 @@ public class JMSPublisherConsumerTest {
 
         // should receive the same message, but will process it successfully
         try {
-            consumer.consume(destinationName, new ConsumerCallback() {
+            consumer.consume(destinationName, false, false, null, new ConsumerCallback() {
                 @Override
                 public void accept(JMSResponse response) {
                     callbackInvoked.set(true);
@@ -186,7 +186,7 @@ public class JMSPublisherConsumerTest {
 
         // receiving next message and fail again
         try {
-            consumer.consume(destinationName, new ConsumerCallback() {
+            consumer.consume(destinationName, false, false, null, new ConsumerCallback() {
                 @Override
                 public void accept(JMSResponse response) {
                     callbackInvoked.set(true);
@@ -202,7 +202,7 @@ public class JMSPublisherConsumerTest {
 
         // should receive the same message, but will process it successfully
         try {
-            consumer.consume(destinationName, new ConsumerCallback() {
+            consumer.consume(destinationName, false, false, null, new ConsumerCallback() {
                 @Override
                 public void accept(JMSResponse response) {
                     callbackInvoked.set(true);


### PR DESCRIPTION
…Topic

Add new optional config option to supply subscription name.
Add logic in Consumer that if subscription name present and destination is pubsub (Topic) then make a SharedDurableConsumer.
Else fallback to existing logic.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ Y] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message? NIFI-3983 

- [ Y] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ Y] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ Y] Is your initial contribution a single, squashed commit?

### For code changes:
- [ Y] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ Y] Have you written or updated unit tests to verify your changes?
- [N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ N/A] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [N/A ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ Y] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [N/A ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.