### PR TITLE
NIFI-4043 Initial commit of nifi-redis-bundle

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -1364,6 +1364,7 @@ The following binary components are provided under the MIT License.  See project
 
   (MIT License) EWS Java API (com.microsoft.ews-java-api:ews-java-api:2.0 - https://github.com/OfficeDev/ews-java-api)
   (MIT License) libffi (libffi-3.2.1 - http://sourceware.org/libffi/)
+  (MIT License) Jedis (redis.clients:jedis:2.9.0 - https://github.com/xetorthio/jedis)
 
 *****************
 Mozilla Public License v2.0

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -476,6 +476,16 @@
             <artifactId>nifi-hwx-schema-registry-nar</artifactId>
             <type>nar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-redis-service-api-nar</artifactId>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-redis-nar</artifactId>
+            <type>nar</type>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-redis-bundle</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-redis-extensions</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Provided deps from nifi-redis-service-api -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-distributed-cache-client-service-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-redis-service-api</artifactId>
+            <version>1.3.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <version>${spring.data.redis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.9.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- End Provided deps from nifi-redis-service-api -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/RedisConnectionPoolService.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/RedisConnectionPoolService.java
@@ -1,0 +1,470 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.util.StringUtils;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisShardInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Tags({ "redis", "cache" })
+@CapabilityDescription("A service that provides connections to Redis.")
+public class RedisConnectionPoolService extends AbstractControllerService implements RedisConnectionPool {
+
+    static final AllowableValue REDIS_MODE_STANDALONE = new AllowableValue(RedisType.STANDALONE.getDisplayName(), RedisType.STANDALONE.getDisplayName(), RedisType.STANDALONE.getDescription());
+    static final AllowableValue REDIS_MODE_SENTINEL = new AllowableValue(RedisType.SENTINEL.getDisplayName(), RedisType.SENTINEL.getDisplayName(), RedisType.SENTINEL.getDescription());
+    static final AllowableValue REDIS_MODE_CLUSTER = new AllowableValue(RedisType.CLUSTER.getDisplayName(), RedisType.CLUSTER.getDisplayName(), RedisType.CLUSTER.getDescription());
+
+    public static final PropertyDescriptor REDIS_MODE = new PropertyDescriptor.Builder()
+            .name("redis-mode")
+            .displayName("Redis Mode")
+            .description("The type of Redis being communicated with - standalone, sentinel, or clustered.")
+            .allowableValues(REDIS_MODE_STANDALONE, REDIS_MODE_SENTINEL, REDIS_MODE_CLUSTER)
+            .defaultValue(REDIS_MODE_STANDALONE.getValue())
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor CONNECTION_STRING = new PropertyDescriptor.Builder()
+            .name("connection-string")
+            .displayName("Connection String")
+            .description("The connection string for Redis. In a standalone instance this value will be of the form hostname:port. " +
+                    "In a sentinel instance this value will be the comma-separated list of sentinels, such as host1:port1,host2:port2,host3:port3. " +
+                    "In a clustered instance this value will be the comma-separated list of cluster masters, such as host1:port,host2:port,host3:port.")
+            .required(true)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(true)
+            .build();
+
+    public static final PropertyDescriptor DATABASE = new PropertyDescriptor.Builder()
+            .name("database-index")
+            .displayName("Database Index")
+            .description("The database index to be used by connections created from this connection pool. " +
+                    "See the databases property in redis.conf, by default databases 0-15 will be available.")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .defaultValue("0")
+            .expressionLanguageSupported(true)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor COMMUNICATION_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("communication-timeout")
+            .displayName("Communication Timeout")
+            .description("The timeout to use when attempting to communicate with Redis.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("10 seconds")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor CLUSTER_MAX_REDIRECTS = new PropertyDescriptor.Builder()
+            .name("cluster-max-redirects")
+            .displayName("Cluster Max Redirects")
+            .description("The maximum number of redirects that can be performed when clustered.")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .defaultValue("5")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor SENTINEL_MASTER = new PropertyDescriptor.Builder()
+            .name("sentinel-master")
+            .displayName("Sentinel Master")
+            .description("The name of the sentinel master, require when Mode is set to Sentinel")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(true)
+            .build();
+
+    public static final PropertyDescriptor PASSWORD = new PropertyDescriptor.Builder()
+            .name("password")
+            .displayName("Password")
+            .description("The password used to authenticate to the Redis server. See the requirepass property in redis.conf.")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(true)
+            .sensitive(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_MAX_TOTAL = new PropertyDescriptor.Builder()
+            .name("pool-max-total")
+            .displayName("Pool - Max Total")
+            .description("The maximum number of connections that can be allocated by the pool (checked out to clients, or idle awaiting checkout). " +
+                    "A negative value indicates that there is no limit.")
+            .addValidator(StandardValidators.INTEGER_VALIDATOR)
+            .defaultValue("8")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_MAX_IDLE = new PropertyDescriptor.Builder()
+            .name("pool-max-idle")
+            .displayName("Pool - Max Idle")
+            .description("The maximum number of idle connections that can be held in the pool, or a negative value if there is no limit.")
+            .addValidator(StandardValidators.INTEGER_VALIDATOR)
+            .defaultValue("8")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_MIN_IDLE = new PropertyDescriptor.Builder()
+            .name("pool-min-idle")
+            .displayName("Pool - Min Idle")
+            .description("The target for the minimum number of idle connections to maintain in the pool. If the configured value of Min Idle is " +
+                    "greater than the configured value for Max Idle, then the value of Max Idle will be used instead.")
+            .addValidator(StandardValidators.INTEGER_VALIDATOR)
+            .defaultValue("0")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_BLOCK_WHEN_EXHAUSTED = new PropertyDescriptor.Builder()
+            .name("pool-block-when-exhausted")
+            .displayName("Pool - Block When Exhausted")
+            .description("Whether or not clients should block and wait when trying to obtain a connection from the pool when the pool has no available connections. " +
+                    "Setting this to false means an error will occur immediately when a client requests a connection and none are available.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_MAX_WAIT_TIME = new PropertyDescriptor.Builder()
+            .name("pool-max-wait-time")
+            .displayName("Pool - Max Wait Time")
+            .description("The amount of time to wait for an available connection when Block When Exhausted is set to true.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("10 seconds")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_MIN_EVICTABLE_IDLE_TIME = new PropertyDescriptor.Builder()
+            .name("pool-min-evictable-idle-time")
+            .displayName("Pool - Min Evictable Idle Time")
+            .description("The minimum amount of time an object may sit idle in the pool before it is eligible for eviction.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("60 seconds")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_TIME_BETWEEN_EVICTION_RUNS = new PropertyDescriptor.Builder()
+            .name("pool-time-between-eviction-runs")
+            .displayName("Pool - Time Between Eviction Runs")
+            .description("The amount of time between attempting to evict idle connections from the pool.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("30 seconds")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_NUM_TESTS_PER_EVICTION_RUN = new PropertyDescriptor.Builder()
+            .name("pool-num-test-per-eviction-run")
+            .displayName("Pool - Num Tests Per Eviction Run")
+            .description("The number of connections to tests per eviction attempt. A negative value indicates to test all connections.")
+            .addValidator(StandardValidators.INTEGER_VALIDATOR)
+            .defaultValue("-1")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_TEST_ON_CREATE = new PropertyDescriptor.Builder()
+            .name("pool-test-on-create")
+            .displayName("Pool - Test On Create")
+            .description("Whether or not connections should be tested upon creation.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_TEST_ON_BORROW = new PropertyDescriptor.Builder()
+            .name("pool-test-on-borrow")
+            .displayName("Pool - Test On Borrow")
+            .description("Whether or not connections should be tested upon borrowing from the pool.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_TEST_ON_RETURN = new PropertyDescriptor.Builder()
+            .name("pool-test-on-return")
+            .displayName("Pool - Test On Return")
+            .description("Whether or not connections should be tested upon returning to the pool.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor POOL_TEST_WHILE_IDLE = new PropertyDescriptor.Builder()
+            .name("pool-test-while-idle")
+            .displayName("Pool - Test While Idle")
+            .description("Whether or not connections should be tested while idle.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .required(true)
+            .build();
+
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS;
+    static {
+        final List<PropertyDescriptor> props = new ArrayList<>();
+        props.add(REDIS_MODE);
+        props.add(CONNECTION_STRING);
+        props.add(DATABASE);
+        props.add(COMMUNICATION_TIMEOUT);
+        props.add(CLUSTER_MAX_REDIRECTS);
+        props.add(SENTINEL_MASTER);
+        props.add(PASSWORD);
+        props.add(POOL_MAX_TOTAL);
+        props.add(POOL_MAX_IDLE);
+        props.add(POOL_MIN_IDLE);
+        props.add(POOL_BLOCK_WHEN_EXHAUSTED);
+        props.add(POOL_MAX_WAIT_TIME);
+        props.add(POOL_MIN_EVICTABLE_IDLE_TIME);
+        props.add(POOL_TIME_BETWEEN_EVICTION_RUNS);
+        props.add(POOL_NUM_TESTS_PER_EVICTION_RUN);
+        props.add(POOL_TEST_ON_CREATE);
+        props.add(POOL_TEST_ON_BORROW);
+        props.add(POOL_TEST_ON_RETURN);
+        props.add(POOL_TEST_WHILE_IDLE);
+        PROPERTY_DESCRIPTORS = Collections.unmodifiableList(props);
+    }
+
+    private volatile ConfigurationContext context;
+    private volatile RedisType redisType;
+    private volatile JedisConnectionFactory connectionFactory;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        final List<ValidationResult> results = new ArrayList<>();
+
+        final String redisMode = validationContext.getProperty(REDIS_MODE).getValue();
+        final String connectionString = validationContext.getProperty(CONNECTION_STRING).evaluateAttributeExpressions().getValue();
+        final Integer dbIndex = validationContext.getProperty(DATABASE).evaluateAttributeExpressions().asInteger();
+
+        if (StringUtils.isBlank(connectionString)) {
+            results.add(new ValidationResult.Builder()
+                    .subject(CONNECTION_STRING.getDisplayName())
+                    .valid(false)
+                    .explanation("Connection String cannot be blank")
+                    .build());
+        } else if (REDIS_MODE_STANDALONE.getValue().equals(redisMode)) {
+            final String[] hostAndPort = connectionString.split("[:]");
+            if (hostAndPort == null || hostAndPort.length != 2 || !isInteger(hostAndPort[1])) {
+                results.add(new ValidationResult.Builder()
+                        .subject(CONNECTION_STRING.getDisplayName())
+                        .input(connectionString)
+                        .valid(false)
+                        .explanation("Standalone Connection String must be in the form host:port")
+                        .build());
+            }
+        } else {
+            for (final String connection : connectionString.split("[,]")) {
+                final String[] hostAndPort = connection.split("[:]");
+                if (hostAndPort == null || hostAndPort.length != 2 || !isInteger(hostAndPort[1])) {
+                    results.add(new ValidationResult.Builder()
+                            .subject(CONNECTION_STRING.getDisplayName())
+                            .input(connection)
+                            .valid(false)
+                            .explanation("Connection String must be in the form host:port")
+                            .build());
+                }
+            }
+        }
+
+        if (REDIS_MODE_CLUSTER.getValue().equals(redisMode) && dbIndex > 0) {
+            results.add(new ValidationResult.Builder()
+                    .subject(DATABASE.getDisplayName())
+                    .valid(false)
+                    .explanation("Database Index must be 0 when using clustered Redis")
+                    .build());
+        }
+
+        if (REDIS_MODE_SENTINEL.getValue().equals(redisMode)) {
+            final String sentinelMaster = validationContext.getProperty(SENTINEL_MASTER).evaluateAttributeExpressions().getValue();
+            if (StringUtils.isEmpty(sentinelMaster)) {
+                results.add(new ValidationResult.Builder()
+                        .subject(SENTINEL_MASTER.getDisplayName())
+                        .valid(false)
+                        .explanation("Sentinel Master must be provided when Mode is Sentinel")
+                        .build());
+            }
+        }
+
+        return results;
+    }
+
+    private boolean isInteger(final String number) {
+        try {
+            Integer.parseInt(number);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        this.context = context;
+
+        final String redisMode = context.getProperty(REDIS_MODE).getValue();
+        this.redisType = RedisType.fromDisplayName(redisMode);
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
+            connectionFactory = null;
+            redisType = null;
+            context = null;
+        }
+    }
+
+    @Override
+    public RedisType getRedisType() {
+        return redisType;
+    }
+
+    @Override
+    public RedisConnection getConnection() {
+        if (connectionFactory == null) {
+            synchronized (this) {
+                if (connectionFactory == null) {
+                    connectionFactory = createConnectionFactory();
+                }
+            }
+        }
+
+        return connectionFactory.getConnection();
+    }
+
+    protected JedisConnectionFactory createConnectionFactory() {
+        final String redisMode = context.getProperty(REDIS_MODE).getValue();
+        final String connectionString = context.getProperty(CONNECTION_STRING).evaluateAttributeExpressions().getValue();
+        final Integer dbIndex = context.getProperty(DATABASE).evaluateAttributeExpressions().asInteger();
+        final String password = context.getProperty(PASSWORD).evaluateAttributeExpressions().getValue();
+        final Integer timeout = context.getProperty(COMMUNICATION_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
+        final JedisPoolConfig poolConfig = createJedisPoolConfig(context);
+
+        JedisConnectionFactory connectionFactory;
+
+        if (REDIS_MODE_STANDALONE.getValue().equals(redisMode)) {
+            final JedisShardInfo jedisShardInfo = createJedisShardInfo(connectionString, timeout, password);
+
+            getLogger().info("Connecting to Redis in standalone mode at " + connectionString);
+            connectionFactory = new JedisConnectionFactory(jedisShardInfo);
+
+        } else if (REDIS_MODE_SENTINEL.getValue().equals(redisMode)) {
+            final String[] sentinels = connectionString.split("[,]");
+            final String sentinelMaster = context.getProperty(SENTINEL_MASTER).evaluateAttributeExpressions().getValue();
+            final RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration(sentinelMaster, new HashSet<>(Arrays.asList(sentinels)));
+            final JedisShardInfo jedisShardInfo = createJedisShardInfo(sentinels[0], timeout, password);
+
+            getLogger().info("Connecting to Redis in sentinel mode...");
+            getLogger().info("Redis master = " + sentinelMaster);
+
+            for (final String sentinel : sentinels) {
+                getLogger().info("Redis sentinel at " + sentinel);
+            }
+
+            connectionFactory = new JedisConnectionFactory(sentinelConfiguration, poolConfig);
+            connectionFactory.setShardInfo(jedisShardInfo);
+
+        } else {
+            final String[] clusterNodes = connectionString.split("[,]");
+            final Integer maxRedirects = context.getProperty(CLUSTER_MAX_REDIRECTS).asInteger();
+
+            final RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration(Arrays.asList(clusterNodes));
+            clusterConfiguration.setMaxRedirects(maxRedirects);
+
+            getLogger().info("Connecting to Redis in clustered mode...");
+            for (final String clusterNode : clusterNodes) {
+                getLogger().info("Redis cluster node at " + clusterNode);
+            }
+
+            connectionFactory = new JedisConnectionFactory(clusterConfiguration, poolConfig);
+        }
+
+        connectionFactory.setUsePool(true);
+        connectionFactory.setPoolConfig(poolConfig);
+        connectionFactory.setDatabase(dbIndex);
+        connectionFactory.setTimeout(timeout);
+
+        if (!StringUtils.isBlank(password)) {
+            connectionFactory.setPassword(password);
+        }
+
+        // need to call this to initialize the pool/connections
+        connectionFactory.afterPropertiesSet();
+        return connectionFactory;
+    }
+
+    protected JedisShardInfo createJedisShardInfo(final String hostAndPort, final Integer timeout, final String password) {
+        final String[] hostAndPortSplit = hostAndPort.split("[:]");
+        final String host = hostAndPortSplit[0].trim();
+        final Integer port = Integer.parseInt(hostAndPortSplit[1].trim());
+
+        final JedisShardInfo jedisShardInfo = new JedisShardInfo(host, port);
+        jedisShardInfo.setConnectionTimeout(timeout);
+        jedisShardInfo.setSoTimeout(timeout);
+
+        if (!StringUtils.isEmpty(password)) {
+            jedisShardInfo.setPassword(password);
+        }
+
+        return jedisShardInfo;
+    }
+
+    protected JedisPoolConfig createJedisPoolConfig(final ConfigurationContext context) {
+        final JedisPoolConfig poolConfig = new JedisPoolConfig();
+        poolConfig.setMaxTotal(context.getProperty(POOL_MAX_TOTAL).asInteger());
+        poolConfig.setMaxIdle(context.getProperty(POOL_MAX_IDLE).asInteger());
+        poolConfig.setMinIdle(context.getProperty(POOL_MIN_IDLE).asInteger());
+        poolConfig.setBlockWhenExhausted(context.getProperty(POOL_BLOCK_WHEN_EXHAUSTED).asBoolean());
+        poolConfig.setMaxWaitMillis(context.getProperty(POOL_MAX_WAIT_TIME).asTimePeriod(TimeUnit.MILLISECONDS));
+        poolConfig.setMinEvictableIdleTimeMillis(context.getProperty(POOL_MIN_EVICTABLE_IDLE_TIME).asTimePeriod(TimeUnit.MILLISECONDS));
+        poolConfig.setTimeBetweenEvictionRunsMillis(context.getProperty(POOL_TIME_BETWEEN_EVICTION_RUNS).asTimePeriod(TimeUnit.MILLISECONDS));
+        poolConfig.setNumTestsPerEvictionRun(context.getProperty(POOL_NUM_TESTS_PER_EVICTION_RUN).asInteger());
+        poolConfig.setTestOnCreate(context.getProperty(POOL_TEST_ON_CREATE).asBoolean());
+        poolConfig.setTestOnBorrow(context.getProperty(POOL_TEST_ON_BORROW).asBoolean());
+        poolConfig.setTestOnReturn(context.getProperty(POOL_TEST_ON_RETURN).asBoolean());
+        poolConfig.setTestWhileIdle(context.getProperty(POOL_TEST_WHILE_IDLE).asBoolean());
+        return poolConfig;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/RedisDistributedMapCacheClientService.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/RedisDistributedMapCacheClientService.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.distributed.cache.client.AtomicDistributedMapCacheClient;
+import org.apache.nifi.distributed.cache.client.Deserializer;
+import org.apache.nifi.distributed.cache.client.Serializer;
+import org.apache.nifi.util.Tuple;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Tags({ "redis", "distributed", "cache", "map" })
+@CapabilityDescription("An implementation of DistributedMapCacheClient that uses Redis as the backing cache. This service relies on " +
+        "the WATCH, MULTI, and EXEC commands in Redis, which are not fully supported when Redis is clustered. As a result, this service " +
+        "can only be used with a Redis Connection Pool that is configured for standalone or sentinel mode. Sentinel mode can be used to " +
+        "provide high-availability configurations.")
+public class RedisDistributedMapCacheClientService extends AbstractControllerService implements AtomicDistributedMapCacheClient {
+
+    public static final PropertyDescriptor REDIS_CONNECTION_POOL = new PropertyDescriptor.Builder()
+            .name("redis-connection-pool")
+            .displayName("Redis Connection Pool")
+            .identifiesControllerService(RedisConnectionPool.class)
+            .required(true)
+            .build();
+
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS;
+    static {
+        final List<PropertyDescriptor> props = new ArrayList<>();
+        props.add(REDIS_CONNECTION_POOL);
+        PROPERTY_DESCRIPTORS = Collections.unmodifiableList(props);
+    }
+
+    private volatile RedisConnectionPool redisConnectionPool;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        final List<ValidationResult> results = new ArrayList<>();
+
+        final RedisConnectionPool redisConnectionPool = validationContext.getProperty(REDIS_CONNECTION_POOL).asControllerService(RedisConnectionPool.class);
+        if (redisConnectionPool != null) {
+            final RedisType redisType = redisConnectionPool.getRedisType();
+            if (redisType != null && redisType == RedisType.CLUSTER) {
+                results.add(new ValidationResult.Builder()
+                        .subject(REDIS_CONNECTION_POOL.getDisplayName())
+                        .valid(false)
+                        .explanation(REDIS_CONNECTION_POOL.getDisplayName()
+                                + " is configured in clustered mode, and this service requires a non-clustered Redis")
+                        .build());
+            }
+        }
+
+        return results;
+    }
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        this.redisConnectionPool = context.getProperty(REDIS_CONNECTION_POOL).asControllerService(RedisConnectionPool.class);
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        this.redisConnectionPool = null;
+    }
+
+    @Override
+    public <K, V> boolean putIfAbsent(final K key, final V value, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) throws IOException {
+        return withConnection(redisConnection -> {
+            final Tuple<byte[],byte[]> kv = serialize(key, value, keySerializer, valueSerializer);
+            return redisConnection.setNX(kv.getKey(), kv.getValue());
+        });
+    }
+
+    @Override
+    public <K, V> V getAndPutIfAbsent(final K key, final V value, final Serializer<K> keySerializer, final Serializer<V> valueSerializer, final Deserializer<V> valueDeserializer) throws IOException {
+        return withConnection(redisConnection -> {
+            final Tuple<byte[],byte[]> kv = serialize(key, value, keySerializer, valueSerializer);
+            do {
+                // start a watch on the key and retrieve the current value
+                redisConnection.watch(kv.getKey());
+                final byte[] existingValue = redisConnection.get(kv.getKey());
+
+                // start a transaction and perform the put-if-absent
+                redisConnection.multi();
+                redisConnection.setNX(kv.getKey(), kv.getValue());
+
+                // execute the transaction
+                final List<Object> results = redisConnection.exec();
+
+                // if the results list was empty, then the transaction failed (i.e. key was modified after we started watching), so keep looping to retry
+                // if the results list has results, then the transaction succeeded and it should have the result of the setNX operation
+                if (results.size() > 0) {
+                    final Object firstResult = results.get(0);
+                    if (firstResult instanceof Boolean) {
+                        final Boolean absent = (Boolean) firstResult;
+                        return absent ? null : valueDeserializer.deserialize(existingValue);
+                    } else {
+                        // this shouldn't really happen, but just in case there is a non-boolean result then bounce out of the loop
+                        throw new IOException("Unexpected result from Redis transaction: Expected Boolean result, but got "
+                                + firstResult.getClass().getName() + " with value " + firstResult.toString());
+                    }
+                }
+            } while (true);
+        });
+    }
+
+    @Override
+    public <K> boolean containsKey(final K key, final Serializer<K> keySerializer) throws IOException {
+        return withConnection(redisConnection -> {
+            final byte[] k = serialize(key, keySerializer);
+            return redisConnection.exists(k);
+        });
+    }
+
+    @Override
+    public <K, V> void put(final K key, final V value, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) throws IOException {
+        withConnection(redisConnection -> {
+            final Tuple<byte[],byte[]> kv = serialize(key, value, keySerializer, valueSerializer);
+            redisConnection.set(kv.getKey(), kv.getValue());
+            return null;
+        });
+    }
+
+    @Override
+    public <K, V> V get(final K key, final Serializer<K> keySerializer, final Deserializer<V> valueDeserializer) throws IOException {
+        return withConnection(redisConnection -> {
+            final byte[] k = serialize(key, keySerializer);
+            final byte[] v = redisConnection.get(k);
+            return valueDeserializer.deserialize(v);
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        // nothing to do
+    }
+
+    @Override
+    public <K> boolean remove(final K key, final Serializer<K> keySerializer) throws IOException {
+        return withConnection(redisConnection -> {
+            final byte[] k = serialize(key, keySerializer);
+            final long numRemoved = redisConnection.del(k);
+            return numRemoved > 0;
+        });
+    }
+
+    @Override
+    public long removeByPattern(final String regex) throws IOException {
+        return withConnection(redisConnection -> {
+            final List<byte[]> allKeys = new ArrayList<>();
+
+            // perform a scan to get all the keys
+            long cursorId = 0;
+            do {
+                final Cursor<byte[]> cursor = redisConnection.scan(ScanOptions.scanOptions().match(regex).build());
+                while (cursor.hasNext()) {
+                    allKeys.add(cursor.next());
+                }
+
+                cursorId = cursor.getCursorId();
+            } while (cursorId > 0);
+
+            // convert the list of all keys to an array
+            final byte[][] allKeysArray = new byte[allKeys.size()][];
+            for (int i=0; i < allKeys.size(); i++) {
+                allKeysArray[i] = allKeys.get(i);
+            }
+
+            // delete all the keys
+            return redisConnection.del(allKeysArray);
+        });
+    }
+
+    // ----------------- Methods from AtomicDistributedMapCacheClient ------------------------
+    @Override
+    public <K, V> CacheEntry<K, V> fetch(K key, Serializer<K> keySerializer, Deserializer<V> valueDeserializer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K, V> boolean replace(K key, V value, Serializer<K> keySerializer, Serializer<V> valueSerializer, long revision) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K, V> boolean replace(K key, V previousValue, V newValue, Serializer<K> keySerializer, Serializer<V> valueSerializer) throws IOException {
+        return withConnection(redisConnection -> {
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            keySerializer.serialize(key, out);
+            final byte[] k = out.toByteArray();
+            out.reset();
+
+            final byte[] prevVal;
+            if (previousValue == null) {
+                prevVal = null;
+            } else {
+                valueSerializer.serialize(previousValue, out);
+                prevVal = out.toByteArray();
+                out.reset();
+            }
+
+            valueSerializer.serialize(newValue, out);
+            final byte[] newVal = out.toByteArray();
+
+            boolean replaced = false;
+
+            // start a watch on the key and retrieve the current value
+            redisConnection.watch(k);
+            final byte[] currValue = redisConnection.get(k);
+
+            // start a transaction
+            redisConnection.multi();
+
+            // compare-and-set
+            if (Arrays.equals(prevVal, currValue)) {
+                // if we use set(k, newVal) then the results list will always have size == 0 b/c when convertPipelineAndTxResults is set to true,
+                // status responses like "OK" are skipped over, so by using getSet we can rely on the results list to know if the transaction succeeded
+                redisConnection.getSet(k, newVal);
+            }
+
+            // execute the transaction
+            final List<Object> results = redisConnection.exec();
+
+            // if we have a result then the replace succeeded
+            if (results.size() > 0) {
+                replaced = true;
+            }
+
+            return replaced;
+        });
+    }
+    // ----------------- END Methods from AtomicDistributedMapCacheClient ------------------------
+
+    private <K, V> Tuple<byte[],byte[]> serialize(final K key, final V value, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        keySerializer.serialize(key, out);
+        final byte[] k = out.toByteArray();
+
+        out.reset();
+
+        valueSerializer.serialize(value, out);
+        final byte[] v = out.toByteArray();
+
+        return new Tuple<>(k, v);
+    }
+
+    private <K> byte[] serialize(final K key, final Serializer<K> keySerializer) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        keySerializer.serialize(key, out);
+        return out.toByteArray();
+    }
+
+    private <T> T withConnection(final RedisAction<T> action) throws IOException {
+        RedisConnection redisConnection = null;
+        try {
+            redisConnection = redisConnectionPool.getConnection();
+            return action.execute(redisConnection);
+        } finally {
+           if (redisConnection != null) {
+               try {
+                   redisConnection.close();
+               } catch (Exception e) {
+                   getLogger().warn("Error closing connection: " + e.getMessage(), e);
+               }
+           }
+        }
+    }
+
+    private static interface RedisAction<T> {
+        T execute(RedisConnection redisConnection) throws IOException;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.redis.RedisConnectionPoolService
+org.apache.nifi.redis.RedisDistributedMapCacheClientService

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/FakeRedisProcessor.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/FakeRedisProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Fake processor used for testing RedisConnectionPoolService.
+ */
+public class FakeRedisProcessor extends AbstractProcessor {
+
+    public static final PropertyDescriptor REDIS_SERVICE = new PropertyDescriptor.Builder()
+            .name("redis-service")
+            .displayName("Redis Service")
+            .identifiesControllerService(RedisConnectionPool.class)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .required(true)
+            .build();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Collections.singletonList(REDIS_SERVICE);
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+
+    }
+
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/TestRedisConnectionPoolService.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/TestRedisConnectionPoolService.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestRedisConnectionPoolService {
+
+    private TestRunner testRunner;
+    private FakeRedisProcessor proc;
+    private RedisConnectionPool redisService;
+
+    @Before
+    public void setup() throws InitializationException {
+        proc = new FakeRedisProcessor();
+        testRunner = TestRunners.newTestRunner(proc);
+
+        redisService = new RedisConnectionPoolService();
+        testRunner.addControllerService("redis-service", redisService);
+    }
+
+    @Test
+    public void testValidateConnectionString() {
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, " ");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "${redis.connection}");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setVariable("redis.connection", "localhost:6379");
+        testRunner.assertValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost:a");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost:6379");
+        testRunner.assertValid(redisService);
+
+        // standalone can only have one host:port pair
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost:6379,localhost:6378");
+        testRunner.assertNotValid(redisService);
+
+        // cluster can have multiple host:port pairs
+        testRunner.setProperty(redisService, RedisConnectionPoolService.REDIS_MODE, RedisConnectionPoolService.REDIS_MODE_CLUSTER.getValue());
+        testRunner.assertValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost:6379,localhost");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "local:host:6379,localhost:6378");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost:a,localhost:b");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost  :6379,  localhost  :6378,    localhost:6377");
+        testRunner.assertValid(redisService);
+    }
+
+    @Test
+    public void testValidateSentinelMasterRequiredInSentinelMode() {
+        testRunner.setProperty(redisService, RedisConnectionPoolService.REDIS_MODE, RedisConnectionPoolService.REDIS_MODE_SENTINEL.getValue());
+        testRunner.setProperty(redisService, RedisConnectionPoolService.CONNECTION_STRING, "localhost:6379,localhost:6378");
+        testRunner.assertNotValid(redisService);
+
+        testRunner.setProperty(redisService, RedisConnectionPoolService.SENTINEL_MASTER, "mymaster");
+        testRunner.assertValid(redisService);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/TestRedisDistributedMapCacheClientService.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/TestRedisDistributedMapCacheClientService.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.distributed.cache.client.AtomicDistributedMapCacheClient;
+import org.apache.nifi.distributed.cache.client.Deserializer;
+import org.apache.nifi.distributed.cache.client.Serializer;
+import org.apache.nifi.distributed.cache.client.exception.DeserializationException;
+import org.apache.nifi.distributed.cache.client.exception.SerializationException;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This is an integration test that is meant to be run against a real Redis instance.
+ */
+public class TestRedisDistributedMapCacheClientService {
+
+    private TestRedisProcessor proc;
+    private TestRunner testRunner;
+    private RedisConnectionPoolService redisConnectionPool;
+    private RedisDistributedMapCacheClientService redisMapCacheClientService;
+
+    @Before
+    public void setup() {
+        proc = new TestRedisProcessor();
+        testRunner = TestRunners.newTestRunner(proc);
+    }
+
+    @Test
+    @Ignore
+    public void testStandaloneRedis() throws InitializationException {
+        try {
+            // create, configure, and enable the RedisConnectionPool service
+            redisConnectionPool = new RedisConnectionPoolService();
+            testRunner.addControllerService("redis-connection-pool", redisConnectionPool);
+            testRunner.setProperty(redisConnectionPool, RedisConnectionPoolService.CONNECTION_STRING, "localhost:6379");
+
+            // uncomment this to test using a different database index than the default 0
+            //testRunner.setProperty(redisConnectionPool, RedisConnectionPoolService.DATABASE, "1");
+
+            // uncomment this to test using a password to authenticate to redis
+            //testRunner.setProperty(redisConnectionPool, RedisConnectionPoolService.PASSWORD, "foobared");
+
+            testRunner.enableControllerService(redisConnectionPool);
+
+            setupRedisMapCacheClientService();
+            executeProcessor();
+        } finally {
+            if (redisConnectionPool != null) {
+                redisConnectionPool.onDisabled();
+            }
+        }
+    }
+
+    private void setupRedisMapCacheClientService() throws InitializationException {
+        // create, configure, and enable the RedisDistributedMapCacheClient service
+        redisMapCacheClientService = new RedisDistributedMapCacheClientService();
+        testRunner.addControllerService("redis-map-cache-client", redisMapCacheClientService);
+        testRunner.setProperty(redisMapCacheClientService, RedisDistributedMapCacheClientService.REDIS_CONNECTION_POOL, "redis-connection-pool");
+        testRunner.enableControllerService(redisMapCacheClientService);
+        testRunner.setProperty(TestRedisProcessor.REDIS_MAP_CACHE, "redis-map-cache-client");
+    }
+
+    private void executeProcessor() {
+        // queue a flow file to trigger the processor and executeProcessor it
+        testRunner.enqueue("trigger");
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(TestRedisProcessor.REL_SUCCESS, 1);
+    }
+
+    /**
+     * Test processor that exercises RedisDistributedMapCacheClient.
+     */
+    private static class TestRedisProcessor extends AbstractProcessor {
+
+        public static final PropertyDescriptor REDIS_MAP_CACHE = new PropertyDescriptor.Builder()
+                .name("redis-map-cache")
+                .displayName("Redis Map Cache")
+                .identifiesControllerService(AtomicDistributedMapCacheClient.class)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .required(true)
+                .build();
+
+        public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success").build();
+        public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure").build();
+
+        @Override
+        protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+            return Collections.singletonList(REDIS_MAP_CACHE);
+        }
+
+        @Override
+        public Set<Relationship> getRelationships() {
+            return new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE));
+        }
+
+        @Override
+        public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+            final FlowFile flowFile = session.get();
+            if (flowFile == null) {
+                return;
+            }
+
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final Serializer<String> stringSerializer = new StringSerializer();
+            final Deserializer<String> stringDeserializer = new StringDeserializer();
+
+            final AtomicDistributedMapCacheClient cacheClient = context.getProperty(REDIS_MAP_CACHE).asControllerService(AtomicDistributedMapCacheClient.class);
+
+            try {
+                final long timestamp = System.currentTimeMillis();
+                final String key = "test-redis-processor-" + timestamp;
+                final String value = "the time is " + timestamp;
+
+                // verify the key doesn't exists, put the key/value, then verify it exists
+                Assert.assertFalse(cacheClient.containsKey(key, stringSerializer));
+                cacheClient.put(key, value, stringSerializer, stringSerializer);
+                Assert.assertTrue(cacheClient.containsKey(key, stringSerializer));
+
+                // verify get returns the expected value we set above
+                final String retrievedValue = cacheClient.get(key, stringSerializer, stringDeserializer);
+                Assert.assertEquals(value, retrievedValue);
+
+                // verify remove removes the entry and contains key returns false after
+                Assert.assertTrue(cacheClient.remove(key, stringSerializer));
+                Assert.assertFalse(cacheClient.containsKey(key, stringSerializer));
+
+                // verify putIfAbsent works the first time and returns false the second time
+                Assert.assertTrue(cacheClient.putIfAbsent(key, value, stringSerializer, stringSerializer));
+                Assert.assertFalse(cacheClient.putIfAbsent(key, "some other value", stringSerializer, stringSerializer));
+                Assert.assertEquals(value, cacheClient.get(key, stringSerializer, stringDeserializer));
+
+                // verify that getAndPutIfAbsent returns the existing value and doesn't modify it in the cache
+                final String getAndPutIfAbsentResult = cacheClient.getAndPutIfAbsent(key, value, stringSerializer, stringSerializer, stringDeserializer);
+                Assert.assertEquals(value, getAndPutIfAbsentResult);
+                Assert.assertEquals(value, cacheClient.get(key, stringSerializer, stringDeserializer));
+
+                // verify that getAndPutIfAbsent on a key that doesn't exist returns null
+                final String keyThatDoesntExist = key + "_DOES_NOT_EXIST";
+                Assert.assertFalse(cacheClient.containsKey(keyThatDoesntExist, stringSerializer));
+                final String getAndPutIfAbsentResultWhenDoesntExist = cacheClient.getAndPutIfAbsent(keyThatDoesntExist, value, stringSerializer, stringSerializer, stringDeserializer);
+                Assert.assertEquals(null, getAndPutIfAbsentResultWhenDoesntExist);
+                Assert.assertEquals(value, cacheClient.get(keyThatDoesntExist, stringSerializer, stringDeserializer));
+
+                final String replacementValue = "this value has been replaced";
+
+                // verify atomic replace does not replace when previous value is not equal
+                Assert.assertFalse(cacheClient.replace(key, "not previous value", replacementValue, stringSerializer, stringSerializer));
+                Assert.assertEquals(value, cacheClient.get(key, stringSerializer, stringDeserializer));
+
+                // verify atomic replace does replace when previous value is equal
+                Assert.assertTrue(cacheClient.replace(key, value, replacementValue, stringSerializer, stringSerializer));
+                Assert.assertEquals(replacementValue, cacheClient.get(key, stringSerializer, stringDeserializer));
+
+                // verify atomic replace does replace no value previous existed
+                final String replaceKeyDoesntExist = key + "_REPLACE_DOES_NOT_EXIST";
+                Assert.assertTrue(cacheClient.replace(replaceKeyDoesntExist, null, replacementValue, stringSerializer, stringSerializer));
+                Assert.assertEquals(replacementValue, cacheClient.get(replaceKeyDoesntExist, stringSerializer, stringDeserializer));
+
+
+                for (int i=0; i < 50; i++) {
+                    cacheClient.put(key + "-" + i, value, stringSerializer, stringSerializer);
+                }
+
+                Assert.assertTrue(cacheClient.removeByPattern("test-redis-processor-*") > 50);
+                Assert.assertFalse(cacheClient.containsKey(key, stringSerializer));
+
+                session.transfer(flowFile, REL_SUCCESS);
+            } catch (final Exception e) {
+                getLogger().error("Routing to failure due to: " + e.getMessage(), e);
+                session.transfer(flowFile, REL_FAILURE);
+            }
+        }
+    }
+
+    private static class StringSerializer implements Serializer<String> {
+        @Override
+        public void serialize(String value, OutputStream output) throws SerializationException, IOException {
+            if (value != null) {
+                output.write(value.getBytes(StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+    private static class StringDeserializer implements Deserializer<String> {
+        @Override
+        public String deserialize(byte[] input) throws DeserializationException, IOException {
+            return input == null ? null : new String(input, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-nar/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-redis-bundle</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-redis-nar</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-redis-extensions</artifactId>
+            <version>1.3.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-redis-service-api-nar</artifactId>
+            <type>nar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-redis-bundle</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-redis-service-api-nar</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-redis-service-api</artifactId>
+            <version>1.3.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,239 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.
+
+  The binary distribution of this product bundles 'ParaNamer' and 'Paranamer Core'
+  which is available under a BSD style license.
+
+    Copyright (c) 2006 Paul Hammant & ThoughtWorks Inc
+     All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions
+     are met:
+     1. Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+     3. Neither the name of the copyright holders nor the names of its
+        contributors may be used to endorse or promote products derived from
+        this software without specific prior written permission.
+
+     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+     LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+     INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+     CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+     THE POSSIBILITY OF SUCH DAMAGE.

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,33 @@
+Apache NiFi
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+******************
+Apache Software License v2
+******************
+
+The following binary components are provided under the Apache Software License v2
+
+    (ASLv2) Apache Commons Pool
+      The following NOTICE information applies:
+        Apache Commons Pool
+        Copyright 1999-2009 The Apache Software Foundation.
+
+************************
+The MIT License
+************************
+
+The following binary components are provided under the MIT License.  See project link for details.
+
+  (MIT License) Jedis (redis.clients:jedis:2.9.0 - https://github.com/xetorthio/jedis)
+
+
+*****************
+Public Domain
+*****************
+
+The following binary components are provided to the 'Public Domain'.  See project link for details.
+
+    (Public Domain) AOP Alliance 1.0 (http://aopalliance.sourceforge.net/)

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-redis-bundle</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-redis-service-api</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <version>${spring.data.redis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/src/main/java/org/apache/nifi/redis/RedisConnectionPool.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/src/main/java/org/apache/nifi/redis/RedisConnectionPool.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+import org.apache.nifi.controller.ControllerService;
+import org.springframework.data.redis.connection.RedisConnection;
+
+/**
+ * A service that provides connections to Redis using spring-data-redis.
+ */
+public interface RedisConnectionPool extends ControllerService {
+
+    /**
+     * Obtains a RedisConnection instance from the pool.
+     *
+     * NOTE: Clients are responsible for ensuring the close() method of the connection is called to return it to the pool.
+     *
+     * @return a RedisConnection instance
+     */
+    RedisConnection getConnection();
+
+    /**
+     * Some Redis operations are only supported in a specific mode. Clients should use this method to ensure
+     * the connection pool they are using supports their required operations.
+     *
+     * @return the type of Redis instance (i.e. standalone, clustered, sentinel)
+     */
+    RedisType getRedisType();
+
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/src/main/java/org/apache/nifi/redis/RedisType.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/src/main/java/org/apache/nifi/redis/RedisType.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.redis;
+
+/**
+ * Possible types of Redis instances.
+ */
+public enum RedisType {
+
+    STANDALONE("Standalone", "A single standalone Redis instance."),
+
+    SENTINEL("Sentinel", "Redis Sentinel which provides high-availability. Described further at https://redis.io/topics/sentinel"),
+
+    CLUSTER("Cluster", "Clustered Redis which provides sharding and replication. Described further at https://redis.io/topics/cluster-spec");
+
+    private final String displayName;
+    private final String description;
+
+    RedisType(final String displayName, final String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static RedisType fromDisplayName(final String displayName) {
+        for (RedisType redisType : values()) {
+            if (redisType.getDisplayName().equals(displayName)) {
+                return redisType;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown RedisType: " + displayName);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-bundles</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.nifi</groupId>
+    <artifactId>nifi-redis-bundle</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <spring.data.redis.version>1.8.3.RELEASE</spring.data.redis.version>
+    </properties>
+
+    <modules>
+        <module>nifi-redis-service-api</module>
+        <module>nifi-redis-service-api-nar</module>
+        <module>nifi-redis-extensions</module>
+        <module>nifi-redis-nar</module>
+    </modules>
+
+</project>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestNotify.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestNotify.java
@@ -21,7 +21,7 @@ import org.apache.nifi.distributed.cache.client.AtomicDistributedMapCacheClient;
 import org.apache.nifi.distributed.cache.client.Deserializer;
 import org.apache.nifi.distributed.cache.client.Serializer;
 import org.apache.nifi.distributed.cache.client.StandardCacheEntry;
-import org.apache.nifi.processors.standard.WaitNotifyProtocol.Signal;
+import org.apache.nifi.processors.standard.WaitNotifyProtocol.SignalHolder;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -74,10 +74,10 @@ public class TestNotify {
         runner.assertAllFlowFilesTransferred(Notify.REL_SUCCESS, 1);
         runner.clearTransferState();
 
-        final Signal signal = new WaitNotifyProtocol(service).getSignal("1");
-        Map<String, String> cachedAttributes = signal.getAttributes();
+        final SignalHolder signal = new WaitNotifyProtocol(service).getSignal("1");
+        Map<String, String> cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("value", cachedAttributes.get("key"));
-        assertTrue(signal.isTotalCountReached(1));
+        assertTrue(signal.getSignal().isTotalCountReached(1));
     }
 
     @Test
@@ -109,12 +109,12 @@ public class TestNotify {
         runner.assertAllFlowFilesTransferred(Notify.REL_SUCCESS, 3);
         runner.clearTransferState();
 
-        final Signal signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
-        Map<String, String> cachedAttributes = signal.getAttributes();
+        final SignalHolder signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
+        Map<String, String> cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("Same attribute key will be overwritten by the latest signal", "data3", cachedAttributes.get("key"));
-        assertTrue(signal.isTotalCountReached(3));
-        assertEquals(2, signal.getCount("success"));
-        assertEquals(1, signal.getCount("failure"));
+        assertTrue(signal.getSignal().isTotalCountReached(3));
+        assertEquals(2, signal.getSignal().getCount("success"));
+        assertEquals(1, signal.getSignal().getCount("failure"));
     }
 
     @Test
@@ -148,12 +148,12 @@ public class TestNotify {
         runner.assertAllFlowFilesTransferred(Notify.REL_SUCCESS, 2);
         runner.clearTransferState();
 
-        Signal signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
-        Map<String, String> cachedAttributes = signal.getAttributes();
+        SignalHolder signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
+        Map<String, String> cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("Same attribute key will be overwritten by the latest signal", "data2", cachedAttributes.get("key"));
-        assertTrue(signal.isTotalCountReached(2));
-        assertEquals(2, signal.getCount("success"));
-        assertEquals(0, signal.getCount("failure"));
+        assertTrue(signal.getSignal().isTotalCountReached(2));
+        assertEquals(2, signal.getSignal().getCount("success"));
+        assertEquals(0, signal.getSignal().getCount("failure"));
 
         // Run it again, and it should process remaining one flow file.
         runner.run();
@@ -161,11 +161,11 @@ public class TestNotify {
         runner.clearTransferState();
 
         signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
-        cachedAttributes = signal.getAttributes();
+        cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("Same attribute key will be overwritten by the latest signal", "data3", cachedAttributes.get("key"));
-        assertTrue(signal.isTotalCountReached(3));
-        assertEquals(2, signal.getCount("success"));
-        assertEquals(1, signal.getCount("failure"));
+        assertTrue(signal.getSignal().isTotalCountReached(3));
+        assertEquals(2, signal.getSignal().getCount("success"));
+        assertEquals(1, signal.getSignal().getCount("failure"));
 
     }
 
@@ -203,12 +203,12 @@ public class TestNotify {
         runner.assertAllFlowFilesTransferred(Notify.REL_SUCCESS, 3);
         runner.clearTransferState();
 
-        final Signal signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
-        Map<String, String> cachedAttributes = signal.getAttributes();
+        final SignalHolder signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
+        Map<String, String> cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("Same attribute key will be overwritten by the latest signal", "data3", cachedAttributes.get("key"));
-        assertTrue(signal.isTotalCountReached(3584));
-        assertEquals(3072, signal.getCount("success"));
-        assertEquals(512, signal.getCount("failure"));
+        assertTrue(signal.getSignal().isTotalCountReached(3584));
+        assertEquals(3072, signal.getSignal().getCount("success"));
+        assertEquals(512, signal.getSignal().getCount("failure"));
     }
 
     @Test
@@ -247,12 +247,12 @@ public class TestNotify {
         runner.assertTransferCount(Notify.REL_FAILURE, 1);
         runner.clearTransferState();
 
-        final Signal signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
-        Map<String, String> cachedAttributes = signal.getAttributes();
+        final SignalHolder signal = new WaitNotifyProtocol(service).getSignal("someDataProcessing");
+        Map<String, String> cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("Same attribute key will be overwritten by the latest signal", "data3", cachedAttributes.get("key"));
-        assertTrue(signal.isTotalCountReached(1536));
-        assertEquals(1024, signal.getCount("success"));
-        assertEquals(512, signal.getCount("failure"));
+        assertTrue(signal.getSignal().isTotalCountReached(1536));
+        assertEquals(1024, signal.getSignal().getCount("success"));
+        assertEquals(512, signal.getSignal().getCount("failure"));
 
     }
 
@@ -272,11 +272,11 @@ public class TestNotify {
         runner.assertAllFlowFilesTransferred(Notify.REL_SUCCESS, 1);
         runner.clearTransferState();
 
-        final Signal signal = new WaitNotifyProtocol(service).getSignal("1");
-        Map<String, String> cachedAttributes = signal.getAttributes();
+        final SignalHolder signal = new WaitNotifyProtocol(service).getSignal("1");
+        Map<String, String> cachedAttributes = signal.getSignal().getAttributes();
         assertEquals("value", cachedAttributes.get("key1"));
         assertNull(cachedAttributes.get("other.key1"));
-        assertTrue(signal.isTotalCountReached(1));
+        assertTrue(signal.getSignal().isTotalCountReached(1));
     }
 
     @Test
@@ -413,6 +413,21 @@ public class TestNotify {
             }
 
             values.put(key, new StandardCacheEntry<>(key, value, revision + 1));
+
+            return true;
+        }
+
+        @Override
+        public <K, V> boolean replace(K key, V previousValue, V newValue, Serializer<K> keySerializer, Serializer<V> valueSerializer) throws IOException {
+            verifyNotFail();
+
+            final CacheEntry existing = values.get(key);
+
+            if (existing != null && !existing.getValue().equals(previousValue)) {
+                return false;
+            }
+
+            values.put(key, new StandardCacheEntry<>(key, newValue, 0));
 
             return true;
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestWait.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestWait.java
@@ -598,7 +598,7 @@ public class TestWait {
         testIteration.expectedWaiting.addAll(Arrays.asList("1", "2"));
         testIteration.run();
 
-        WaitNotifyProtocol.Signal signal = protocol.getSignal("key");
+        WaitNotifyProtocol.SignalHolder signal = protocol.getSignal("key");
         assertNull(signal);
 
         /*
@@ -610,8 +610,8 @@ public class TestWait {
         testIteration.run();
 
         signal = protocol.getSignal("key");
-        assertEquals(0, signal.getCount("count"));
-        assertEquals(4, signal.getReleasableCount());
+        assertEquals(0, signal.getSignal().getCount("count"));
+        assertEquals(4, signal.getSignal().getReleasableCount());
 
         /*
          * 3rd run
@@ -621,8 +621,8 @@ public class TestWait {
         testIteration.run();
 
         signal = protocol.getSignal("key");
-        assertEquals(0, signal.getCount("count"));
-        assertEquals(2, signal.getReleasableCount());
+        assertEquals(0, signal.getSignal().getCount("count"));
+        assertEquals(2, signal.getSignal().getReleasableCount());
     }
 
     @Test
@@ -655,7 +655,7 @@ public class TestWait {
         testIteration.expectedWaiting.addAll(Arrays.asList("1", "2"));
         testIteration.run();
 
-        WaitNotifyProtocol.Signal signal = protocol.getSignal("key");
+        WaitNotifyProtocol.SignalHolder signal = protocol.getSignal("key");
         assertNull(signal);
 
         /*
@@ -667,8 +667,8 @@ public class TestWait {
         testIteration.run();
 
         signal = protocol.getSignal("key");
-        assertEquals(3, signal.getCount("counter"));
-        assertEquals(0, signal.getReleasableCount());
+        assertEquals(3, signal.getSignal().getCount("counter"));
+        assertEquals(0, signal.getSignal().getReleasableCount());
 
         /*
          * 3rd run
@@ -678,7 +678,7 @@ public class TestWait {
         testIteration.run();
 
         signal = protocol.getSignal("key");
-        assertEquals(3, signal.getCount("counter"));
-        assertEquals(0, signal.getReleasableCount());
+        assertEquals(3, signal.getSignal().getCount("counter"));
+        assertEquals(0, signal.getSignal().getReleasableCount());
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/AtomicDistributedMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/AtomicDistributedMapCacheClient.java
@@ -35,6 +35,7 @@ import java.io.IOException;
         + "multiple nodes to coordinate state with a single remote entity.")
 public interface AtomicDistributedMapCacheClient extends DistributedMapCacheClient {
 
+    @Deprecated
     interface CacheEntry<K, V> {
 
         long getRevision();
@@ -55,6 +56,7 @@ public interface AtomicDistributedMapCacheClient extends DistributedMapCacheClie
      * @return A CacheEntry instance if one exists, otherwise <cod>null</cod>.
      * @throws IOException if unable to communicate with the remote instance
      */
+    @Deprecated
     <K, V> CacheEntry<K, V> fetch(K key, Serializer<K> keySerializer, Deserializer<V> valueDeserializer) throws IOException;
 
     /**
@@ -71,6 +73,23 @@ public interface AtomicDistributedMapCacheClient extends DistributedMapCacheClie
      * @return true only if the key is replaced.
      * @throws IOException if unable to communicate with the remote instance
      */
+    @Deprecated
     <K, V> boolean replace(K key, V value, Serializer<K> keySerializer, Serializer<V> valueSerializer, long revision) throws IOException;
+
+
+    /**
+     * Replaces the value of a key, only if the current value is equal the given previous value.
+     *
+     * @param key the key to replace
+     * @param previousValue the value to compare against the current value of the key, passing a null previousValue indicates no value previously existed
+     * @param newValue the new value for the key
+     * @param keySerializer key serializer
+     * @param valueSerializer value serializer
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return true only if the key is replaced, false otherwise
+     * @throws IOException if unable to communicate with the remote cache
+     */
+    <K, V> boolean replace(K key, V previousValue, V newValue, Serializer<K> keySerializer, Serializer<V> valueSerializer) throws IOException;
 
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCache.java
@@ -38,5 +38,7 @@ public interface MapCache {
 
     MapPutResult replace(MapCacheRecord record) throws IOException;
 
+    MapPutResult replace(ByteBuffer key, ByteBuffer previousValue, ByteBuffer newValue) throws IOException;
+
     void shutdown() throws IOException;
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheServer.java
@@ -56,7 +56,7 @@ public class MapCacheServer extends AbstractCacheServer {
      * for details of each version enhancements.
      */
     protected StandardVersionNegotiator getVersionNegotiator() {
-        return new StandardVersionNegotiator(2, 1);
+        return new StandardVersionNegotiator(3, 2, 1);
     }
 
     @Override
@@ -155,6 +155,14 @@ public class MapCacheServer extends AbstractCacheServer {
                 final long revision = dis.readLong();
                 final byte[] value = readValue(dis);
                 final MapPutResult result = cache.replace(new MapCacheRecord(ByteBuffer.wrap(key), ByteBuffer.wrap(value), revision));
+                dos.writeBoolean(result.isSuccessful());
+                break;
+            }
+            case "replaceIfEqual": {
+                final byte[] key = readValue(dis);
+                final byte[] prevValue = readValue(dis);
+                final byte[] newValue = readValue(dis);
+                final MapPutResult result = cache.replace(ByteBuffer.wrap(key), ByteBuffer.wrap(prevValue), ByteBuffer.wrap(newValue));
                 dos.writeBoolean(result.isSuccessful());
                 break;
             }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
@@ -111,6 +111,13 @@ public class PersistentMapCache implements MapCache {
     }
 
     @Override
+    public MapPutResult replace(ByteBuffer key, ByteBuffer previousValue, ByteBuffer newValue) throws IOException {
+        final MapPutResult putResult = wrapped.replace(key, previousValue, newValue);
+        putWriteAheadLog(key, newValue, putResult);
+        return putResult;
+    }
+
+    @Override
     public ByteBuffer remove(final ByteBuffer key) throws IOException {
         final ByteBuffer removeResult = wrapped.remove(key);
         if (removeResult != null) {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
@@ -249,6 +249,23 @@ public class SimpleMapCache implements MapCache {
     }
 
     @Override
+    public MapPutResult replace(ByteBuffer key, ByteBuffer previousValue, ByteBuffer newValue) throws IOException {
+        writeLock.lock();
+        try {
+            final MapCacheRecord existing = fetch(key);
+
+            // if there is an existing record for the key, and it's value is not the passed in previousValue, then don't replace
+            if (existing != null && !existing.getValue().equals(previousValue)) {
+                return new MapPutResult(false, new MapCacheRecord(key, previousValue), existing, null);
+            }
+
+            return put(key, newValue, existing);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
     public void shutdown() throws IOException {
     }
 }

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -83,6 +83,7 @@
         <module>nifi-cybersecurity-bundle</module>
         <module>nifi-parquet-bundle</module>
         <module>nifi-extension-utils</module>
+    <module>nifi-redis-bundle</module>
   </modules>
 
     <build>
@@ -105,7 +106,7 @@
                     <doUpdate>false</doUpdate>
                     <shortRevisionLength>7</shortRevisionLength>
                     <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
-                    <revisionOnScmFailure />
+                    <revisionOnScmFailure/>
                     <buildNumberPropertyName>buildRevision</buildNumberPropertyName>
                     <scmBranchPropertyName>buildBranch</scmBranchPropertyName>
                 </configuration>
@@ -124,8 +125,8 @@
                 </file>
             </activation>
             <properties>
-                <buildRevision />
-                <buildBranch />
+                <buildRevision/>
+                <buildBranch/>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1435,6 +1435,18 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-redis-service-api-nar</artifactId>
+                <version>1.3.0-SNAPSHOT</version>
+                <type>nar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-redis-nar</artifactId>
+                <version>1.3.0-SNAPSHOT</version>
+                <type>nar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-properties</artifactId>
                 <version>1.3.0-SNAPSHOT</version>
             </dependency>


### PR DESCRIPTION
Adds RedisConnectionPoolService and RedisDistributedMapCacheClientService

- Refactored Wait/Notify to use new replace method based on previous value, depracating replace based on revision
- Updating protocol version on DMC and require v3 for new replace
- Wait/Notify working against Redis and standard DMCS
- Working connection to sentinel configuration
- Adding validtion to ensure Redis DMCS doesn't use a connection pool in clustered mode
- Adding NOTICE and LICENSE to nifi-redis-service-api-nar
