### PR TITLE
NIFI-4057 Docker Image is twice as large as necessary

### DIFF
--- a/nifi-docker/dockerhub/DockerBuild.sh
+++ b/nifi-docker/dockerhub/DockerBuild.sh
@@ -20,12 +20,17 @@ if [ -n "$1" ]; then
   DOCKER_UID="$1"
 fi
 
-DOCKER_GID=50
+DOCKER_GID=1000
 if [ -n "$2" ]; then
   DOCKER_GID="$2"
 fi
 
+MIRROR=https://archive.apache.org/dist
+if [ -n "$3" ]; then
+  MIRROR="$3"
+fi
+
 DOCKER_IMAGE="$(egrep -v '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
 NIFI_IMAGE_VERSION="$(echo $DOCKER_IMAGE | cut -d : -f 2)"
-echo "Building NiFi Image: '$DOCKER_IMAGE' Version: $NIFI_IMAGE_VERSION"
-docker build --build-arg UID="$DOCKER_UID" --build-arg GID="$DOCKER_GID" --build-arg NIFI_VERSION="$NIFI_IMAGE_VERSION" -t $DOCKER_IMAGE .
+echo "Building NiFi Image: '$DOCKER_IMAGE' Version: $NIFI_IMAGE_VERSION Mirror: $MIRROR"
+docker build --build-arg UID="$DOCKER_UID" --build-arg GID="$DOCKER_GID" --build-arg NIFI_VERSION="$NIFI_IMAGE_VERSION" --build-arg MIRROR="$MIRROR" -t $DOCKER_IMAGE .

--- a/nifi-docker/dockerhub/Dockerfile
+++ b/nifi-docker/dockerhub/Dockerfile
@@ -16,37 +16,38 @@
 # under the License.
 #
 
-FROM openjdk:8
-MAINTAINER Apache NiFi <dev@nifi.apache.org>
+FROM openjdk:8-jre
+LABEL maintainer "Apache NiFi <dev@nifi.apache.org>"
 
 ARG UID=1000
-ARG GID=50
+ARG GID=1000
 ARG NIFI_VERSION=1.4.0
+ARG MIRROR=https://archive.apache.org/dist
 
-ENV NIFI_BASE_DIR /opt/nifi
-ENV NIFI_HOME $NIFI_BASE_DIR/nifi-$NIFI_VERSION
-ENV NIFI_BINARY_URL https://archive.apache.org/dist/nifi/$NIFI_VERSION/nifi-$NIFI_VERSION-bin.tar.gz
+ENV NIFI_BASE_DIR /opt/nifi 
+ENV NIFI_HOME=$NIFI_BASE_DIR/nifi-$NIFI_VERSION \
+    NIFI_BINARY_URL=/nifi/$NIFI_VERSION/nifi-$NIFI_VERSION-bin.tar.gz
 
 # Setup NiFi user
-RUN groupadd -g $GID nifi || groupmod -n nifi `getent group $GID | cut -d: -f1`
-RUN useradd --shell /bin/bash -u $UID -g $GID -m nifi
-RUN mkdir -p $NIFI_HOME
-
-# Download, validate, and expand Apache NiFi binary.
-RUN curl -fSL $NIFI_BINARY_URL -o $NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz \
-	&& echo "$(curl $NIFI_BINARY_URL.sha256) *$NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz" | sha256sum -c - \
-	&& tar -xvzf $NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz -C $NIFI_BASE_DIR \
-	&& rm $NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz
-
-RUN chown -R nifi:nifi $NIFI_HOME
-
-# Web HTTP Port
-EXPOSE 8080
-
-# Remote Site-To-Site Port
-EXPOSE 8181
+RUN groupadd -g $GID nifi || groupmod -n nifi `getent group $GID | cut -d: -f1` \
+    && useradd --shell /bin/bash -u $UID -g $GID -m nifi \
+    && mkdir -p $NIFI_HOME/conf/templates \
+    && chown -R nifi:nifi $NIFI_BASE_DIR
 
 USER nifi
 
+# Download, validate, and expand Apache NiFi binary.
+RUN curl -fSL $MIRROR/$NIFI_BINARY_URL -o $NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz \
+    && echo "$(curl https://archive.apache.org/dist/$NIFI_BINARY_URL.sha256) *$NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz" | sha256sum -c - \
+    && tar -xvzf $NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz -C $NIFI_BASE_DIR \
+    && rm $NIFI_BASE_DIR/nifi-$NIFI_VERSION-bin.tar.gz \
+    && chown -R nifi:nifi $NIFI_HOME
+
+# Web HTTP Port & Remote Site-to-Site Ports
+EXPOSE 8080 8181
+
+WORKDIR $NIFI_HOME
+
 # Startup NiFi
-CMD $NIFI_HOME/bin/nifi.sh run
+ENTRYPOINT ["bin/nifi.sh"]
+CMD ["run"]

--- a/nifi-docker/dockermaven/Dockerfile
+++ b/nifi-docker/dockermaven/Dockerfile
@@ -16,11 +16,11 @@
 # under the License.
 #
 
-FROM openjdk:8
-MAINTAINER Apache NiFi <dev@nifi.apache.org>
+FROM openjdk:8-jre
+LABEL maintainer "Apache NiFi <dev@nifi.apache.org>"
 
 ARG UID=1000
-ARG GID=50
+ARG GID=1000
 ARG NIFI_VERSION
 ARG NIFI_BINARY
 
@@ -28,20 +28,21 @@ ENV NIFI_BASE_DIR /opt/nifi
 ENV NIFI_HOME $NIFI_BASE_DIR/nifi-$NIFI_VERSION
 
 # Setup NiFi user
-RUN groupadd -g $GID nifi || groupmod -n nifi `getent group $GID | cut -d: -f1`
-RUN useradd --shell /bin/bash -u $UID -g $GID -m nifi
-RUN mkdir -p $NIFI_HOME 
+RUN groupadd -g $GID nifi || groupmod -n nifi `getent group $GID | cut -d: -f1` \
+    && useradd --shell /bin/bash -u $UID -g $GID -m nifi \
+    && mkdir -p $NIFI_HOME/conf/templates
+    && chown -R nifi:nifi $NIFI_BASE_DIR
+
+USER nifi
 
 ADD $NIFI_BINARY $NIFI_BASE_DIR
 RUN chown -R nifi:nifi $NIFI_HOME
 
-# Web HTTP Port
-EXPOSE 8080
+# Web HTTP Port & Remote Site-to-Site Ports
+EXPOSE 8080 8181
 
-# Remote Site-To-Site Port
-EXPOSE 8181
-
-USER nifi
+WORKDIR $NIFI_HOME
 
 # Startup NiFi
-CMD $NIFI_HOME/bin/nifi.sh run
+ENTRYPOINT ["bin/nifi.sh"]
+CMD ["run"]

--- a/nifi-docker/pom.xml
+++ b/nifi-docker/pom.xml
@@ -24,7 +24,7 @@ language governing permissions and limitations under the License. -->
     <packaging>pom</packaging>
 
     <properties>
-        <nifi.version>1.2.0-SNAPSHOT</nifi.version>
+        <nifi.version>1.4.0-SNAPSHOT</nifi.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Resulting Docker image is now 1.29 GB instead of 2.58 GB

**Detailed changes**

  * Merging unnecessary layers
  * MAINTAINER is deprecated
  * Using JRE as base since JDK is not necessary
  * Set GID=1000 since openjdk image already defines 50
  * Add ability to specify Apache mirror site to reduce load on Apache Archive
  * Created templates directory since this is not included in the binary

---

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
