### PR TITLE
NIFI-4099

### DIFF
--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,8 +20,8 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>1.10.1</snmp4j.version>
-        <snmp4j-agent.version>1.3.1</snmp4j-agent.version>
+        <snmp4j.version>2.5.6</snmp4j.version>
+        <snmp4j-agent.version>2.5.3</snmp4j-agent.version>
     </properties>
 
     <dependencies>

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/AbstractSNMPProcessor.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/AbstractSNMPProcessor.java
@@ -56,7 +56,7 @@ import org.snmp4j.transport.DefaultUdpTransportMapping;
 abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProcessor {
 
     /** property to define host of the SNMP agent */
-    public static final PropertyDescriptor HOST = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor HOST = new PropertyDescriptor.Builder()
             .name("snmp-hostname")
             .displayName("Host Name")
             .description("Network address of SNMP Agent (e.g., localhost)")
@@ -66,7 +66,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define port of the SNMP agent */
-    public static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
             .name("snmp-port")
             .displayName("Port")
             .description("Numeric value identifying Port of SNMP Agent (e.g., 161)")
@@ -76,7 +76,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP version to use */
-    public static final PropertyDescriptor SNMP_VERSION = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_VERSION = new PropertyDescriptor.Builder()
             .name("snmp-version")
             .displayName("SNMP Version")
             .description("SNMP Version to use")
@@ -86,7 +86,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP community to use */
-    public static final PropertyDescriptor SNMP_COMMUNITY = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_COMMUNITY = new PropertyDescriptor.Builder()
             .name("snmp-community")
             .displayName("SNMP Community (v1 & v2c)")
             .description("SNMP Community to use (e.g., public)")
@@ -96,7 +96,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP security level to use */
-    public static final PropertyDescriptor SNMP_SECURITY_LEVEL = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_SECURITY_LEVEL = new PropertyDescriptor.Builder()
             .name("snmp-security-level")
             .displayName("SNMP Security Level")
             .description("SNMP Security Level to use")
@@ -106,7 +106,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP security name to use */
-    public static final PropertyDescriptor SNMP_SECURITY_NAME = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_SECURITY_NAME = new PropertyDescriptor.Builder()
             .name("snmp-security-name")
             .displayName("SNMP Security name / user name")
             .description("Security name used for SNMP exchanges")
@@ -115,7 +115,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP authentication protocol to use */
-    public static final PropertyDescriptor SNMP_AUTH_PROTOCOL = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_AUTH_PROTOCOL = new PropertyDescriptor.Builder()
             .name("snmp-authentication-protocol")
             .displayName("SNMP Authentication Protocol")
             .description("SNMP Authentication Protocol to use")
@@ -125,7 +125,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP authentication password to use */
-    public static final PropertyDescriptor SNMP_AUTH_PASSWORD = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_AUTH_PASSWORD = new PropertyDescriptor.Builder()
             .name("snmp-authentication-passphrase")
             .displayName("SNMP Authentication pass phrase")
             .description("Pass phrase used for SNMP authentication protocol")
@@ -135,7 +135,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP private protocol to use */
-    public static final PropertyDescriptor SNMP_PRIV_PROTOCOL = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_PRIV_PROTOCOL = new PropertyDescriptor.Builder()
             .name("snmp-private-protocol")
             .displayName("SNMP Private Protocol")
             .description("SNMP Private Protocol to use")
@@ -145,7 +145,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define SNMP private password to use */
-    public static final PropertyDescriptor SNMP_PRIV_PASSWORD = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_PRIV_PASSWORD = new PropertyDescriptor.Builder()
             .name("snmp-private-protocol-passphrase")
             .displayName("SNMP Private protocol pass phrase")
             .description("Pass phrase used for SNMP private protocol")
@@ -155,7 +155,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define the number of SNMP retries when requesting the SNMP Agent */
-    public static final PropertyDescriptor SNMP_RETRIES = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_RETRIES = new PropertyDescriptor.Builder()
             .name("snmp-retries")
             .displayName("Number of retries")
             .description("Set the number of retries when requesting the SNMP Agent")
@@ -165,7 +165,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             .build();
 
     /** property to define the timeout when requesting the SNMP Agent */
-    public static final PropertyDescriptor SNMP_TIMEOUT = new PropertyDescriptor.Builder()
+    private static final PropertyDescriptor SNMP_TIMEOUT = new PropertyDescriptor.Builder()
             .name("snmp-timeout")
             .displayName("Timeout (ms)")
             .description("Set the timeout (in milliseconds) when requesting the SNMP Agent")
@@ -200,7 +200,7 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
     protected volatile AbstractTarget snmpTarget;
 
     /** transport mapping */
-    protected volatile TransportMapping transportMapping;
+    private volatile TransportMapping<UdpAddress> transportMapping;
 
     /** SNMP */
     protected volatile Snmp snmp;
@@ -216,9 +216,9 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
         synchronized (this) {
-            this.buildTargetResource(context);
+            buildTargetResource(context);
         }
-        this.onTriggerSnmp(context, session);
+        onTriggerSnmp(context, session);
     }
 
     /**
@@ -227,45 +227,43 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
     @OnStopped
     public void close() {
         try {
-            if (this.targetResource != null) {
-                this.targetResource.close();
+            if (targetResource != null) {
+                targetResource.close();
             }
         } catch (Exception e) {
-            this.getLogger().warn("Failure while closing target resource " + this.targetResource, e);
+            getLogger().warn("Failure while closing target resource " + targetResource, e);
         }
-        this.targetResource = null;
+        targetResource = null;
 
         try {
-            if (this.transportMapping != null) {
-                this.transportMapping.close();
+            if (transportMapping != null) {
+                transportMapping.close();
             }
         } catch (IOException e) {
-            this.getLogger().warn("Failure while closing UDP transport mapping", e);
+            getLogger().warn("Failure while closing UDP transport mapping", e);
         }
-        this.transportMapping = null;
+        transportMapping = null;
 
         try {
-            if (this.snmp != null) {
-                this.snmp.close();
+            if (snmp != null) {
+                snmp.close();
             }
         } catch (IOException e) {
-            this.getLogger().warn("Failure while closing UDP transport mapping", e);
+            getLogger().warn("Failure while closing UDP transport mapping", e);
         }
-        this.snmp = null;
+        snmp = null;
+        snmpTarget = null;
     }
 
-    /**
-     * @see org.apache.nifi.components.AbstractConfigurableComponent#customValidate(org.apache.nifi.components.ValidationContext)
-     */
     @Override
     protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
-        final List<ValidationResult> problems = new ArrayList<>(super.customValidate(validationContext));
+        List<ValidationResult> problems = new ArrayList<>(super.customValidate(validationContext));
 
-        final boolean isVersion3 = "SNMPv3".equals(validationContext.getProperty(SNMP_VERSION).getValue());
+        boolean isVersion3 = "SNMPv3".equals(validationContext.getProperty(SNMP_VERSION).getValue());
 
-        if(isVersion3) {
-            final boolean isSecurityNameSet = validationContext.getProperty(SNMP_SECURITY_NAME).isSet();
-            if(!isSecurityNameSet) {
+        if (isVersion3) {
+            boolean isSecurityNameSet = validationContext.getProperty(SNMP_SECURITY_NAME).isSet();
+            if (!isSecurityNameSet) {
                 problems.add(new ValidationResult.Builder()
                         .input("SNMP Security Name")
                         .valid(false)
@@ -273,10 +271,14 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
                         .build());
             }
 
-            final boolean isAuthProtOK = !"".equals(validationContext.getProperty(SNMP_AUTH_PROTOCOL).getValue());
-            final boolean isAuthPwdSet = validationContext.getProperty(SNMP_AUTH_PASSWORD).isSet();
-            final boolean isPrivProtOK = !"".equals(validationContext.getProperty(SNMP_PRIV_PROTOCOL).getValue());
-            final boolean isPrivPwdSet = validationContext.getProperty(SNMP_PRIV_PASSWORD).isSet();
+            boolean isAuthProtOK =
+              validationContext.getProperty(SNMP_AUTH_PROTOCOL).getValue() != null && !validationContext.getProperty(
+                SNMP_AUTH_PROTOCOL).getValue().isEmpty();
+            boolean isAuthPwdSet = validationContext.getProperty(SNMP_AUTH_PASSWORD).isSet();
+            boolean isPrivProtOK =
+              validationContext.getProperty(SNMP_PRIV_PROTOCOL).getValue() != null && !validationContext.getProperty(
+                SNMP_PRIV_PROTOCOL).getValue().isEmpty();
+            boolean isPrivPwdSet = validationContext.getProperty(SNMP_PRIV_PASSWORD).isSet();
 
             switch(validationContext.getProperty(SNMP_SECURITY_LEVEL).getValue()) {
             case "authNoPriv":
@@ -302,8 +304,8 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
                 break;
             }
         } else {
-            final boolean isCommunitySet = validationContext.getProperty(SNMP_COMMUNITY).isSet();
-            if(!isCommunitySet) {
+            boolean isCommunitySet = validationContext.getProperty(SNMP_COMMUNITY).isSet();
+            if (!isCommunitySet) {
                 problems.add(new ValidationResult.Builder()
                         .input("SNMP Community")
                         .valid(false)
@@ -320,10 +322,9 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
      * {@link #onTrigger(ProcessContext, ProcessSession)}. It is implemented by
      * sub-classes to perform {@link Processor} specific functionality.
      *
-     * @param context
-     *            instance of {@link ProcessContext}
-     * @param session
-     *            instance of {@link ProcessSession}
+     * @param context instance of {@link ProcessContext}
+     * @param session instance of {@link ProcessSession}
+     *
      * @throws ProcessException Process exception
      */
     protected abstract void onTriggerSnmp(ProcessContext context, ProcessSession session) throws ProcessException;
@@ -333,8 +334,8 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
      * {@link SNMPSetter} or {@link SNMPGetter}) and is implemented by
      * sub-classes.
      *
-     * @param context
-     *            instance of {@link ProcessContext}
+     * @param context instance of {@link ProcessContext}
+     *
      * @return new instance of {@link SNMPWorker}
      */
     protected abstract T finishBuildingTargetResource(ProcessContext context);
@@ -344,26 +345,28 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
      * @param context Process context
      */
     private void buildTargetResource(ProcessContext context) {
-        if((this.transportMapping == null) || !this.transportMapping.isListening() || (this.snmp == null)) {
+        if ((transportMapping == null) || !transportMapping.isListening() || (snmp == null)) {
             try {
-                this.transportMapping = new DefaultUdpTransportMapping();
-                this.snmp = new Snmp(this.transportMapping);
+                transportMapping = new DefaultUdpTransportMapping();
+                snmp = new Snmp(transportMapping);
 
-                if("SNMPv3".equals(context.getProperty(SNMP_VERSION).getValue())) {
-                    USM usm = new USM(SecurityProtocols.getInstance(), new OctetString(MPv3.createLocalEngineID()), 0);
+                if ("SNMPv3".equals(context.getProperty(SNMP_VERSION).getValue())) {
+                    byte[] localEngineId = MPv3.createLocalEngineID();
+                    USM usm = new USM(SecurityProtocols.getInstance(), new OctetString(localEngineId), 0);
                     SecurityModels.getInstance().addSecurityModel(usm);
+                    //snmp.setLocalEngine(localEngineId, 0, 0);
                 }
 
-                this.transportMapping.listen();
+                transportMapping.listen();
             } catch (Exception e) {
                 throw new IllegalStateException("Failed to initialize UDP transport mapping", e);
             }
         }
-        if (this.snmpTarget == null) {
-            this.snmpTarget = this.createSnmpTarget(context);
+        if (snmpTarget == null) {
+            snmpTarget = createSnmpTarget(context);
         }
-        if (this.targetResource == null) {
-            this.targetResource = this.finishBuildingTargetResource(context);
+        if (targetResource == null) {
+            targetResource = finishBuildingTargetResource(context);
         }
     }
 
@@ -373,9 +376,8 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
      * @return the SNMP target
      */
     private AbstractTarget createSnmpTarget(ProcessContext context) {
-        AbstractTarget result = null;
         String snmpVersion = context.getProperty(SNMP_VERSION).getValue();
-        int version = 0;
+        int version;
         switch (snmpVersion) {
         case "SNMPv2c":
             version = SnmpConstants.version2c;
@@ -389,30 +391,31 @@ abstract class AbstractSNMPProcessor<T extends SNMPWorker> extends AbstractProce
             break;
         }
 
-        if(version == SnmpConstants.version3) {
-            final String username = context.getProperty(SNMP_SECURITY_NAME).getValue();
-            final String authPassword = context.getProperty(SNMP_AUTH_PASSWORD).getValue();
-            final String privPassword = context.getProperty(SNMP_PRIV_PASSWORD).getValue();
-            final String authProtocol = context.getProperty(SNMP_AUTH_PROTOCOL).getValue();
-            final String privProtocol = context.getProperty(SNMP_PRIV_PROTOCOL).getValue();
+        AbstractTarget result;
+        if (version == SnmpConstants.version3) {
+            String username = context.getProperty(SNMP_SECURITY_NAME).getValue();
+            String authPassword = context.getProperty(SNMP_AUTH_PASSWORD).getValue();
+            String privPassword = context.getProperty(SNMP_PRIV_PASSWORD).getValue();
+            String authProtocol = context.getProperty(SNMP_AUTH_PROTOCOL).getValue();
+            String privProtocol = context.getProperty(SNMP_PRIV_PROTOCOL).getValue();
             OctetString aPwd = authPassword != null ? new OctetString(authPassword) : null;
             OctetString pPwd = privPassword != null ? new OctetString(privPassword) : null;
 
             // add user information
-            this.snmp.getUSM().addUser(new OctetString(username),
+            snmp.getUSM().addUser(new OctetString(username),
                     new UsmUser(new OctetString(username), SNMPUtils.getAuth(authProtocol), aPwd, SNMPUtils.getPriv(privProtocol), pPwd));
 
             result = new UserTarget();
 
-            ((UserTarget) result).setSecurityLevel(SNMPUtils.getSecLevel(context.getProperty(SNMP_SECURITY_LEVEL).getValue()));
-            final String securityName = context.getProperty(SNMP_SECURITY_NAME).getValue();
-            if(securityName != null) {
-                ((UserTarget) result).setSecurityName(new OctetString(securityName));
+            result.setSecurityLevel(SNMPUtils.getSecLevel(context.getProperty(SNMP_SECURITY_LEVEL).getValue()));
+            String securityName = context.getProperty(SNMP_SECURITY_NAME).getValue();
+            if (securityName != null) {
+                result.setSecurityName(new OctetString(securityName));
             }
         } else {
             result = new CommunityTarget();
             String community = context.getProperty(SNMP_COMMUNITY).getValue();
-            if(community != null) {
+            if (community != null) {
                 ((CommunityTarget) result).setCommunity(new OctetString(community));
             }
         }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPSetter.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPSetter.java
@@ -30,8 +30,7 @@ import org.snmp4j.event.ResponseEvent;
  */
 final class SNMPSetter extends SNMPWorker {
 
-    /** logger */
-    private final static Logger logger = LoggerFactory.getLogger(SNMPSetter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SNMPSetter.class);
 
     /**
      * Creates an instance of this setter
@@ -40,7 +39,7 @@ final class SNMPSetter extends SNMPWorker {
      */
     SNMPSetter(Snmp snmp, AbstractTarget target) {
         super(snmp, target);
-        logger.info("Successfully initialized SNMP Setter");
+        LOGGER.info("Successfully initialized SNMP Setter");
     }
 
     /**
@@ -50,7 +49,7 @@ final class SNMPSetter extends SNMPWorker {
      * @throws IOException IO Exception
      */
     public ResponseEvent set(PDU pdu) throws IOException {
-        return this.snmp.set(pdu, this.target);
+        return snmp.set(pdu, target);
     }
 
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPUtils.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPUtils.java
@@ -54,7 +54,7 @@ public final class SNMPUtils {
 
     /** prefix for SNMP properties in flow file */
     public static final String SNMP_PROP_PREFIX = "snmp" + SNMP_PROP_DELIMITER;
-    
+
     /** used to validate OID syntax */
     public static final Validator SNMP_OID_VALIDATOR = (subject, input, context) -> {
         ValidationResult.Builder builder = new ValidationResult.Builder();

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPUtils.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPUtils.java
@@ -16,16 +16,10 @@
  */
 package org.apache.nifi.snmp.processors;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 import java.util.regex.Pattern;
 
-import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.flowfile.FlowFile;
@@ -48,77 +42,58 @@ import org.snmp4j.util.TreeEvent;
 /**
  * Utility helper class that simplifies interactions with target SNMP API and NIFI API.
  */
-abstract class SNMPUtils {
+public final class SNMPUtils {
 
-    /** logger */
-    private final static Logger logger = LoggerFactory.getLogger(SNMPUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SNMPUtils.class);
 
     /** OID Pattern */
-    public final static Pattern OID_PATTERN = Pattern.compile("[[0-9]+\\.]*");
+    public static final Pattern OID_PATTERN = Pattern.compile("[[0-9]+\\.]*");
 
     /** delimiter for properties name */
-    public final static String SNMP_PROP_DELIMITER = "$";
+    public static final String SNMP_PROP_DELIMITER = "$";
 
     /** prefix for SNMP properties in flow file */
-    public final static String SNMP_PROP_PREFIX = "snmp" + SNMP_PROP_DELIMITER;
-
-    /** list of properties name when performing simple get */
-    private final static List<String> propertyNames = Arrays.asList("snmp$errorIndex", "snmp$errorStatus", "snmp$errorStatusText",
-            "snmp$nonRepeaters", "snmp$requestID", "snmp$type", "snmp$variableBindings");
-
+    public static final String SNMP_PROP_PREFIX = "snmp" + SNMP_PROP_DELIMITER;
+    
     /** used to validate OID syntax */
-    public static final Validator SNMP_OID_VALIDATOR = new Validator() {
-        @Override
-        public ValidationResult validate(final String subject, final String input, final ValidationContext context) {
-            final ValidationResult.Builder builder = new ValidationResult.Builder();
-            builder.subject(subject).input(input);
-            if (context.isExpressionLanguageSupported(subject) && context.isExpressionLanguagePresent(input)) {
-                return builder.valid(true).explanation("Contains Expression Language").build();
-            }
-            try {
-                if (OID_PATTERN.matcher(input).matches()) {
-                    builder.valid(true);
-                } else {
-                    builder.valid(false).explanation(input + "is not a valid OID");
-                }
-            } catch (final IllegalArgumentException e) {
-                builder.valid(false).explanation(e.getMessage());
-            }
-            return builder.build();
+    public static final Validator SNMP_OID_VALIDATOR = (subject, input, context) -> {
+        ValidationResult.Builder builder = new ValidationResult.Builder();
+        builder.subject(subject).input(input);
+        if (context.isExpressionLanguageSupported(subject) && context.isExpressionLanguagePresent(input)) {
+            return builder.valid(true).explanation("Contains Expression Language").build();
         }
+        try {
+            if (OID_PATTERN.matcher(input).matches()) {
+                builder.valid(true);
+            } else {
+                builder.valid(false).explanation(input + "is not a valid OID");
+            }
+        } catch (final IllegalArgumentException e) {
+            builder.valid(false).explanation(e.getMessage());
+        }
+        return builder.build();
     };
 
     /**
      * Updates {@link FlowFile} with attributes representing PDU properties
-     * @param response PDU retried from SNMP Agent
+     * @param response PDU retrieved from SNMP Agent
      * @param flowFile instance of target {@link FlowFile}
      * @param processSession instance of {@link ProcessSession}
      * @return updated {@link FlowFile}
      */
     public static FlowFile updateFlowFileAttributesWithPduProperties(PDU response, FlowFile flowFile, ProcessSession processSession) {
         if (response != null) {
-            try {
-                Method[] methods = PDU.class.getDeclaredMethods();
-                Map<String, String> attributes = new HashMap<String, String>();
-                for (Method method : methods) {
-                    if (Modifier.isPublic(method.getModifiers()) && (method.getParameterTypes().length == 0) && method.getName().startsWith("get")) {
-                        String propertyName = extractPropertyNameFromMethod(method);
-                        if (isValidSnmpPropertyName(propertyName)) {
-                            Object amqpPropertyValue = method.invoke(response);
-                            if (amqpPropertyValue != null) {
-                                if (propertyName.equals(SNMP_PROP_PREFIX + "variableBindings") && (amqpPropertyValue instanceof Vector)) {
-                                    addGetOidValues(attributes, amqpPropertyValue);
-                                } else {
-                                    attributes.put(propertyName, amqpPropertyValue.toString());
-                                }
-                            }
-                        }
-                    }
-                }
-                flowFile = processSession.putAllAttributes(flowFile, attributes);
-            } catch (Exception e) {
-                logger.warn("Failed to update FlowFile with AMQP attributes", e);
-            }
+            Map<String, String> attributes = new HashMap<String, String>();
+            attributes.put(SNMP_PROP_PREFIX + "errorIndex", String.valueOf(response.getErrorIndex()));
+            attributes.put(SNMP_PROP_PREFIX + "errorStatus", String.valueOf(response.getErrorStatus()));
+            attributes.put(SNMP_PROP_PREFIX + "errorStatusText", response.getErrorStatusText());
+            attributes.put(SNMP_PROP_PREFIX + "nonRepeaters", String.valueOf(response.getNonRepeaters()));
+            attributes.put(SNMP_PROP_PREFIX + "requestId", String.valueOf(response.getRequestID()));
+            attributes.put(SNMP_PROP_PREFIX + "type", String.valueOf(response.getType()));
+
+            addGetOidValues(attributes, response.getVariableBindings());
+
+            flowFile = processSession.putAllAttributes(flowFile, attributes);
         }
         return flowFile;
     }
@@ -171,11 +146,9 @@ abstract class SNMPUtils {
      * @param attributes attributes
      * @param vector vector of {@link VariableBinding}
      */
-    private static void addGetOidValues(Map<String, String> attributes, Object vector) {
-        if (vector instanceof Vector) {
-            @SuppressWarnings("unchecked")
-            Vector<VariableBinding> variables = (Vector<VariableBinding>) vector;
-            for (VariableBinding variableBinding : variables) {
+    private static void addGetOidValues(Map<String, String> attributes, Iterable<? extends VariableBinding> vector) {
+        if (vector != null) {
+            for (VariableBinding variableBinding : vector) {
                 addAttributeFromVariable(variableBinding, attributes);
             }
         }
@@ -188,26 +161,6 @@ abstract class SNMPUtils {
      */
     private static void addAttributeFromVariable(VariableBinding variableBinding, Map<String, String> attributes) {
         attributes.put(SNMP_PROP_PREFIX + variableBinding.getOid() + SNMP_PROP_DELIMITER + variableBinding.getVariable().getSyntax(), variableBinding.getVariable().toString());
-    }
-
-    /**
-     * Will validate if provided name corresponds to valid SNMP property.
-     * @param name the name of the property
-     * @return 'true' if valid otherwise 'false'
-     */
-    public static boolean isValidSnmpPropertyName(String name) {
-        return propertyNames.contains(name);
-    }
-
-    /**
-     * Method to extract property name from given {@link Method}
-     * @param method method
-     * @return property name
-     */
-    private static String extractPropertyNameFromMethod(Method method) {
-        char c[] = method.getName().substring(3).toCharArray();
-        c[0] = Character.toLowerCase(c[0]);
-        return SNMP_PROP_PREFIX + new String(c);
     }
 
     /**
@@ -265,4 +218,6 @@ abstract class SNMPUtils {
         }
     }
 
+    private SNMPUtils() {
+    }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPWorker.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SNMPWorker.java
@@ -32,8 +32,7 @@ import org.snmp4j.Snmp;
  */
 abstract class SNMPWorker implements AutoCloseable {
 
-    /** logger */
-    private final static Logger logger = LoggerFactory.getLogger(SNMPWorker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SNMPWorker.class);
 
     /** SNMP abstraction */
     protected final Snmp snmp;
@@ -47,7 +46,7 @@ abstract class SNMPWorker implements AutoCloseable {
      * @param snmp instance of {@link Snmp}
      * @param target instance of {@link AbstractTarget}
      */
-    public SNMPWorker(Snmp snmp, AbstractTarget target) {
+    protected SNMPWorker(Snmp snmp, AbstractTarget target) {
         this.snmp = snmp;
         this.target = target;
     }
@@ -57,18 +56,15 @@ abstract class SNMPWorker implements AutoCloseable {
      */
     @Override
     public void close() throws TimeoutException, IOException {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Closing SNMP connection");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Closing SNMP connection");
         }
-        this.snmp.close();
+        snmp.close();
     }
 
-    /**
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-        return this.getClass().getSimpleName() + ":" + this.snmp.toString();
+        return getClass().getSimpleName() + ":" + snmp;
     }
 
 }


### PR DESCRIPTION
- Code cleanup (consistent formatting, naming etc.)
- Update of SNMP4J from 1.10.1 to 2.5.6
- Fixes restartability issue because snmpTarget was not recreated
- Updates SNMPUtils to not use Reflection (initialized from a static list of method names) to create a FlowFile