### PR TITLE
NIFI-3193: added ability to authenticate with AMQP using cert common names

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
@@ -16,13 +16,13 @@
  */
 package org.apache.nifi.amqp.processors;
 
-import com.rabbitmq.client.AMQP.BasicProperties;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ReturnListener;
+import java.io.IOException;
 
 import org.apache.nifi.logging.ComponentLog;
 
-import java.io.IOException;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ReturnListener;
 
 /**
  * Generic publisher of messages to AMQP-based messaging system. It is based on
@@ -38,7 +38,7 @@ final class AMQPPublisher extends AMQPWorker {
      * Creates an instance of this publisher
      *
      * @param connection
-     *            instance of AMQP {@link Connection}
+     *         instance of AMQP {@link Connection}
      */
     AMQPPublisher(Connection connection, ComponentLog processLog) {
         super(connection);
@@ -52,15 +52,15 @@ final class AMQPPublisher extends AMQPWorker {
      * {@link BasicProperties}) to a pre-defined AMQP Exchange.
      *
      * @param bytes
-     *            bytes representing a message.
+     *         bytes representing a message.
      * @param properties
-     *            instance of {@link BasicProperties}
+     *         instance of {@link BasicProperties}
      * @param exchange
-     *            the name of AMQP exchange to which messages will be published.
-     *            If not provided 'default' exchange will be used.
+     *         the name of AMQP exchange to which messages will be published. If not
+     *         provided 'default' exchange will be used.
      * @param routingKey
-     *            (required) the name of the routingKey to be used by AMQP-based
-     *            system to route messages to its final destination (queue).
+     *         (required) the name of the routingKey to be used by AMQP-based system to
+     *         route messages to its final destination (queue).
      */
     void publish(byte[] bytes, BasicProperties properties, String routingKey, String exchange) {
         this.validateStringProperty("routingKey", routingKey);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
@@ -38,7 +38,7 @@ final class AMQPPublisher extends AMQPWorker {
      * Creates an instance of this publisher
      *
      * @param connection
-     *         instance of AMQP {@link Connection}
+     *            instance of AMQP {@link Connection}
      */
     AMQPPublisher(Connection connection, ComponentLog processLog) {
         super(connection);
@@ -52,15 +52,15 @@ final class AMQPPublisher extends AMQPWorker {
      * {@link BasicProperties}) to a pre-defined AMQP Exchange.
      *
      * @param bytes
-     *         bytes representing a message.
+     *            bytes representing a message.
      * @param properties
-     *         instance of {@link BasicProperties}
+     *            instance of {@link BasicProperties}
      * @param exchange
-     *         the name of AMQP exchange to which messages will be published. If not
-     *         provided 'default' exchange will be used.
+     *            the name of AMQP exchange to which messages will be published.
+     *            If not provided 'default' exchange will be used.
      * @param routingKey
-     *         (required) the name of the routingKey to be used by AMQP-based system to
-     *         route messages to its final destination (queue).
+     *            (required) the name of the routingKey to be used by AMQP-based
+     *            system to route messages to its final destination (queue).
      */
     void publish(byte[] bytes, BasicProperties properties, String routingKey, String exchange) {
         this.validateStringProperty("routingKey", routingKey);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
@@ -16,13 +16,13 @@
  */
 package org.apache.nifi.amqp.processors;
 
-import java.io.IOException;
-
-import org.apache.nifi.logging.ComponentLog;
-
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ReturnListener;
+
+import org.apache.nifi.logging.ComponentLog;
+
+import java.io.IOException;
 
 /**
  * Generic publisher of messages to AMQP-based messaging system. It is based on

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -102,7 +102,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
     public static final PropertyDescriptor USE_CERT_AUTHENTICATION = new PropertyDescriptor.Builder()
             .name("cert-authentication")
             .displayName("Use Certificate Authentication")
-            .description("Authenticate using the SSL certificate common name rather than username/password.")
+            .description("Authenticate using the SSL certificate common name rather than user name/password.")
             .required(false)
             .defaultValue("false")
             .allowableValues("true", "false")
@@ -220,10 +220,10 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
      */
     private Connection createConnection(ProcessContext context) {
         ConnectionFactory cf = new ConnectionFactory();
-        cf.setUsername(context.getProperty(USER).getValue());
-        cf.setPassword(context.getProperty(PASSWORD).getValue());
         cf.setHost(context.getProperty(HOST).getValue());
         cf.setPort(Integer.parseInt(context.getProperty(PORT).getValue()));
+        cf.setUsername(context.getProperty(USER).getValue());
+        cf.setPassword(context.getProperty(PASSWORD).getValue());
         String vHost = context.getProperty(V_HOST).getValue();
         if (vHost != null) {
             cf.setVirtualHost(vHost);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -16,9 +16,11 @@
  */
 package org.apache.nifi.amqp.processors;
 
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.DefaultSaslConfig;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
@@ -33,19 +35,18 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.ssl.SSLContextService;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultSaslConfig;
 
-import javax.net.ssl.SSLContext;
 
 /**
  * Base processor that uses RabbitMQ client API
  * (https://www.rabbitmq.com/api-guide.html) to rendezvous with AMQP-based
  * messaging systems version 0.9.1
  *
- * @param <T> the type of {@link AMQPWorker}. Please see {@link AMQPPublisher} and {@link
- *            AMQPConsumer}
+ * @param <T> the type of {@link AMQPWorker}. Please see {@link AMQPPublisher}
+ *         and {@link AMQPConsumer}
  */
 abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProcessor {
 
@@ -182,8 +183,10 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
      * {@link #onTrigger(ProcessContext, ProcessSession)}. It is implemented by
      * sub-classes to perform {@link Processor} specific functionality.
      *
-     * @param context instance of {@link ProcessContext}
-     * @param session instance of {@link ProcessSession}
+     * @param context
+     *         instance of {@link ProcessContext}
+     * @param session
+     *         instance of {@link ProcessSession}
      */
     protected abstract void rendezvousWithAmqp(ProcessContext context, ProcessSession session) throws ProcessException;
 
@@ -192,7 +195,8 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
      * {@link AMQPPublisher} or {@link AMQPConsumer}) and is implemented by
      * sub-classes.
      *
-     * @param context instance of {@link ProcessContext}
+     * @param context
+     *         instance of {@link ProcessContext}
      * @return new instance of {@link AMQPWorker}
      */
     protected abstract T finishBuildingTargetResource(ProcessContext context);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -46,7 +46,7 @@ import com.rabbitmq.client.DefaultSaslConfig;
  * messaging systems version 0.9.1
  *
  * @param <T> the type of {@link AMQPWorker}. Please see {@link AMQPPublisher}
- *         and {@link AMQPConsumer}
+ *            and {@link AMQPConsumer}
  */
 abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProcessor {
 
@@ -184,9 +184,9 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
      * sub-classes to perform {@link Processor} specific functionality.
      *
      * @param context
-     *         instance of {@link ProcessContext}
+     *            instance of {@link ProcessContext}
      * @param session
-     *         instance of {@link ProcessSession}
+     *            instance of {@link ProcessSession}
      */
     protected abstract void rendezvousWithAmqp(ProcessContext context, ProcessSession session) throws ProcessException;
 
@@ -196,7 +196,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
      * sub-classes.
      *
      * @param context
-     *         instance of {@link ProcessContext}
+     *            instance of {@link ProcessContext}
      * @return new instance of {@link AMQPWorker}
      */
     protected abstract T finishBuildingTargetResource(ProcessContext context);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -99,8 +99,9 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
             .identifiesControllerService(SSLContextService.class)
             .build();
     public static final PropertyDescriptor USE_CERT_AUTHENTICATION = new PropertyDescriptor.Builder()
-            .name("Cert Authentication")
-            .description("Authenticate using the SSL certificate rather than username/password.")
+            .name("cert-authentication")
+            .displayName("Use Certificate Authentication")
+            .description("Authenticate using the SSL certificate common name rather than username/password.")
             .required(false)
             .defaultValue("false")
             .allowableValues("true", "false")

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
@@ -63,7 +63,7 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
-    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
+    <li><b>Use Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
     This can only be used in conjunction with SSL. Defaults to 'false'.
     </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
@@ -63,7 +63,7 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
-    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate for authentication rather than user name and password.
+    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
     This can only be used in conjunction with SSL. Defaults to 'false'.
     </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
@@ -63,6 +63,9 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
+    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate for authentication rather than user name and password.
+    This can only be used in conjunction with SSL. Defaults to 'false'.
+    </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.
     Please refer to <a href="http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html">this blog</a> for more details on Virtual Host.
     </li>

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
@@ -63,7 +63,7 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
-    <li><b>Use Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
+    <li><b>Use Certificate Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
     This can only be used in conjunction with SSL. Defaults to 'false'.
     </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
@@ -84,7 +84,7 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
-    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
+    <li><b>Use Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
     This can only be used in conjunction with SSL. Defaults to 'false'.
     </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
@@ -84,7 +84,7 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
-    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate for authentication rather than user name and password.
+    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
     This can only be used in conjunction with SSL. Defaults to 'false'.
     </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
@@ -84,6 +84,9 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
+    <li><b>Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate for authentication rather than user name and password.
+    This can only be used in conjunction with SSL. Defaults to 'false'.
+    </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.
     Please refer to <a href="http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html">this blog</a> for more details on Virtual Host.
     </li>

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
@@ -84,7 +84,7 @@
     <li><b>Password</b> - [REQUIRED] password to use with user name to connect to AMQP broker. 
     Usually provided by the administrator. Defaults to 'guest'.
     </li>
-    <li><b>Use Cert Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
+    <li><b>Use Certificate Authentication</b> - [OPTIONAL] whether or not to use the SSL certificate common name for authentication rather than user name/password.
     This can only be used in conjunction with SSL. Defaults to 'false'.
     </li>
     <li><b>Virtual Host</b> - [OPTIONAL] Virtual Host name which segregates AMQP system for enhanced security.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.nifi.amqp.processors;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import org.apache.nifi.authentication.exception.ProviderCreationException;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -28,6 +25,9 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the AbstractAMQPProcessor class
@@ -50,12 +50,24 @@ public class AbstractAMQPProcessorTest {
         testRunner.addControllerService("ssl-context", sslService);
         testRunner.enableControllerService(sslService);
         testRunner.setProperty(AbstractAMQPProcessor.SSL_CONTEXT_SERVICE, "ssl-context");
+        testRunner.setProperty(AbstractAMQPProcessor.USE_CERT_AUTHENTICATION, "false");
         testRunner.setProperty(AbstractAMQPProcessor.HOST, "test");
         testRunner.setProperty(AbstractAMQPProcessor.PORT, "9999");
         testRunner.setProperty(AbstractAMQPProcessor.USER, "test");
         testRunner.setProperty(AbstractAMQPProcessor.PASSWORD, "test");
         testRunner.assertValid(sslService);
         testRunner.setProperty(AbstractAMQPProcessor.CLIENT_AUTH, "BAD");
+        processor.onTrigger(testRunner.getProcessContext(), testRunner.getProcessSessionFactory());
+    }
+
+    @Test(expected = ProviderCreationException.class)
+    public void testInvalidSSLConfiguration() throws Exception {
+        // it's invalid to have use_cert_auth enabled and not have the SSL Context Service configured
+        testRunner.setProperty(AbstractAMQPProcessor.USE_CERT_AUTHENTICATION, "true");
+        testRunner.setProperty(AbstractAMQPProcessor.HOST, "test");
+        testRunner.setProperty(AbstractAMQPProcessor.PORT, "9999");
+        testRunner.setProperty(AbstractAMQPProcessor.USER, "test");
+        testRunner.setProperty(AbstractAMQPProcessor.PASSWORD, "test");
         processor.onTrigger(testRunner.getProcessContext(), testRunner.getProcessSessionFactory());
     }
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.nifi.amqp.processors;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.apache.nifi.authentication.exception.ProviderCreationException;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -26,8 +29,6 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the AbstractAMQPProcessor class
@@ -79,6 +80,7 @@ public class AbstractAMQPProcessorTest {
         protected void rendezvousWithAmqp(ProcessContext context, ProcessSession session) throws ProcessException {
             // nothing to do
         }
+
         @Override
         protected AMQPConsumer finishBuildingTargetResource(ProcessContext context) {
             return null;


### PR DESCRIPTION
This change allows for PublishAMQP and ConsumeAMQP to use SSL cert authentication instead of username/password. The change is backward compatible, so it shouldn't affect anyone who plans to continue using SSL as a transport _and_ username/password authentication.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
