### PR TITLE
NiFi-2829: Add Date and Time Format Support for PutSQL

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -72,6 +72,10 @@ import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
@@ -110,11 +114,15 @@ import static org.apache.nifi.processor.util.pattern.ExceptionHandler.createOnEr
                 + "sql.args.1.value, sql.args.2.value, sql.args.3.value, and so on. The type of the sql.args.1.value Parameter is specified by the sql.args.1.type attribute."),
         @ReadsAttribute(attribute = "sql.args.N.format", description = "This attribute is always optional, but default options may not always work for your data. "
                 + "Incoming FlowFiles are expected to be parametrized SQL statements. In some cases "
-                + "a format option needs to be specified, currently this is only applicable for binary data types and timestamps. For binary data types "
-                + "available options are 'ascii', 'base64' and 'hex'.  In 'ascii' format each string character in your attribute value represents a single byte, this is the default format "
-                + "and the format provided by Avro Processors. In 'base64' format your string is a Base64 encoded string.  In 'hex' format the string is hex encoded with all "
-                + "letters in upper case and no '0x' at the beginning. For timestamps, the format can be specified according to java.time.format.DateTimeFormatter."
-                + "Customer and named patterns are accepted i.e. ('yyyy-MM-dd','ISO_OFFSET_DATE_TIME')")
+                + "a format option needs to be specified, currently this is only applicable for binary data types, dates, times and timestamps. Binary Data Types (defaults to 'ascii') - "
+                + "ascii: each string character in your attribute value represents a single byte. This is the format provided by Avro Processors. "
+                + "base64: the string is a Base64 encoded string that can be decoded to bytes. "
+                + "hex: the string is hex encoded with all letters in upper case and no '0x' at the beginning. "
+                + "Dates/Times/Timestamps - "
+                + "Date, Time and Timestamp formats all support both custom formats or named format ('yyyy-MM-dd','ISO_OFFSET_DATE_TIME') "
+                + "as specified according to java.time.format.DateTimeFormatter."
+                + "If not specified, a long value input is expected to be an unix epoch (milli seconds from 1970/1/1) and "
+                + "'yyyy-MM-dd' format for Date, 'HH:mm:ss.SSS' for Time (Derby and MySQL will truncate milliseconds), 'yyyy-MM-dd HH:mm:ss.SSS' for Timestamp is used.")
 })
 @WritesAttributes({
         @WritesAttribute(attribute = "sql.generated.key", description = "If the database generated a key for an INSERT statement and the Obtain Generated Keys property is set to true, "
@@ -828,10 +836,48 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
                     stmt.setBigDecimal(parameterIndex, new BigDecimal(parameterValue));
                     break;
                 case Types.DATE:
-                    stmt.setDate(parameterIndex, new Date(Long.parseLong(parameterValue)));
+                    Date date;
+
+                    if (valueFormat.equals("")) {
+                        if (LONG_PATTERN.matcher(parameterValue).matches()) {
+                            date = new Date(Long.parseLong(parameterValue));
+                        } else {
+                            String dateFormatString = "yyyy-MM-dd";
+
+                            SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
+                            java.util.Date parsedDate = dateFormat.parse(parameterValue);
+                            date = new Date(parsedDate.getTime());
+                        }
+                    } else {
+                        final DateTimeFormatter dtFormatter = getDateTimeFormatter(valueFormat);
+                        LocalDate parsedDate = LocalDate.parse(parameterValue, dtFormatter);
+                        date = new Date(Date.from(parsedDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()).getTime());
+                    }
+
+                    stmt.setDate(parameterIndex, date);
                     break;
                 case Types.TIME:
-                    stmt.setTime(parameterIndex, new Time(Long.parseLong(parameterValue)));
+                    Time time;
+
+                    if (valueFormat.equals("")) {
+                        if (LONG_PATTERN.matcher(parameterValue).matches()) {
+                            time = new Time(Long.parseLong(parameterValue));
+                        } else {
+                            String timeFormatString = "HH:mm:ss.SSS";
+
+                            SimpleDateFormat dateFormat = new SimpleDateFormat(timeFormatString);
+                            java.util.Date parsedDate = dateFormat.parse(parameterValue);
+                            time = new Time(parsedDate.getTime());
+                        }
+                    } else {
+                        final DateTimeFormatter dtFormatter = getDateTimeFormatter(valueFormat);
+                        LocalTime parsedTime = LocalTime.parse(parameterValue, dtFormatter);
+                        LocalDateTime localDateTime = parsedTime.atDate(LocalDate.ofEpochDay(0));
+                        Instant instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
+                        time = new Time(instant.toEpochMilli());
+                    }
+
+                    stmt.setTime(parameterIndex, time);
                     break;
                 case Types.TIMESTAMP:
                     long lTimestamp=0L;
@@ -845,7 +891,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
                             java.util.Date parsedDate = dateFormat.parse(parameterValue);
                             lTimestamp = parsedDate.getTime();
                         }
-                    }else {
+                    } else {
                         final DateTimeFormatter dtFormatter = getDateTimeFormatter(valueFormat);
                         TemporalAccessor accessor = dtFormatter.parse(parameterValue);
                         java.util.Date parsedDate = java.util.Date.from(Instant.from(accessor));


### PR DESCRIPTION
Fix unit test for Date and Time type time zone problem while testing PutSQL processor

@paulgibeault made the original PR #1073, #1468 
@patricker add support of **DATE** and **TIME** in Epoch format for PutSQL processor.
I’ve fix the unit test in different time zone problem.
The detail is list below

The originally problem with unit test happens because of different time zone.
Internally without specifying time zone, java.sql.Date and java.sql.Time will use local time zone to parse the time.
As a result, different time zone will have different format result for a given constant time value.
This is mentioned by @mattyb149 in https://github.com/apache/nifi/pull/1524

Currently solve the problem by giving time zone before insert and parse result with same time zone. (GMT)
Currently build and test successfully with NiFi newest version on GitHub which is 1.4.0-SNAPSHOT.


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
