### PR TITLE
NIFI-4155: Expand EnforceOrder capability to cluster

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EnforceOrder.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EnforceOrder.java
@@ -25,10 +25,12 @@ import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.flowfile.FlowFile;
@@ -182,6 +184,21 @@ public class EnforceOrder extends AbstractProcessor {
         .expressionLanguageSupported(false)
         .build();
 
+    public static final AllowableValue ORDERING_SCOPE_LOCAL = new AllowableValue("local", "Local",
+            "Enforce ordering within a node. Each node enforces ordering with FlowFiles it processes individually.");
+    public static final AllowableValue ORDERING_SCOPE_CLUSTER = new AllowableValue("cluster", "Cluster",
+            "Enforce ordering across a NiFi cluster. Since it can be costly to enforce order among nodes, it's recommended to use if and only if necessary.");
+    public static final PropertyDescriptor ORDERING_SCOPE = new PropertyDescriptor.Builder()
+            .name("ordering-scope")
+            .displayName("Ordering Scope")
+            .description("Specify how ordering is enforced with a NiFi cluster. This property does not have any effect if this is a standalone NiFi.")
+            .required(true)
+            .allowableValues(ORDERING_SCOPE_LOCAL, ORDERING_SCOPE_CLUSTER)
+            .defaultValue(ORDERING_SCOPE_LOCAL.getValue())
+            .addValidator(Validator.VALID)
+            .expressionLanguageSupported(false)
+            .build();
+
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
         .name("success")
         .description("A FlowFile with a matching order number will be routed to this relationship.")
@@ -229,6 +246,7 @@ public class EnforceOrder extends AbstractProcessor {
         descriptors.add(BATCH_COUNT);
         descriptors.add(WAIT_TIMEOUT);
         descriptors.add(INACTIVE_TIMEOUT);
+        descriptors.add(ORDERING_SCOPE);
         return descriptors;
     }
 
@@ -269,9 +287,10 @@ public class EnforceOrder extends AbstractProcessor {
             return;
         }
 
+        final Scope scope = Scope.valueOf(context.getProperty(ORDERING_SCOPE).getValue().toUpperCase());
         final StateMap stateMap;
         try {
-            stateMap = context.getStateManager().getState(Scope.LOCAL);
+            stateMap = context.getStateManager().getState(scope);
         } catch (final IOException e) {
             logger.error("Failed to retrieve state from StateManager due to {}" + e, e);
             context.yield();
@@ -303,11 +322,18 @@ public class EnforceOrder extends AbstractProcessor {
 
         oc.cleanupInactiveStates();
 
-        try {
-            context.getStateManager().setState(oc.groupStates, Scope.LOCAL);
-        } catch (final IOException e) {
-            throw new RuntimeException("Failed to update state due to " + e
-                    + ". Session will be rollback and processor will be yielded for a while.", e);
+        // Update state only if it proceeds.
+        if (!stateMap.toMap().equals(oc.groupStates)) {
+            try {
+                if (!context.getStateManager().replace(stateMap, oc.groupStates, scope)) {
+                    // The state is updated from other node within the same cluster.
+                    // Discard current ordering progress.
+                    session.rollback(false);
+                }
+            } catch (final IOException e) {
+                throw new RuntimeException("Failed to update state due to " + e
+                        + ". Session will be rollback and processor will be yielded for a while.", e);
+            }
         }
 
     }


### PR DESCRIPTION
- Added 'Ordering Scope' to specify how it should manage state, to choose from local and cluster.
- Avoid unnecessary status update if it does not make any progress, only update it when order proceeds.
- If updating state fails, due to it is already updated by other nodes, rollback the session to process the same FlowFiles again.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
