### PR TITLE
NIFI-4157 Improvements to PutTCP

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/put/AbstractPutEventProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/put/AbstractPutEventProcessor.java
@@ -128,9 +128,8 @@ public abstract class AbstractPutEventProcessor extends AbstractSessionFactoryPr
                     + "that is transmitted over the stream so that the receiver can determine when one message ends and the next message begins. Users should "
                     + "ensure that the FlowFile content does not contain the delimiter character to avoid errors. In order to use a new line character you can "
                     + "enter '\\n'. For a tab character use '\\t'. Finally for a carriage return use '\\r'.")
-            .required(true)
+            .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .defaultValue("\\n")
             .expressionLanguageSupported(true)
             .build();
     public static final PropertyDescriptor CONNECTION_PER_FLOWFILE = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/put/sender/SSLSocketChannelSender.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/put/sender/SSLSocketChannelSender.java
@@ -19,17 +19,20 @@ package org.apache.nifi.processor.util.put.sender;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.remote.io.socket.ssl.SSLSocketChannel;
+import org.apache.nifi.remote.io.socket.ssl.SSLSocketChannelOutputStream;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Sends messages over an SSLSocketChannel.
  */
 public class SSLSocketChannelSender extends SocketChannelSender {
 
-    private SSLSocketChannel sslChannel;
     private SSLContext sslContext;
+    private SSLSocketChannel sslChannel;
+    private SSLSocketChannelOutputStream sslOutputStream;
 
     public SSLSocketChannelSender(final String host,
                                   final int port,
@@ -50,6 +53,7 @@ public class SSLSocketChannelSender extends SocketChannelSender {
 
         // SSLSocketChannel will check if already connected so we can safely call this
         sslChannel.connect();
+        sslOutputStream = new SSLSocketChannelOutputStream(sslChannel);
     }
 
     @Override
@@ -65,7 +69,14 @@ public class SSLSocketChannelSender extends SocketChannelSender {
     @Override
     public void close() {
         super.close();
+        IOUtils.closeQuietly(sslOutputStream);
         IOUtils.closeQuietly(sslChannel);
         sslChannel = null;
     }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return sslOutputStream;
+    }
+
 }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/put/sender/SocketChannelSender.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/put/sender/SocketChannelSender.java
@@ -21,6 +21,7 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.remote.io.socket.SocketChannelOutputStream;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
@@ -95,4 +96,9 @@ public class SocketChannelSender extends ChannelSender {
         socketChannelOutput = null;
         channel = null;
     }
+
+    public OutputStream getOutputStream() {
+        return socketChannelOutput;
+    }
+
 }


### PR DESCRIPTION
- Expose the ChannelSender's OutputStream
- Use IOUtils to copy the flow file InputStream to the OutputStream
- Make Outgoing Message Delimiter optional and remove default value so it can be blank