### PR TITLE
NIFI-4183 - Fix handshake error logic in SocketFlowFileServerProtocol

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/socket/SocketFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/socket/SocketFlowFileServerProtocol.java
@@ -74,9 +74,6 @@ public class SocketFlowFileServerProtocol extends AbstractFlowFileServerProtocol
             properties.put(propertyName, propertyValue);
         }
 
-        // evaluate the properties received
-        boolean responseWritten = false;
-
         try {
             validateHandshakeRequest(confirmed, peer, properties);
         } catch (HandshakeException e) {
@@ -86,21 +83,11 @@ public class SocketFlowFileServerProtocol extends AbstractFlowFileServerProtocol
             } else {
                 handshakeResult.writeResponse(dos);
             }
-            switch (handshakeResult) {
-                case UNAUTHORIZED:
-                case PORT_NOT_IN_VALID_STATE:
-                case PORTS_DESTINATION_FULL:
-                    responseWritten = true;
-                    break;
-                default:
-                    throw e;
-            }
+            throw e;
         }
 
         // send "OK" response
-        if (!responseWritten) {
-            ResponseCode.PROPERTIES_OK.writeResponse(dos);
-        }
+        ResponseCode.PROPERTIES_OK.writeResponse(dos);
 
         return confirmed;
     }
@@ -114,7 +101,7 @@ public class SocketFlowFileServerProtocol extends AbstractFlowFileServerProtocol
             throw new IllegalStateException("Protocol is shutdown");
         }
 
-        logger.debug("{} Negotiating Codec with {} using {}", new Object[]{this, peer, peer.getCommunicationsSession()});
+        logger.debug("{} Negotiating Codec with {} using {}", this, peer, peer.getCommunicationsSession());
         final CommunicationsSession commsSession = peer.getCommunicationsSession();
         final DataInputStream dis = new DataInputStream(commsSession.getInput().getInputStream());
         final DataOutputStream dos = new DataOutputStream(commsSession.getOutput().getOutputStream());
@@ -126,7 +113,7 @@ public class SocketFlowFileServerProtocol extends AbstractFlowFileServerProtocol
         // Negotiate the FlowFileCodec to use.
         try {
             negotiatedFlowFileCodec = RemoteResourceFactory.receiveCodecNegotiation(dis, dos);
-            logger.debug("{} Negotiated Codec {} with {}", new Object[]{this, negotiatedFlowFileCodec, peer});
+            logger.debug("{} Negotiated Codec {} with {}", this, negotiatedFlowFileCodec, peer);
             return negotiatedFlowFileCodec;
         } catch (final HandshakeException e) {
             throw new ProtocolException(e.toString());
@@ -143,9 +130,9 @@ public class SocketFlowFileServerProtocol extends AbstractFlowFileServerProtocol
             throw new IllegalStateException("Protocol is shutdown");
         }
 
-        logger.debug("{} Reading Request Type from {} using {}", new Object[]{this, peer, peer.getCommunicationsSession()});
+        logger.debug("{} Reading Request Type from {} using {}", this, peer, peer.getCommunicationsSession());
         final RequestType requestType = RequestType.readRequestType(new DataInputStream(peer.getCommunicationsSession().getInput().getInputStream()));
-        logger.debug("{} Got Request Type {} from {}", new Object[]{this, requestType, peer});
+        logger.debug("{} Got Request Type {} from {}", this, requestType, peer);
 
         return requestType;
     }


### PR DESCRIPTION
* Added new unit tests to show how the suppressed handshake exceptions leave the server in a connected status.
* Fixed SocketFlowFileServerProtocol handshake logic to remove suppression of handshake exceptions.
* Cleaned up log entry argument lists.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
