### PR TITLE
NIFI-4156: Fixed fragment.count in SplitText to equal emitted flow files

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitText.java
@@ -771,7 +771,38 @@ public class TestSplitText {
         splitRunner.assertTransferCount(SplitText.REL_FAILURE, 0);
 
         final List<MockFlowFile> splits = splitRunner.getFlowFilesForRelationship(SplitText.REL_SPLITS);
-        splits.get(0).assertContentEquals("1\n2");
+        MockFlowFile split0 = splits.get(0);
+        split0.assertContentEquals("1\n2");
+        split0.assertAttributeEquals(SplitText.FRAGMENT_INDEX, "1");
+        split0.assertAttributeEquals(SplitText.FRAGMENT_COUNT, "1");
+        split0.assertAttributeEquals(SplitText.SPLIT_LINE_COUNT, "2");
+    }
+
+    @Test
+    public void testFragmentCountIsActualFlowFileCount() {
+        final TestRunner splitRunner = TestRunners.newTestRunner(new SplitText());
+        splitRunner.setProperty(SplitText.HEADER_LINE_COUNT, "0");
+        splitRunner.setProperty(SplitText.LINE_SPLIT_COUNT, "1");
+        splitRunner.setProperty(SplitText.REMOVE_TRAILING_NEWLINES, "true");
+
+        splitRunner.enqueue("1\n2\n\n\n\n\n\n\n\n");
+
+        splitRunner.run();
+        splitRunner.assertTransferCount(SplitText.REL_SPLITS, 2);
+        splitRunner.assertTransferCount(SplitText.REL_ORIGINAL, 1);
+        splitRunner.assertTransferCount(SplitText.REL_FAILURE, 0);
+
+        final List<MockFlowFile> splits = splitRunner.getFlowFilesForRelationship(SplitText.REL_SPLITS);
+        MockFlowFile split0 = splits.get(0);
+        split0.assertContentEquals("1");
+        split0.assertAttributeEquals(SplitText.FRAGMENT_INDEX, "1");
+        split0.assertAttributeEquals(SplitText.FRAGMENT_COUNT, "2");
+        split0.assertAttributeEquals(SplitText.SPLIT_LINE_COUNT, "1");
+        MockFlowFile split1 = splits.get(1);
+        split1.assertContentEquals("2");
+        split1.assertAttributeEquals(SplitText.FRAGMENT_INDEX, "2");
+        split1.assertAttributeEquals(SplitText.FRAGMENT_COUNT, "2");
+        split1.assertAttributeEquals(SplitText.SPLIT_LINE_COUNT, "1");
     }
 
 


### PR DESCRIPTION
Tried a few different use cases / code paths, to check for correct change in behavior.


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
