### PR TITLE
NIFI-1027 - Treat label and node of a provenance

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/provenance/nf-provenance-lineage.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/provenance/nf-provenance-lineage.js
@@ -1015,6 +1015,20 @@
 
                 events
                     .classed('event', true)
+                    // join node to its label
+                    .append('rect')
+                    .attr({
+                        'x': 0,
+                        'y': -8,
+                        'height': 16,
+                        'width': 14,
+                        'opacity': 0,
+                        'id': function (d) {
+                            return 'event-filler-' + d.id;
+                        }
+                    });
+
+                events    
                     .append('circle')
                     .classed('selected', function (d) {
                         return d.id === eventId;


### PR DESCRIPTION
...graph event as one unit

The JIRA issue asks for treating both node and its label as one unit.
Described cursor issues seems to be fixed already.

However, there is an annoying dead space between a node and label
preventing displaying context menu, etc. Due to SVG group's nature
there has been added an opaque joint to remove the dead space.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?