### PR TITLE
NIFI-4023, NIFI-4077: Addressed issue where repository was aging off …

### DIFF
--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/IndexDirectoryManager.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/IndexDirectoryManager.java
@@ -125,9 +125,9 @@ public class IndexDirectoryManager {
         // If looking at index N, we can determine the index end time by assuming that it is the same as the
         // start time of index N+1. So we determine the time range of each index and select an index only if
         // its start time is before the given timestamp and its end time is <= the given timestamp.
-        for (final List<IndexLocation> startTimeWithFile : startTimeWithFileByStorageDirectory.values()) {
-            for (int i = 0; i < startTimeWithFile.size(); i++) {
-                final IndexLocation indexLoc = startTimeWithFile.get(i);
+        for (final List<IndexLocation> locationList : startTimeWithFileByStorageDirectory.values()) {
+            for (int i = 0; i < locationList.size(); i++) {
+                final IndexLocation indexLoc = locationList.get(i);
 
                 final String partition = indexLoc.getPartitionName();
                 final IndexLocation activeLocation = activeIndices.get(partition);
@@ -143,16 +143,13 @@ public class IndexDirectoryManager {
                     break;
                 }
 
-                if (i < startTimeWithFile.size() - 1) {
-                    final IndexLocation nextLocation = startTimeWithFile.get(i + 1);
-                    final Long indexEndTime = nextLocation.getIndexStartTimestamp();
-                    if (indexEndTime <= timestamp) {
-                        logger.debug("Considering Index Location {} older than {} ({}) because its events have an EventTime "
-                            + "ranging from {} ({}) to {} ({}) based on the following IndexLocations: {}", nextLocation, timestamp, new Date(timestamp),
-                            indexStartTime, new Date(indexStartTime), indexEndTime, new Date(indexEndTime), startTimeWithFile);
+                final long indexEndTime = indexLoc.getIndexEndTimestamp();
+                if (indexEndTime <= timestamp) {
+                    logger.debug("Considering Index Location {} older than {} ({}) because its events have an EventTime "
+                        + "ranging from {} ({}) to {} ({}) based on the following IndexLocations: {}", indexLoc, timestamp, new Date(timestamp),
+                        indexStartTime, new Date(indexStartTime), indexEndTime, new Date(indexEndTime), locationList);
 
-                        selected.add(nextLocation.getIndexDirectory());
-                    }
+                    selected.add(indexLoc.getIndexDirectory());
                 }
             }
         }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/IndexLocation.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/IndexLocation.java
@@ -38,6 +38,15 @@ public class IndexLocation {
         return indexStartTimestamp;
     }
 
+    public long getIndexEndTimestamp() {
+        final long lastMod = indexDirectory.lastModified();
+        if (lastMod == 0) {
+            return System.currentTimeMillis();
+        }
+
+        return lastMod;
+    }
+
     public String getPartitionName() {
         return partitionName;
     }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/store/iterator/TestSelectiveRecordReaderEventIterator.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/store/iterator/TestSelectiveRecordReaderEventIterator.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.provenance.store.iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -81,6 +83,27 @@ public class TestSelectiveRecordReaderEventIterator {
 
         filteredFiles = SelectiveRecordReaderEventIterator.filterUnneededFiles(files, eventIds);
         assertEquals(Arrays.asList(new File[] {file1, file1000}), filteredFiles);
+    }
+
+    @Test
+    public void testFileNotFound() throws IOException {
+        final File file1 = new File("1.prov");
+
+        // Filter out the first file.
+        final List<File> files = new ArrayList<>();
+        files.add(file1);
+
+        List<Long> eventIds = new ArrayList<>();
+        eventIds.add(1L);
+        eventIds.add(5L);
+
+        final RecordReaderFactory readerFactory = (file, logs, maxChars) -> {
+            return RecordReaders.newRecordReader(file, logs, maxChars);
+        };
+
+        final SelectiveRecordReaderEventIterator itr = new SelectiveRecordReaderEventIterator(files, readerFactory, eventIds, 65536);
+        final Optional<ProvenanceEventRecord> firstRecordOption = itr.nextEvent();
+        assertFalse(firstRecordOption.isPresent());
     }
 
     @Test


### PR DESCRIPTION
…the wrong index. When it should age off Index 1, it was removing Index 2. As a result, the earliest index is never aged off, and the newest index could potentially be aged off before it is ready to be. Also addressed issue where a query that attempts to read an event that has aged off throws FileNotFoundException (NIFI-4077) instead of skipping over the event. The JavaDocs indicate that the EventIterator should skip records that it cannot find, but SelectiveRecordReaderEventIterator throw FileNotFoundException instead

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
