### PR TITLE
NIFI-2829: Fixed PutSQL time unit test.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -190,7 +190,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
     private static final String FRAGMENT_INDEX_ATTR = FragmentAttributes.FRAGMENT_INDEX.key();
     private static final String FRAGMENT_COUNT_ATTR = FragmentAttributes.FRAGMENT_COUNT.key();
 
-    private static final Pattern LONG_PATTERN = Pattern.compile("^\\d{1,19}$");
+    private static final Pattern LONG_PATTERN = Pattern.compile("^-?\\d{1,19}$");
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -38,7 +38,6 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,7 +59,6 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import javax.xml.bind.DatatypeConverter;
-import org.junit.Ignore;
 
 public class TestPutSQL {
     private static final String createPersons = "CREATE TABLE PERSONS (id integer primary key, name varchar(100), code integer)";
@@ -460,7 +458,6 @@ public class TestPutSQL {
         }
     }
 
-    @Ignore("this test needs fixing due to TestPutSQL.testUsingDateTimeValuesWithFormatAttribute:551 expected:<1012608000000> but was:<1012521600000>")
     @Test
     public void testUsingDateTimeValuesWithFormatAttribute() throws InitializationException, ProcessException, SQLException, IOException, ParseException {
         final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
@@ -492,19 +489,7 @@ public class TestPutSQL {
         final long expectedTimeInLong = expectedTime.getTime();
         final long expectedDateInLong = expectedDate.getTime();
 
-        //test with time zone GMT to avoid negative value unmatched with long pattern problem.
-        SimpleDateFormat timeFormat = new SimpleDateFormat(timeFormatString);
-        timeFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        java.util.Date parsedTimeGMT = timeFormat.parse(timeStr);
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        java.util.Date parsedDateGMT = dateFormat.parse(dateStr);
-
-        Calendar gmtCalendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-
-
-        //test with ISO LOCAL format attribute
+        // test with ISO LOCAL format attribute
         Map<String, String> attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.TIME));
         attributes.put("sql.args.1.value", timeStr);
@@ -515,16 +500,25 @@ public class TestPutSQL {
 
         runner.enqueue("INSERT INTO TIMESTAMPTEST3 (ID, ts1, ts2) VALUES (1, ?, ?)".getBytes(), attributes);
 
-        //test Long pattern without format attribute
+        // Since Derby database which is used for unit test does not have timezone in DATE and TIME type,
+        // and PutSQL converts date string into long representation using local timezone,
+        // we need to use local timezone.
+        SimpleDateFormat timeFormat = new SimpleDateFormat(timeFormatString);
+        java.util.Date parsedLocalTime = timeFormat.parse(timeStr);
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
+        java.util.Date parsedLocalDate = dateFormat.parse(dateStr);
+
+        // test Long pattern without format attribute
         attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.TIME));
-        attributes.put("sql.args.1.value", Long.toString(parsedTimeGMT.getTime()));
+        attributes.put("sql.args.1.value", Long.toString(parsedLocalTime.getTime()));
         attributes.put("sql.args.2.type", String.valueOf(Types.DATE));
-        attributes.put("sql.args.2.value", Long.toString(parsedDateGMT.getTime()));
+        attributes.put("sql.args.2.value", Long.toString(parsedLocalDate.getTime()));
 
         runner.enqueue("INSERT INTO TIMESTAMPTEST3 (ID, ts1, ts2) VALUES (2, ?, ?)".getBytes(), attributes);
 
-        //test with format attribute
+        // test with format attribute
         attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.TIME));
         attributes.put("sql.args.1.value", "120202000");
@@ -549,8 +543,8 @@ public class TestPutSQL {
 
                 assertTrue(rs.next());
                 assertEquals(2, rs.getInt(1));
-                assertEquals(parsedTimeGMT.getTime(), rs.getTime(2).getTime());
-                assertEquals(parsedDateGMT.getTime(), rs.getDate(3,gmtCalendar).getTime());
+                assertEquals(parsedLocalTime.getTime(), rs.getTime(2).getTime());
+                assertEquals(parsedLocalDate.getTime(), rs.getDate(3).getTime());
 
                 assertTrue(rs.next());
                 assertEquals(3, rs.getInt(1));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -33,9 +33,11 @@ import java.sql.Time;
 import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Date;
@@ -471,8 +473,8 @@ public class TestPutSQL {
         runner.enableControllerService(service);
         runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
 
-        final String dateStr = "2002-02-02";
-        final String timeStr = "12:02:02";
+        final String dateStr = "2002-03-04";
+        final String timeStr = "02:03:04";
 
         final String timeFormatString = "HH:mm:ss";
         final String dateFormatString ="yyyy-MM-dd";
@@ -521,10 +523,10 @@ public class TestPutSQL {
         // test with format attribute
         attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.TIME));
-        attributes.put("sql.args.1.value", "120202000");
+        attributes.put("sql.args.1.value", "020304000");
         attributes.put("sql.args.1.format", "HHmmssSSS");
         attributes.put("sql.args.2.type", String.valueOf(Types.DATE));
-        attributes.put("sql.args.2.value", "20020202");
+        attributes.put("sql.args.2.value", "20020304");
         attributes.put("sql.args.2.format", "yyyyMMdd");
 
         runner.enqueue("INSERT INTO TIMESTAMPTEST3 (ID, ts1, ts2) VALUES (3, ?, ?)".getBytes(), attributes);
@@ -686,11 +688,10 @@ public class TestPutSQL {
         runner.enableControllerService(service);
         runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
 
-        final String arg2TS = "00:01:01";
-        final String art3TS = "12:02:02";
+        final String arg2TS = "00:01:02";
+        final String art3TS = "02:03:04";
         final String timeFormatString = "HH:mm:ss";
         SimpleDateFormat dateFormat = new SimpleDateFormat(timeFormatString);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         java.util.Date parsedDate = dateFormat.parse(arg2TS);
 
 


### PR DESCRIPTION
The unit test for DATE type used GMT timezone, that causes an assertion error in timezones such as EST (-5).
We need to use local timezone instead of GMT, as Derby and PutSQL uses local timezone.

The unit test failed before as follows:
- Unit test code, passed: '2002-02-02 GMT'
- PutSQL code convertedi it to local: '2002-02-01 EST', and stored as '2002-02-01' in Derby database without timezone info
- Unit test code SELECT the inserted value, passed a GMT calender, then got epoch timestamp, which was '2002-01-31'

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
