### PR TITLE
NIFI-4324: Addressing sub context menu issue

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
@@ -778,7 +778,8 @@
          * Hides the context menu.
          */
         hide: function () {
-            $('.context-menu').hide();
+            $('#context-menu').hide();
+            $('div.context-menu.sub-menu').remove();
         },
 
         /**


### PR DESCRIPTION
NIFI-4324:
- Ensuring that sub context menus are removed when hiding to ensure they are correctly (re)created during mouseenter events.