### PR TITLE
NIFI-4326 - ExtractEmailHeaders.java unhandled NullPointerException

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailAttachments.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailAttachments.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.Date;
 
 import javax.activation.DataSource;
-import javax.mail.Address;
 import javax.mail.internet.InternetAddress;
 import javax.mail.MessagingException;
 import javax.mail.Session;

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailAttachments.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailAttachments.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import java.util.Date;
 
 import javax.activation.DataSource;
-import javax.mail.internet.InternetAddress;
+import javax.mail.Address;
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
@@ -121,20 +121,22 @@ public class ExtractEmailAttachments extends AbstractProcessor {
         final List<FlowFile> invalidFlowFilesList = new ArrayList<>();
         final List<FlowFile> originalFlowFilesList = new ArrayList<>();
 
+        final String requireStrictAddresses = "false";
+
         session.read(originalFlowFile, new InputStreamCallback() {
                 @Override
                 public void process(final InputStream rawIn) throws IOException {
                     try (final InputStream in = new BufferedInputStream(rawIn)) {
                         Properties props = new Properties();
-                        Session mailSession = Session.getDefaultInstance(props, null);
+                        props.put("mail.mime.address.strict", requireStrictAddresses);
+                        Session mailSession = Session.getInstance(props);
                         MimeMessage originalMessage = new MimeMessage(mailSession, in);
                         MimeMessageParser parser = new MimeMessageParser(originalMessage).parse();
                         // RFC-2822 determines that a message must have a "From:" header
                         // if a message lacks the field, it is flagged as invalid
-                        if (InternetAddress.parseHeader(originalMessage.getHeader("From", ","), false) == null) {
-                            if (InternetAddress.parseHeader(originalMessage.getHeader("Sender", ","), false) == null) {
-                                throw new MessagingException("Message failed RFC2822 validation: No Sender");
-                            }
+                        Address[] from = originalMessage.getFrom();
+                        if (from == null) {
+                            throw new MessagingException("Message failed RFC-2822 validation: No Sender");
                         }
                         Date sentDate = originalMessage.getSentDate();
                         if (sentDate == null) {

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
@@ -168,15 +168,17 @@ public class ExtractEmailHeaders extends AbstractProcessor {
                             }
                         }
                     }
-                    if (Array.getLength(originalMessage.getAllRecipients()) > 0) {
-                        for (int toCount = 0; toCount < ArrayUtils.getLength(originalMessage.getRecipients(Message.RecipientType.TO)); toCount++) {
-                            attributes.put(EMAIL_HEADER_TO + "." + toCount, originalMessage.getRecipients(Message.RecipientType.TO)[toCount].toString());
-                        }
-                        for (int toCount = 0; toCount < ArrayUtils.getLength(originalMessage.getRecipients(Message.RecipientType.BCC)); toCount++) {
-                            attributes.put(EMAIL_HEADER_BCC + "." + toCount, originalMessage.getRecipients(Message.RecipientType.BCC)[toCount].toString());
-                        }
-                        for (int toCount = 0; toCount < ArrayUtils.getLength(originalMessage.getRecipients(Message.RecipientType.CC)); toCount++) {
-                            attributes.put(EMAIL_HEADER_CC + "." + toCount, originalMessage.getRecipients(Message.RecipientType.CC)[toCount].toString());
+                    if (originalMessage.getAllRecipients() != null) {
+                        if (Array.getLength(originalMessage.getAllRecipients()) > 0) {
+                            for (int toCount = 0; toCount < ArrayUtils.getLength(originalMessage.getRecipients(Message.RecipientType.TO)); toCount++) {
+                                attributes.put(EMAIL_HEADER_TO + "." + toCount, originalMessage.getRecipients(Message.RecipientType.TO)[toCount].toString());
+                            }
+                            for (int toCount = 0; toCount < ArrayUtils.getLength(originalMessage.getRecipients(Message.RecipientType.BCC)); toCount++) {
+                                attributes.put(EMAIL_HEADER_BCC + "." + toCount, originalMessage.getRecipients(Message.RecipientType.BCC)[toCount].toString());
+                            }
+                            for (int toCount = 0; toCount < ArrayUtils.getLength(originalMessage.getRecipients(Message.RecipientType.CC)); toCount++) {
+                                attributes.put(EMAIL_HEADER_CC + "." + toCount, originalMessage.getRecipients(Message.RecipientType.CC)[toCount].toString());
+                            }
                         }
                     }
                     // Incredibly enough RFC-2822 specified From as a "mailbox-list" so an array I returned by getFrom

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
@@ -103,8 +103,10 @@ public class ExtractEmailHeaders extends AbstractProcessor {
             .defaultValue("x-mailer")
             .build();
 
-    private static final AllowableValue STRICT_ADDRESSING = new AllowableValue("true", "Strict Address Parsing", "Strict email address format will be enforced. FlowFiles will be transfered to the failure relationship if the email address is invalid.");
-    private static final AllowableValue NONSTRICT_ADDRESSING = new AllowableValue("false", "Non-Strict Address Parsing", "Accept emails, even if the address is poorly formed and doesn't strictly comply with RFC Validation.");
+    private static final AllowableValue STRICT_ADDRESSING = new AllowableValue("true", "Strict Address Parsing",
+        "Strict email address format will be enforced. FlowFiles will be transfered to the failure relationship if the email address is invalid.");
+    private static final AllowableValue NONSTRICT_ADDRESSING = new AllowableValue("false", "Non-Strict Address Parsing",
+        "Accept emails, even if the address is poorly formed and doesn't strictly comply with RFC Validation.");
     public static final PropertyDescriptor STRICT_PARSING = new PropertyDescriptor.Builder()
             .name("STRICT_ADDRESS_PARSING")
             .displayName("Email Address Parsing")

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/GenerateAttachment.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/GenerateAttachment.java
@@ -44,6 +44,20 @@ public class GenerateAttachment {
     }
 
     public byte[] SimpleEmail() {
+        MimeMessage mimeMessage = SimpleEmailMimeMessage();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            mimeMessage.writeTo(output);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+
+        return output.toByteArray();
+    }
+
+    public MimeMessage SimpleEmailMimeMessage() {
         Email email = new SimpleEmail();
         try {
             email.setFrom(from);
@@ -56,18 +70,9 @@ public class GenerateAttachment {
             e.printStackTrace();
         }
 
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        MimeMessage mimeMessage = email.getMimeMessage();
-        try {
-            mimeMessage.writeTo(output);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (MessagingException e) {
-            e.printStackTrace();
-        }
-
-        return output.toByteArray();
+        return email.getMimeMessage();
     }
+
 
     public byte[] WithAttachments(int amount) {
         MultiPartEmail email = new MultiPartEmail();

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestExtractEmailHeaders.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestExtractEmailHeaders.java
@@ -130,7 +130,7 @@ public class TestExtractEmailHeaders {
     @Test
     public void testNonStrictParsingPassesForInvalidAddresses() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailHeaders());
-        runner.setProperty(ExtractEmailHeaders.STRICT_ADDRESSING, "false");
+        runner.setProperty(ExtractEmailHeaders.STRICT_PARSING, "false");
 
         MimeMessage simpleEmailMimeMessage = attachmentGenerator.SimpleEmailMimeMessage();
 
@@ -168,7 +168,7 @@ public class TestExtractEmailHeaders {
     @Test
     public void testStrictParsingFailsForInvalidAddresses() throws Exception {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailHeaders());
-        runner.setProperty(ExtractEmailHeaders.STRICT_ADDRESSING, "true");
+        runner.setProperty(ExtractEmailHeaders.STRICT_PARSING, "true");
 
         MimeMessage simpleEmailMimeMessage = attachmentGenerator.SimpleEmailMimeMessage();
 

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestExtractEmailHeaders.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestExtractEmailHeaders.java
@@ -17,11 +17,15 @@
 
 package org.apache.nifi.processors.email;
 
+import org.apache.nifi.stream.io.ByteArrayOutputStream;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.Test;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
 import java.util.List;
 
 public class TestExtractEmailHeaders {
@@ -79,6 +83,111 @@ public class TestExtractEmailHeaders {
         splits.get(0).assertAttributeExists("email.headers.mime-version");
     }
 
+    /**
+     * Test case added for NIFI-4326 for a potential NPE bug
+     * if the email message contains no recipient header fields, ie,
+     * TO, CC, BCC.
+     */
+    @Test
+    public void testValidEmailWithNoRecipients() throws Exception {
+        final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailHeaders());
+        runner.setProperty(ExtractEmailHeaders.CAPTURED_HEADERS, "MIME-Version");
+
+        MimeMessage simpleEmailMimeMessage = attachmentGenerator.SimpleEmailMimeMessage();
+
+        simpleEmailMimeMessage.removeHeader("To");
+        simpleEmailMimeMessage.removeHeader("Cc");
+        simpleEmailMimeMessage.removeHeader("Bcc");
+
+        ByteArrayOutputStream messageBytes = new ByteArrayOutputStream();
+        try {
+            simpleEmailMimeMessage.writeTo(messageBytes);
+        } catch (IOException | MessagingException e) {
+            e.printStackTrace();
+        }
+
+        runner.enqueue(messageBytes.toByteArray());
+        runner.run();
+
+        runner.assertTransferCount(ExtractEmailHeaders.REL_SUCCESS, 1);
+        runner.assertTransferCount(ExtractEmailHeaders.REL_FAILURE, 0);
+
+        runner.assertQueueEmpty();
+        final List<MockFlowFile> splits = runner.getFlowFilesForRelationship(ExtractEmailHeaders.REL_SUCCESS);
+        splits.get(0).assertAttributeEquals("email.headers.from.0", from);
+        splits.get(0).assertAttributeExists("email.headers.mime-version");
+        splits.get(0).assertAttributeNotExists("email.headers.to");
+        splits.get(0).assertAttributeNotExists("email.headers.cc");
+        splits.get(0).assertAttributeNotExists("email.headers.bcc");
+    }
+
+    /**
+     * NIFI-4326 adds a new feature to disable strict address parsing for
+     * mailbox list header fields. This is a test case that asserts that
+     * lax address parsing passes (when set to "strict=false") for malformed
+     * addresses.
+     */
+    @Test
+    public void testNonStrictParsingPassesForInvalidAddresses() throws Exception {
+        final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailHeaders());
+        runner.setProperty(ExtractEmailHeaders.STRICT_ADDRESSING, "false");
+
+        MimeMessage simpleEmailMimeMessage = attachmentGenerator.SimpleEmailMimeMessage();
+
+        simpleEmailMimeMessage.setHeader("From", "<bad_email>");
+        simpleEmailMimeMessage.setHeader("To", "<>, Joe, \"\" <>");
+
+        ByteArrayOutputStream messageBytes = new ByteArrayOutputStream();
+        try {
+            simpleEmailMimeMessage.writeTo(messageBytes);
+        } catch (IOException | MessagingException e) {
+            e.printStackTrace();
+        }
+
+        runner.enqueue(messageBytes.toByteArray());
+        runner.run();
+
+        runner.assertTransferCount(ExtractEmailHeaders.REL_SUCCESS, 1);
+        runner.assertTransferCount(ExtractEmailHeaders.REL_FAILURE, 0);
+
+
+        runner.assertQueueEmpty();
+        final List<MockFlowFile> splits = runner.getFlowFilesForRelationship(ExtractEmailHeaders.REL_SUCCESS);
+        splits.get(0).assertAttributeEquals("email.headers.from.0", "bad_email");
+        splits.get(0).assertAttributeEquals("email.headers.to.0", "");
+        splits.get(0).assertAttributeEquals("email.headers.to.1", "Joe");
+        splits.get(0).assertAttributeEquals("email.headers.to.2", "");
+    }
+
+    /**
+     * NIFI-4326 adds a new feature to disable strict address parsing for
+     * mailbox list header fields. This is a test case that asserts that
+     * strict address parsing fails (when set to "strict=true") for malformed
+     * addresses.
+     */
+    @Test
+    public void testStrictParsingFailsForInvalidAddresses() throws Exception {
+        final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailHeaders());
+        runner.setProperty(ExtractEmailHeaders.STRICT_ADDRESSING, "true");
+
+        MimeMessage simpleEmailMimeMessage = attachmentGenerator.SimpleEmailMimeMessage();
+
+        simpleEmailMimeMessage.setHeader("From", "<bad_email>");
+        simpleEmailMimeMessage.setHeader("To", "<>, Joe, <invalid>");
+
+        ByteArrayOutputStream messageBytes = new ByteArrayOutputStream();
+        try {
+            simpleEmailMimeMessage.writeTo(messageBytes);
+        } catch (IOException | MessagingException e) {
+            e.printStackTrace();
+        }
+
+        runner.enqueue(messageBytes.toByteArray());
+        runner.run();
+
+        runner.assertTransferCount(ExtractEmailHeaders.REL_SUCCESS, 0);
+        runner.assertTransferCount(ExtractEmailHeaders.REL_FAILURE, 1);
+    }
 
     @Test
     public void testInvalidEmail() throws Exception {


### PR DESCRIPTION
Resolve a null pointer exception when there is no recipient available in a TO, CC, or BCC header field.

No JIRA, although I did pull and build and test this change. It fixes the previously broken case.