### PR TITLE
NIFI-4363 Replaced hardcoded heap size options with JAVA_ARGS environ…

### DIFF
--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms128m -Xmx256m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms128m -Xmx256m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.properties.ConfigEncryptionTool
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.properties.ConfigEncryptionTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms128m -Xmx256m org.apache.nifi.properties.ConfigEncryptionTool
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms128m -Xmx256m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.properties.ConfigEncryptionTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms128m -Xmx256m} org.apache.nifi.properties.ConfigEncryptionTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} org.apache.nifi.properties.ConfigEncryptionTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms128m -Xmx256m org.apache.nifi.properties.ConfigEncryptionTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms128m -Xmx256m} org.apache.nifi.properties.ConfigEncryptionTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms12m -Xmx24m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.admin.filemanager.FileManagerTool
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.admin.filemanager.FileManagerTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.toolkit.admin.filemanager.FileManagerTool
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.admin.filemanager.FileManagerTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.sh
@@ -110,7 +110,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx24m org.apache.nifi.toolkit.admin.filemanager.FileManagerTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.filemanager.FileManagerTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.sh
@@ -110,7 +110,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.filemanager.FileManagerTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.filemanager.FileManagerTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms12m -Xmx24m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx24m org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~sdp0..\classpath;%~sdp0..\lib
 
-Sif "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+Sif "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms12m -Xmx24m
 
-ET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool
+ET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~sdp0..\classpath;%~sdp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool
+Sif "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+
+ET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.sh
@@ -110,7 +110,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx24m org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.sh
@@ -110,7 +110,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~sdp0..\classpath;%~sdp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms12m -Xmx24m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.admin.notify.NotificationTool
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.admin.notify.NotificationTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~sdp0..\classpath;%~sdp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.toolkit.admin.notify.NotificationTool
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.admin.notify.NotificationTool
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx24m org.apache.nifi.toolkit.admin.notify.NotificationTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.notify.NotificationTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.notify.NotificationTool "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.notify.NotificationTool "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms128m -Xmx256m %JAVA_ARGS% org.apache.nifi.toolkit.s2s.SiteToSiteCliMain
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms128m -Xmx256m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.s2s.SiteToSiteCliMain
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms128m -Xmx256m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms128m -Xmx256m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.s2s.SiteToSiteCliMain
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.s2s.SiteToSiteCliMain
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms128m -Xmx256m org.apache.nifi.toolkit.s2s.SiteToSiteCliMain "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms128m -Xmx256m} org.apache.nifi.toolkit.s2s.SiteToSiteCliMain "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms128m -Xmx256m} org.apache.nifi.toolkit.s2s.SiteToSiteCliMain "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} org.apache.nifi.toolkit.s2s.SiteToSiteCliMain "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.toolkit.tls.TlsToolkitMain
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.tls.TlsToolkitMain
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms12m -Xmx24m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.tls.TlsToolkitMain
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.tls.TlsToolkitMain
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx24m org.apache.nifi.toolkit.tls.TlsToolkitMain "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.tls.TlsToolkitMain "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.tls.TlsToolkitMain "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.tls.TlsToolkitMain "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.bat
@@ -33,7 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain
+if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.bat
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.bat
@@ -33,9 +33,9 @@ goto startConfig
 :startConfig
 set LIB_DIR=%~dp0..\classpath;%~dp0..\lib
 
-if "%JAVA_ARGS%" == "" set JAVA_ARGS=-Xms12m -Xmx24m
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xms12m -Xmx24m
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_ARGS% org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain
+SET JAVA_PARAMS=-cp %LIB_DIR%\* %JAVA_OPTS% org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain
 
 cmd.exe /C ""%JAVA_EXE%" %JAVA_PARAMS% %* ""
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain "$@"
    return $?
 }
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.sh
@@ -111,7 +111,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx24m org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain "$@"
+   "${JAVA}" -cp "${CLASSPATH}" ${JAVA_ARGS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain "$@"
    return $?
 }
 


### PR DESCRIPTION
…ment variable.

Hardcoded heap size settings have been preserved as defaults in the JAVA_ARGS variable if it is not available in the scope of the script.

To test in *nix and OS X, temporarily use "set -x" in a script to echo commands to the terminal.
Example:
```sh
$ JAVA_ARGS="-Xms1m -Xmx24m" ./encrypt-config.sh
```
will run:
```sh
/usr/bin/java -cp '/Users/jstorck/git-repos/nifi/nifi-toolkit/nifi-toolkit-assembly/target/nifi-toolkit-1.4.0-SNAPSHOT-bin/nifi-toolkit-1.4.0-SNAPSHOT/classpath:/Users/jstorck/git-repos/nifi/nifi-toolkit/nifi-toolkit-assembly/target/nifi-toolkit-1.4.0-SNAPSHOT-bin/nifi-toolkit-1.4.0-SNAPSHOT/lib/*' -Xms1m -Xmx24m org.apache.nifi.properties.ConfigEncryptionTool
```
Without specifying JAVA_ARGS:
```sh
$ ./encrypt-config.sh
```
will run:
```sh
/usr/bin/java -cp '/Users/jstorck/git-repos/nifi/nifi-toolkit/nifi-toolkit-assembly/target/nifi-toolkit-1.4.0-SNAPSHOT-bin/nifi-toolkit-1.4.0-SNAPSHOT/classpath:/Users/jstorck/git-repos/nifi/nifi-toolkit/nifi-toolkit-assembly/target/nifi-toolkit-1.4.0-SNAPSHOT-bin/nifi-toolkit-1.4.0-SNAPSHOT/lib/*' -Xms128m -Xmx256m org.apache.nifi.properties.ConfigEncryptionTool
```

To test in Windows, temporarily remove @echo off from a batch file to echo commands to the terminal.
Example:
```bat
C:\Users\Administrator\Documents>set JAVA_ARGS=-Xmx24m
C:\Users\Administrator\Documents>encrypt-config.bat
```
will run:
```bat
C:\Users\Administrator\Documents>cmd.exe /C ""java" -cp C:\Users\Administrator\Documents\..\classpath;C:\Users\Administrator\Documents\..\lib\* -Xmx24m org.apache.nifi.properties.ConfigEncryptionTool  ""
```
Without setting JAVA_ARGS:
```bat
C:\Users\Administrator\Documents>encrypt-config.bat
```
will run:
```bat
C:\Users\Administrator\Documents>cmd.exe /C ""java" -cp C:\Users\Administrator\Documents\..\classpath;C:\Users\Administrator\Documents\..\lib\* -Xms128m -Xmx256m org.apache.nifi.properties.ConfigEncryptionTool  ""```