### PR TITLE
NIFI-4193 Converting to use the dockerfile-maven plugin 

### DIFF
--- a/nifi-docker/dockermaven/pom.xml
+++ b/nifi-docker/dockermaven/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+    license agreements. See the NOTICE file distributed with this work for additional
+    information regarding copyright ownership. The ASF licenses this file to
+    You under the Apache License, Version 2.0 (the "License"); you may not use
+    this file except in compliance with the License. You may obtain a copy of
+    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+    by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied. See the License for the specific
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-docker</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dockermaven</artifactId>
+
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.3.5</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <buildArgs>
+                                        <UID>1000</UID>
+                                        <GID>1000</GID>
+                                        <NIFI_VERSION>${project.version}</NIFI_VERSION>
+                                        <NIFI_BINARY>target/nifi-${nifi.version}-bin.tar.gz</NIFI_BINARY>
+                                    </buildArgs>
+                                    <repository>apache/nifi</repository>
+                                    <tag>${project.version}</tag>
+                                    <tag>latest</tag>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Copy generated artifact to nifi-docker -->
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <id>copy-for-docker</id>
+                                <phase>process-sources</phase>
+                                <configuration>
+                                    <target name="copy assembly to nifi-docker for image build">
+                                        <copy todir="${project.basedir}/target" overwrite="true"
+                                              flatten="true">
+                                            <fileset dir="${project.basedir}/../../nifi-assembly/target" includes="*.tar.gz">
+                                                <include name="*.tar.gz"/>
+                                            </fileset>
+                                        </copy>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/nifi-docker/pom.xml
+++ b/nifi-docker/pom.xml
@@ -24,51 +24,35 @@ language governing permissions and limitations under the License. -->
     <packaging>pom</packaging>
 
     <properties>
-        <nifi.version>1.4.0-SNAPSHOT</nifi.version>
+        <nifi.version>${project.version}</nifi.version>
     </properties>
 
-    <profiles>
-        <!-- Profile for building official Docker images. Not bound to build phases since that would require anyone build to have the Docker engine installed on their machine -->       
-        <profile>                                   
-            <id>docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.4.13</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <imageName>apachenifi</imageName>
-                            <dockerDirectory>${project.basedir}/dockermaven</dockerDirectory>
-                            <imageTags>
-                               <imageTag>${nifi.version}</imageTag>
-                            </imageTags>
-                            <buildArgs>
-                                <UID>1000</UID>
-                                <GID>1000</GID>
-                                <NIFI_VERSION>${nifi.version}</NIFI_VERSION>
-                                <NIFI_BINARY>nifi-${nifi.version}-bin.tar.gz</NIFI_BINARY>
-                            </buildArgs>
-                            <resources>
-                               <resource>
-                                 <targetPath>/</targetPath>
-                                 <directory>${project.basedir}/../nifi-assembly/target</directory>
-                                 <include>nifi-${nifi.version}-bin.tar.gz</include>
-                               </resource>
-                            </resources>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>      
+    <modules>
+        <module>dockermaven</module>
+    </modules>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>1.3.5</version>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>build</goal>
+                                <goal>push</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <tag>${nifi.version}</tag>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>


### PR DESCRIPTION
NIFI-4193 Converting to use the dockerfile-maven plugin to replace deprecated plugin.