### PR TITLE
NIFI-4333: Providing Docker support of the NiFi Toolkit

### DIFF
--- a/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:8-jre-alpine
+LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
+
+ARG UID=1000
+ARG GID=1000
+ARG NIFI_TOOLKIT_VERSION=${project.version}
+ARG NIFI_TOOLKIT_BINARY=nifi-toolkit-${NIFI_TOOLKIT_VERSION}-bin.tar.gz
+
+ENV NIFI_TOOLKIT_BASE_DIR=/opt/nifi-toolkit
+ENV NIFI_TOOLKIT_HOME=${NIFI_TOOLKIT_BASE_DIR}/nifi-toolkit-${NIFI_TOOLKIT_VERSION}
+
+ADD ./sh/docker-entrypoint.sh /opt/sh/docker-entrypoint.sh
+
+# Fix docker-entrypoint perms as per https://issues.apache.org/jira/browse/MRESOURCES-236 and Setup NiFi user
+RUN chmod +x /opt/sh/docker-entrypoint.sh \
+    && addgroup -g $GID nifi \
+    && adduser -D -s /bin/ash -u $UID -G nifi nifi \
+    && mkdir -p ${NIFI_TOOLKIT_BASE_DIR}
+
+ADD ${NIFI_TOOLKIT_BINARY} ${NIFI_TOOLKIT_BASE_DIR}
+RUN chown -R nifi:nifi ${NIFI_TOOLKIT_BASE_DIR}
+
+USER nifi
+
+# Default port for TLS Toolkit CA Server
+EXPOSE 8443
+
+WORKDIR ${NIFI_TOOLKIT_HOME}
+
+# Startup NiFi
+ENTRYPOINT ["/opt/sh/docker-entrypoint.sh"]

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile.hub
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile.hub
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:8-jre-alpine
+LABEL maintainer "Apache NiFi <dev@nifi.apache.org>"
+
+ARG UID=1000
+ARG GID=1000
+ARG NIFI_TOOLKIT_VERSION=1.5.0
+ARG MIRROR=https://archive.apache.org/dist
+
+ENV NIFI_TOOLKIT_BASE_DIR=/opt/nifi-toolkit
+ENV NIFI_TOOLKIT_HOME=${NIFI_TOOLKIT_BASE_DIR}/nifi-toolkit-${NIFI_TOOLKIT_VERSION} \
+    NIFI_TOOLKIT_BINARY_URL=${MIRROR}/nifi/${NIFI_TOOLKIT_VERSION}/nifi-toolkit-${NIFI_TOOLKIT_VERSION}-bin.tar.gz
+
+ADD sh/docker-entrypoint.sh /opt/sh/docker-entrypoint.sh
+
+# Setup NiFi user
+# Download, validate, and expand Apache NiFi Toolkit binary.
+RUN apk add --update curl \
+    && rm -rf /var/cache/apk/* \
+    && addgroup -g $GID nifi \
+    && adduser -D -s /bin/ash -u $UID -G nifi nifi \
+    && mkdir -p ${NIFI_TOOLKIT_BASE_DIR} \
+    && curl -fSL ${NIFI_TOOLKIT_BINARY_URL} -o ${NIFI_TOOLKIT_BASE_DIR}/nifi-toolkit-${NIFI_TOOLKIT_VERSION}-bin.tar.gz \
+    && echo "$(curl ${NIFI_TOOLKIT_BINARY_URL}.sha256) *${NIFI_TOOLKIT_BASE_DIR}/nifi-toolkit-${NIFI_TOOLKIT_VERSION}-bin.tar.gz" | sha256sum -c - \
+    && tar -xvzf ${NIFI_TOOLKIT_BASE_DIR}/nifi-toolkit-${NIFI_TOOLKIT_VERSION}-bin.tar.gz -C ${NIFI_TOOLKIT_BASE_DIR} \
+    && rm ${NIFI_TOOLKIT_BASE_DIR}/nifi-toolkit-${NIFI_TOOLKIT_VERSION}-bin.tar.gz \
+    && chown -R nifi:nifi ${NIFI_TOOLKIT_BASE_DIR}
+
+USER nifi
+
+# Default port for TLS Toolkit CA Server
+EXPOSE 8443
+
+WORKDIR ${NIFI_TOOLKIT_HOME}
+
+# Startup NiFi
+ENTRYPOINT ["/opt/sh/docker-entrypoint.sh"]

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/sh/docker-entrypoint.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/sh/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+toolkit_path="${NIFI_TOOLKIT_HOME}/bin"
+
+program=$1
+
+function print_help() {
+    if [ -z ${program} ]; then
+        echo "No program option specified."
+    else
+        echo "Could not find program \"${program}\" to execute."
+    fi
+    echo 'Options available include: ' $(for script in $(find "${toolkit_path}" -type f -name '*.sh'); do basename ${script} '.sh'; done)
+}
+
+# Find out which component of the Toolkit we are using
+if ! [ -f "${toolkit_path}/${program}.sh" ]; then
+    print_help ${program}
+else
+    shift
+    ${toolkit_path}/${program}.sh $@
+fi

--- a/nifi-toolkit/nifi-toolkit-assembly/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-assembly/pom.xml
@@ -100,4 +100,87 @@ language governing permissions and limitations under the License. -->
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
+
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.basedir}/target/docker-build</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>docker</directory>
+                                            <filtering>true</filtering>
+                                            <includes>
+                                                <include>Dockerfile</include>
+                                                <include>**/sh/*.sh</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Copy generated artifact to nifi-docker -->
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <id>copy-for-docker</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target name="copy assembly to docker for image build">
+                                        <copy todir="${project.basedir}/target/docker-build" overwrite="true"
+                                              flatten="true">
+                                            <fileset dir="${project.basedir}/target" includes="*.tar.gz">
+                                                <include name="*.tar.gz"/>
+                                            </fileset>
+                                        </copy>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.3.5</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <contextDirectory>./target/docker-build</contextDirectory>
+                                    <buildArgs>
+                                        <UID>1000</UID>
+                                        <GID>1000</GID>
+                                    </buildArgs>
+                                    <repository>apache/nifi-toolkit</repository>
+                                    <tag>${project.version}</tag>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
NIFI-4333: 
Providing Docker support of the NiFi Toolkit via Maven build and Docker
Hub.