### PR TITLE
NIFI-2184 JettyServer should confirm "docs" path exists before using it in .createDocsWebApp().

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -491,23 +491,15 @@ public class JettyServer implements NiFiServer {
             final ResourceHandler resourceHandler = new ResourceHandler();
             resourceHandler.setDirectoriesListed(false);
 
-            // load the docs directory
-            final File docsDir = Paths.get("docs").toRealPath().toFile();
+            final File docsDir = getDocsDir("docs");
             final Resource docsResource = Resource.newResource(docsDir);
 
             // load the component documentation working directory
             final File componentDocsDirPath = props.getComponentDocumentationWorkingDirectory();
-            final File workingDocsDirectory = componentDocsDirPath.toPath().toRealPath().getParent().toFile();
+            final File workingDocsDirectory = getWorkingDocsDirectory(componentDocsDirPath);
             final Resource workingDocsResource = Resource.newResource(workingDocsDirectory);
 
-            // load the rest documentation
-            final File webApiDocsDir = new File(webApiContext.getTempDirectory(), "webapp/docs");
-            if (!webApiDocsDir.exists()) {
-                final boolean made = webApiDocsDir.mkdirs();
-                if (!made) {
-                    throw new RuntimeException(webApiDocsDir.getAbsolutePath() + " could not be created");
-                }
-            }
+            final File webApiDocsDir = getWebApiDocsDir();
             final Resource webApiDocsResource = Resource.newResource(webApiDocsDir);
 
             // create resources for both docs locations
@@ -521,8 +513,65 @@ public class JettyServer implements NiFiServer {
             logger.info("Loading documents web app with context path set to " + contextPath);
             return handler;
         } catch (Exception ex) {
-            throw new IllegalStateException("Resource directory paths are malformed: " + ex.getMessage());
+            logger.error("Unhandled Exception in createDocsWebApp: " + ex.getMessage());
+            startUpFailure(ex);
+            return null;    // required by compiler, though never be executed.
         }
+    }
+
+    /**
+     * Returns a File object for the directory containing NIFI documentation.
+     *
+     * Formerly, if the docsDirectory did not exist NIFI would fail to start
+     * with an IllegalStateException and a rather unhelpful log message.
+     * NIFI-2184 updates the process such that if the docsDirectory does not
+     * exist an attempt will be made to create the directory. If that is
+     * successful NIFI will no longer fail and will start successfully barring
+     * any other errors. The side effect of the docsDirectory not being present
+     * is that the documentation links under the 'General' portion of the help
+     * page will not be accessible, but at least the process will be running.
+     *
+     * @param docsDirectory Name of documentation directory in installation directory.
+     * @return A File object to the documentation directory; else startUpFailure called.
+     */
+    private File getDocsDir(final String docsDirectory) {
+        File docsDir;
+        try {
+            docsDir = Paths.get(docsDirectory).toRealPath().toFile();
+        } catch (IOException ex) {
+            logger.info("Directory '" + docsDirectory + "' is missing. Some documentation will be unavailable.");
+            docsDir = new File(docsDirectory).getAbsoluteFile();
+            final boolean made = docsDir.mkdirs();
+            if (!made) {
+                logger.error("Failed to create 'docs' directory!");
+                startUpFailure(new IOException(docsDir.getAbsolutePath() + " could not be created"));
+            }
+        }
+        return docsDir;
+    }
+
+    private File getWorkingDocsDirectory(final File componentDocsDirPath) {
+        File workingDocsDirectory = null;
+        try {
+            workingDocsDirectory = componentDocsDirPath.toPath().toRealPath().getParent().toFile();
+        } catch (IOException ex) {
+            logger.error("Failed to load :" + componentDocsDirPath.getAbsolutePath());
+            startUpFailure(ex);
+        }
+        return workingDocsDirectory;
+    }
+
+    private File getWebApiDocsDir() {
+        // load the rest documentation
+        final File webApiDocsDir = new File(webApiContext.getTempDirectory(), "webapp/docs");
+        if (!webApiDocsDir.exists()) {
+            final boolean made = webApiDocsDir.mkdirs();
+            if (!made) {
+                logger.error("Failed to create " + webApiDocsDir.getAbsolutePath());
+                startUpFailure(new IOException(webApiDocsDir.getAbsolutePath() + " could not be created"));
+            }
+        }
+        return webApiDocsDir;
     }
 
     private void configureConnectors(final Server server) throws ServerConfigurationException {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -1305,7 +1305,8 @@ public class ProcessGroupResource extends ApplicationResource {
     }
 
     private void activateControllerServices(final String groupId, final URI originalUri, final VariableRegistryUpdateRequest updateRequest,
-        final Pause pause, final Collection<AffectedComponentDTO> affectedServices, final ControllerServiceState desiredState, final VariableRegistryUpdateStep updateStep) throws InterruptedException {
+        final Pause pause, final Collection<AffectedComponentDTO> affectedServices, final ControllerServiceState desiredState, final VariableRegistryUpdateStep updateStep)
+            throws InterruptedException {
 
         final Set<String> affectedServiceIds = affectedServices.stream()
             .map(component -> component.getId())


### PR DESCRIPTION
NIFI-2184 JettyServer should confirm "docs" path exists before using it in .createDocsWebApp().

Refactored the createDocsWebApp method of the JettyServer.java class. Previously NiFi would fail to
start up and instead throw an IllegalStatException if the ''docs' directory did not exist in the
installation directory. With the update, if the 'docs' directory is missing, an attempt to create
the missing directory will be made and if successful will enable NIFI to startup successfully, barring
any other startup errors of course. The side effect of this change is that the help documentation
under the 'General' heading of the help page will be missing but the start up process will have 
succeeded.

Three small helper methods were extracted from the original method.  Each related to a section of the
original code that could throw an exception. In each case if an exception is now thrown a more helpful
log message will be output and the process will be closed via the startUpfailure method rather than
throwing an exception

The update was tested successfully on my local instance of NiFi with various scenarios (missing directories, introduced exceptions, etc).  Due to the fact that the updated method is private and several layers into the call chain of the Jetty server constructor there did not appear to be a clean way to write a unit test.  Conversation with one of the committers suggested submitting without a unit test given this situation. 

Additionally, Contrib-check build discovered a long line in ProcessGroupResource.java. Re-formatted line to pass checkstyle requirement.



Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [n/a] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [n/a] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [n/a] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [n/a] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
