### PR TITLE
NIFI-4443 Increase StoreInKiteDataset flexibility

### DIFF
--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
@@ -281,6 +281,10 @@
             <scope>test</scope>
             <version>${kite.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-hadoop-utils</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/main/java/org/apache/nifi/processors/kite/StoreInKiteDataset.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/main/java/org/apache/nifi/processors/kite/StoreInKiteDataset.java
@@ -38,6 +38,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StopWatch;
 import org.kitesdk.data.DatasetIOException;
 import org.kitesdk.data.DatasetWriter;
@@ -79,10 +80,21 @@ public class StoreInKiteDataset extends AbstractKiteProcessor {
             .required(true)
             .build();
 
+    public static final PropertyDescriptor ADDITIONAL_CLASSPATH_RESOURCES = new PropertyDescriptor.Builder()
+            .name("additional-classpath-resources")
+            .displayName("Additional Classpath Resources")
+            .description("A comma-separated list of paths to files and/or directories that will be added to the classpath. When specifying a " +
+                    "directory, all files with in the directory will be added to the classpath, but further sub-directories will not be included.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dynamicallyModifiesClasspath(true)
+            .build();
+
     private static final List<PropertyDescriptor> PROPERTIES
             = ImmutableList.<PropertyDescriptor>builder()
             .addAll(AbstractKiteProcessor.getProperties())
             .add(KITE_DATASET_URI)
+            .add(ADDITIONAL_CLASSPATH_RESOURCES)
             .build();
 
     private static final Set<Relationship> RELATIONSHIPS

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/test/java/org/apache/nifi/processors/kite/TestConfigurationProperty.java
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/test/java/org/apache/nifi/processors/kite/TestConfigurationProperty.java
@@ -21,6 +21,7 @@ package org.apache.nifi.processors.kite;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.TestRunner;
@@ -29,14 +30,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.After;
 import org.junit.rules.TemporaryFolder;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.Datasets;
 import org.kitesdk.data.spi.DefaultConfiguration;
+import org.kitesdk.data.Dataset;
 
 public class TestConfigurationProperty {
 
     @Rule
     public final TemporaryFolder temp = new TemporaryFolder();
     public File confLocation;
+
+    private String datasetUri = null;
+    private Dataset<Record> dataset = null;
 
     @Before
     public void saveConfiguration() throws IOException {
@@ -47,6 +55,20 @@ public class TestConfigurationProperty {
         FileOutputStream out = new FileOutputStream(confLocation);
         conf.writeXml(out);
         out.close();
+    }
+
+    @Before
+    public void createDataset() throws Exception {
+        DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+                .schema(TestUtil.USER_SCHEMA)
+                .build();
+        this.datasetUri = "dataset:file:" + temp.newFolder("ns", "temp").toString();
+        this.dataset = Datasets.create(datasetUri, descriptor, Record.class);
+    }
+
+    @After
+    public void deleteDataset() throws Exception {
+        Datasets.delete(datasetUri);
     }
 
     @Test
@@ -71,6 +93,20 @@ public class TestConfigurationProperty {
         TestRunner runner = TestRunners.newTestRunner(StoreInKiteDataset.class);
         runner.setProperty(
                 AbstractKiteProcessor.CONF_XML_FILES, temp.newFile().toString());
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testConfigurationExpressionLanguage() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(StoreInKiteDataset.class);
+        runner.setProperty(
+                AbstractKiteProcessor.CONF_XML_FILES, "${filename:substring(0,0):append('pom.xml')}");
+        runner.setProperty(
+                StoreInKiteDataset.KITE_DATASET_URI, datasetUri);
+        runner.assertValid();
+        // botch the Expression Language evaluation
+        runner.setProperty(
+                AbstractKiteProcessor.CONF_XML_FILES, "${filename:substring(0,0):");
         runner.assertNotValid();
     }
 }


### PR DESCRIPTION
* The configuration property CONF_XML_FILE now support Expression
  Language and reuse a Hadoop validator;
* The ADDITIONAL_CLASSPATH_RESOURCES property has been added, so that
  things such as writing to Azure Blob Storage should become possible.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?

Note: `nifi-scripting-processors` is giving a, to me, completely unrelated error to the proposed changes

```java
java.lang.ClassCastException: Cannot cast jdk.nashorn.internal.objects.NativeArray to java.util.Collection
```

- [x] Have you written or updated unit tests to verify your changes?

I had to put in a Dataset creation in the test because otherwise I couldn't use `runner.assertValid()`. If there is a simpler way to do this, please let me know and I'll update accordingly.

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.