### PR TITLE
NIFI-1547: DistributedMapCacheServer: Ambiguous error on misconfiguration

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
@@ -21,12 +21,15 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.OverlappingFileLockException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.wali.MinimalLockingWriteAheadLog;
 import org.wali.SerDe;
@@ -34,13 +37,22 @@ import org.wali.UpdateType;
 import org.wali.WriteAheadRepository;
 
 public class PersistentMapCache implements MapCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(PersistentMapCache.class);
+
     private final MapCache wrapped;
     private final WriteAheadRepository<MapWaliRecord> wali;
 
     private final AtomicLong modifications = new AtomicLong(0L);
 
     public PersistentMapCache(final String serviceIdentifier, final File persistencePath, final MapCache cacheToWrap) throws IOException {
-        wali = new MinimalLockingWriteAheadLog<>(persistencePath.toPath(), 1, new Serde(), null);
+        try {
+            wali = new MinimalLockingWriteAheadLog<>(persistencePath.toPath(), 1, new Serde(), null);
+        } catch (OverlappingFileLockException ex) {
+            logger.error("OverlappingFileLockException thrown: Check lock location - possible duplicate persistencePath conflict in PersistentMapCache.");
+            // Propagate the exception
+            throw ex;
+        }
         wrapped = cacheToWrap;
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/test/java/org/apache/nifi/distributed/cache/server/map/TestPersistentMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/test/java/org/apache/nifi/distributed/cache/server/map/TestPersistentMapCache.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.distributed.cache.server.map;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.OverlappingFileLockException;
+import org.apache.nifi.distributed.cache.server.EvictionPolicy;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class TestPersistentMapCache {
+
+    /**
+     * Test OverlappingFileLockException is caught when persistent path is duplicated.
+     */
+    @Test(expected=OverlappingFileLockException.class)
+    public void testDuplicatePersistenceDirectory() {
+        try {
+            File duplicatedFilePath = new File("/tmp/path1");
+            final MapCache cache = new SimpleMapCache("simpleCache", 2, EvictionPolicy.FIFO);
+            PersistentMapCache pmc1 = new PersistentMapCache("id1", duplicatedFilePath, cache);
+            PersistentMapCache pmc2 = new PersistentMapCache("id2", duplicatedFilePath, cache);
+        } catch (IOException ex) {
+            fail("Unexpected IOException thrown: " + ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
NIFI-1547: DistributedMapCacheServer: Ambiguous error on misconfiguration

Updated PersistentMapCache constructor in PersistentMapCache.java to
catch an OverlappingFileLockException and present a more useful error
message before propagating the exception forward. The log message alerts
user to possible duplicated persistencePath in call to
PersistentMapCache.

Created a test method to verify the exception is thrown as expected.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
