### PR TITLE
NIFI-4497: Fixing issue preventing separators in sub context menus

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
@@ -704,7 +704,9 @@
 
             // whether or not a group item should be included
             var includeGroupItem = function (groupItem) {
-                if (groupItem.menuItem) {
+                if (groupItem.separator) {
+                    return true;
+                } else if (groupItem.menuItem) {
                     return groupItem.condition(selection);
                 } else {
                     var descendantItems = [];
@@ -754,7 +756,12 @@
                             applicableGroupItems.push(groupItem);
                         }
                     });
-                    included = applicableGroupItems.length > 0;
+
+                    // ensure the included menu items includes more than just separators
+                    var includedMenuItems = $.grep(applicableGroupItems, function (gi) {
+                        return nfCommon.isUndefinedOrNull(gi.separator);
+                    });
+                    included = includedMenuItems.length > 0;
                     if (included) {
                         addGroupItem(menu, i.id, i.groupMenuItem, applicableGroupItems);
                     }


### PR DESCRIPTION
NIFI-4497:
- Fixing issue preventing separators in sub context menus.

@scottyaslan Was hoping you could take a peek at this. To reproduce the issue, add a separator to the menu items in a sub-group. The separator will be ignored. With this change, the separator should be visible.