### PR TITLE
NIFI-4499 Updated default content-viewer URL property to be relative …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -71,7 +71,7 @@
         <nifi.content.repository.archive.max.usage.percentage>50%</nifi.content.repository.archive.max.usage.percentage>
         <nifi.content.repository.archive.enabled>true</nifi.content.repository.archive.enabled>
         <nifi.content.repository.always.sync>false</nifi.content.repository.always.sync>
-        <nifi.content.viewer.url>/nifi-content-viewer/</nifi.content.viewer.url>
+        <nifi.content.viewer.url>../nifi-content-viewer/</nifi.content.viewer.url>
 
         <nifi.restore.directory />
         <nifi.ui.banner.text />


### PR DESCRIPTION
…rather than assuming it is deployed at the root context.

To test this PR:
* Build NiFi and start it with the default nifi.properties file.
* Configure a proxy, and point it at NiFi.
* Access NiFi via the proxy
* Add a processor that creates flowfiles with viewable (ie, text) data, such as GenerateFlowFile.
* Add any other processor, such as UpdateAttribute.
* Route the first processor to the second processor
* Start the first processor to get some data into the outgoing queue, then stop the flow.
* Right-click on the queue and view the queue listing
* Select the info icon next to one of the queue items
* From the Details tab, click View.  A new tab should open with the content viewer and the flowfile data can be viewed.  Close the content-viewer tab.  Close the dialog with the FlowFile details.
* From the queue listing dialog, click the Provenance icon.
* In the Provenance frame, click the info icon for one of the events
* Select the Content tab and click View.  A new tab should open with the content viewer and the flowfile data can be viewed.
* Shut down NiFi and the proxy.