### PR TITLE
NIFI-2979 PriorityAttributePrioritizer violates Comparator contract

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizer.java
@@ -49,7 +49,7 @@ public class PriorityAttributePrioritizer implements FlowFilePrioritizer {
         String o1Priority = o1.getAttribute(CoreAttributes.PRIORITY.key());
         String o2Priority = o2.getAttribute(CoreAttributes.PRIORITY.key());
         if (o1Priority == null && o2Priority == null) {
-            return -1; // this is not 0 to match FirstInFirstOut
+            return 0;
         } else if (o2Priority == null) {
             return -1;
         } else if (o1Priority == null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizerTest.java
@@ -83,7 +83,7 @@ public class PriorityAttributePrioritizerTest {
         assertEquals(-1, prioritizer.compare(ffNoPriority, null));
         assertEquals(1, prioritizer.compare(null, ffNoPriority));
 
-        assertEquals(-1, prioritizer.compare(ffNoPriority, ffNoPriority));
+        assertEquals(0, prioritizer.compare(ffNoPriority, ffNoPriority));
         assertEquals(-1, prioritizer.compare(ffPri1, ffNoPriority));
         assertEquals(1, prioritizer.compare(ffNoPriority, ffPri1));
 


### PR DESCRIPTION
NIFI-2979 PriorityAttributePrioritizer violates Comparator contract

Modified the return value when both objects priority values are null to
zero in order to match the expected return value based upon the Comparator
contract.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X ] Is your initial contribution a single, squashed commit?

### For code changes:
- [X ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [X ] Have you written or updated unit tests to verify your changes?
- [X ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [X ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [X ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [X ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
