### PR TITLE
NIFI-4528 The ref attribute in the request to view content sent by th…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/java/org/apache/nifi/web/ContentViewerController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/java/org/apache/nifi/web/ContentViewerController.java
@@ -56,7 +56,10 @@ public class ContentViewerController extends HttpServlet {
     // 1.5kb - multiple of 12 (3 bytes = 4 base 64 encoded chars)
     private final static int BUFFER_LENGTH = 1536;
 
-    /**
+    private static final String PROXY_CONTEXT_PATH_HTTP_HEADER = "X-ProxyContextPath";
+    private static final String FORWARDED_CONTEXT_HTTP_HEADER = "X-Forwarded-Context";
+
+  /**
      * Gets the content and defers to registered viewers to generate the markup.
      *
      * @param request servlet request
@@ -301,11 +304,19 @@ public class ContentViewerController extends HttpServlet {
         final String ref = request.getParameter("ref");
         final String clientId = request.getParameter("clientId");
 
+        final UriBuilder refUriBuilder = UriBuilder.fromUri(ref);
+
         // base the data ref on the request parameter but ensure the scheme is based off the incoming request...
         // this is necessary for scenario's where the NiFi instance is behind a proxy running a different scheme
-        final URI refUri = UriBuilder.fromUri(ref)
-                .scheme(request.getScheme())
-                .build();
+        refUriBuilder.scheme(request.getScheme());
+
+        // If there is path context from a proxy, remove it since this request will be used inside the cluster
+        final String proxyContextPath = getFirstHeaderValue(request, PROXY_CONTEXT_PATH_HTTP_HEADER, FORWARDED_CONTEXT_HTTP_HEADER);
+        if (StringUtils.isNotBlank(proxyContextPath)) {
+            refUriBuilder.replacePath(StringUtils.substringAfter(UriBuilder.fromUri(ref).build().getPath(), proxyContextPath));
+        }
+
+        final URI refUri = refUriBuilder.build();
 
         final String query = refUri.getQuery();
 
@@ -342,5 +353,30 @@ public class ContentViewerController extends HttpServlet {
                 return null;
             }
         };
+    }
+
+    /**
+     * Returns the value for the first key discovered when inspecting the current request. Will
+     * return null if there are no keys specified or if none of the specified keys are found.
+     *
+     * @param keys http header keys
+     * @return the value for the first key found
+     */
+    private String getFirstHeaderValue(HttpServletRequest httpServletRequest, final String... keys) {
+        if (keys == null) {
+            return null;
+        }
+
+        for (final String key : keys) {
+            final String value = httpServletRequest.getHeader(key);
+
+            // if we found an entry for this key, return the value
+            if (value != null) {
+                return value;
+            }
+        }
+
+        // unable to find any matching keys
+        return null;
     }
 }


### PR DESCRIPTION
…e client will now be inspected for the proxy context path. If found, it will be removed so the request can be successfully made within the cluster.

To test this PR:
Start a NiFi cluster
Start a proxy that points to one of the nodes in the NiFi cluster
From the NiFi UI, create a flow with a GenerateFlowFile processor creating text flowfiles sent to a downstream processor.  No need to start the downstream processor.
List the queue contents
Click the info icon of a flowfile in the queue
Click View

You should successfully see the content of the flowfile in the Content Viewer UI.
