### PR TITLE
NIFI-4548: Add REMOTE_INVOCATION provenance event type

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventType.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventType.java
@@ -47,6 +47,13 @@ public enum ProvenanceEventType {
     SEND,
 
     /**
+     * Indicates a provenance event for sending remote invocation request to an external process.
+     * This event type is used to represent other operations than transferring data (RECEIVE, FETCH or SEND),
+     * for example, deleting object from an external process or storage.
+     */
+    REMOTE_INVOCATION,
+
+    /**
      * Indicates that the contents of a FlowFile were downloaded by a user or external entity.
      */
     DOWNLOAD,

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceReporter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceReporter.java
@@ -317,6 +317,18 @@ public interface ProvenanceReporter {
     void send(FlowFile flowFile, String transitUri, String details, long transmissionMillis, boolean force);
 
     /**
+     * Emits a Provenance Event of type {@link ProvenanceEventType#REMOTE_INVOCATION}
+     * that indicates a remote invocation is requested to an external endpoint using
+     * the given FlowFile. The external endpoint may exist in a remote or a local system,
+     * but is external to NiFi.
+     * @param flowFile the FlowFile that was used to make the remote invocation
+     * @param transitUri A URI that provides information about the System and
+     * Protocol information over which the invocation occurred. The intent of this
+     * field is to identify they type and target resource or object of the invocation.
+     */
+    void invokeRemoteProcess(FlowFile flowFile, String transitUri);
+
+    /**
      * Emits a Provenance Event of type
      * {@link ProvenanceEventType#ADDINFO ADDINFO} that provides a linkage
      * between the given FlowFile and alternate identifier. This information can

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceReporter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceReporter.java
@@ -329,6 +329,20 @@ public interface ProvenanceReporter {
     void invokeRemoteProcess(FlowFile flowFile, String transitUri);
 
     /**
+     * Emits a Provenance Event of type {@link ProvenanceEventType#REMOTE_INVOCATION}
+     * that indicates a remote invocation is requested to an external endpoint using
+     * the given FlowFile. The external endpoint may exist in a remote or a local system,
+     * but is external to NiFi.
+     * @param flowFile the FlowFile that was used to make the remote invocation
+     * @param transitUri A URI that provides information about the System and
+     * Protocol information over which the invocation occurred. The intent of this
+     * field is to identify they type and target resource or object of the invocation.
+     * @param details additional details related to the REMOTE_INVOCATION event, such as an
+     * explanation of the invoked process.
+     */
+    void invokeRemoteProcess(FlowFile flowFile, String transitUri, String details);
+
+    /**
      * Emits a Provenance Event of type
      * {@link ProvenanceEventType#ADDINFO ADDINFO} that provides a linkage
      * between the given FlowFile and alternate identifier. This information can

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProvenanceReporter.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProvenanceReporter.java
@@ -233,8 +233,14 @@ public class MockProvenanceReporter implements ProvenanceReporter {
 
     @Override
     public void invokeRemoteProcess(final FlowFile flowFile, final String transitUri) {
+        invokeRemoteProcess(flowFile, transitUri, null);
+    }
+
+    @Override
+    public void invokeRemoteProcess(FlowFile flowFile, String transitUri, String details) {
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION).setTransitUri(transitUri).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION)
+                    .setTransitUri(transitUri).setDetails(details).build();
             events.add(record);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProvenanceReporter.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProvenanceReporter.java
@@ -232,6 +232,19 @@ public class MockProvenanceReporter implements ProvenanceReporter {
     }
 
     @Override
+    public void invokeRemoteProcess(final FlowFile flowFile, final String transitUri) {
+        try {
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION).setTransitUri(transitUri).build();
+            events.add(record);
+        } catch (final Exception e) {
+            logger.error("Failed to generate Provenance Event due to " + e);
+            if (logger.isDebugEnabled()) {
+                logger.error("", e);
+            }
+        }
+    }
+
+    @Override
     public void associate(final FlowFile flowFile, final String alternateIdentifierNamespace, final String alternateIdentifier) {
         try {
             String trimmedNamespace = alternateIdentifierNamespace.trim();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
@@ -230,6 +230,19 @@ public class StandardProvenanceReporter implements ProvenanceReporter {
     }
 
     @Override
+    public void invokeRemoteProcess(final FlowFile flowFile, final String transitUri) {
+        try {
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION).setTransitUri(transitUri).build();
+            events.add(record);
+        } catch (final Exception e) {
+            logger.error("Failed to generate Provenance Event due to " + e);
+            if (logger.isDebugEnabled()) {
+                logger.error("", e);
+            }
+        }
+    }
+
+    @Override
     public void associate(final FlowFile flowFile, final String alternateIdentifierNamespace, final String alternateIdentifier) {
         try {
             String trimmedNamespace = alternateIdentifierNamespace.trim();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
@@ -231,8 +231,14 @@ public class StandardProvenanceReporter implements ProvenanceReporter {
 
     @Override
     public void invokeRemoteProcess(final FlowFile flowFile, final String transitUri) {
+        invokeRemoteProcess(flowFile, transitUri, null);
+    }
+
+    @Override
+    public void invokeRemoteProcess(FlowFile flowFile, String transitUri, String details) {
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION).setTransitUri(transitUri).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION)
+                    .setTransitUri(transitUri).setDetails(details).build();
             events.add(record);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/provenance/nf-provenance-table.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/provenance/nf-provenance-table.js
@@ -1351,6 +1351,11 @@
                         formatEventDetail('Transit Uri', event.transitUri);
                     }
 
+                    // conditionally show REMOTE_INVOCATION details
+                    if (event.eventType === 'REMOTE_INVOCATION') {
+                        formatEventDetail('Transit Uri', event.transitUri);
+                    }
+
                     // conditionally show ADDINFO details
                     if (event.eventType === 'ADDINFO') {
                         formatEventDetail('Alternate Identifier Uri', event.alternateIdentifierUri);

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -60,8 +60,10 @@ import com.google.common.collect.Maps;
         + " knowledge of globbed files deleted is necessary use ListHDFS first to produce a specific list of files to delete. ")
 @Restricted("Provides operator the ability to delete any file that NiFi has access to in HDFS or the local filesystem.")
 @WritesAttributes({
-        @WritesAttribute(attribute="hdfs.filename", description="HDFS file to be deleted"),
-        @WritesAttribute(attribute="hdfs.path", description="HDFS Path specified in the delete request"),
+        @WritesAttribute(attribute="hdfs.filename", description="HDFS file to be deleted. "
+                + "If multiple files are deleted, then only the last filename is set."),
+        @WritesAttribute(attribute="hdfs.path", description="HDFS Path specified in the delete request. "
+                + "If multiple paths are deleted, then only the last path is set."),
         @WritesAttribute(attribute="hdfs.error.message", description="HDFS error message related to the hdfs.error.code")
 })
 @SeeAlso({ListHDFS.class, PutHDFS.class})
@@ -132,12 +134,10 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
             return;
         }
 
-        final String fileOrDirectoryName;
-        if (originalFlowFile == null) {
-            fileOrDirectoryName = context.getProperty(FILE_OR_DIRECTORY).evaluateAttributeExpressions().getValue();
-        } else {
-            fileOrDirectoryName = context.getProperty(FILE_OR_DIRECTORY).evaluateAttributeExpressions(originalFlowFile).getValue();
-        }
+        // We need a FlowFile to report provenance correctly.
+        FlowFile flowFile = originalFlowFile != null ? originalFlowFile : session.create();
+
+        final String fileOrDirectoryName = context.getProperty(FILE_OR_DIRECTORY).evaluateAttributeExpressions(flowFile).getValue();
 
         final FileSystem fileSystem = getFileSystem();
         try {
@@ -154,34 +154,43 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
                 pathList.add(new Path(fileOrDirectoryName));
             }
 
+            int failedPath = 0;
             for (Path path : pathList) {
                 if (fileSystem.exists(path)) {
                     try {
+                        Map<String, String> attributes = Maps.newHashMapWithExpectedSize(2);
+                        attributes.put("hdfs.filename", path.getName());
+                        attributes.put("hdfs.path", path.getParent().toString());
+                        flowFile = session.putAllAttributes(flowFile, attributes);
+
                         fileSystem.delete(path, context.getProperty(RECURSIVE).asBoolean());
                         getLogger().debug("For flowfile {} Deleted file at path {} with name {}", new Object[]{originalFlowFile, path.getParent().toString(), path.getName()});
+                        final Path qualifiedPath = path.makeQualified(fileSystem.getUri(), fileSystem.getWorkingDirectory());
+                        session.getProvenanceReporter().invokeRemoteProcess(flowFile, qualifiedPath.toString());
                     } catch (IOException ioe) {
                         // One possible scenario is that the IOException is permissions based, however it would be impractical to check every possible
                         // external HDFS authorization tool (Ranger, Sentry, etc). Local ACLs could be checked but the operation would be expensive.
                         getLogger().warn("Failed to delete file or directory", ioe);
 
-                        Map<String, String> attributes = Maps.newHashMapWithExpectedSize(3);
-                        attributes.put("hdfs.filename", path.getName());
-                        attributes.put("hdfs.path", path.getParent().toString());
+                        Map<String, String> attributes = Maps.newHashMapWithExpectedSize(1);
                         // The error message is helpful in understanding at a flowfile level what caused the IOException (which ACL is denying the operation, e.g.)
                         attributes.put("hdfs.error.message", ioe.getMessage());
 
-                        session.transfer(session.putAllAttributes(session.clone(originalFlowFile), attributes), REL_FAILURE);
+                        session.transfer(session.putAllAttributes(session.clone(flowFile), attributes), REL_FAILURE);
+                        failedPath++;
                     }
                 }
             }
-            if (originalFlowFile != null) {
-                session.transfer(originalFlowFile, DeleteHDFS.REL_SUCCESS);
+
+            if (failedPath == 0) {
+                session.transfer(flowFile, DeleteHDFS.REL_SUCCESS);
+            } else {
+                // If any path has been failed to be deleted, remove the FlowFile as it's been cloned and sent to failure.
+                session.remove(flowFile);
             }
         } catch (IOException e) {
-            if (originalFlowFile != null) {
-                getLogger().error("Error processing delete for flowfile {} due to {}", new Object[]{originalFlowFile, e.getMessage()}, e);
-                session.transfer(originalFlowFile, DeleteHDFS.REL_FAILURE);
-            }
+            getLogger().error("Error processing delete for flowfile {} due to {}", new Object[]{flowFile, e.getMessage()}, e);
+            session.transfer(flowFile, DeleteHDFS.REL_FAILURE);
         }
 
     }


### PR DESCRIPTION
This commit includes changes to DeleteHDFS to report REMOTE_INVOCATION
event. In order to do so, the processor had to be changed to create
output FlowFile because a provenance event needs a FlowFile it
associates with.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
