### PR TITLE
NIFI-4463 New MQTT Consume logic

### DIFF
--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.0.2</version>
+            <version>1.2.0</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/common/AbstractMQTTProcessor.java
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/common/AbstractMQTTProcessor.java
@@ -17,6 +17,24 @@
 
 package org.apache.nifi.processors.mqtt.common;
 
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_CLEAN_SESSION_FALSE;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_CLEAN_SESSION_TRUE;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_MQTT_VERSION_310;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_MQTT_VERSION_311;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_MQTT_VERSION_AUTO;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_QOS_0;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_QOS_1;
+import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_QOS_2;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.ValidationContext;
@@ -31,342 +49,280 @@ import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.ssl.SSLContextService;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
-import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_CLEAN_SESSION_FALSE;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_CLEAN_SESSION_TRUE;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_MQTT_VERSION_310;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_MQTT_VERSION_311;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_MQTT_VERSION_AUTO;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_QOS_0;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_QOS_1;
-import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VALUE_QOS_2;
-
 public abstract class AbstractMQTTProcessor extends AbstractSessionFactoryProcessor {
 
-    protected ComponentLog logger;
-    protected IMqttClient mqttClient;
-    protected final ReadWriteLock mqttClientConnectLock = new ReentrantReadWriteLock(true);
-    protected volatile String broker;
-    protected volatile String clientID;
-    protected MqttConnectOptions connOpts;
-    protected MemoryPersistence persistence = new MemoryPersistence();
+	protected ComponentLog logger;
+	protected IMqttAsyncClient mqttClient;
+	protected final ReadWriteLock mqttClientConnectLock = new ReentrantReadWriteLock(true);
+	protected volatile String broker;
+	protected volatile String clientID;
+	protected MqttConnectOptions connOpts;
+	protected MemoryPersistence persistence = new MemoryPersistence();
 
-    public ProcessSessionFactory processSessionFactory;
+	public ProcessSessionFactory processSessionFactory;
 
-    public static final Validator QOS_VALIDATOR = new Validator() {
+	public static final Validator QOS_VALIDATOR = new Validator() {
 
-        @Override
-        public ValidationResult validate(String subject, String input, ValidationContext context) {
-            Integer inputInt = Integer.parseInt(input);
-            if (inputInt < 0 || inputInt > 2) {
-                return new ValidationResult.Builder().subject(subject).valid(false).explanation("QoS must be an integer between 0 and 2").build();
-            }
-            return new ValidationResult.Builder().subject(subject).valid(true).build();
-        }
-    };
+		@Override
+		public ValidationResult validate(String subject, String input, ValidationContext context) {
+			Integer inputInt = Integer.parseInt(input);
+			if (inputInt < 0 || inputInt > 2) {
+				return new ValidationResult.Builder().subject(subject).valid(false).explanation("QoS must be an integer between 0 and 2")
+						.build();
+			}
+			return new ValidationResult.Builder().subject(subject).valid(true).build();
+		}
+	};
 
-    public static final Validator BROKER_VALIDATOR = new Validator() {
+	public static final Validator BROKER_VALIDATOR = new Validator() {
 
-        @Override
-        public ValidationResult validate(String subject, String input, ValidationContext context) {
-            try{
-                URI brokerURI = new URI(input);
-                if (!"".equals(brokerURI.getPath())) {
-                    return new ValidationResult.Builder().subject(subject).valid(false).explanation("the broker URI cannot have a path. It currently is:" + brokerURI.getPath()).build();
-                }
-                if (!("tcp".equals(brokerURI.getScheme()) || "ssl".equals(brokerURI.getScheme()))) {
-                    return new ValidationResult.Builder().subject(subject).valid(false).explanation("only the 'tcp' and 'ssl' schemes are supported.").build();
-                }
-            } catch (URISyntaxException e) {
-                return new ValidationResult.Builder().subject(subject).valid(false).explanation("it is not valid URI syntax.").build();
-            }
-            return new ValidationResult.Builder().subject(subject).valid(true).build();
-        }
-    };
+		@Override
+		public ValidationResult validate(String subject, String input, ValidationContext context) {
+			try {
+				URI brokerURI = new URI(input);
+				if (!"".equals(brokerURI.getPath())) {
+					return new ValidationResult.Builder().subject(subject).valid(false)
+							.explanation("the broker URI cannot have a path. It currently is:" + brokerURI.getPath()).build();
+				}
+				if (!("tcp".equals(brokerURI.getScheme()) || "ssl".equals(brokerURI.getScheme()))) {
+					return new ValidationResult.Builder().subject(subject).valid(false)
+							.explanation("only the 'tcp' and 'ssl' schemes are supported.").build();
+				}
+			} catch (URISyntaxException e) {
+				return new ValidationResult.Builder().subject(subject).valid(false).explanation("it is not valid URI syntax.").build();
+			}
+			return new ValidationResult.Builder().subject(subject).valid(true).build();
+		}
+	};
 
-    public static final Validator RETAIN_VALIDATOR = new Validator() {
+	public static final Validator RETAIN_VALIDATOR = new Validator() {
 
-        @Override
-        public ValidationResult validate(String subject, String input, ValidationContext context) {
-            if("true".equalsIgnoreCase(input) || "false".equalsIgnoreCase(input)){
-                return new ValidationResult.Builder().subject(subject).valid(true).build();
-            } else{
-                return StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.BOOLEAN, false)
-                        .validate(subject, input, context);
-            }
+		@Override
+		public ValidationResult validate(String subject, String input, ValidationContext context) {
+			if ("true".equalsIgnoreCase(input) || "false".equalsIgnoreCase(input)) {
+				return new ValidationResult.Builder().subject(subject).valid(true).build();
+			} else {
+				return StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.BOOLEAN, false)
+						.validate(subject, input, context);
+			}
 
-        }
-    };
+		}
+	};
 
-    public static final PropertyDescriptor PROP_BROKER_URI = new PropertyDescriptor.Builder()
-            .name("Broker URI")
-            .description("The URI to use to connect to the MQTT broker (e.g. tcp://localhost:1883). The 'tcp' and 'ssl' schemes are supported. In order to use 'ssl', the SSL Context " +
-                    "Service property must be set.")
-            .required(true)
-            .addValidator(BROKER_VALIDATOR)
-            .build();
+	public static final PropertyDescriptor PROP_BROKER_URI = new PropertyDescriptor.Builder().name("Broker URI")
+			.description(
+					"The URI to use to connect to the MQTT broker (e.g. tcp://localhost:1883). The 'tcp' and 'ssl' schemes are supported. In order to use 'ssl', the SSL Context "
+							+ "Service property must be set.")
+			.required(true).addValidator(BROKER_VALIDATOR).build();
 
+	public static final PropertyDescriptor PROP_CLIENTID = new PropertyDescriptor.Builder().name("Client ID")
+			.description("MQTT client ID to use").required(true).addValidator(StandardValidators.NON_BLANK_VALIDATOR).build();
 
-    public static final PropertyDescriptor PROP_CLIENTID = new PropertyDescriptor.Builder()
-            .name("Client ID")
-            .description("MQTT client ID to use")
-            .required(true)
-            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .build();
+	public static final PropertyDescriptor PROP_USERNAME = new PropertyDescriptor.Builder().name("Username")
+			.description("Username to use when connecting to the broker").required(false)
+			.addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
 
-    public static final PropertyDescriptor PROP_USERNAME = new PropertyDescriptor.Builder()
-            .name("Username")
-            .description("Username to use when connecting to the broker")
-            .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .build();
+	public static final PropertyDescriptor PROP_PASSWORD = new PropertyDescriptor.Builder().name("Password")
+			.description("Password to use when connecting to the broker").required(false)
+			.addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
 
-    public static final PropertyDescriptor PROP_PASSWORD = new PropertyDescriptor.Builder()
-            .name("Password")
-            .description("Password to use when connecting to the broker")
-            .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .build();
+	public static final PropertyDescriptor PROP_SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder().name("SSL Context Service")
+			.description("The SSL Context Service used to provide client certificate information for TLS/SSL connections.").required(false)
+			.identifiesControllerService(SSLContextService.class).build();
 
-    public static final PropertyDescriptor PROP_SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
-            .name("SSL Context Service")
-            .description("The SSL Context Service used to provide client certificate information for TLS/SSL connections.")
-            .required(false)
-            .identifiesControllerService(SSLContextService.class)
-            .build();
+	public static final PropertyDescriptor PROP_LAST_WILL_TOPIC = new PropertyDescriptor.Builder().name("Last Will Topic")
+			.description(
+					"The topic to send the client's Last Will to. If the Last Will topic and message are not set then a Last Will will not be sent.")
+			.required(false).addValidator(StandardValidators.NON_BLANK_VALIDATOR).build();
 
+	public static final PropertyDescriptor PROP_LAST_WILL_MESSAGE = new PropertyDescriptor.Builder().name("Last Will Message")
+			.description(
+					"The message to send as the client's Last Will. If the Last Will topic and message are not set then a Last Will will not be sent.")
+			.required(false).addValidator(StandardValidators.NON_BLANK_VALIDATOR).build();
 
-    public static final PropertyDescriptor PROP_LAST_WILL_TOPIC = new PropertyDescriptor.Builder()
-            .name("Last Will Topic")
-            .description("The topic to send the client's Last Will to. If the Last Will topic and message are not set then a Last Will will not be sent.")
-            .required(false)
-            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .build();
+	public static final PropertyDescriptor PROP_LAST_WILL_RETAIN = new PropertyDescriptor.Builder().name("Last Will Retain")
+			.description(
+					"Whether to retain the client's Last Will. If the Last Will topic and message are not set then a Last Will will not be sent.")
+			.required(false).allowableValues("true", "false").build();
 
-    public static final PropertyDescriptor PROP_LAST_WILL_MESSAGE = new PropertyDescriptor.Builder()
-            .name("Last Will Message")
-            .description("The message to send as the client's Last Will. If the Last Will topic and message are not set then a Last Will will not be sent.")
-            .required(false)
-            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .build();
+	public static final PropertyDescriptor PROP_LAST_WILL_QOS = new PropertyDescriptor.Builder().name("Last Will QoS Level")
+			.description("QoS level to be used when publishing the Last Will Message").required(false)
+			.allowableValues(ALLOWABLE_VALUE_QOS_0, ALLOWABLE_VALUE_QOS_1, ALLOWABLE_VALUE_QOS_2).build();
 
-    public static final PropertyDescriptor PROP_LAST_WILL_RETAIN = new PropertyDescriptor.Builder()
-            .name("Last Will Retain")
-            .description("Whether to retain the client's Last Will. If the Last Will topic and message are not set then a Last Will will not be sent.")
-            .required(false)
-            .allowableValues("true","false")
-            .build();
+	public static final PropertyDescriptor PROP_CLEAN_SESSION = new PropertyDescriptor.Builder().name("Session state")
+			.description("Whether to start afresh or resume previous flows. See the allowable value descriptions for more details.")
+			.required(true).allowableValues(ALLOWABLE_VALUE_CLEAN_SESSION_TRUE, ALLOWABLE_VALUE_CLEAN_SESSION_FALSE)
+			.defaultValue(ALLOWABLE_VALUE_CLEAN_SESSION_TRUE.getValue()).build();
 
-    public static final PropertyDescriptor PROP_LAST_WILL_QOS = new PropertyDescriptor.Builder()
-            .name("Last Will QoS Level")
-            .description("QoS level to be used when publishing the Last Will Message")
-            .required(false)
-            .allowableValues(
-                    ALLOWABLE_VALUE_QOS_0,
-                    ALLOWABLE_VALUE_QOS_1,
-                    ALLOWABLE_VALUE_QOS_2
-            )
-            .build();
+	public static final PropertyDescriptor PROP_MQTT_VERSION = new PropertyDescriptor.Builder().name("MQTT Specification Version")
+			.description(
+					"The MQTT specification version when connecting with the broker. See the allowable value descriptions for more details.")
+			.allowableValues(ALLOWABLE_VALUE_MQTT_VERSION_AUTO, ALLOWABLE_VALUE_MQTT_VERSION_311, ALLOWABLE_VALUE_MQTT_VERSION_310)
+			.defaultValue(ALLOWABLE_VALUE_MQTT_VERSION_AUTO.getValue()).required(true).build();
 
-    public static final PropertyDescriptor PROP_CLEAN_SESSION = new PropertyDescriptor.Builder()
-            .name("Session state")
-            .description("Whether to start afresh or resume previous flows. See the allowable value descriptions for more details.")
-            .required(true)
-            .allowableValues(
-                    ALLOWABLE_VALUE_CLEAN_SESSION_TRUE,
-                    ALLOWABLE_VALUE_CLEAN_SESSION_FALSE
-            )
-            .defaultValue(ALLOWABLE_VALUE_CLEAN_SESSION_TRUE.getValue())
-            .build();
+	public static final PropertyDescriptor PROP_CONN_TIMEOUT = new PropertyDescriptor.Builder().name("Connection Timeout (seconds)")
+			.description("Maximum time interval the client will wait for the network connection to the MQTT server "
+					+ "to be established. The default timeout is 30 seconds. "
+					+ "A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.")
+			.required(false).defaultValue("30").addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR).build();
 
-    public static final PropertyDescriptor PROP_MQTT_VERSION = new PropertyDescriptor.Builder()
-            .name("MQTT Specification Version")
-            .description("The MQTT specification version when connecting with the broker. See the allowable value descriptions for more details.")
-            .allowableValues(
-                    ALLOWABLE_VALUE_MQTT_VERSION_AUTO,
-                    ALLOWABLE_VALUE_MQTT_VERSION_311,
-                    ALLOWABLE_VALUE_MQTT_VERSION_310
-            )
-            .defaultValue(ALLOWABLE_VALUE_MQTT_VERSION_AUTO.getValue())
-            .required(true)
-            .build();
+	public static final PropertyDescriptor PROP_KEEP_ALIVE_INTERVAL = new PropertyDescriptor.Builder().name("Keep Alive Interval (seconds)")
+			.description("Defines the maximum time interval between messages sent or received. It enables the "
+					+ "client to detect if the server is no longer available, without having to wait for the TCP/IP timeout. "
+					+ "The client will ensure that at least one message travels across the network within each keep alive period. In the absence of a data-related message during the time period, "
+					+ "the client sends a very small \"ping\" message, which the server will acknowledge. A value of 0 disables keepalive processing in the client.")
+			.required(false).defaultValue("60").addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR).build();
 
-    public static final PropertyDescriptor PROP_CONN_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("Connection Timeout (seconds)")
-            .description("Maximum time interval the client will wait for the network connection to the MQTT server " +
-                    "to be established. The default timeout is 30 seconds. " +
-                    "A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.")
-            .required(false)
-            .defaultValue("30")
-            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .build();
+	public static List<PropertyDescriptor> getAbstractPropertyDescriptors() {
+		final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+		descriptors.add(PROP_BROKER_URI);
+		descriptors.add(PROP_CLIENTID);
+		descriptors.add(PROP_USERNAME);
+		descriptors.add(PROP_PASSWORD);
+		descriptors.add(PROP_SSL_CONTEXT_SERVICE);
+		descriptors.add(PROP_LAST_WILL_TOPIC);
+		descriptors.add(PROP_LAST_WILL_MESSAGE);
+		descriptors.add(PROP_LAST_WILL_RETAIN);
+		descriptors.add(PROP_LAST_WILL_QOS);
+		descriptors.add(PROP_CLEAN_SESSION);
+		descriptors.add(PROP_MQTT_VERSION);
+		descriptors.add(PROP_CONN_TIMEOUT);
+		descriptors.add(PROP_KEEP_ALIVE_INTERVAL);
+		return descriptors;
+	}
 
-    public static final PropertyDescriptor PROP_KEEP_ALIVE_INTERVAL = new PropertyDescriptor.Builder()
-            .name("Keep Alive Interval (seconds)")
-            .description("Defines the maximum time interval between messages sent or received. It enables the " +
-                    "client to detect if the server is no longer available, without having to wait for the TCP/IP timeout. " +
-                    "The client will ensure that at least one message travels across the network within each keep alive period. In the absence of a data-related message during the time period, " +
-                    "the client sends a very small \"ping\" message, which the server will acknowledge. A value of 0 disables keepalive processing in the client.")
-            .required(false)
-            .defaultValue("60")
-            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .build();
+	@Override
+	public Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
+		final List<ValidationResult> results = new ArrayList<>(1);
+		final boolean usernameSet = validationContext.getProperty(PROP_USERNAME).isSet();
+		final boolean passwordSet = validationContext.getProperty(PROP_PASSWORD).isSet();
 
-    public static List<PropertyDescriptor> getAbstractPropertyDescriptors(){
-        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
-        descriptors.add(PROP_BROKER_URI);
-        descriptors.add(PROP_CLIENTID);
-        descriptors.add(PROP_USERNAME);
-        descriptors.add(PROP_PASSWORD);
-        descriptors.add(PROP_SSL_CONTEXT_SERVICE);
-        descriptors.add(PROP_LAST_WILL_TOPIC);
-        descriptors.add(PROP_LAST_WILL_MESSAGE);
-        descriptors.add(PROP_LAST_WILL_RETAIN);
-        descriptors.add(PROP_LAST_WILL_QOS);
-        descriptors.add(PROP_CLEAN_SESSION);
-        descriptors.add(PROP_MQTT_VERSION);
-        descriptors.add(PROP_CONN_TIMEOUT);
-        descriptors.add(PROP_KEEP_ALIVE_INTERVAL);
-        return descriptors;
-    }
+		if ((usernameSet && !passwordSet) || (!usernameSet && passwordSet)) {
+			results.add(new ValidationResult.Builder().subject("Username and Password").valid(false)
+					.explanation("if username or password is set, both must be set").build());
+		}
 
-    @Override
-    public Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
-        final List<ValidationResult> results = new ArrayList<>(1);
-        final boolean usernameSet = validationContext.getProperty(PROP_USERNAME).isSet();
-        final boolean passwordSet = validationContext.getProperty(PROP_PASSWORD).isSet();
+		final boolean lastWillTopicSet = validationContext.getProperty(PROP_LAST_WILL_TOPIC).isSet();
+		final boolean lastWillMessageSet = validationContext.getProperty(PROP_LAST_WILL_MESSAGE).isSet();
 
-        if ((usernameSet && !passwordSet) || (!usernameSet && passwordSet)) {
-            results.add(new ValidationResult.Builder().subject("Username and Password").valid(false).explanation("if username or password is set, both must be set").build());
-        }
+		final boolean lastWillRetainSet = validationContext.getProperty(PROP_LAST_WILL_RETAIN).isSet();
+		final boolean lastWillQosSet = validationContext.getProperty(PROP_LAST_WILL_QOS).isSet();
 
-        final boolean lastWillTopicSet = validationContext.getProperty(PROP_LAST_WILL_TOPIC).isSet();
-        final boolean lastWillMessageSet = validationContext.getProperty(PROP_LAST_WILL_MESSAGE).isSet();
+		// If any of the Last Will Properties are set
+		if (lastWillTopicSet || lastWillMessageSet || lastWillRetainSet || lastWillQosSet) {
+			// And any are not set
+			if (!(lastWillTopicSet && lastWillMessageSet && lastWillRetainSet && lastWillQosSet)) {
+				// Then mark as invalid
+				results.add(new ValidationResult.Builder().subject("Last Will Properties").valid(false)
+						.explanation("if any of the Last Will Properties (message, topic, retain and QoS) are " + "set, all must be set.")
+						.build());
+			}
+		}
 
-        final boolean lastWillRetainSet = validationContext.getProperty(PROP_LAST_WILL_RETAIN).isSet();
-        final boolean lastWillQosSet = validationContext.getProperty(PROP_LAST_WILL_QOS).isSet();
+		try {
+			URI brokerURI = new URI(validationContext.getProperty(PROP_BROKER_URI).getValue());
+			if (brokerURI.getScheme().equalsIgnoreCase("ssl") && !validationContext.getProperty(PROP_SSL_CONTEXT_SERVICE).isSet()) {
+				results.add(new ValidationResult.Builder().subject(PROP_SSL_CONTEXT_SERVICE.getName() + " or " + PROP_BROKER_URI.getName())
+						.valid(false)
+						.explanation("if the 'ssl' scheme is used in " + "the broker URI, the SSL Context Service must be set.").build());
+			}
+		} catch (URISyntaxException e) {
+			results.add(new ValidationResult.Builder().subject(PROP_BROKER_URI.getName()).valid(false)
+					.explanation("it is not valid URI syntax.").build());
+		}
 
-        // If any of the Last Will Properties are set
-        if (lastWillTopicSet || lastWillMessageSet || lastWillRetainSet || lastWillQosSet) {
-            // And any are not set
-            if(!(lastWillTopicSet && lastWillMessageSet && lastWillRetainSet && lastWillQosSet)){
-                // Then mark as invalid
-                results.add(new ValidationResult.Builder().subject("Last Will Properties").valid(false).explanation("if any of the Last Will Properties (message, topic, retain and QoS) are " +
-                        "set, all must be set.").build());
-            }
-        }
+		return results;
+	}
 
-        try {
-            URI brokerURI = new URI(validationContext.getProperty(PROP_BROKER_URI).getValue());
-            if (brokerURI.getScheme().equalsIgnoreCase("ssl") && !validationContext.getProperty(PROP_SSL_CONTEXT_SERVICE).isSet()) {
-                results.add(new ValidationResult.Builder().subject(PROP_SSL_CONTEXT_SERVICE.getName() + " or " + PROP_BROKER_URI.getName()).valid(false).explanation("if the 'ssl' scheme is used in " +
-                        "the broker URI, the SSL Context Service must be set.").build());
-            }
-        } catch (URISyntaxException e) {
-            results.add(new ValidationResult.Builder().subject(PROP_BROKER_URI.getName()).valid(false).explanation("it is not valid URI syntax.").build());
-        }
+	public static Properties transformSSLContextService(SSLContextService sslContextService) {
+		Properties properties = new Properties();
+		properties.setProperty("com.ibm.ssl.protocol", sslContextService.getSslAlgorithm());
+		properties.setProperty("com.ibm.ssl.keyStore", sslContextService.getKeyStoreFile());
+		properties.setProperty("com.ibm.ssl.keyStorePassword", sslContextService.getKeyStorePassword());
+		properties.setProperty("com.ibm.ssl.keyStoreType", sslContextService.getKeyStoreType());
+		properties.setProperty("com.ibm.ssl.trustStore", sslContextService.getTrustStoreFile());
+		properties.setProperty("com.ibm.ssl.trustStorePassword", sslContextService.getTrustStorePassword());
+		properties.setProperty("com.ibm.ssl.trustStoreType", sslContextService.getTrustStoreType());
+		return properties;
+	}
 
-        return results;
-    }
+	protected void buildClient(ProcessContext context) {
+		try {
+			broker = context.getProperty(PROP_BROKER_URI).getValue();
+			clientID = context.getProperty(PROP_CLIENTID).getValue();
 
-    public static Properties transformSSLContextService(SSLContextService sslContextService){
-        Properties properties = new Properties();
-        properties.setProperty("com.ibm.ssl.protocol", sslContextService.getSslAlgorithm());
-        properties.setProperty("com.ibm.ssl.keyStore", sslContextService.getKeyStoreFile());
-        properties.setProperty("com.ibm.ssl.keyStorePassword", sslContextService.getKeyStorePassword());
-        properties.setProperty("com.ibm.ssl.keyStoreType", sslContextService.getKeyStoreType());
-        properties.setProperty("com.ibm.ssl.trustStore", sslContextService.getTrustStoreFile());
-        properties.setProperty("com.ibm.ssl.trustStorePassword", sslContextService.getTrustStorePassword());
-        properties.setProperty("com.ibm.ssl.trustStoreType", sslContextService.getTrustStoreType());
-        return  properties;
-    }
+			connOpts = new MqttConnectOptions();
+			connOpts.setCleanSession(context.getProperty(PROP_CLEAN_SESSION).asBoolean());
+			connOpts.setKeepAliveInterval(context.getProperty(PROP_KEEP_ALIVE_INTERVAL).asInteger());
+			connOpts.setMqttVersion(context.getProperty(PROP_MQTT_VERSION).asInteger());
+			connOpts.setConnectionTimeout(context.getProperty(PROP_CONN_TIMEOUT).asInteger());
 
-    protected void buildClient(ProcessContext context){
-        try {
-            broker = context.getProperty(PROP_BROKER_URI).getValue();
-            clientID = context.getProperty(PROP_CLIENTID).getValue();
+			PropertyValue sslProp = context.getProperty(PROP_SSL_CONTEXT_SERVICE);
+			if (sslProp.isSet()) {
+				Properties sslProps = transformSSLContextService((SSLContextService) sslProp.asControllerService());
+				connOpts.setSSLProperties(sslProps);
+			}
 
-            connOpts = new MqttConnectOptions();
-            connOpts.setCleanSession(context.getProperty(PROP_CLEAN_SESSION).asBoolean());
-            connOpts.setKeepAliveInterval(context.getProperty(PROP_KEEP_ALIVE_INTERVAL).asInteger());
-            connOpts.setMqttVersion(context.getProperty(PROP_MQTT_VERSION).asInteger());
-            connOpts.setConnectionTimeout(context.getProperty(PROP_CONN_TIMEOUT).asInteger());
+			PropertyValue lastWillTopicProp = context.getProperty(PROP_LAST_WILL_TOPIC);
+			if (lastWillTopicProp.isSet()) {
+				String lastWillMessage = context.getProperty(PROP_LAST_WILL_MESSAGE).getValue();
+				PropertyValue lastWillRetain = context.getProperty(PROP_LAST_WILL_RETAIN);
+				Integer lastWillQOS = context.getProperty(PROP_LAST_WILL_QOS).asInteger();
+				connOpts.setWill(lastWillTopicProp.getValue(), lastWillMessage.getBytes(), lastWillQOS,
+						lastWillRetain.isSet() ? lastWillRetain.asBoolean() : false);
+			}
 
-            PropertyValue sslProp = context.getProperty(PROP_SSL_CONTEXT_SERVICE);
-            if (sslProp.isSet()) {
-                Properties sslProps = transformSSLContextService((SSLContextService) sslProp.asControllerService());
-                connOpts.setSSLProperties(sslProps);
-            }
+			PropertyValue usernameProp = context.getProperty(PROP_USERNAME);
+			if (usernameProp.isSet()) {
+				connOpts.setUserName(usernameProp.getValue());
+				connOpts.setPassword(context.getProperty(PROP_PASSWORD).getValue().toCharArray());
+			}
 
-            PropertyValue lastWillTopicProp = context.getProperty(PROP_LAST_WILL_TOPIC);
-            if (lastWillTopicProp.isSet()){
-                String lastWillMessage = context.getProperty(PROP_LAST_WILL_MESSAGE).getValue();
-                PropertyValue lastWillRetain = context.getProperty(PROP_LAST_WILL_RETAIN);
-                Integer lastWillQOS = context.getProperty(PROP_LAST_WILL_QOS).asInteger();
-                connOpts.setWill(lastWillTopicProp.getValue(), lastWillMessage.getBytes(), lastWillQOS, lastWillRetain.isSet() ? lastWillRetain.asBoolean() : false);
-            }
+			mqttClientConnectLock.writeLock().lock();
+			try {
+				mqttClient = getMqttClient(broker, clientID, persistence);
 
+			} finally {
+				mqttClientConnectLock.writeLock().unlock();
+			}
+		} catch (MqttException me) {
+			logger.error("Failed to initialize the connection to the  " + me.getMessage());
+		}
+	}
 
-            PropertyValue usernameProp = context.getProperty(PROP_USERNAME);
-            if(usernameProp.isSet()) {
-                connOpts.setUserName(usernameProp.getValue());
-                connOpts.setPassword(context.getProperty(PROP_PASSWORD).getValue().toCharArray());
-            }
+	protected IMqttAsyncClient getMqttClient(String broker, String clientID, MemoryPersistence persistence) throws MqttException {
+		return new MqttAsyncClient(broker, clientID, persistence);
+	}
 
-            mqttClientConnectLock.writeLock().lock();
-            try{
-                mqttClient = getMqttClient(broker, clientID, persistence);
+	@Override
+	public final void onTrigger(final ProcessContext context, final ProcessSessionFactory sessionFactory) throws ProcessException {
+		if (processSessionFactory == null) {
+			processSessionFactory = sessionFactory;
+		}
+		ProcessSession session = sessionFactory.createSession();
+		try {
+			onTrigger(context, session);
+			session.commit();
+		} catch (final Throwable t) {
+			getLogger().error("{} failed to process due to {}; rolling back session", new Object[] { this, t });
+			session.rollback(true);
+			throw t;
+		}
+	}
 
-            } finally {
-                mqttClientConnectLock.writeLock().unlock();
-            }
-        } catch(MqttException me) {
-            logger.error("Failed to initialize the connection to the  " + me.getMessage());
-        }
-    }
+	public abstract void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException;
 
-    protected IMqttClient getMqttClient(String broker, String clientID, MemoryPersistence persistence) throws MqttException {
-        return new MqttClient(broker, clientID, persistence);
-    }
-
-
-    @Override
-    public final void onTrigger(final ProcessContext context, final ProcessSessionFactory sessionFactory) throws ProcessException {
-        if (processSessionFactory == null) {
-            processSessionFactory = sessionFactory;
-        }
-        ProcessSession session = sessionFactory.createSession();
-        try {
-            onTrigger(context, session);
-            session.commit();
-        } catch (final Throwable t) {
-            getLogger().error("{} failed to process due to {}; rolling back session", new Object[]{this, t});
-            session.rollback(true);
-            throw t;
-        }
-    }
-
-    public abstract void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException;
-
-    // Caller should obtain the necessary lock
-    protected void setAndConnectClient(MqttCallback mqttCallback) throws MqttException {
-        mqttClient = getMqttClient(broker, clientID, persistence);
-        mqttClient.setCallback(mqttCallback);
-        mqttClient.connect(connOpts);
-    }
+	// Caller should obtain the necessary lock
+	protected void setAndConnectClient(MqttCallback mqttCallback) throws MqttException {
+		mqttClient = getMqttClient(broker, clientID, persistence);
+		mqttClient.setCallback(mqttCallback);
+		mqttClient.connect(connOpts).waitForCompletion();
+	}
 }

--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestConsumeMQTT.java
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestConsumeMQTT.java
@@ -17,19 +17,10 @@
 
 package org.apache.nifi.processors.mqtt;
 
-import io.moquette.proto.messages.PublishMessage;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processors.mqtt.common.MQTTQueueMessage;
-import org.apache.nifi.processors.mqtt.common.MqttTestClient;
-import org.apache.nifi.processors.mqtt.common.TestConsumeMqttCommon;
-import org.apache.nifi.util.TestRunners;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttException;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
-import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -38,10 +29,20 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.BlockingQueue;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processors.mqtt.common.MQTTQueueMessage;
+import org.apache.nifi.processors.mqtt.common.MqttTestClient;
+import org.apache.nifi.processors.mqtt.common.TestConsumeMqttCommon;
+import org.apache.nifi.util.TestRunners;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.moquette.proto.messages.PublishMessage;
 
 
 public class TestConsumeMQTT extends TestConsumeMqttCommon {
@@ -54,7 +55,7 @@ public class TestConsumeMQTT extends TestConsumeMqttCommon {
         }
 
         @Override
-        public IMqttClient getMqttClient(String broker, String clientID, MemoryPersistence persistence) throws MqttException {
+		public IMqttAsyncClient getMqttClient(String broker, String clientID, MemoryPersistence persistence) throws MqttException {
             mqttTestClient =  new MqttTestClient(broker, clientID, MqttTestClient.ConnectType.Subscriber);
             return mqttTestClient;
         }

--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestPublishMQTT.java
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestPublishMQTT.java
@@ -17,22 +17,22 @@
 
 package org.apache.nifi.processors.mqtt;
 
-import org.apache.nifi.processors.mqtt.common.MQTTQueueMessage;
-import org.apache.nifi.processors.mqtt.common.MqttTestClient;
-import org.apache.nifi.processors.mqtt.common.TestPublishMqttCommon;
-import org.apache.nifi.util.TestRunners;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttException;
-import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.junit.After;
-import org.junit.Before;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.nifi.processors.mqtt.common.MQTTQueueMessage;
+import org.apache.nifi.processors.mqtt.common.MqttTestClient;
+import org.apache.nifi.processors.mqtt.common.TestPublishMqttCommon;
+import org.apache.nifi.util.TestRunners;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.After;
+import org.junit.Before;
 
 
 public class TestPublishMQTT extends TestPublishMqttCommon {
@@ -56,7 +56,7 @@ public class TestPublishMQTT extends TestPublishMqttCommon {
         }
 
         @Override
-        public IMqttClient getMqttClient(String broker, String clientID, MemoryPersistence persistence) throws MqttException {
+		public IMqttAsyncClient getMqttClient(String broker, String clientID, MemoryPersistence persistence) throws MqttException {
             mqttTestClient =  new MqttTestClient(broker, clientID, MqttTestClient.ConnectType.Publisher);
             return mqttTestClient;
         }

--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/common/MqttTestClient.java
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/common/MqttTestClient.java
@@ -17,8 +17,12 @@
 
 package org.apache.nifi.processors.mqtt.common;
 
-import org.eclipse.paho.client.mqttv3.IMqttClient;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
@@ -26,173 +30,432 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.MqttPersistenceException;
 import org.eclipse.paho.client.mqttv3.MqttSecurityException;
-import org.eclipse.paho.client.mqttv3.MqttTopic;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+public class MqttTestClient implements IMqttAsyncClient {
 
-public class MqttTestClient implements IMqttClient {
+	public String serverURI;
+	public String clientId;
 
-    public String serverURI;
-    public String clientId;
+	public AtomicBoolean connected = new AtomicBoolean(false);
 
-    public AtomicBoolean connected = new AtomicBoolean(false);
+	public MqttCallback mqttCallback;
+	public ConnectType type;
 
-    public MqttCallback mqttCallback;
-    public ConnectType type;
-    public enum ConnectType {Publisher, Subscriber}
+	public enum ConnectType {
+		Publisher, Subscriber
+	}
 
-    public MQTTQueueMessage publishedMessage;
+	public MQTTQueueMessage publishedMessage;
 
-    public String subscribedTopic;
-    public int subscribedQos;
+	public String subscribedTopic;
+	public int subscribedQos;
 
+	public MqttTestClient(String serverURI, String clientId, ConnectType type) throws MqttException {
+		this.serverURI = serverURI;
+		this.clientId = clientId;
+		this.type = type;
+	}
 
-    public MqttTestClient(String serverURI, String clientId, ConnectType type) throws MqttException {
-        this.serverURI = serverURI;
-        this.clientId = clientId;
-        this.type = type;
-    }
+	@Override
+	public IMqttToken connect() throws MqttSecurityException, MqttException {
+		connected.set(true);
+		return new IMqttToken() {
 
-    @Override
-    public void connect() throws MqttSecurityException, MqttException {
-        connected.set(true);
-    }
+			@Override
+			public void waitForCompletion(long timeout) throws MqttException {
+				// TODO Auto-generated method stub
 
-    @Override
-    public void connect(MqttConnectOptions options) throws MqttSecurityException, MqttException {
-        connected.set(true);
-    }
+			}
 
-    @Override
-    public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecurityException, MqttException {
-        return null;
-    }
+			@Override
+			public void waitForCompletion() throws MqttException {
+				// TODO Auto-generated method stub
 
-    @Override
-    public void disconnect() throws MqttException {
-        connected.set(false);
-    }
+			}
 
-    @Override
-    public void disconnect(long quiesceTimeout) throws MqttException {
-        connected.set(false);
-    }
+			@Override
+			public void setUserContext(Object userContext) {
+				// TODO Auto-generated method stub
 
-    @Override
-    public void disconnectForcibly() throws MqttException {
-        connected.set(false);
-    }
+			}
 
-    @Override
-    public void disconnectForcibly(long disconnectTimeout) throws MqttException {
-        connected.set(false);
-    }
+			@Override
+			public void setActionCallback(IMqttActionListener listener) {
+				// TODO Auto-generated method stub
 
-    @Override
-    public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout) throws MqttException {
-        connected.set(false);
-    }
+			}
 
-    @Override
-    public void subscribe(String topicFilter) throws MqttException, MqttSecurityException {
-        subscribedTopic = topicFilter;
-        subscribedQos = -1;
-    }
+			@Override
+			public boolean isComplete() {
+				// TODO Auto-generated method stub
+				return false;
+			}
 
-    @Override
-    public void subscribe(String[] topicFilters) throws MqttException {
-        throw new UnsupportedOperationException("Multiple topic filters is not supported");
-    }
+			@Override
+			public Object getUserContext() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 
-    @Override
-    public void subscribe(String topicFilter, int qos) throws MqttException {
-        subscribedTopic = topicFilter;
-        subscribedQos = qos;
-    }
+			@Override
+			public String[] getTopics() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 
-    @Override
-    public void subscribe(String[] topicFilters, int[] qos) throws MqttException {
-        throw new UnsupportedOperationException("Multiple topic filters is not supported");
-    }
+			@Override
+			public boolean getSessionPresent() {
+				// TODO Auto-generated method stub
+				return false;
+			}
 
-    @Override
-    public void unsubscribe(String topicFilter) throws MqttException {
-        subscribedTopic = "";
-        subscribedQos = -2;
-    }
+			@Override
+			public MqttWireMessage getResponse() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 
-    @Override
-    public void unsubscribe(String[] topicFilters) throws MqttException {
-        throw new UnsupportedOperationException("Multiple topic filters is not supported");
-    }
+			@Override
+			public int getMessageId() {
+				// TODO Auto-generated method stub
+				return 0;
+			}
 
-    @Override
-    public void publish(String topic, byte[] payload, int qos, boolean retained) throws MqttException, MqttPersistenceException {
-        MqttMessage message = new MqttMessage(payload);
-        message.setQos(qos);
-        message.setRetained(retained);
-        switch (type) {
-            case Publisher:
-                publishedMessage = new MQTTQueueMessage(topic, message);
-                break;
-            case Subscriber:
-                try {
-                    mqttCallback.messageArrived(topic, message);
-                } catch (Exception e) {
-                    throw new MqttException(e);
-                }
-                break;
-        }
-    }
+			@Override
+			public int[] getGrantedQos() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 
-    @Override
-    public void publish(String topic, MqttMessage message) throws MqttException, MqttPersistenceException {
-        switch (type) {
-            case Publisher:
-                publishedMessage = new MQTTQueueMessage(topic, message);
-                break;
-            case Subscriber:
-                try {
-                    mqttCallback.messageArrived(topic, message);
-                } catch (Exception e) {
-                    throw new MqttException(e);
-                }
-                break;
-        }
-    }
+			@Override
+			public MqttException getException() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 
-    @Override
-    public void setCallback(MqttCallback callback) {
-        this.mqttCallback = callback;
-    }
+			@Override
+			public IMqttAsyncClient getClient() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 
-    @Override
-    public MqttTopic getTopic(String topic) {
-        return null;
-    }
+			@Override
+			public IMqttActionListener getActionCallback() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		};
+	}
 
-    @Override
-    public boolean isConnected() {
-        return connected.get();
-    }
+	@Override
+	public IMqttToken connect(MqttConnectOptions options) throws MqttSecurityException, MqttException {
+		connected.set(true);
+		return new IMqttToken() {
 
-    @Override
-    public String getClientId() {
-        return clientId;
-    }
+			@Override
+			public void waitForCompletion(long timeout) throws MqttException {
+				// TODO Auto-generated method stub
 
-    @Override
-    public String getServerURI() {
-        return serverURI;
-    }
+			}
 
-    @Override
-    public IMqttDeliveryToken[] getPendingDeliveryTokens() {
-        return new IMqttDeliveryToken[0];
-    }
+			@Override
+			public void waitForCompletion() throws MqttException {
+				// TODO Auto-generated method stub
 
-    @Override
-    public void close() throws MqttException {
+			}
 
-    }
+			@Override
+			public void setUserContext(Object userContext) {
+				// TODO Auto-generated method stub
+
+			}
+
+			@Override
+			public void setActionCallback(IMqttActionListener listener) {
+				// TODO Auto-generated method stub
+
+			}
+
+			@Override
+			public boolean isComplete() {
+				// TODO Auto-generated method stub
+				return false;
+			}
+
+			@Override
+			public Object getUserContext() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public String[] getTopics() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public boolean getSessionPresent() {
+				// TODO Auto-generated method stub
+				return false;
+			}
+
+			@Override
+			public MqttWireMessage getResponse() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public int getMessageId() {
+				// TODO Auto-generated method stub
+				return 0;
+			}
+
+			@Override
+			public int[] getGrantedQos() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public MqttException getException() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public IMqttAsyncClient getClient() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public IMqttActionListener getActionCallback() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		};
+	}
+
+	@Override
+	public IMqttToken disconnect() throws MqttException {
+		connected.set(false);
+		return null;
+	}
+
+	@Override
+	public IMqttToken disconnect(long quiesceTimeout) throws MqttException {
+		connected.set(false);
+		return null;
+	}
+
+	@Override
+	public void disconnectForcibly() throws MqttException {
+		connected.set(false);
+	}
+
+	@Override
+	public void disconnectForcibly(long disconnectTimeout) throws MqttException {
+		connected.set(false);
+	}
+
+	@Override
+	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout) throws MqttException {
+		connected.set(false);
+	}
+
+	@Override
+	public IMqttToken subscribe(String topicFilter, int qos) throws MqttException {
+		subscribedTopic = topicFilter;
+		subscribedQos = qos;
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String[] topicFilters, int[] qos) throws MqttException {
+		throw new UnsupportedOperationException("Multiple topic filters is not supported");
+	}
+
+	@Override
+	public IMqttToken unsubscribe(String topicFilter) throws MqttException {
+		subscribedTopic = "";
+		subscribedQos = -2;
+		return null;
+	}
+
+	@Override
+	public IMqttToken unsubscribe(String[] topicFilters) throws MqttException {
+		throw new UnsupportedOperationException("Multiple topic filters is not supported");
+	}
+
+	@Override
+	public IMqttDeliveryToken publish(String topic, byte[] payload, int qos, boolean retained)
+			throws MqttException, MqttPersistenceException {
+		MqttMessage message = new MqttMessage(payload);
+		message.setQos(qos);
+		message.setRetained(retained);
+		switch (type) {
+		case Publisher:
+			publishedMessage = new MQTTQueueMessage(topic, message);
+			break;
+		case Subscriber:
+			try {
+				mqttCallback.messageArrived(topic, message);
+			} catch (Exception e) {
+				throw new MqttException(e);
+			}
+			break;
+		}
+		return null;
+	}
+
+	@Override
+	public IMqttDeliveryToken publish(String topic, MqttMessage message) throws MqttException, MqttPersistenceException {
+		switch (type) {
+		case Publisher:
+			publishedMessage = new MQTTQueueMessage(topic, message);
+			break;
+		case Subscriber:
+			try {
+				mqttCallback.messageArrived(topic, message);
+			} catch (Exception e) {
+				throw new MqttException(e);
+			}
+			break;
+		}
+		return null;
+	}
+
+	@Override
+	public void setCallback(MqttCallback callback) {
+		this.mqttCallback = callback;
+	}
+
+	@Override
+	public boolean isConnected() {
+		return connected.get();
+	}
+
+	@Override
+	public String getClientId() {
+		return clientId;
+	}
+
+	@Override
+	public String getServerURI() {
+		return serverURI;
+	}
+
+	@Override
+	public IMqttDeliveryToken[] getPendingDeliveryTokens() {
+		return new IMqttDeliveryToken[0];
+	}
+
+	@Override
+	public void close() throws MqttException {
+
+	}
+
+	@Override
+	public IMqttToken connect(Object userContext, IMqttActionListener callback) throws MqttException, MqttSecurityException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken connect(MqttConnectOptions options, Object userContext, IMqttActionListener callback)
+			throws MqttException, MqttSecurityException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken disconnect(Object userContext, IMqttActionListener callback) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken disconnect(long quiesceTimeout, Object userContext, IMqttActionListener callback) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttDeliveryToken publish(String topic, byte[] payload, int qos, boolean retained, Object userContext,
+			IMqttActionListener callback) throws MqttException, MqttPersistenceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttDeliveryToken publish(String topic, MqttMessage message, Object userContext, IMqttActionListener callback)
+			throws MqttException, MqttPersistenceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String topicFilter, int qos, Object userContext, IMqttActionListener callback) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String[] topicFilters, int[] qos, Object userContext, IMqttActionListener callback) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String topicFilter, int qos, Object userContext, IMqttActionListener callback,
+			IMqttMessageListener messageListener) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken subscribe(String[] topicFilters, int[] qos, Object userContext, IMqttActionListener callback,
+			IMqttMessageListener[] messageListeners) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken unsubscribe(String topicFilter, Object userContext, IMqttActionListener callback) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IMqttToken unsubscribe(String[] topicFilters, Object userContext, IMqttActionListener callback) throws MqttException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void setManualAcks(boolean manualAcks) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void messageArrivedComplete(int messageId, int qos) throws MqttException {
+		// TODO Auto-generated method stub
+
+	}
 }

--- a/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/common/TestConsumeMqttCommon.java
+++ b/nifi-nar-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/common/TestConsumeMqttCommon.java
@@ -17,27 +17,6 @@
 
 package org.apache.nifi.processors.mqtt.common;
 
-import io.moquette.proto.messages.AbstractMessage;
-import io.moquette.proto.messages.PublishMessage;
-import io.moquette.server.Server;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processors.mqtt.ConsumeMQTT;
-import org.apache.nifi.provenance.ProvenanceEventRecord;
-import org.apache.nifi.provenance.ProvenanceEventType;
-import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.TestRunner;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
-import org.junit.Test;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-
 import static org.apache.nifi.processors.mqtt.ConsumeMQTT.BROKER_ATTRIBUTE_KEY;
 import static org.apache.nifi.processors.mqtt.ConsumeMQTT.IS_DUPLICATE_ATTRIBUTE_KEY;
 import static org.apache.nifi.processors.mqtt.ConsumeMQTT.IS_RETAINED_ATTRIBUTE_KEY;
@@ -48,378 +27,350 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processors.mqtt.ConsumeMQTT;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.Test;
+
+import io.moquette.proto.messages.AbstractMessage;
+import io.moquette.proto.messages.PublishMessage;
+import io.moquette.server.Server;
+
 public abstract class TestConsumeMqttCommon {
 
-    public int PUBLISH_WAIT_MS = 1000;
+	public int PUBLISH_WAIT_MS = 1000;
 
-    public Server MQTT_server;
-    public TestRunner testRunner;
-    public String broker;
+	public Server MQTT_server;
+	public TestRunner testRunner;
+	public String broker;
 
-    public abstract void internalPublish(PublishMessage publishMessage);
+	public abstract void internalPublish(PublishMessage publishMessage);
 
-    @Test
-    public void testLastWillConfig() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_MESSAGE, "lastWill message");
-        testRunner.assertNotValid();
-        testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_TOPIC, "lastWill topic");
-        testRunner.assertNotValid();
-        testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_QOS, "1");
-        testRunner.assertNotValid();
-        testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_RETAIN, "false");
-        testRunner.assertValid();
-    }
+	@Test
+	public void testLastWillConfig() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_MESSAGE, "lastWill message");
+		testRunner.assertNotValid();
+		testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_TOPIC, "lastWill topic");
+		testRunner.assertNotValid();
+		testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_QOS, "1");
+		testRunner.assertNotValid();
+		testRunner.setProperty(ConsumeMQTT.PROP_LAST_WILL_RETAIN, "false");
+		testRunner.assertValid();
+	}
 
+	@Test
+	public void testQoS2() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
 
-    @Test
-    public void testQoS2() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
+		testRunner.assertValid();
 
-        testRunner.assertValid();
+		ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		assertTrue(isConnected(consumeMQTT));
 
-        assertTrue(isConnected(consumeMQTT));
+		PublishMessage testMessage = new PublishMessage();
+		testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
+		testMessage.setTopicName("testTopic");
+		testMessage.setDupFlag(false);
+		testMessage.setQos(AbstractMessage.QOSType.EXACTLY_ONCE);
+		testMessage.setRetainFlag(false);
 
-        PublishMessage testMessage = new PublishMessage();
-        testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
-        testMessage.setTopicName("testTopic");
-        testMessage.setDupFlag(false);
-        testMessage.setQos(AbstractMessage.QOSType.EXACTLY_ONCE);
-        testMessage.setRetainFlag(false);
+		internalPublish(testMessage);
 
-        internalPublish(testMessage);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		testRunner.run(1, false, false);
 
-        testRunner.run(1, false, false);
+		testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
+		assertProvenanceEvents(1);
 
-        testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
-        assertProvenanceEvents(1);
+		List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
+		MockFlowFile flowFile = flowFiles.get(0);
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        MockFlowFile flowFile = flowFiles.get(0);
+		flowFile.assertContentEquals("testMessage");
+		flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
+		flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
+		flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
+		flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
+		flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
+	}
 
-        flowFile.assertContentEquals("testMessage");
-        flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-        flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-        flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
-        flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-        flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-    }
+	@Test
+	public void testQoS2NotCleanSession() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
+		testRunner.setProperty(ConsumeMQTT.PROP_CLEAN_SESSION, ALLOWABLE_VALUE_CLEAN_SESSION_FALSE);
 
-    @Test
-    public void testQoS2NotCleanSession() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
-        testRunner.setProperty(ConsumeMQTT.PROP_CLEAN_SESSION, ALLOWABLE_VALUE_CLEAN_SESSION_FALSE);
+		testRunner.assertValid();
 
-        testRunner.assertValid();
+		ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		assertTrue(isConnected(consumeMQTT));
 
-        assertTrue(isConnected(consumeMQTT));
+		consumeMQTT.onUnscheduled(testRunner.getProcessContext());
 
-        consumeMQTT.onUnscheduled(testRunner.getProcessContext());
+		PublishMessage testMessage = new PublishMessage();
+		testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
+		testMessage.setTopicName("testTopic");
+		testMessage.setDupFlag(false);
+		testMessage.setQos(AbstractMessage.QOSType.EXACTLY_ONCE);
+		testMessage.setRetainFlag(false);
 
-        PublishMessage testMessage = new PublishMessage();
-        testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
-        testMessage.setTopicName("testTopic");
-        testMessage.setDupFlag(false);
-        testMessage.setQos(AbstractMessage.QOSType.EXACTLY_ONCE);
-        testMessage.setRetainFlag(false);
+		internalPublish(testMessage);
 
-        internalPublish(testMessage);
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		assertTrue(isConnected(consumeMQTT));
 
-        assertTrue(isConnected(consumeMQTT));
+		testRunner.run(1, false, false);
 
-        testRunner.run(1, false, false);
+		testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
+		assertProvenanceEvents(1);
 
-        testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
-        assertProvenanceEvents(1);
+		List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
+		MockFlowFile flowFile = flowFiles.get(0);
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        MockFlowFile flowFile = flowFiles.get(0);
+		flowFile.assertContentEquals("testMessage");
+		flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
+		flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
+		flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
+		flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
+		flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
+	}
 
-        flowFile.assertContentEquals("testMessage");
-        flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-        flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-        flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
-        flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-        flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-    }
+	@Test
+	public void testQoS1() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_QOS, "1");
 
+		testRunner.assertValid();
 
-    @Test
-    public void testQoS1() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "1");
+		ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        testRunner.assertValid();
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		assertTrue(isConnected(consumeMQTT));
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		PublishMessage testMessage = new PublishMessage();
+		testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
+		testMessage.setTopicName("testTopic");
+		testMessage.setDupFlag(false);
+		testMessage.setQos(AbstractMessage.QOSType.LEAST_ONE);
+		testMessage.setRetainFlag(false);
 
-        assertTrue(isConnected(consumeMQTT));
+		internalPublish(testMessage);
 
-        PublishMessage testMessage = new PublishMessage();
-        testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
-        testMessage.setTopicName("testTopic");
-        testMessage.setDupFlag(false);
-        testMessage.setQos(AbstractMessage.QOSType.LEAST_ONE);
-        testMessage.setRetainFlag(false);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        internalPublish(testMessage);
+		testRunner.run(1, false, false);
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
+		assertTrue(flowFiles.size() > 0);
+		assertProvenanceEvents(flowFiles.size());
+		MockFlowFile flowFile = flowFiles.get(0);
 
-        testRunner.run(1, false, false);
+		flowFile.assertContentEquals("testMessage");
+		flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
+		flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
+		flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "1");
+		flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
+		flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
+	}
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        assertTrue(flowFiles.size() > 0);
-        assertProvenanceEvents(flowFiles.size());
-        MockFlowFile flowFile = flowFiles.get(0);
+	@Test
+	public void testQoS1NotCleanSession() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_QOS, "1");
+		testRunner.setProperty(ConsumeMQTT.PROP_CLEAN_SESSION, ALLOWABLE_VALUE_CLEAN_SESSION_FALSE);
 
-        flowFile.assertContentEquals("testMessage");
-        flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-        flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-        flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "1");
-        flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-        flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-    }
+		testRunner.assertValid();
 
-    @Test
-    public void testQoS1NotCleanSession() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "1");
-        testRunner.setProperty(ConsumeMQTT.PROP_CLEAN_SESSION, ALLOWABLE_VALUE_CLEAN_SESSION_FALSE);
+		ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        testRunner.assertValid();
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		assertTrue(isConnected(consumeMQTT));
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		consumeMQTT.onUnscheduled(testRunner.getProcessContext());
 
-        assertTrue(isConnected(consumeMQTT));
+		PublishMessage testMessage = new PublishMessage();
+		testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
+		testMessage.setTopicName("testTopic");
+		testMessage.setDupFlag(false);
+		testMessage.setQos(AbstractMessage.QOSType.LEAST_ONE);
+		testMessage.setRetainFlag(false);
 
-        consumeMQTT.onUnscheduled(testRunner.getProcessContext());
+		internalPublish(testMessage);
 
-        PublishMessage testMessage = new PublishMessage();
-        testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
-        testMessage.setTopicName("testTopic");
-        testMessage.setDupFlag(false);
-        testMessage.setQos(AbstractMessage.QOSType.LEAST_ONE);
-        testMessage.setRetainFlag(false);
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        internalPublish(testMessage);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		assertTrue(isConnected(consumeMQTT));
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		testRunner.run(1, false, false);
 
-        assertTrue(isConnected(consumeMQTT));
+		testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
 
-        testRunner.run(1, false, false);
+		List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
+		assertTrue(flowFiles.size() > 0);
+		assertProvenanceEvents(flowFiles.size());
+		MockFlowFile flowFile = flowFiles.get(0);
 
-        testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
+		flowFile.assertContentEquals("testMessage");
+		flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
+		flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
+		flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "1");
+		flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
+		flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
+	}
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        assertTrue(flowFiles.size() > 0);
-        assertProvenanceEvents(flowFiles.size());
-        MockFlowFile flowFile = flowFiles.get(0);
+	@Test
+	public void testQoS0() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_QOS, "0");
 
-        flowFile.assertContentEquals("testMessage");
-        flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-        flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-        flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "1");
-        flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-        flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-    }
+		testRunner.assertValid();
 
-    @Test
-    public void testQoS0() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "0");
+		ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        testRunner.assertValid();
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		assertTrue(isConnected(consumeMQTT));
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		PublishMessage testMessage = new PublishMessage();
+		testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
+		testMessage.setTopicName("testTopic");
+		testMessage.setDupFlag(false);
+		testMessage.setQos(AbstractMessage.QOSType.MOST_ONE);
+		testMessage.setRetainFlag(false);
 
-        assertTrue(isConnected(consumeMQTT));
+		internalPublish(testMessage);
 
-        PublishMessage testMessage = new PublishMessage();
-        testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
-        testMessage.setTopicName("testTopic");
-        testMessage.setDupFlag(false);
-        testMessage.setQos(AbstractMessage.QOSType.MOST_ONE);
-        testMessage.setRetainFlag(false);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        internalPublish(testMessage);
+		testRunner.run(1, false, false);
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
+		assertTrue(flowFiles.size() < 2);
+		assertProvenanceEvents(flowFiles.size());
 
-        testRunner.run(1, false, false);
+		if (flowFiles.size() == 1) {
+			MockFlowFile flowFile = flowFiles.get(0);
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        assertTrue(flowFiles.size() < 2);
-        assertProvenanceEvents(flowFiles.size());
+			flowFile.assertContentEquals("testMessage");
+			flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
+			flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
+			flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "0");
+			flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
+			flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
+		}
+	}
 
-        if(flowFiles.size() == 1) {
-            MockFlowFile flowFile = flowFiles.get(0);
+	@Test
+	public void testOnStoppedFinish() throws Exception {
+		testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
 
-            flowFile.assertContentEquals("testMessage");
-            flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-            flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-            flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "0");
-            flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-            flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-        }
-    }
+		testRunner.assertValid();
 
-    @Test
-    public void testOnStoppedFinish() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
+		MqttMessage innerMessage = new MqttMessage();
+		innerMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()).array());
+		innerMessage.setQos(2);
+		MQTTQueueMessage testMessage = new MQTTQueueMessage("testTopic", innerMessage);
 
-        testRunner.assertValid();
+		ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
+		consumeMQTT.onScheduled(testRunner.getProcessContext());
+		reconnect(consumeMQTT);
 
-        MqttMessage innerMessage = new MqttMessage();
-        innerMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()).array());
-        innerMessage.setQos(2);
-        MQTTQueueMessage testMessage = new MQTTQueueMessage("testTopic", innerMessage);
+		Thread.sleep(PUBLISH_WAIT_MS);
 
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
+		assertTrue(isConnected(consumeMQTT));
 
-        Thread.sleep(PUBLISH_WAIT_MS);
+		consumeMQTT.processSessionFactory = testRunner.getProcessSessionFactory();
 
-        assertTrue(isConnected(consumeMQTT));
+		Field f = ConsumeMQTT.class.getDeclaredField("mqttQueue");
+		f.setAccessible(true);
+		LinkedBlockingQueue<MQTTQueueMessage> queue = (LinkedBlockingQueue<MQTTQueueMessage>) f.get(consumeMQTT);
+		queue.add(testMessage);
 
-        consumeMQTT.processSessionFactory = testRunner.getProcessSessionFactory();
+		consumeMQTT.onUnscheduled(testRunner.getProcessContext());
+		consumeMQTT.onStopped(testRunner.getProcessContext());
 
-        Field f = ConsumeMQTT.class.getDeclaredField("mqttQueue");
-        f.setAccessible(true);
-        LinkedBlockingQueue<MQTTQueueMessage> queue = (LinkedBlockingQueue<MQTTQueueMessage>) f.get(consumeMQTT);
-        queue.add(testMessage);
+		testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
+		assertProvenanceEvents(1);
 
-        consumeMQTT.onUnscheduled(testRunner.getProcessContext());
-        consumeMQTT.onStopped(testRunner.getProcessContext());
+		List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
+		MockFlowFile flowFile = flowFiles.get(0);
 
-        testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
-        assertProvenanceEvents(1);
+		flowFile.assertContentEquals("testMessage");
+		flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
+		flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
+		flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
+		flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
+		flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
+	}
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        MockFlowFile flowFile = flowFiles.get(0);
+	private static boolean isConnected(AbstractMQTTProcessor processor) throws NoSuchFieldException, IllegalAccessException {
+		Field f = AbstractMQTTProcessor.class.getDeclaredField("mqttClient");
+		f.setAccessible(true);
+		IMqttAsyncClient mqttClient = (IMqttAsyncClient) f.get(processor);
+		return mqttClient.isConnected();
+	}
 
-        flowFile.assertContentEquals("testMessage");
-        flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-        flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-        flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
-        flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-        flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-    }
+	public static void reconnect(ConsumeMQTT processor)
+			throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+		Method method = ConsumeMQTT.class.getDeclaredMethod("reconnect");
+		method.setAccessible(true);
+		method.invoke(processor);
+	}
 
-    @Test
-    public void testResizeBuffer() throws Exception {
-        testRunner.setProperty(ConsumeMQTT.PROP_QOS, "2");
-        testRunner.setProperty(ConsumeMQTT.PROP_MAX_QUEUE_SIZE, "2");
+	public static BlockingQueue<MQTTQueueMessage> getMqttQueue(ConsumeMQTT consumeMQTT)
+			throws IllegalAccessException, NoSuchFieldException {
+		Field mqttQueueField = ConsumeMQTT.class.getDeclaredField("mqttQueue");
+		mqttQueueField.setAccessible(true);
+		return (BlockingQueue<MQTTQueueMessage>) mqttQueueField.get(consumeMQTT);
+	}
 
-        testRunner.assertValid();
+	public static void transferQueue(ConsumeMQTT consumeMQTT, ProcessSession session)
+			throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		Method transferQueue = ConsumeMQTT.class.getDeclaredMethod("transferQueue", ProcessSession.class);
+		transferQueue.setAccessible(true);
+		transferQueue.invoke(consumeMQTT, session);
+	}
 
-        PublishMessage testMessage = new PublishMessage();
-        testMessage.setPayload(ByteBuffer.wrap("testMessage".getBytes()));
-        testMessage.setTopicName("testTopic");
-        testMessage.setDupFlag(false);
-        testMessage.setQos(AbstractMessage.QOSType.EXACTLY_ONCE);
-        testMessage.setRetainFlag(false);
-
-        ConsumeMQTT consumeMQTT = (ConsumeMQTT) testRunner.getProcessor();
-        consumeMQTT.onScheduled(testRunner.getProcessContext());
-        reconnect(consumeMQTT);
-
-        Thread.sleep(PUBLISH_WAIT_MS);
-
-        assertTrue(isConnected(consumeMQTT));
-
-        internalPublish(testMessage);
-        internalPublish(testMessage);
-
-        Thread.sleep(PUBLISH_WAIT_MS);
-        consumeMQTT.onUnscheduled(testRunner.getProcessContext());
-
-        testRunner.setProperty(ConsumeMQTT.PROP_MAX_QUEUE_SIZE, "1");
-        testRunner.assertNotValid();
-
-        testRunner.setProperty(ConsumeMQTT.PROP_MAX_QUEUE_SIZE, "3");
-        testRunner.assertValid();
-
-        testRunner.run(1);
-
-        testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 2);
-        assertProvenanceEvents(2);
-
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        MockFlowFile flowFile = flowFiles.get(0);
-
-        flowFile.assertContentEquals("testMessage");
-        flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, broker);
-        flowFile.assertAttributeEquals(TOPIC_ATTRIBUTE_KEY, "testTopic");
-        flowFile.assertAttributeEquals(QOS_ATTRIBUTE_KEY, "2");
-        flowFile.assertAttributeEquals(IS_DUPLICATE_ATTRIBUTE_KEY, "false");
-        flowFile.assertAttributeEquals(IS_RETAINED_ATTRIBUTE_KEY, "false");
-    }
-
-    private static boolean isConnected(AbstractMQTTProcessor processor) throws NoSuchFieldException, IllegalAccessException {
-        Field f = AbstractMQTTProcessor.class.getDeclaredField("mqttClient");
-        f.setAccessible(true);
-        IMqttClient mqttClient = (IMqttClient) f.get(processor);
-        return mqttClient.isConnected();
-    }
-
-
-    public static void reconnect(ConsumeMQTT processor) throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-        Method method = ConsumeMQTT.class.getDeclaredMethod("reconnect");
-        method.setAccessible(true);
-        method.invoke(processor);
-    }
-
-    public static BlockingQueue<MQTTQueueMessage> getMqttQueue(ConsumeMQTT consumeMQTT) throws IllegalAccessException, NoSuchFieldException {
-        Field mqttQueueField = ConsumeMQTT.class.getDeclaredField("mqttQueue");
-        mqttQueueField.setAccessible(true);
-        return (BlockingQueue<MQTTQueueMessage>) mqttQueueField.get(consumeMQTT);
-    }
-
-    public static void transferQueue(ConsumeMQTT consumeMQTT, ProcessSession session) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method transferQueue = ConsumeMQTT.class.getDeclaredMethod("transferQueue", ProcessSession.class);
-        transferQueue.setAccessible(true);
-        transferQueue.invoke(consumeMQTT, session);
-    }
-
-    private void assertProvenanceEvents(int count){
-        List<ProvenanceEventRecord> provenanceEvents = testRunner.getProvenanceEvents();
-        assertNotNull(provenanceEvents);
-        assertEquals(count, provenanceEvents.size());
-        if (count > 0) {
-            assertEquals(ProvenanceEventType.RECEIVE, provenanceEvents.get(0).getEventType());
-        }
-    }
+	private void assertProvenanceEvents(int count) {
+		List<ProvenanceEventRecord> provenanceEvents = testRunner.getProvenanceEvents();
+		assertNotNull(provenanceEvents);
+		assertEquals(count, provenanceEvents.size());
+		if (count > 0) {
+			assertEquals(ProvenanceEventType.RECEIVE, provenanceEvents.get(0).getEventType());
+		}
+	}
 }


### PR DESCRIPTION
I've updated the Paho library used by this module and switch to AsyncClient from the sync one. 
I've changed the logic that manages the LinkedBlockedQueue: I use the "Max Queue Size" parameter as an indication of how many messages the queue has to be store, and not to set their size, since the MQTT callback method messageArrive can be called many time after the client asks for disconnection.

I fixed the unit test for this plugin but when I tried to run mvn -Pcontrib-check clean install in the project root the unit test is failing in nifi-standard-processors.
  