### PR TITLE
NIFI-4561 ExecuteSQL returns no FlowFile for some queries

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQL.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -91,12 +92,15 @@ import static org.apache.nifi.processors.standard.util.JdbcCommon.USE_AVRO_LOGIC
 })
 @WritesAttributes({
     @WritesAttribute(attribute="executesql.row.count", description = "Contains the number of rows returned in the select query"),
-    @WritesAttribute(attribute="executesql.query.duration", description = "Duration of the query in milliseconds")
+    @WritesAttribute(attribute="executesql.query.duration", description = "Duration of the query in milliseconds"),
+    @WritesAttribute(attribute="executesql.resultset.index", description = "Assuming multiple result sets are returned, "
+       + "the zero based index of this result set.")
 })
 public class ExecuteSQL extends AbstractProcessor {
 
     public static final String RESULT_ROW_COUNT = "executesql.row.count";
     public static final String RESULT_QUERY_DURATION = "executesql.query.duration";
+    public static final String RESULTSET_INDEX = "executesql.resultset.index";
 
     // Relationships
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -220,53 +224,60 @@ public class ExecuteSQL extends AbstractProcessor {
                 JdbcCommon.setParameters(st, fileToProcess.getAttributes());
             }
             logger.debug("Executing query {}", new Object[]{selectQuery});
-            boolean results = st.execute();
+            boolean hasResults = st.execute();
+            boolean hasUpdateCount = st.getUpdateCount() != -1;
 
+            while(hasResults || hasUpdateCount) {
+                //getMoreResults() and execute() return false to indicate that the result of the statement is just a number and not a ResultSet
+                if (hasResults) {
+                    FlowFile resultSetFF;
+                    if (fileToProcess == null) {
+                        resultSetFF = session.create();
+                    } else {
+                        resultSetFF = session.create(fileToProcess);
+                        resultSetFF = session.putAllAttributes(resultSetFF, fileToProcess.getAttributes());
+                    }
 
-            while(results){
-                FlowFile resultSetFF;
-                if(fileToProcess == null){
-                    resultSetFF = session.create();
-                } else {
-                    resultSetFF = session.create(fileToProcess);
-                    resultSetFF = session.putAllAttributes(resultSetFF, fileToProcess.getAttributes());
+                    final AtomicLong nrOfRows = new AtomicLong(0L);
+                    resultSetFF = session.write(resultSetFF, out -> {
+                        try {
+
+                            final ResultSet resultSet = st.getResultSet();
+                            final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
+                                    .convertNames(convertNamesForAvro)
+                                    .useLogicalTypes(useAvroLogicalTypes)
+                                    .defaultPrecision(defaultPrecision)
+                                    .defaultScale(defaultScale)
+                                    .build();
+                            nrOfRows.set(JdbcCommon.convertToAvroStream(resultSet, out, options, null));
+                        } catch (final SQLException e) {
+                            throw new ProcessException(e);
+                        }
+                    });
+
+                    long duration = stopWatch.getElapsed(TimeUnit.MILLISECONDS);
+
+                    // set attribute how many rows were selected
+                    resultSetFF = session.putAttribute(resultSetFF, RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
+                    resultSetFF = session.putAttribute(resultSetFF, RESULT_QUERY_DURATION, String.valueOf(duration));
+                    resultSetFF = session.putAttribute(resultSetFF, CoreAttributes.MIME_TYPE.key(), JdbcCommon.MIME_TYPE_AVRO_BINARY);
+                    resultSetFF = session.putAttribute(resultSetFF, RESULTSET_INDEX, String.valueOf(resultCount));
+
+                    logger.info("{} contains {} Avro records; transferring to 'success'",
+                            new Object[]{resultSetFF, nrOfRows.get()});
+                    session.getProvenanceReporter().modifyContent(resultSetFF, "Retrieved " + nrOfRows.get() + " rows", duration);
+                    session.transfer(resultSetFF, REL_SUCCESS);
+
+                    resultCount++;
                 }
 
-                final AtomicLong nrOfRows = new AtomicLong(0L);
-                resultSetFF = session.write(resultSetFF, out -> {
-                    try {
-
-                        final ResultSet resultSet = st.getResultSet();
-                        final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
-                                .convertNames(convertNamesForAvro)
-                                .useLogicalTypes(useAvroLogicalTypes)
-                                .defaultPrecision(defaultPrecision)
-                                .defaultScale(defaultScale)
-                                .build();
-                        nrOfRows.set(JdbcCommon.convertToAvroStream(resultSet, out, options, null));
-                    } catch (final SQLException e) {
-                        throw new ProcessException(e);
-                    }
-                });
-
-                long duration = stopWatch.getElapsed(TimeUnit.MILLISECONDS);
-
-                // set attribute how many rows were selected
-                resultSetFF = session.putAttribute(resultSetFF, RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
-                resultSetFF = session.putAttribute(resultSetFF, RESULT_QUERY_DURATION, String.valueOf(duration));
-                resultSetFF = session.putAttribute(resultSetFF, CoreAttributes.MIME_TYPE.key(), JdbcCommon.MIME_TYPE_AVRO_BINARY);
-
-                logger.info("{} contains {} Avro records; transferring to 'success'",
-                        new Object[]{resultSetFF, nrOfRows.get()});
-                session.getProvenanceReporter().modifyContent(resultSetFF, "Retrieved " + nrOfRows.get() + " rows", duration);
-                session.transfer(resultSetFF, REL_SUCCESS);
-
-                resultCount++;
                 // are there anymore result sets?
                 try{
-                    results = st.getMoreResults();
+                    hasResults = st.getMoreResults(Statement.CLOSE_CURRENT_RESULT);
+                    hasUpdateCount = st.getUpdateCount() != -1;
                 } catch(SQLException ex){
-                    results = false;
+                    hasResults = false;
+                    hasUpdateCount = false;
                 }
             }
 
@@ -278,8 +289,20 @@ public class ExecuteSQL extends AbstractProcessor {
                 } else {
                     fileToProcess = session.write(fileToProcess, JdbcCommon::createEmptyAvroStream);
 
+                    fileToProcess = session.putAttribute(fileToProcess, RESULT_ROW_COUNT, "0");
+                    fileToProcess = session.putAttribute(fileToProcess, CoreAttributes.MIME_TYPE.key(), JdbcCommon.MIME_TYPE_AVRO_BINARY);
                     session.transfer(fileToProcess, REL_SUCCESS);
                 }
+            } else if(resultCount == 0){
+                //If we had no inbound FlowFile, no exceptions, and the SQL generated no result sets (Insert/Update/Delete statements only)
+                // Then generate an empty Output FlowFile
+                FlowFile resultSetFF = session.create();
+
+                resultSetFF = session.write(resultSetFF, out -> JdbcCommon.createEmptyAvroStream(out));
+
+                resultSetFF = session.putAttribute(resultSetFF, RESULT_ROW_COUNT, "0");
+                resultSetFF = session.putAttribute(resultSetFF, CoreAttributes.MIME_TYPE.key(), JdbcCommon.MIME_TYPE_AVRO_BINARY);
+                session.transfer(resultSetFF, REL_SUCCESS);
             }
         } catch (final ProcessException | SQLException e) {
             //If we had at least one result then it's OK to drop the original file, but if we had no results then


### PR DESCRIPTION
In some scenarios the updated ExecuteSQL returns no FlowFile, even when the SQL was executed without error. This is a bug I introduced in https://github.com/apache/nifi/pull/1471.

If you execute a stored procedure that returns only a row count, or if the row count is the first result and the ResultSet follows it, then no FlowFile will be generated. This is because `getMoreResults()` and `execute()` return false to indicate that the ResultSet does not exist OR that the statement returned a number and not a ResultSet. So if ResultSet's and numerical responses are inter mixed this will also result in missed result sets.

Some JDBC drivers allow for multi-statement requests to be submitted using `Statement.execute`. In these cases you can have an INSERT statement followed by a SELECT statement. In this case no ResultSet would be returned either.

Prior to NIFI-3432, executing any number of statements would result in a single ResultSet, which may or may not include data. I've seen examples of a DELETE followed by several INSERT statements and our JDBC driver (Teradata) would execute them and NiFi would return a single empty FlowFile.

This update corrects the logic. The new logic:
- For every ResultSet, output a FlowFile
- Skip non-ResultSet outputs
- If we have no more results, there were no errors, there was no original inbound FlowFile, and no ResultSet's were found at all (statements were Insert/Update/Delete only), then output a blank FlowFile.

@mattyb149 You reviewed https://github.com/apache/nifi/pull/1471 for me, not sure if you have the time to review this fix as well. I know in the past you weren't big on the idea of executing non SELECT statements from ExecuteSQL, but it's something I'm seeing in our environment since the JDBC driver allows it, and since we can do multi-statement requests.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
