### PR TITLE
NIFI-4473: Fixed SelectHiveQL flowfile handling during error conditions

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
@@ -257,7 +257,7 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
     }
 
     private void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
-        final FlowFile fileToProcess = (context.hasIncomingConnection() ? session.get() : null);
+        FlowFile fileToProcess = (context.hasIncomingConnection() ? session.get() : null);
         FlowFile flowfile = null;
 
         // If we have no FlowFile, and all incoming connections are self-loops then we can continue on.
@@ -338,8 +338,9 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
                 try {
                     resultSet = (flowbased ? ((PreparedStatement) st).executeQuery() : st.executeQuery(selectQuery));
                 } catch (SQLException se) {
-                    // If an error occurs during the query, a flowfile is expected to be routed to failure, so create one here (the original will be removed)
-                    flowfile = session.create(fileToProcess);
+                    // If an error occurs during the query, a flowfile is expected to be routed to failure, so ensure one here
+                    flowfile = (fileToProcess == null) ? session.create() : fileToProcess;
+                    fileToProcess = null;
                     throw se;
                 }
 


### PR DESCRIPTION
So the behavior is inconsistent with other processors like ExecuteSQL, but it has always been that way, so this fix is just to ensure it isn't any worse :)

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
