### PR TITLE
NIFI-4593: Ensuring jackson dependencies are bundled

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml
@@ -206,6 +206,18 @@ limitations under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- explicitly pulling in jackson and excluding above to not conflict with transitive test dependencies from nifi-mock -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
NIFI-4593:
- Ensuring the necessary jackson dependencies are bundled.