### PR TITLE
NIFI-4504, NIFI-4505 added methods to MapCache API …

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectDuplicate.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectDuplicate.java
@@ -244,7 +244,12 @@ public class TestDetectDuplicate {
 
         @Override
         public long removeByPattern(String regex) throws IOException {
-            return exists ? 1L : 0L;
+            if (exists) {
+                exists = false;
+                return 1L;
+            } else {
+                return 0L;
+            }
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClient.java
@@ -167,6 +167,23 @@ public interface DistributedMapCacheClient extends ControllerService {
     <K> boolean remove(K key, Serializer<K> serializer) throws IOException;
 
     /**
+     * Removes the entry with the given key from the cache, if it is present,
+     * and returns the value that was removed from the map.
+     *
+     * @param <K> type of key
+     * @param <V> type of value
+     * @param key key
+     * @param keySerializer key serializer
+     * @param valueDeserializer value deserializer
+     * @return the value previously associated with the key, or null if there was no mapping
+     * null can also indicate that the map previously associated null with the key
+     * @throws IOException ex
+     */
+    default <K, V> V removeAndGet(K key, Serializer<K> keySerializer, Deserializer<V> valueDeserializer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Removes entries whose keys match the specified pattern
      *
      * @param regex The regular expression / pattern on which to match the keys to be removed
@@ -174,4 +191,32 @@ public interface DistributedMapCacheClient extends ControllerService {
      * @throws IOException if any error occurred while removing an entry
      */
     long removeByPattern(String regex) throws IOException;
+
+    /**
+     * Removes entries whose keys match the specified pattern, and returns a map of entries that
+     * were removed.
+     *
+     * @param <K> type of key
+     * @param <V> type of value
+     * @param regex The regular expression / pattern on which to match the keys to be removed
+     * @param keyDeserializer key deserializer
+     * @param valueDeserializer value deserializer
+     * @return A map of key/value entries that were removed from the cache
+     * @throws IOException if any error occurred while removing an entry
+     */
+    default <K, V> Map<K, V> removeByPatternAndGet(String regex, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a set of all keys currently in the cache
+     *
+     * @param <K> type of key
+     * @param keyDeserializer key deserializer
+     * @return a Set of all keys currently in the cache
+     * @throws IOException ex
+     */
+    default <K> Set<K> keySet(Deserializer<K> keyDeserializer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
@@ -16,7 +16,9 @@
  */
 package org.apache.nifi.distributed.cache.client;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,8 +42,6 @@ import org.apache.nifi.remote.StandardVersionNegotiator;
 import org.apache.nifi.remote.VersionNegotiator;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.ssl.SSLContextService.ClientAuth;
-import org.apache.nifi.stream.io.ByteArrayOutputStream;
-import org.apache.nifi.stream.io.DataOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SSLCommsSession.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SSLCommsSession.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.distributed.cache.client;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,8 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.nifi.stream.io.BufferedInputStream;
-import org.apache.nifi.stream.io.BufferedOutputStream;
 import org.apache.nifi.remote.io.socket.ssl.SSLSocketChannel;
 import org.apache.nifi.remote.io.socket.ssl.SSLSocketChannelInputStream;
 import org.apache.nifi.remote.io.socket.ssl.SSLSocketChannelOutputStream;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/StandardCommsSession.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/StandardCommsSession.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.distributed.cache.client;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,8 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.nifi.stream.io.BufferedInputStream;
-import org.apache.nifi.stream.io.BufferedOutputStream;
 import org.apache.nifi.remote.io.InterruptableInputStream;
 import org.apache.nifi.remote.io.InterruptableOutputStream;
 import org.apache.nifi.remote.io.socket.SocketChannelInputStream;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-protocol/src/main/java/org/apache/nifi/distributed/cache/protocol/ProtocolHandshake.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-protocol/src/main/java/org/apache/nifi/distributed/cache/protocol/ProtocolHandshake.java
@@ -38,6 +38,7 @@ public class ProtocolHandshake {
      * If the server doesn't support requested protocol version, HandshakeException will be thrown.</p>
      *
      * <p>DistributedMapCache version histories:<ul>
+     *     <li>3: Added subMap, keySet, removeAndGet, removeByPatternAndGet methods.</li>
      *     <li>2: Added atomic update operations (fetch and replace) using optimistic lock with revision number.</li>
      *     <li>1: Initial version.</li>
      * </ul></p>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/SetCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/SetCacheServer.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.distributed.cache.server;
 
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,7 +30,6 @@ import org.apache.nifi.distributed.cache.server.set.PersistentSetCache;
 import org.apache.nifi.distributed.cache.server.set.SetCache;
 import org.apache.nifi.distributed.cache.server.set.SetCacheResult;
 import org.apache.nifi.distributed.cache.server.set.SimpleSetCache;
-import org.apache.nifi.stream.io.DataOutputStream;
 
 public class SetCacheServer extends AbstractCacheServer {
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCache.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface MapCache {
 
@@ -40,6 +41,8 @@ public interface MapCache {
     MapCacheRecord fetch(ByteBuffer key) throws IOException;
 
     MapPutResult replace(MapCacheRecord record) throws IOException;
+
+    Set<ByteBuffer> keySet() throws IOException;
 
     void shutdown() throws IOException;
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/MapCacheServer.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Set;
 
 import javax.net.ssl.SSLContext;
 
@@ -144,10 +145,45 @@ public class MapCacheServer extends AbstractCacheServer {
                 dos.writeBoolean(removed);
                 break;
             }
+            case "removeAndGet": {
+                final byte[] key = readValue(dis);
+                final ByteBuffer removed = cache.remove(ByteBuffer.wrap(key));
+                if (removed == null) {
+                    // there was no value removed
+                    dos.writeInt(0);
+                } else {
+                    // reply with the value that was removed
+                    final byte[] byteArray = removed.array();
+                    dos.writeInt(byteArray.length);
+                    dos.write(byteArray);
+                }
+                break;
+            }
             case "removeByPattern": {
                 final String pattern = dis.readUTF();
                 final Map<ByteBuffer, ByteBuffer> removed = cache.removeByPattern(pattern);
                 dos.writeLong(removed == null ? 0 : removed.size());
+                break;
+            }
+            case "removeByPatternAndGet": {
+                final String pattern = dis.readUTF();
+                final Map<ByteBuffer, ByteBuffer> removed = cache.removeByPattern(pattern);
+                if (removed == null || removed.size() == 0) {
+                    dos.writeLong(0);
+                } else {
+                    // write the map size
+                    dos.writeInt(removed.size());
+                    for (Map.Entry<ByteBuffer, ByteBuffer> entry : removed.entrySet()) {
+                        // write map entry key
+                        final byte[] key = entry.getKey().array();
+                        dos.writeInt(key.length);
+                        dos.write(key);
+                        // write map entry value
+                        final byte[] value = entry.getValue().array();
+                        dos.writeInt(value.length);
+                        dos.write(value);
+                    }
+                }
                 break;
             }
             case "fetch": {
@@ -173,6 +209,18 @@ public class MapCacheServer extends AbstractCacheServer {
                 final byte[] value = readValue(dis);
                 final MapPutResult result = cache.replace(new MapCacheRecord(ByteBuffer.wrap(key), ByteBuffer.wrap(value), revision));
                 dos.writeBoolean(result.isSuccessful());
+                break;
+            }
+            case "keySet": {
+                final Set<ByteBuffer> result = cache.keySet();
+                // write the set size
+                dos.writeInt(result.size());
+                // write each key in the set
+                for (ByteBuffer bb : result) {
+                    final byte[] byteArray = bb.array();
+                    dos.writeInt(byteArray.length);
+                    dos.write(byteArray);
+                }
                 break;
             }
             default: {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,6 +169,11 @@ public class PersistentMapCache implements MapCache {
             }
         }
         return removeResult;
+    }
+
+    @Override
+    public Set<ByteBuffer> keySet() throws IOException {
+        return wrapped.keySet();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/SimpleMapCache.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.locks.Lock;
@@ -270,6 +271,16 @@ public class SimpleMapCache implements MapCache {
             return put(key, value, existing);
         } finally {
             writeLock.unlock();
+        }
+    }
+
+    @Override
+    public Set<ByteBuffer> keySet() throws IOException {
+        readLock.lock();
+        try {
+            return cache.keySet();
+        } finally {
+            readLock.unlock();
         }
     }
 


### PR DESCRIPTION
… including keySet, removeAndGet, removeByPatternAndGet
  cleaned up some warnings on deprecated nifi.stream.io classes

I attempted to update the various implementations of DistributedMapCacheClient,
but if the reviewer feels I should leave them unsupported then let me know.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
