### PR TITLE
NIFI-4630  Added Satori RTM processor bundle (ConsumeSatoriRTM, PublishSatoriRTM)

### DIFF
--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-nar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-satori-bundle</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-satori-bundle-nar</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+    <packaging>nar</packaging>
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <source.skip>true</source.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-satori-bundle-processors</artifactId>
+            <version>1.5.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-satori-bundle</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-satori-bundle-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.satori</groupId>
+            <artifactId>satori-sdk-java</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/ConsumeSatoriRTM.java
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/ConsumeSatoriRTM.java
@@ -16,36 +16,55 @@
  */
 package org.apache.nifi.processors.satori;
 
-import org.apache.nifi.annotation.behavior.*;
+import com.satori.rtm.RtmClient;
+import com.satori.rtm.RtmClientAdapter;
+import com.satori.rtm.RtmClientBuilder;
+import com.satori.rtm.SubscriptionMode;
+import com.satori.rtm.SubscriptionConfig;
+import com.satori.rtm.SubscriptionAdapter;
+import com.satori.rtm.auth.RoleSecretAuthProvider;
+import com.satori.rtm.model.AnyJson;
+import com.satori.rtm.model.SubscribeRequest;
+import com.satori.rtm.model.SubscriptionData;
+import com.satori.rtm.model.SubscriptionError;
+import com.satori.rtm.model.SubscribeReply;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.ReadsAttributes;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.documentation.CapabilityDescription;
-import org.apache.nifi.annotation.documentation.SeeAlso;
-import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import com.satori.rtm.*;
-import com.satori.rtm.auth.*;
-import com.satori.rtm.model.*;
 
 @Tags({"pubsub", "satori", "rtm", "realtime", "json"})
 @CapabilityDescription("Consumes a streaming data feed from Satori RTM (https://www.satori.com/docs/using-satori/overview)")
@@ -299,8 +318,7 @@ public class ConsumeSatoriRTM extends AbstractProcessor {
             // Get message(s) from queue
             final String message;
 
-            if (batch)
-            {
+            if (batch) {
                 // Wait for minimum number of messages as configured in the batch size
                 if (messageQueue.size() < batchSize) {
                     context.yield();

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/ConsumeSatoriRTM.java
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/ConsumeSatoriRTM.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.satori;
+
+import org.apache.nifi.annotation.behavior.*;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.io.OutputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import com.satori.rtm.*;
+import com.satori.rtm.auth.*;
+import com.satori.rtm.model.*;
+
+@Tags({"pubsub", "satori", "rtm", "realtime", "json"})
+@CapabilityDescription("Consumes a streaming data feed from Satori RTM (https://www.satori.com/docs/using-satori/overview)")
+@SeeAlso({})
+@ReadsAttributes({@ReadsAttribute(attribute="", description="")})
+@WritesAttributes({@WritesAttribute(attribute="", description="")})
+@InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
+@SupportsBatching
+public class ConsumeSatoriRTM extends AbstractProcessor {
+
+    private static final AllowableValue SUB_MODE_SIMPLE = new AllowableValue("SIMPLE", "SIMPLE",
+            "RTM doesn't track the position value for the subscription. Instead, when RTM resubscribes following a reconnection, "
+                    + "it fast-forwards to the earliest position that points to a non-expired message.");
+
+    private static final AllowableValue SUB_MODE_RELIABLE = new AllowableValue("RELIABLE", "RELIABLE",
+            "RTM tracks the position value for the subscription and tries to use it when resubscribing after the connection drops and the client reconnects. "
+                    + "If the position points to an expired message, RTM fast-forwards to the earliest position that points to a non-expired message.");
+
+    public static final PropertyDescriptor ENDPOINT = new PropertyDescriptor
+            .Builder().name("ENDPOINT")
+            .displayName("Endpoint")
+            .description("Entry point to RTM")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("wss://open-data.api.satori.com")
+            .build();
+
+    public static final PropertyDescriptor APPKEY = new PropertyDescriptor
+            .Builder().name("APPKEY")
+            .displayName("Appkey")
+            .description("String used by RTM to identify the client when it connects to RTM")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .sensitive(true)
+            .build();
+
+    public static final PropertyDescriptor ROLE = new PropertyDescriptor
+            .Builder().name("ROLE")
+            .displayName("Role")
+            .description("Role and Role Secret Key are only required when connecting to a channel that is explicitly "
+                    + "configured with channel permissions requiring authentication. Not required for consuming Open Data Channels.")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor ROLE_SECRET_KEY = new PropertyDescriptor
+            .Builder().name("ROLE_SECRET_KEY")
+            .displayName("Role Secret Key")
+            .description("Role and Role Secret Key are only required when connecting to a channel that is explicitly "
+                    + "configured with channel permissions requiring authentication. Not required for consuming Open Data Channels.")
+            .required(false)
+            .addValidator(Validator.VALID)
+            .sensitive(true)
+            .build();
+
+    public static final PropertyDescriptor SUBSCRIPTION_MODE = new PropertyDescriptor
+            .Builder().name("SUBSCRIPTION_MODE")
+            .displayName("Subscription Mode")
+            .description("Determines how the position in the queue will be tracked")
+            .required(true)
+            .allowableValues(SUB_MODE_SIMPLE,SUB_MODE_RELIABLE)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("SIMPLE")
+            .build();
+
+    public static final PropertyDescriptor CHANNEL = new PropertyDescriptor
+            .Builder().name("CHANNEL")
+            .displayName("Channel")
+            .description("Name of channel to consume from")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor FILTER = new PropertyDescriptor
+            .Builder().name("FILTER")
+            .displayName("Filter")
+            .description("Stream SQL used to filter or aggregate data consumed from the RTM channel")
+            .addValidator(Validator.VALID)
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor
+            .Builder().name("BATCH_SIZE")
+            .displayName("Minimum Batch Size")
+            .description("Configures the number of messages to be grouped into a single FlowFile (accepts values up to 10000). Setting no value will map a single message per FlowFile.")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .required(false)
+            .build();
+
+    public static final Relationship SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles received from RTM. Depending on batching strategy it is a flow file per message or a bundle of messages grouped together.")
+            .build();
+
+
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+
+
+    private volatile RtmClient client;
+    private volatile BlockingQueue<String> messageQueue = new LinkedBlockingQueue<>(10000);
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        descriptors.add(ENDPOINT);
+        descriptors.add(APPKEY);
+        descriptors.add(ROLE);
+        descriptors.add(ROLE_SECRET_KEY);
+        descriptors.add(SUBSCRIPTION_MODE);
+        descriptors.add(CHANNEL);
+        descriptors.add(FILTER);
+        descriptors.add(BATCH_SIZE);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<Relationship>();
+        relationships.add(SUCCESS);
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+
+        // Get the user defined configuration properties
+        String endpoint = context.getProperty(ENDPOINT).getValue();
+        String appkey = context.getProperty(APPKEY).getValue();
+        String role = context.getProperty(ROLE).getValue();
+        String roleSecretKey = context.getProperty(ROLE_SECRET_KEY).getValue();
+        String channel = context.getProperty(CHANNEL).getValue();
+        String filter = context.getProperty(FILTER).getValue();
+        String subMode = context.getProperty(SUBSCRIPTION_MODE).getValue();
+        boolean shouldAuthenticate = context.getProperty(ROLE).isSet();
+        boolean useFilter = context.getProperty(FILTER).isSet();
+
+        // Connect to satori
+        final RtmClientBuilder builder = new RtmClientBuilder(endpoint, appkey)
+                .setListener(new RtmClientAdapter() {
+                    @Override
+                    public void onConnectingError(RtmClient client, Exception ex) {
+                        String msg = String.format("RTM client failed to connect to '%s': %s",
+                                endpoint, ex.getMessage());
+                        getLogger().error(msg);
+                    }
+
+                    @Override
+                    public void onError(RtmClient client, Exception ex) {
+                        String msg = String.format("RTM client failed: %s", ex.getMessage());
+                        getLogger().error(msg);
+                    }
+
+                    @Override
+                    public void onEnterConnected(RtmClient client) {
+                        getLogger().info("Connected to Satori!");
+                    }
+
+                });
+
+        // Authenticate with role and secret key if required
+        if (shouldAuthenticate) {
+            builder.setAuthProvider(new RoleSecretAuthProvider(role, roleSecretKey));
+        }
+
+        client = builder.build();
+
+        getLogger().info(String.format(
+                "RTM connection config:\n" +
+                        "\tendpoint='%s'\n" +
+                        "\tappkey='%s'\n" +
+                        "\tauthenticate?=%b", endpoint, appkey, shouldAuthenticate));
+
+        client.start();
+
+        // Set up Satori Subscription Config
+        SubscriptionConfig subConfig = new SubscriptionConfig(
+                (subMode.equals("SIMPLE")) ? SubscriptionMode.SIMPLE : SubscriptionMode.RELIABLE, // Set sub mode
+                new SubscriptionAdapter() {
+                    @Override
+                    public void onEnterSubscribed(SubscribeRequest request, SubscribeReply reply) {
+                        // when subscription is established (confirmed by RTM)
+                        getLogger().info("Subscribed to the channel: " + channel);
+                    }
+
+                    @Override
+                    public void onSubscriptionError(SubscriptionError error) {
+                        // when a subscribe or subscription error occurs
+                        getLogger().error("Failed to subscribe: " + error.getReason());
+                    }
+
+                    @Override
+                    public void onSubscriptionData(SubscriptionData data) {
+                        // when incoming messages arrive
+                        for (AnyJson json : data.getMessages()) {
+                            try {
+                                messageQueue.add(json.toString());
+                            } catch (NullPointerException e) {
+                                getLogger().error(e.toString());
+                            }
+                        }
+                    }
+                });
+
+        // Apply SQL filter if supplied
+        if (useFilter) {
+            subConfig.setFilter(filter);
+        }
+
+        // Create the subscription!
+        try {
+            client.createSubscription(channel,subConfig);
+        } catch (Exception e) {
+            getLogger().error(e.toString());
+        }
+
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+
+        try {
+
+            // Get required user properties
+            String endpoint = context.getProperty(ENDPOINT).getValue();
+            String channel = context.getProperty(CHANNEL).getValue();
+            String batchSizeStr = context.getProperty(BATCH_SIZE).getValue();
+            int batchSize = 1;
+            boolean batch;
+
+            try {
+                batchSize = Integer.parseInt(batchSizeStr);
+                batch = true;
+            } catch (NumberFormatException e) {
+                batch = false;
+            }
+
+            // Check messageQueue for new messages
+            if (messageQueue.isEmpty()) {
+                context.yield();
+                return;
+            }
+
+            // Get message(s) from queue
+            final String message;
+
+            if (batch)
+            {
+                // Wait for minimum number of messages as configured in the batch size
+                if (messageQueue.size() < batchSize) {
+                    context.yield();
+                    return;
+                } else {
+                    List<String> messages = new ArrayList<>();
+                    messageQueue.drainTo(messages);
+
+                    // Merge into a single new-line delimited message
+                    message = String.join("\n", messages);
+                }
+            } else {
+                // Get a single message from the queue
+                message = messageQueue.poll(100, TimeUnit.MILLISECONDS);
+            }
+
+            // Write message to FlowFile
+            FlowFile flowFile = session.create();
+            flowFile = session.write(flowFile, new OutputStreamCallback() {
+                @Override
+                public void process(final OutputStream outputStream) throws IOException {
+                    outputStream.write(message.getBytes());
+                }
+            });
+
+            // Set relevant attributes
+            final Map<String, String> attributes = new HashMap<>();
+            attributes.put(CoreAttributes.MIME_TYPE.key(), "application/json");
+            attributes.put(CoreAttributes.FILENAME.key(), flowFile.getAttribute(CoreAttributes.FILENAME.key()) + ".json");
+            attributes.put("endpoint", endpoint);
+            attributes.put("channel", channel);
+            flowFile = session.putAllAttributes(flowFile, attributes);
+
+            //Success!
+            session.transfer(flowFile, SUCCESS);
+
+        } catch (InterruptedException e) {
+            getLogger().error(e.toString());
+        }
+
+    }
+
+    @OnStopped
+    public void shutdownClient() {
+        if (client != null) {
+            client.stop();
+        }
+    }
+
+    @Override
+    public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
+        // Destroy all messages in the queue when configurations are changed.
+        messageQueue.clear();
+    }
+}

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/PublishSatoriRTM.java
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/PublishSatoriRTM.java
@@ -16,41 +16,47 @@
  */
 package org.apache.nifi.processors.satori;
 
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
-import org.apache.nifi.annotation.behavior.*;
+import com.satori.rtm.Ack;
+import com.satori.rtm.RtmClient;
+import com.satori.rtm.RtmClientAdapter;
+import com.satori.rtm.RtmClientBuilder;
+import com.satori.rtm.auth.RoleSecretAuthProvider;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.ReadsAttributes;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.documentation.CapabilityDescription;
-import org.apache.nifi.annotation.documentation.SeeAlso;
-import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.commons.io.IOUtils;
+import org.apache.nifi.stream.io.util.StreamDemarcator;
 
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicReference;
-
-import com.satori.rtm.*;
-import com.satori.rtm.auth.*;
-import com.google.gson.JsonObject;
-import org.apache.nifi.stream.io.exception.TokenTooLargeException;
-import org.apache.nifi.stream.io.util.StreamDemarcator;
 
 @Tags({"pubsub", "satori", "rtm", "realtime", "json"})
 @CapabilityDescription("Publishes incoming messages to Satori RTM (https://www.satori.com/docs/using-satori/overview)")
@@ -274,8 +280,7 @@ public class PublishSatoriRTM extends AbstractProcessor {
         });
 
 
-        if (!failures.isEmpty())
-        {
+        if (!failures.isEmpty()) {
             // Deal with failures
             getLogger().error("Failed to publish message to Satori: " + failures.get(flowFile).toString());
             failures.clear();

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/PublishSatoriRTM.java
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/java/org/apache/nifi/processors/satori/PublishSatoriRTM.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.satori;
+
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.apache.nifi.annotation.behavior.*;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.commons.io.IOUtils;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.satori.rtm.*;
+import com.satori.rtm.auth.*;
+import com.google.gson.JsonObject;
+import org.apache.nifi.stream.io.exception.TokenTooLargeException;
+import org.apache.nifi.stream.io.util.StreamDemarcator;
+
+@Tags({"pubsub", "satori", "rtm", "realtime", "json"})
+@CapabilityDescription("Publishes incoming messages to Satori RTM (https://www.satori.com/docs/using-satori/overview)")
+@SeeAlso({})
+@ReadsAttributes({@ReadsAttribute(attribute="", description="")})
+@WritesAttributes({@WritesAttribute(attribute="", description="")})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@SupportsBatching
+public class PublishSatoriRTM extends AbstractProcessor {
+
+    public static final PropertyDescriptor ENDPOINT = new PropertyDescriptor
+            .Builder().name("ENDPOINT")
+            .displayName("Endpoint")
+            .description("Entry point to RTM")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .defaultValue("wss://open-data.api.satori.com")
+            .build();
+
+    public static final PropertyDescriptor APPKEY = new PropertyDescriptor
+            .Builder().name("APPKEY")
+            .displayName("Appkey")
+            .description("String used by RTM to identify the client when it connects to RTM")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .sensitive(true)
+            .build();
+
+    public static final PropertyDescriptor ROLE = new PropertyDescriptor
+            .Builder().name("ROLE")
+            .displayName("Role")
+            .description("Role and Role Secret Key are only required when connecting to a channel that is explicitly "
+                    + "configured with channel permissions requiring authentication. Not required for consuming Open Data Channels.")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor ROLE_SECRET_KEY = new PropertyDescriptor
+            .Builder().name("ROLE_SECRET_KEY")
+            .displayName("Role Secret Key")
+            .description("Role and Role Secret Key are only required when connecting to a channel that is explicitly "
+                    + "configured with channel permissions requiring authentication. Not required for consuming Open Data Channels.")
+            .required(false)
+            .addValidator(Validator.VALID)
+            .sensitive(true)
+            .build();
+
+    public static final PropertyDescriptor CHANNEL = new PropertyDescriptor
+            .Builder().name("CHANNEL")
+            .displayName("Channel")
+            .description("Name of channel to publish to")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor MSG_DEMARCATOR = new PropertyDescriptor
+            .Builder().name("MSG_DEMARCATOR")
+            .displayName("Message Demarcator")
+            .description("Specifies the string to use for demarcating multiple messages within a single FlowFile. "
+                    + "If not specified, the entire content of the FlowFile will be used as a single message. "
+                    + "If specified, the contents of the FlowFile will be split on this delimiter and each section sent "
+                    + "as a separate RTM message.")
+            .addValidator(Validator.VALID)
+            .required(false)
+            .build();
+
+    public static final Relationship SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles published successfully to RTM.")
+            .build();
+
+    public static final Relationship FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("FlowFiles failed to publish to RTM.")
+            .build();
+
+
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+
+
+    private volatile RtmClient client;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        descriptors.add(ENDPOINT);
+        descriptors.add(APPKEY);
+        descriptors.add(ROLE);
+        descriptors.add(ROLE_SECRET_KEY);
+        descriptors.add(CHANNEL);
+        descriptors.add(MSG_DEMARCATOR);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<Relationship>();
+        relationships.add(SUCCESS);
+        relationships.add(FAILURE);
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+
+        // Get the user defined configuration properties
+        String endpoint = context.getProperty(ENDPOINT).getValue();
+        String appkey = context.getProperty(APPKEY).getValue();
+        String role = context.getProperty(ROLE).getValue();
+        String roleSecretKey = context.getProperty(ROLE_SECRET_KEY).getValue();
+        boolean shouldAuthenticate = context.getProperty(ROLE).isSet();
+
+        // Connect to satori
+        final RtmClientBuilder builder = new RtmClientBuilder(endpoint, appkey)
+                .setListener(new RtmClientAdapter() {
+                    @Override
+                    public void onConnectingError(RtmClient client, Exception ex) {
+                        String msg = String.format("RTM client failed to connect to '%s': %s",
+                                endpoint, ex.getMessage());
+                        getLogger().error(msg);
+                    }
+
+                    @Override
+                    public void onError(RtmClient client, Exception ex) {
+                        String msg = String.format("RTM client failed: %s", ex.getMessage());
+                        getLogger().error(msg);
+                    }
+
+                    @Override
+                    public void onEnterConnected(RtmClient client) {
+                        getLogger().info("Connected to Satori!");
+                    }
+
+                });
+
+        // Authenticate with role and secret key if required
+        if (shouldAuthenticate) {
+            builder.setAuthProvider(new RoleSecretAuthProvider(role, roleSecretKey));
+        }
+
+        client = builder.build();
+
+        getLogger().info(String.format(
+                "RTM connection config:\n" +
+                        "\tendpoint='%s'\n" +
+                        "\tappkey='%s'\n" +
+                        "\tauthenticate?=%b", endpoint, appkey, shouldAuthenticate));
+
+        client.start();
+
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        final FlowFile flowFile = session.get();
+        if ( flowFile == null ) {
+            return;
+        }
+
+        final ConcurrentMap<FlowFile, Exception> failures = new ConcurrentHashMap<>();
+
+        // Get required user properties
+        String channel = context.getProperty(CHANNEL).getValue();
+        boolean useDemarcator = context.getProperty(MSG_DEMARCATOR).isSet();
+
+        // Set demarcator value if required
+        final byte[] demarcatorBytes;
+        if (useDemarcator) {
+            demarcatorBytes = context.getProperty(MSG_DEMARCATOR).getValue().getBytes(StandardCharsets.UTF_8);
+        } else {
+            demarcatorBytes = null;
+        }
+
+        // Read incoming FlowFile & publish message(s) to Satori
+        session.read(flowFile, rawIn -> {
+            try (final InputStream in = new BufferedInputStream(rawIn)) {
+
+                // Split stream based on demarcator
+                // Note: Satori limits all user generated payloads to 64kB (so we will hardcode maxDataSize here)
+                try (final StreamDemarcator demarcator = new StreamDemarcator(in, demarcatorBytes, 64000)) {
+                    byte[] messageBytes;
+
+                    while ((messageBytes = demarcator.nextToken()) != null) {
+                        // Publish message to Satori
+                        String message = new String(messageBytes);
+
+                        //RTM currently uses JSON data
+                        try {
+                            // try for JSON object
+                            JsonObject obj = new JsonParser().parse(message).getAsJsonObject();
+                            client.publish(channel, obj, Ack.YES);
+                        } catch (final JsonSyntaxException e) {
+                            // Send invalid JSON messages as raw string
+                            client.publish(channel, message, Ack.YES);
+                        } catch (final Exception e) {
+                            // Failure!
+                            failures.putIfAbsent(flowFile, e);
+                        }
+
+                        // If we have a failure, don't try to send anything else.
+                        if (!failures.isEmpty()) {
+                            return;
+                        }
+                    }
+
+                } catch (final Exception e) {
+                    // Failure!
+                    failures.putIfAbsent(flowFile, e);
+                }
+
+            }
+        });
+
+
+        if (!failures.isEmpty())
+        {
+            // Deal with failures
+            getLogger().error("Failed to publish message to Satori: " + failures.get(flowFile).toString());
+            failures.clear();
+            session.transfer(flowFile, FAILURE);
+            context.yield();
+        } else {
+            // Success!
+            session.transfer(flowFile, SUCCESS);
+        }
+    }
+
+    @OnStopped
+    public void shutdownClient() {
+        if (client != null) {
+            client.stop();
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/resources/META-INF.services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/main/resources/META-INF.services/org.apache.nifi.processor.Processor
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.satori.ConsumeSatoriRTM
+org.apache.nifi.processors.satori.PublishSatoriRTM

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/test/java/org/apache/nifi/processors/satori/ConsumeSatoriRTMTest.java
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/test/java/org/apache/nifi/processors/satori/ConsumeSatoriRTMTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.satori;
+
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConsumeSatoriRTMTest {
+
+    private TestRunner testRunner;
+
+    @Before
+    public void init() {
+        testRunner = TestRunners.newTestRunner(ConsumeSatoriRTM.class);
+    }
+
+    @Test
+    public void testConfigValidators() {
+
+        // Generate a test runner to mock a processor in a flow
+        TestRunner runner = TestRunners.newTestRunner(new ConsumeSatoriRTM());
+
+        // Define satori connection properties
+        runner.setProperty(ConsumeSatoriRTM.ENDPOINT, "wss://open-data.api.satori.com");
+        runner.setProperty(ConsumeSatoriRTM.APPKEY, "aaa");
+        runner.setProperty(ConsumeSatoriRTM.CHANNEL, "big-rss");
+        runner.setProperty(ConsumeSatoriRTM.SUBSCRIPTION_MODE, "SIMPLE");
+        runner.setProperty(ConsumeSatoriRTM.BATCH_SIZE, "100");
+        runner.assertValid();
+
+        // Test endpoint is not empty
+        runner.setProperty(ConsumeSatoriRTM.ENDPOINT, "");
+        runner.assertNotValid();
+        runner.setProperty(ConsumeSatoriRTM.ENDPOINT, "wss://open-data.api.satori.com");
+
+        // Test Batch size is a valid int
+        runner.setProperty(ConsumeSatoriRTM.BATCH_SIZE, "-1");
+        runner.assertNotValid();
+        runner.setProperty(ConsumeSatoriRTM.BATCH_SIZE, "100");
+
+    }
+
+}

--- a/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/test/java/org/apache/nifi/processors/satori/PublishSatoriRTMTest.java
+++ b/nifi-nar-bundles/nifi-satori-bundle/nifi-satori-bundle-processors/src/test/java/org/apache/nifi/processors/satori/PublishSatoriRTMTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.satori;
+
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class PublishSatoriRTMTest {
+
+    private TestRunner testRunner;
+
+    @Before
+    public void init() {
+        testRunner = TestRunners.newTestRunner(PublishSatoriRTM.class);
+    }
+
+    @Test
+    public void testProcessor() {
+
+        // Content to be mock a geo csv file
+        String inputJson = "{\"test1\":1,\"test2\":\"two\"}\n{test2}";
+        InputStream content = new ByteArrayInputStream(inputJson.getBytes());
+
+        // Generate a test runner to mock a processor in a flow
+        TestRunner runner = TestRunners.newTestRunner(new PublishSatoriRTM());
+
+        // Define satori connection properties
+        runner.setProperty(PublishSatoriRTM.ENDPOINT, "wss://qwxhvwv6.api.satori.com");
+        runner.setProperty(PublishSatoriRTM.APPKEY, "aaa");
+        runner.setProperty(PublishSatoriRTM.CHANNEL, "nifitest");
+        runner.setProperty(PublishSatoriRTM.MSG_DEMARCATOR, "\n");
+        runner.assertValid();
+
+        // Uncomment the lines below if you want to publish messages within this unit test.
+        // Note, you will need to update the properties above to a relevant channel.
+
+        //runner.enqueue(content);
+        //runner.run(1);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-satori-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-satori-bundle/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-bundles</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.nifi</groupId>
+    <artifactId>nifi-satori-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>nifi-satori-bundle-processors</module>
+        <module>nifi-satori-bundle-nar</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-satori-bundle-processors</artifactId>
+                <version>1.5.0-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -90,6 +90,7 @@
         <module>nifi-grpc-bundle</module>
         <module>nifi-redis-bundle</module>
         <module>nifi-metrics-reporting-bundle</module>
+        <module>nifi-satori-bundle</module>
   </modules>
 
     <build>


### PR DESCRIPTION
Pull Request for the addition of a Satori RTM processor bundle:

**ConsumeSatoriRTM**
Consumes a live data stream from Satori RTM based on a user specified Endpoint, Appkey, and Channel. Also supports the following features and configurations:
- Connection to Satori private channels (using Role & Role Secret Key configurations for authentication)
- Satori's Streamview filters, which allow you to provide SQL-like queries to select, transform, or aggregate messages from a subscribed channel
- Batching of multiple messages into a single FlowFile, which will provide a new-line delimited list of messages in each output FlowFile (based on a 'minimum batch size' configuration)

Example walkthrough on using the processor can be found here:
https://community.hortonworks.com/articles/144322/stream-satori-open-data-feeds-with-apache-nifi.html

**PublishSatoriRTM**
Publishes incoming FlowFiles to Satori RTM, based on user specified Satori configurations for Endpoint, Appkey, Role, Role Secret Key, and Channel. Supports the use of a Message Demarcator to split the incoming flowfile as separate RTM messages, or if unspecified will send an entire flowfile content as a single RTM message.



Happy to make any changes based on review & feedback.