### PR TITLE
NIFI-4640 Sub source w/ . in nifi.sh to be POSIX compliant

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
@@ -83,9 +83,8 @@ detectOS() {
     fi
     # In addition to those, go around the linux space and query the widely
     # adopted /etc/os-release to detect linux variants
-    if [ -f /etc/os-release ]
-    then
-        source /etc/os-release
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
     fi
 }
 


### PR DESCRIPTION
Tested against official Docker image (based on Debian stretch), Amazon Linux, and OS X (which doesn't run that part of the script anyway).