### PR TITLE
NIFI-4650 Added independent hadoop.http.core.version property

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>${hadoop.http.client.version}</version>
+                <version>${hadoop.http.core.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <hadoop.version>2.7.3</hadoop.version>
         <hadoop.guava.version>12.0.1</hadoop.guava.version>
         <hadoop.http.client.version>4.2.5</hadoop.http.client.version>
+        <hadoop.http.core.version>4.2.5</hadoop.http.core.version>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
         <ranger.version>0.7.1</ranger.version>
         <hive.version>1.2.1</hive.version>


### PR DESCRIPTION
For later releases of HttpComponents HttpClient and HttpCore versioning diverges so these need to be separate properties to support overriding them, e.g., for builds against Hadoop 2.8.x, etc.