### PR TITLE
NIFI-4645: Remove activation rules for including the grpc bundle

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -534,11 +534,9 @@ language governing permissions and limitations under the License. -->
     </dependencies>
     <profiles>
         <profile>
-            <id>includeifnotppc</id>
+            <id>include-grpc</id>
             <activation>
-                <os>
-                    <arch>!ppc64le</arch>
-                </os>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -135,11 +135,9 @@
             </properties>
         </profile>
         <profile>
-            <id>includeifnotppc</id>
+            <id>include-grpc</id>
             <activation>
-                <os>
-                    <arch>!ppc64le</arch>
-                </os>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
                 <module>nifi-grpc-bundle</module>


### PR DESCRIPTION
NIFI-4645:
- Removing rule based activation because it was causing the generateArchives profile to not activate. Now the grpc bundle can be excluded by disabling the include-grpc profile.