### PR TITLE
NIFI-4655: Fixed NPE in the InvokeHTTP processor 

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpSSL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpSSL.java
@@ -29,9 +29,15 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Executes the same tests as TestInvokeHttp but with one-way SSL enabled.  The Jetty server created for these tests
+ * will not require client certificates and the client will not use keystore properties in the SSLContextService.
+ */
 public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
 
-    private static Map<String, String> sslProperties;
+    protected static Map<String, String> sslProperties;
+    protected static Map<String, String> serverSslProperties;
+
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -41,7 +47,8 @@ public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
 
         // create the SSL properties, which basically store keystore / trustore information
         // this is used by the StandardSSLContextService and the Jetty Server
-        sslProperties = createSslProperties();
+        serverSslProperties = createServerSslProperties(false);
+        sslProperties = createSslProperties(false);
 
         // create a Jetty server on a random port
         server = createServer();
@@ -81,15 +88,39 @@ public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
         runner.shutdown();
     }
 
-    private static TestServer createServer() throws IOException {
-        return new TestServer(sslProperties);
+    protected static TestServer createServer() throws IOException {
+        return new TestServer(serverSslProperties);
     }
 
-    private static Map<String, String> createSslProperties() {
+    protected static Map<String, String> createServerSslProperties(boolean clientAuth) {
         final Map<String, String> map = new HashMap<>();
+        // if requesting client auth then we must also provide a truststore
+        if (clientAuth) {
+            map.put(TestServer.NEED_CLIENT_AUTH, Boolean.toString(true));
+            map.put(StandardSSLContextService.TRUSTSTORE.getName(), "src/test/resources/localhost-ts.jks");
+            map.put(StandardSSLContextService.TRUSTSTORE_PASSWORD.getName(), "localtest");
+            map.put(StandardSSLContextService.TRUSTSTORE_TYPE.getName(), "JKS");
+        } else {
+            map.put(TestServer.NEED_CLIENT_AUTH, Boolean.toString(false));
+        }
+        // keystore is always required for the server SSL properties
         map.put(StandardSSLContextService.KEYSTORE.getName(), "src/test/resources/localhost-ks.jks");
         map.put(StandardSSLContextService.KEYSTORE_PASSWORD.getName(), "localtest");
         map.put(StandardSSLContextService.KEYSTORE_TYPE.getName(), "JKS");
+
+        return map;
+    }
+
+
+    protected static Map<String, String> createSslProperties(boolean clientAuth) {
+        final Map<String, String> map = new HashMap<>();
+        // if requesting client auth then we must provide a keystore
+        if (clientAuth) {
+            map.put(StandardSSLContextService.KEYSTORE.getName(), "src/test/resources/localhost-ks.jks");
+            map.put(StandardSSLContextService.KEYSTORE_PASSWORD.getName(), "localtest");
+            map.put(StandardSSLContextService.KEYSTORE_TYPE.getName(), "JKS");
+        }
+        // truststore is always required for the client SSL properties
         map.put(StandardSSLContextService.TRUSTSTORE.getName(), "src/test/resources/localhost-ts.jks");
         map.put(StandardSSLContextService.TRUSTSTORE_PASSWORD.getName(), "localtest");
         map.put(StandardSSLContextService.TRUSTSTORE_TYPE.getName(), "JKS");

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpTwoWaySSL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpTwoWaySSL.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.standard;
+
+import org.junit.BeforeClass;
+
+/**
+ * This is probably overkill but in keeping with the same pattern as the TestInvokeHttp and TestInvokeHttpSSL class,
+ * we will execute the same tests using two-way SSL. The Jetty server created for these tests will require client
+ * certificates and the client will utilize keystore properties in the SSLContextService.
+ */
+public class TestInvokeHttpTwoWaySSL extends TestInvokeHttpSSL {
+
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // useful for verbose logging output
+        // don't commit this with this property enabled, or any 'mvn test' will be really verbose
+        // System.setProperty("org.slf4j.simpleLogger.log.nifi.processors.standard", "debug");
+
+        // create the SSL properties, which basically store keystore / trustore information
+        // this is used by the StandardSSLContextService and the Jetty Server
+        serverSslProperties = createServerSslProperties(true);
+        sslProperties = createSslProperties(true);
+
+        // create a Jetty server on a random port
+        server = createServer();
+        server.startServer();
+
+        // Allow time for the server to start
+        Thread.sleep(500);
+        // this is the base url with the random port
+        url = server.getSecureUrl();
+    }
+
+}


### PR DESCRIPTION
NIFI-4655: Fixed NPE in the InvokeHTTP processor caused when an SSLContextService was assigned without keystore properties.  

- Added check for keystore properties and only initialized keystore when necessary. 
- Added TestInvokeHttpTwoWaySSL test class to test with two-way SSL
- Modified TestInvokeHttpSSL to test with one-way SSL

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
