### PR TITLE
NIFI-4689: WriteAheadProvenance Properties

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -109,6 +109,8 @@ nifi.provenance.repository.index.shard.size=${nifi.provenance.repository.index.s
 # Indicates the maximum length that a FlowFile attribute can be when retrieving a Provenance Event from
 # the repository. If the length of any attribute exceeds this value, it will be truncated when the event is retrieved.
 nifi.provenance.repository.max.attribute.length=${nifi.provenance.repository.max.attribute.length}
+nifi.provenance.repository.concurrent.merge.threads=${nifi.provenance.repository.concurrent.merge.threads}
+nifi.provenance.repository.warm.cache.frequency=${nifi.provenance.repository.warm.cache.frequency}
 
 # Volatile Provenance Respository Properties
 nifi.provenance.repository.buffer.size=${nifi.provenance.repository.buffer.size}


### PR DESCRIPTION
NIFI-4689:
- Ensuring all provenance properties are represented in nifi.properties.