### PR TITLE
NIFI-4444: Ensuring the /nifi-api/controller redirection filter runs

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/filter/RedirectResourceFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/filter/RedirectResourceFilter.java
@@ -21,6 +21,7 @@ import org.apache.nifi.web.api.SiteToSiteResource;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.net.URI;
 /**
  * This filter provides backward compatibility for Resource URI changes.
  */
+@PreMatching
 public class RedirectResourceFilter implements ContainerRequestFilter {
 
     /**


### PR DESCRIPTION
NIFI-4444:
- Ensure the /nifi-api/controller redirection filter executes before matching.