### PR TITLE
NIFI-4727 Add CountText processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -390,6 +390,7 @@
                         <exclude>src/test/resources/TestConvertJSONToSQL/person-with-null-code.json</exclude>
                         <exclude>src/test/resources/TestConvertJSONToSQL/person-without-id.json</exclude>
                         <exclude>src/test/resources/TestConvertJSONToSQL/person-with-bool.json</exclude>
+                        <exclude>src/test/resources/TestCountText/jabberwocky.txt</exclude>
                         <exclude>src/test/resources/TestModifyBytes/noFooter.txt</exclude>
                         <exclude>src/test/resources/TestModifyBytes/noFooter_noHeader.txt</exclude>
                         <exclude>src/test/resources/TestModifyBytes/noHeader.txt</exclude>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
@@ -69,7 +69,7 @@ import org.apache.nifi.util.StringUtils;
 public class CountText extends AbstractProcessor {
     private static final List<Charset> STANDARD_CHARSETS = Arrays.asList(StandardCharsets.UTF_8, StandardCharsets.US_ASCII, StandardCharsets.ISO_8859_1, StandardCharsets.UTF_16, StandardCharsets.UTF_16LE, StandardCharsets.UTF_16BE);
 
-    private static final String SYMBOL_REGEX = "\\s-\\._";
+    private static final String SYMBOL_REGEX = "[\\s-\\._]";
     private static final String WHITESPACE_ONLY_REGEX = "\\s";
 
     // Attribute keys

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
@@ -67,7 +67,13 @@ import org.apache.nifi.util.StringUtils;
 })
 @SeeAlso(SplitText.class)
 public class CountText extends AbstractProcessor {
-    private static final List<Charset> STANDARD_CHARSETS = Arrays.asList(StandardCharsets.UTF_8, StandardCharsets.US_ASCII, StandardCharsets.ISO_8859_1, StandardCharsets.UTF_16, StandardCharsets.UTF_16LE, StandardCharsets.UTF_16BE);
+    private static final List<Charset> STANDARD_CHARSETS = Arrays.asList(
+            StandardCharsets.UTF_8,
+            StandardCharsets.US_ASCII,
+            StandardCharsets.ISO_8859_1,
+            StandardCharsets.UTF_16,
+            StandardCharsets.UTF_16LE,
+            StandardCharsets.UTF_16BE);
 
     private static final String SYMBOL_REGEX = "[\\s-\\._]";
     private static final String WHITESPACE_ONLY_REGEX = "\\s";
@@ -100,7 +106,8 @@ public class CountText extends AbstractProcessor {
     public static final PropertyDescriptor TEXT_WORD_COUNT_PD = new PropertyDescriptor.Builder()
             .name("text-word-count")
             .displayName("Text Word Count")
-            .description("If enabled, will count the number of words (alphanumeric character groups bounded by whitespace) present in the incoming text. Common logical delimiters [_-.] do not bound a word unless 'Split Words on Symbols' is true.")
+            .description("If enabled, will count the number of words (alphanumeric character groups bounded by whitespace)" +
+                    " present in the incoming text. Common logical delimiters [_-.] do not bound a word unless 'Split Words on Symbols' is true.")
             .required(true)
             .allowableValues("true", "false")
             .defaultValue("false")
@@ -195,7 +202,7 @@ public class CountText extends AbstractProcessor {
     }
 
     /**
-     * Will split the incoming stream releasing all splits as FlowFile at once.
+     * Will count text attributes of the incoming stream.
      */
     @Override
     public void onTrigger(ProcessContext context, ProcessSession processSession) throws ProcessException {
@@ -204,6 +211,11 @@ public class CountText extends AbstractProcessor {
             return;
         }
         AtomicBoolean error = new AtomicBoolean();
+
+        lineCount = 0;
+        lineNonEmptyCount = 0;
+        wordCount = 0;
+        characterCount = 0;
 
         processSession.read(sourceFlowFile, in -> {
             long start = System.nanoTime();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.util.StringUtils;
+
+@EventDriven
+@SideEffectFree
+@SupportsBatching
+@Tags({"count", "text", "line", "word", "character"})
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@CapabilityDescription("Counts various metrics on incoming text. The requested results will be recorded as attributes. "
+        + "The resulting flowfile will not have its content modified.")
+@WritesAttributes({
+        @WritesAttribute(attribute = "text.line.count", description = "The number of lines of text present in the FlowFile content"),
+        @WritesAttribute(attribute = "text.line.nonempty.count", description = "The number of lines of text (with at least one non-whitespace character) present in the original FlowFile"),
+        @WritesAttribute(attribute = "text.word.count", description = "The number of words present in the original FlowFile"),
+        @WritesAttribute(attribute = "text.character.count", description = "The number of characters (given the specified character encoding) present in the original FlowFile"),
+})
+@SeeAlso(SplitText.class)
+public class CountText extends AbstractProcessor {
+    private static final List<Charset> STANDARD_CHARSETS = Arrays.asList(StandardCharsets.UTF_8, StandardCharsets.US_ASCII, StandardCharsets.ISO_8859_1, StandardCharsets.UTF_16, StandardCharsets.UTF_16LE, StandardCharsets.UTF_16BE);
+
+    private static final String SYMBOL_REGEX = "\\s-\\._";
+    private static final String WHITESPACE_ONLY_REGEX = "\\s";
+
+    // Attribute keys
+    public static final String TEXT_LINE_COUNT = "text.line.count";
+    public static final String TEXT_LINE_NONEMPTY_COUNT = "text.line.nonempty.count";
+    public static final String TEXT_WORD_COUNT = "text.word.count";
+    public static final String TEXT_CHARACTER_COUNT = "text.character.count";
+
+
+    public static final PropertyDescriptor TEXT_LINE_COUNT_PD = new PropertyDescriptor.Builder()
+            .name("text-line-count")
+            .displayName("Text Line Count")
+            .description("If enabled, will count the number of lines present in the incoming text.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+    public static final PropertyDescriptor TEXT_LINE_NONEMPTY_COUNT_PD = new PropertyDescriptor.Builder()
+            .name("text-line-nonempty-count")
+            .displayName("Text Line (non-empty) Count")
+            .description("If enabled, will count the number of lines that contain a non-whitespace character present in the incoming text.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+    public static final PropertyDescriptor TEXT_WORD_COUNT_PD = new PropertyDescriptor.Builder()
+            .name("text-word-count")
+            .displayName("Text Word Count")
+            .description("If enabled, will count the number of words (alphanumeric character groups bounded by whitespace) present in the incoming text. Common logical delimiters [_-.] do not bound a word unless 'Split Words on Symbols' is true.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+    public static final PropertyDescriptor TEXT_CHARACTER_COUNT_PD = new PropertyDescriptor.Builder()
+            .name("text-character-count")
+            .displayName("Text Character Count")
+            .description("If enabled, will count the number of characters (including whitespace and symbols) present in the incoming text.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+    public static final PropertyDescriptor SPLIT_WORDS_ON_SYMBOLS_PD = new PropertyDescriptor.Builder()
+            .name("split-words-on-symbols")
+            .displayName("Split Words on Symbols")
+            .description("If enabled, the word count will identify strings separated by common logical delimiters [_-.] as independent words (ex. split-words-on-symbols = 4 words).")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+    // TODO: Stream map allowable values to name/key pair?
+    public static final PropertyDescriptor CHARACTER_ENCODING_PD = new PropertyDescriptor.Builder()
+            .name("character-encoding")
+            .displayName("Character Encoding")
+            .description("Specifies a character encoding to use.")
+            .required(true)
+            .allowableValues(getStandardCharsetNames())
+            .defaultValue(StandardCharsets.UTF_8.displayName())
+            .build();
+
+    private static Set<String> getStandardCharsetNames() {
+        return STANDARD_CHARSETS.stream().map(c -> c.displayName()).collect(Collectors.toSet());
+    }
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("The flowfile contains the original content with one or more attributes added containing the respective counts")
+            .build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("If the flowfile text cannot be counted for some reason, the original file will be routed to this destination and nothing will be routed elsewhere")
+            .build();
+
+    private static final List<PropertyDescriptor> properties;
+    private static final Set<Relationship> relationships;
+
+    static {
+        properties = Collections.unmodifiableList(Arrays.asList(TEXT_LINE_COUNT_PD,
+                TEXT_LINE_NONEMPTY_COUNT_PD,
+                TEXT_WORD_COUNT_PD,
+                TEXT_CHARACTER_COUNT_PD,
+                SPLIT_WORDS_ON_SYMBOLS_PD,
+                CHARACTER_ENCODING_PD));
+
+        relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_SUCCESS,
+                REL_FAILURE)));
+    }
+
+    private volatile boolean countLines;
+    private volatile boolean countLinesNonEmpty;
+    private volatile boolean countWords;
+    private volatile boolean countCharacters;
+    private volatile boolean splitWordsOnSymbols;
+    private volatile String characterEncoding;
+
+    private volatile int lineCount;
+    private volatile int lineNonEmptyCount;
+    private volatile int wordCount;
+    private volatile int characterCount;
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @OnScheduled
+    public void onSchedule(ProcessContext context) {
+        this.countLines = context.getProperty(TEXT_LINE_COUNT_PD).isSet()
+                ? context.getProperty(TEXT_LINE_COUNT_PD).asBoolean() : false;
+        this.countLinesNonEmpty = context.getProperty(TEXT_LINE_NONEMPTY_COUNT_PD).isSet()
+                ? context.getProperty(TEXT_LINE_NONEMPTY_COUNT_PD).asBoolean() : false;
+        this.countWords = context.getProperty(TEXT_WORD_COUNT_PD).isSet()
+                ? context.getProperty(TEXT_WORD_COUNT_PD).asBoolean() : false;
+        this.countCharacters = context.getProperty(TEXT_CHARACTER_COUNT_PD).isSet()
+                ? context.getProperty(TEXT_CHARACTER_COUNT_PD).asBoolean() : false;
+        this.splitWordsOnSymbols = context.getProperty(SPLIT_WORDS_ON_SYMBOLS_PD).isSet()
+                ? context.getProperty(SPLIT_WORDS_ON_SYMBOLS_PD).asBoolean() : false;
+        this.characterEncoding = context.getProperty(CHARACTER_ENCODING_PD).getValue();
+    }
+
+    /**
+     * Will split the incoming stream releasing all splits as FlowFile at once.
+     */
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession processSession) throws ProcessException {
+        FlowFile sourceFlowFile = processSession.get();
+        if (sourceFlowFile == null) {
+            return;
+        }
+        AtomicBoolean error = new AtomicBoolean();
+
+        processSession.read(sourceFlowFile, in -> {
+            long start = System.nanoTime();
+
+            // Iterate over the lines in the text input
+            try {
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(in, characterEncoding));
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    if (countLines) {
+                        lineCount++;
+                    }
+
+                    if (countLinesNonEmpty) {
+                        if (line.trim().length() > 0) {
+                            lineNonEmptyCount++;
+                        }
+                    }
+
+                    if (countWords) {
+                        wordCount += countWordsInLine(line, splitWordsOnSymbols);
+                    }
+
+                    if (countCharacters) {
+                        characterCount += line.length();
+                    }
+                }
+                long stop = System.nanoTime();
+                if (getLogger().isDebugEnabled()) {
+                    final long durationNanos = stop - start;
+                    DecimalFormat df = new DecimalFormat("#.###");
+                    getLogger().debug("Computed metrics in " + durationNanos + " nanoseconds (" + df.format(durationNanos / 1_000_000_000.0) + " seconds).");
+                }
+                getLogger().info("Counted {} lines, {} non-empty lines, {} words, {} characters", new Object[]{lineCount, lineNonEmptyCount, wordCount, characterCount});
+            } catch (IllegalStateException e) {
+                error.set(true);
+                getLogger().error(e.getMessage() + " Routing to failure.", e);
+            }
+        });
+
+        if (error.get()) {
+            processSession.transfer(sourceFlowFile, REL_FAILURE);
+        } else {
+            Map<String, String> metricAttributes = new HashMap<>();
+            if (countLines) {
+                metricAttributes.put(TEXT_LINE_COUNT, String.valueOf(lineCount));
+            }
+            if (countLinesNonEmpty) {
+                metricAttributes.put(TEXT_LINE_NONEMPTY_COUNT, String.valueOf(lineNonEmptyCount));
+            }
+            if (countWords) {
+                metricAttributes.put(TEXT_WORD_COUNT, String.valueOf(wordCount));
+            }
+            if (countCharacters) {
+                metricAttributes.put(TEXT_CHARACTER_COUNT, String.valueOf(characterCount));
+            }
+            FlowFile updatedFlowFile = processSession.putAllAttributes(sourceFlowFile, metricAttributes);
+            processSession.transfer(updatedFlowFile, REL_SUCCESS);
+        }
+    }
+
+    private int countWordsInLine(String line, boolean splitWordsOnSymbols) {
+        if (line == null || line.trim().length() == 0) {
+            return 0;
+        } else {
+            String regex = splitWordsOnSymbols ? SYMBOL_REGEX : WHITESPACE_ONLY_REGEX;
+            final String[] words = line.split(regex);
+            // TODO: Trim individual words before counting to eliminate whitespace words?
+            if (getLogger().isDebugEnabled()) {
+                getLogger().debug("Split " + line + " to [" + StringUtils.join(Arrays.asList(words), ", ") + "] (" + words.length + ")");
+            }
+            return words.length;
+        }
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
@@ -21,6 +21,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -236,7 +237,8 @@ public class CountText extends AbstractProcessor {
                     DecimalFormat df = new DecimalFormat("#.###");
                     getLogger().debug("Computed metrics in " + durationNanos + " nanoseconds (" + df.format(durationNanos / 1_000_000_000.0) + " seconds).");
                 }
-                getLogger().info("Counted {} lines, {} non-empty lines, {} words, {} characters", new Object[]{lineCount, lineNonEmptyCount, wordCount, characterCount});
+                String message = generateMetricsMessage();
+                getLogger().info(message);
             } catch (IllegalStateException e) {
                 error.set(true);
                 getLogger().error(e.getMessage() + " Routing to failure.", e);
@@ -264,6 +266,25 @@ public class CountText extends AbstractProcessor {
         }
     }
 
+    private String generateMetricsMessage() {
+        StringBuilder sb = new StringBuilder("Counted ");
+        List<String> metrics = new ArrayList<>();
+        if (countLines) {
+            metrics.add(lineCount + " lines");
+        }
+        if (countLinesNonEmpty) {
+            metrics.add(lineNonEmptyCount + " non-empty lines");
+        }
+        if (countWords) {
+            metrics.add(wordCount + " words");
+        }
+        if (countCharacters) {
+            metrics.add(characterCount + " characters");
+        }
+        sb.append(StringUtils.join(metrics, ", "));
+        return sb.toString();
+    }
+
     private int countWordsInLine(String line, boolean splitWordsOnSymbols) {
         if (line == null || line.trim().length() == 0) {
             return 0;
@@ -272,7 +293,7 @@ public class CountText extends AbstractProcessor {
             final String[] words = line.split(regex);
             // TODO: Trim individual words before counting to eliminate whitespace words?
             if (getLogger().isDebugEnabled()) {
-                getLogger().debug("Split " + line + " to [" + StringUtils.join(Arrays.asList(words), ", ") + "] (" + words.length + ")");
+                getLogger().debug("Split [" + line + "] to [" + StringUtils.join(Arrays.asList(words), ", ") + "] (" + words.length + ")");
             }
             return words.length;
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -19,6 +19,7 @@ org.apache.nifi.processors.standard.ControlRate
 org.apache.nifi.processors.standard.ConvertCharacterSet
 org.apache.nifi.processors.standard.ConvertJSONToSQL
 org.apache.nifi.processors.standard.ConvertRecord
+org.apache.nifi.processors.standard.CountText
 org.apache.nifi.processors.standard.DebugFlow
 org.apache.nifi.processors.standard.DetectDuplicate
 org.apache.nifi.processors.standard.DistributeLoad

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/CountTextTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/CountTextTest.groovy
@@ -123,7 +123,7 @@ And the mome raths outgrabe."""
     void testShouldCountEachMetric() throws Exception {
         // Arrange
         final TestRunner runner = TestRunners.newTestRunner(CountText.class)
-        String INPUT_TEXT = new File("src/test/resources/TestCountText/jabberwocky.txt")
+        String INPUT_TEXT = new File("src/test/resources/TestCountText/jabberwocky.txt").text
 
         final def EXPECTED_VALUES = [
                 "text.line.count"         : 34,
@@ -164,10 +164,39 @@ And the mome raths outgrabe."""
             logger.info("Generated flowfile: ${flowFile} | ${flowFile.attributes}")
             EXPECTED_VALUES.each { key, value ->
                 if (flowFile.attributes.containsKey(key)) {
-                    assert EXPECTED_VALUES.get(key) == value
+                    assert flowFile.attributes.get(key) == value as String
                 }
             }
         }
+    }
+
+    @Test
+    void testShouldCountWordsSplitOnSymbol() throws Exception {
+        // Arrange
+        final TestRunner runner = TestRunners.newTestRunner(CountText.class)
+        String INPUT_TEXT = new File("src/test/resources/TestCountText/jabberwocky.txt").text
+
+        final int EXPECTED_WORD_COUNT = 167
+
+        // Reset the processor properties
+        runner.setProperty(CountText.TEXT_LINE_COUNT_PD, "false")
+        runner.setProperty(CountText.TEXT_LINE_NONEMPTY_COUNT_PD, "false")
+        runner.setProperty(CountText.TEXT_WORD_COUNT_PD, "true")
+        runner.setProperty(CountText.TEXT_CHARACTER_COUNT_PD, "false")
+        runner.setProperty(CountText.SPLIT_WORDS_ON_SYMBOLS_PD, "true")
+
+        runner.clearProvenanceEvents()
+        runner.clearTransferState()
+        runner.enqueue(INPUT_TEXT.bytes)
+
+        // Act
+        runner.run()
+
+        // Assert
+        runner.assertAllFlowFilesTransferred(CountText.REL_SUCCESS, 1)
+        FlowFile flowFile = runner.getFlowFilesForRelationship(CountText.REL_SUCCESS).first()
+        logger.info("Generated flowfile: ${flowFile} | ${flowFile.attributes}")
+        assert flowFile.attributes.get(CountText.TEXT_WORD_COUNT) == EXPECTED_WORD_COUNT as String
     }
 
     @Ignore("Not yet implemented")

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/CountTextTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/CountTextTest.groovy
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License") you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard
+
+import org.apache.nifi.components.ValidationResult
+import org.apache.nifi.flowfile.FlowFile
+import org.apache.nifi.security.util.EncryptionMethod
+import org.apache.nifi.security.util.KeyDerivationFunction
+import org.apache.nifi.security.util.crypto.PasswordBasedEncryptor
+import org.apache.nifi.util.MockProcessContext
+import org.apache.nifi.util.TestRunner
+import org.apache.nifi.util.TestRunners
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.security.Security
+
+@RunWith(JUnit4.class)
+class CountTextTest extends GroovyTestCase {
+    private static final Logger logger = LoggerFactory.getLogger(CountTextTest.class)
+
+    @BeforeClass
+    static void setUpOnce() throws Exception {
+        Security.addProvider(new BouncyCastleProvider())
+
+        logger.metaClass.methodMissing = { String name, args ->
+            logger.info("[${name?.toUpperCase()}] ${(args as List).join(" ")}")
+        }
+    }
+
+    @Before
+    void setUp() throws Exception {
+    }
+
+    @After
+    void tearDown() throws Exception {
+    }
+
+    @Test
+    void testShouldCountAllMetrics() throws Exception {
+        // Arrange
+        final TestRunner runner = TestRunners.newTestRunner(CountText.class)
+        Collection<ValidationResult> results
+        MockProcessContext pc
+
+        runner.setProperty(CountText.TEXT_LINE_COUNT_PD, "true")
+        runner.setProperty(CountText.TEXT_LINE_NONEMPTY_COUNT_PD, "true")
+        runner.setProperty(CountText.TEXT_WORD_COUNT_PD, "true")
+        runner.setProperty(CountText.TEXT_CHARACTER_COUNT_PD, "true")
+
+        String INPUT_TEXT = """’Twas brillig, and the slithy toves
+Did gyre and gimble in the wade;
+All mimsy were the borogoves,
+And the mome raths outgrabe.
+
+"Beware the Jabberwock, my son!
+The jaws that bite, the claws that catch!
+Beware the Jubjub bird, and shun
+The frumious Bandersnatch!"
+
+He took his vorpal sword in hand:
+Long time the manxome foe he sought—
+So rested he by the Tumtum tree,
+And stood awhile in thought.
+
+And as in uffish thought he stood,
+The Jabberwock, with eyes of flame,
+Came whiffling through the tulgey wood.
+And burbled as it came!
+
+One, two! One, two! And through and through
+The vorpal blade went snicker-snack!
+He left it dead, and with its head
+He went galumphing back.
+
+"And hast thou slain the Jabberwock?
+Come to my arms, my beamish boy!
+O frabjous day! Callooh! Callay!"
+He chortled in his joy.
+
+’Twas brillig, and the slithy toves
+Did gyre and gimble in the wabe;
+All mimsy were the borogoves,
+And the mome raths outgrabe."""
+
+        runner.enqueue(INPUT_TEXT.bytes)
+        pc = (MockProcessContext) runner.getProcessContext()
+
+        // Act
+        runner.run()
+
+        // Assert
+       runner.assertAllFlowFilesTransferred(CountText.REL_SUCCESS, 1)
+        FlowFile flowFile = runner.getFlowFilesForRelationship(CountText.REL_SUCCESS).first()
+        assert flowFile.attributes."text.line.count" == 34 as String
+        assert flowFile.attributes."text.line.nonempty.count" == 28 as String
+        assert flowFile.attributes."text.word.count" == 166 as String
+        assert flowFile.attributes."text.character.count" == 933 as String
+    }
+
+    @Ignore("Not yet implemented")
+    @Test
+    void testShouldValidateCharacterEncodings() throws Exception {
+        // Arrange
+        final TestRunner runner = TestRunners.newTestRunner(EncryptContent.class)
+        Collection<ValidationResult> results
+        MockProcessContext pc
+
+        EncryptionMethod encryptionMethod = EncryptionMethod.AES_CBC
+
+        // Integer.MAX_VALUE or 128, so use 256 or 128
+        final int MAX_KEY_LENGTH = [PasswordBasedEncryptor.getMaxAllowedKeyLength(encryptionMethod.algorithm), 256].min()
+        final String TOO_LONG_KEY_HEX = "ab" * (MAX_KEY_LENGTH / 8 + 1)
+        logger.info("Using key ${TOO_LONG_KEY_HEX} (${TOO_LONG_KEY_HEX.length() * 4} bits)")
+
+        runner.setProperty(EncryptContent.MODE, EncryptContent.ENCRYPT_MODE)
+        runner.setProperty(EncryptContent.ENCRYPTION_ALGORITHM, encryptionMethod.name())
+        runner.setProperty(EncryptContent.KEY_DERIVATION_FUNCTION, KeyDerivationFunction.NONE.name())
+        runner.setProperty(EncryptContent.RAW_KEY_HEX, TOO_LONG_KEY_HEX)
+
+        runner.enqueue(new byte[0])
+        pc = (MockProcessContext) runner.getProcessContext()
+
+        // Act
+        results = pc.validate()
+
+        // Assert
+        Assert.assertEquals(1, results.size())
+        logger.expected(results)
+        ValidationResult vr = results.first()
+
+        String expectedResult = "'raw-key-hex' is invalid because Key must be valid length [128, 192, 256]"
+        String message = "'" + vr.toString() + "' contains '" + expectedResult + "'"
+        Assert.assertTrue(message, vr.toString().contains(expectedResult))
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestCountText/jabberwocky.txt
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestCountText/jabberwocky.txt
@@ -1,0 +1,34 @@
+’Twas brillig, and the slithy toves
+Did gyre and gimble in the wade;
+All mimsy were the borogoves,
+And the mome raths outgrabe.
+
+"Beware the Jabberwock, my son!
+The jaws that bite, the claws that catch!
+Beware the Jubjub bird, and shun
+The frumious Bandersnatch!"
+
+He took his vorpal sword in hand:
+Long time the manxome foe he sought—
+So rested he by the Tumtum tree,
+And stood awhile in thought.
+
+And as in uffish thought he stood,
+The Jabberwock, with eyes of flame,
+Came whiffling through the tulgey wood.
+And burbled as it came!
+
+One, two! One, two! And through and through
+The vorpal blade went snicker-snack!
+He left it dead, and with its head
+He went galumphing back.
+
+"And hast thou slain the Jabberwock?
+Come to my arms, my beamish boy!
+O frabjous day! Callooh! Callay!"
+He chortled in his joy.
+
+’Twas brillig, and the slithy toves
+Did gyre and gimble in the wabe;
+All mimsy were the borogoves,
+And the mome raths outgrabe.


### PR DESCRIPTION
This new processor performs basic text metrics on incoming flowfile content (line count, non-empty line count, word count, and character count). Each metric is independent, and word count can be configured to accept or split on symbol boundaries. 

The performance is fairly decent (a document with ~370k lines / words ~= 80 - 90 ms on a commodity laptop) and handles the text in a streaming manner so as not to damage the heap. 

A sample flow.xml.gz is [posted here](https://gist.github.com/alopresto/86eb04437c079cf2a48e2aeadf2df7c0) to allow for local testing (relying on a locally downloaded file or an HTTP GET to a GitHub hosted file). 

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
