### PR TITLE
NIFI-4739: Ensure logout action is using a relative URL

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-header-controller.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-header-controller.js
@@ -118,7 +118,7 @@
             this.logoutCtrl = {
                 logout: function () {
                     nfStorage.removeItem("jwt");
-                    window.location = '/nifi';
+                    window.location = '../nifi/login';
                 }
             };
         }


### PR DESCRIPTION
NIFI-4739:
- Ensuring the logout action is using a relative link.