### PR TITLE
NIFI-4740 Fix User Group Data Integrity Checks

### DIFF
--- a/nifi-framework-api/src/main/java/org/apache/nifi/authorization/UserAndGroups.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/authorization/UserAndGroups.java
@@ -24,6 +24,21 @@ import java.util.Set;
 public interface UserAndGroups {
 
     /**
+     * A static, immutable, empty implementation of the UserAndGroups interface.
+     */
+    UserAndGroups EMPTY = new UserAndGroups() {
+        @Override
+        public User getUser() {
+            return null;
+        }
+
+        @Override
+        public Set<Group> getGroups() {
+            return null;
+        }
+    };
+
+    /**
      * Retrieves the user, or null if the user is unknown
      *
      * @return the user with the given identity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/main/java/org/apache/nifi/authorization/FileUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/main/java/org/apache/nifi/authorization/FileUserGroupProvider.java
@@ -331,9 +331,6 @@ public class FileUserGroupProvider implements ConfigurableUserGroupProvider {
         final UserGroupHolder holder = userGroupHolder.get();
         final Tenants tenants = holder.getTenants();
 
-        // determine that all users in the group exist before doing anything, throw an exception if they don't
-        checkGroupUsers(group, tenants.getUsers().getUser());
-
         // create a new JAXB Group based on the incoming Group
         final org.apache.nifi.authorization.file.tenants.generated.Group jaxbGroup = new org.apache.nifi.authorization.file.tenants.generated.Group();
         jaxbGroup.setIdentifier(group.getIdentifier());
@@ -599,25 +596,6 @@ public class FileUserGroupProvider implements ConfigurableUserGroupProvider {
         jaxbUser.setIdentifier(user.getIdentifier());
         jaxbUser.setIdentity(user.getIdentity());
         return jaxbUser;
-    }
-
-    private Set<org.apache.nifi.authorization.file.tenants.generated.User> checkGroupUsers(final Group group, final List<org.apache.nifi.authorization.file.tenants.generated.User> users) {
-        final Set<org.apache.nifi.authorization.file.tenants.generated.User> jaxbUsers = new HashSet<>();
-        for (String groupUser : group.getUsers()) {
-            boolean found = false;
-            for (org.apache.nifi.authorization.file.tenants.generated.User jaxbUser : users) {
-                if (jaxbUser.getIdentifier().equals(groupUser)) {
-                    jaxbUsers.add(jaxbUser);
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
-                throw new IllegalStateException("Unable to add group because user " + groupUser + " does not exist");
-            }
-        }
-        return jaxbUsers;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/test/java/org/apache/nifi/authorization/FileAuthorizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/test/java/org/apache/nifi/authorization/FileAuthorizerTest.java
@@ -1150,7 +1150,7 @@ public class FileAuthorizerTest {
         assertEquals(3, groups.size());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testAddGroupWhenUserDoesNotExist() throws Exception {
         writeFile(primaryAuthorizations, EMPTY_AUTHORIZATIONS);
         writeFile(primaryTenants, EMPTY_TENANTS);
@@ -1164,6 +1164,8 @@ public class FileAuthorizerTest {
                 .build();
 
         authorizer.addGroup(group);
+
+        assertEquals(1, authorizer.getGroups().size());
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/test/java/org/apache/nifi/authorization/FileUserGroupProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/test/java/org/apache/nifi/authorization/FileUserGroupProviderTest.java
@@ -551,7 +551,7 @@ public class FileUserGroupProviderTest {
         assertEquals(3, groups.size());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testAddGroupWhenUserDoesNotExist() throws Exception {
         writeFile(primaryTenants, EMPTY_TENANTS);
         userGroupProvider.onConfigured(configurationContext);
@@ -564,6 +564,7 @@ public class FileUserGroupProviderTest {
                 .build();
 
         userGroupProvider.addGroup(group);
+        assertEquals(1, userGroupProvider.getGroups().size());
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/CompositeUserAndGroups.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/CompositeUserAndGroups.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class CompositeUserAndGroups implements UserAndGroups {
+
+    private User user;
+    private Set<Group> groups;
+
+    public CompositeUserAndGroups() {
+        this.user = null;
+        this.groups = null;
+    }
+
+    public CompositeUserAndGroups(User user, Set<Group> groups) {
+        this.user = user;
+        setGroups(groups);
+    }
+
+    @Override
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Set<Group> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<Group> groups) {
+        // copy the collection so that if we add to this collection it does not modify other references
+        if (groups != null) {
+            this.groups = new HashSet<>(groups);
+        } else {
+            this.groups = null;
+        }
+    }
+
+    public void addAllGroups(Set<Group> groups) {
+        if (groups != null) {
+            if (this.groups == null) {
+                this.groups = new HashSet<>();
+            }
+            this.groups.addAll(groups);
+        }
+    }
+
+    public void addGroup(Group group) {
+        if (group != null) {
+            if (this.groups == null) {
+                this.groups = new HashSet<>();
+            }
+            this.groups.add(group);
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/CompositeConfigurableUserGroupProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/CompositeConfigurableUserGroupProviderTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CompositeConfigurableUserGroupProviderTest extends CompositeUserGroupProviderTest {
+public class CompositeConfigurableUserGroupProviderTest extends CompositeUserGroupProviderTestBase {
 
     public static final String USER_5_IDENTIFIER = "user-identifier-5";
     public static final String USER_5_IDENTITY = "user-identity-5";
@@ -99,7 +99,7 @@ public class CompositeConfigurableUserGroupProviderTest extends CompositeUserGro
 
         // users and groups
         assertEquals(3, userGroupProvider.getUsers().size());
-        assertEquals(1, userGroupProvider.getGroups().size());
+        assertEquals(2, userGroupProvider.getGroups().size());
 
         // unknown
         assertNull(userGroupProvider.getUser(NOT_A_REAL_USER_IDENTIFIER));
@@ -111,8 +111,49 @@ public class CompositeConfigurableUserGroupProviderTest extends CompositeUserGro
         assertNull(unknownUserAndGroups.getGroups());
 
         // providers
-        testConfigurableUserGroupProvider(userGroupProvider);
-        testConflictingUserGroupProvider(userGroupProvider);
+        try {
+            testConfigurableUserGroupProvider(userGroupProvider);
+            assertTrue("Should never get here as we expect the line above to throw an exception", false);
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertTrue(e.getMessage().contains(USER_1_IDENTITY));
+        }
+
+        try {
+            testConflictingUserGroupProvider(userGroupProvider);
+            assertTrue("Should never get here as we expect the line above to throw an exception", false);
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertTrue(e.getMessage().contains(USER_1_IDENTITY));
+        }
+    }
+
+    @Test
+    public void testConfigurableUserGroupProviderWithCollaboratingUserGroupProvider() throws Exception {
+        final UserGroupProvider userGroupProvider = initCompositeUserGroupProvider(new CompositeConfigurableUserGroupProvider(), lookup -> {
+            when(lookup.getUserGroupProvider(eq(CONFIGURABLE_USER_GROUP_PROVIDER))).thenReturn(getConfigurableUserGroupProvider());
+        }, configurationContext -> {
+            when(configurationContext.getProperty(PROP_CONFIGURABLE_USER_GROUP_PROVIDER)).thenReturn(new StandardPropertyValue(CONFIGURABLE_USER_GROUP_PROVIDER, null));
+        }, getCollaboratingUserGroupProvider());
+
+        // users and groups
+        assertEquals(3, userGroupProvider.getUsers().size());
+        assertEquals(2, userGroupProvider.getGroups().size());
+
+        // unknown
+        assertNull(userGroupProvider.getUser(NOT_A_REAL_USER_IDENTIFIER));
+        assertNull(userGroupProvider.getUserByIdentity(NOT_A_REAL_USER_IDENTITY));
+
+        final UserAndGroups unknownUserAndGroups = userGroupProvider.getUserAndGroups(NOT_A_REAL_USER_IDENTITY);
+        assertNotNull(unknownUserAndGroups);
+        assertNull(unknownUserAndGroups.getUser());
+        assertNull(unknownUserAndGroups.getGroups());
+
+        // providers
+        final UserAndGroups user1AndGroups = userGroupProvider.getUserAndGroups(USER_1_IDENTITY);
+        assertNotNull(user1AndGroups);
+        assertNotNull(user1AndGroups.getUser());
+        assertEquals(2, user1AndGroups.getGroups().size()); // from CollaboratingUGP
     }
 
     private UserGroupProvider getConfigurableUserGroupProvider() {
@@ -122,7 +163,7 @@ public class CompositeConfigurableUserGroupProviderTest extends CompositeUserGro
         ).collect(Collectors.toSet());
 
         final Set<Group> groups = Stream.of(
-                new Group.Builder().identifier(GROUP_2_IDENTIFIER).name(GROUP_2_NAME).addUser(USER_1_IDENTIFIER).build()
+                new Group.Builder().identifier(GROUP_1_IDENTIFIER).name(GROUP_1_NAME).addUser(USER_1_IDENTIFIER).build()
         ).collect(Collectors.toSet());
 
         return new SimpleConfigurableUserGroupProvider(users, groups);
@@ -145,7 +186,7 @@ public class CompositeConfigurableUserGroupProviderTest extends CompositeUserGro
         assertNotNull(user5AndGroups.getUser());
         assertTrue(user5AndGroups.getGroups().isEmpty());
 
-        assertNotNull(userGroupProvider.getGroup(GROUP_2_IDENTIFIER));
-        assertEquals(1, userGroupProvider.getGroup(GROUP_2_IDENTIFIER).getUsers().size());
+        assertNotNull(userGroupProvider.getGroup(GROUP_1_IDENTIFIER));
+        assertEquals(1, userGroupProvider.getGroup(GROUP_1_IDENTIFIER).getUsers().size());
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/CompositeUserGroupProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/CompositeUserGroupProviderTest.java
@@ -18,15 +18,7 @@ package org.apache.nifi.authorization;
 
 import org.apache.nifi.attribute.expression.language.StandardPropertyValue;
 import org.apache.nifi.authorization.exception.AuthorizerCreationException;
-import org.apache.nifi.components.PropertyValue;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.nifi.authorization.CompositeUserGroupProvider.PROP_USER_GROUP_PROVIDER_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -37,28 +29,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CompositeUserGroupProviderTest {
-
-    public static final String USER_1_IDENTIFIER = "user-identifier-1";
-    public static final String USER_1_IDENTITY = "user-identity-1";
-
-    public static final String USER_2_IDENTIFIER = "user-identifier-2";
-    public static final String USER_2_IDENTITY = "user-identity-2";
-
-    public static final String USER_3_IDENTIFIER = "user-identifier-3";
-    public static final String USER_3_IDENTITY = "user-identity-3";
-
-    public static final String USER_4_IDENTIFIER = "user-identifier-4";
-    public static final String USER_4_IDENTITY = "user-identity-4";
-
-    public static final String GROUP_1_IDENTIFIER = "group-identifier-1";
-    public static final String GROUP_1_NAME = "group-name-1";
-
-    public static final String GROUP_2_IDENTIFIER = "group-identifier-2";
-    public static final String GROUP_2_NAME = "group-name-2";
-
-    public static final String NOT_A_REAL_USER_IDENTIFIER = "not-a-real-user-identifier";
-    public static final String NOT_A_REAL_USER_IDENTITY = "not-a-real-user-identity";
+public class CompositeUserGroupProviderTest extends CompositeUserGroupProviderTestBase {
 
     @Test(expected = AuthorizerCreationException.class)
     public void testNoConfiguredProviders() throws Exception {
@@ -154,148 +125,49 @@ public class CompositeUserGroupProviderTest {
         assertNull(unknownUserAndGroups.getGroups());
 
         // providers
-        testUserGroupProviderOne(userGroupProvider);
         testUserGroupProviderTwo(userGroupProvider);
-        testConflictingUserGroupProvider(userGroupProvider);
+
+        try {
+            testUserGroupProviderOne(userGroupProvider);
+            assertTrue("Should never get here as we expect the line above to throw an exception", false);
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertTrue(e.getMessage().contains(USER_1_IDENTITY));
+        }
+
+        try {
+            testConflictingUserGroupProvider(userGroupProvider);
+            assertTrue("Should never get here as we expect the line above to throw an exception", false);
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertTrue(e.getMessage().contains(USER_1_IDENTITY));
+        }
     }
 
-    protected UserGroupProvider getUserGroupProviderOne() {
-        final Set<User> users = Stream.of(
-                new User.Builder().identifier(USER_1_IDENTIFIER).identity(USER_1_IDENTITY).build(),
-                new User.Builder().identifier(USER_2_IDENTIFIER).identity(USER_2_IDENTITY).build()
-        ).collect(Collectors.toSet());
+    @Test
+    public void testMultipleProvidersWithCollaboratingUserGroupProvider() throws Exception {
+        final UserGroupProvider userGroupProvider = initCompositeUserGroupProvider(new CompositeUserGroupProvider(), null, null,
+                getUserGroupProviderOne(), getUserGroupProviderTwo(), getCollaboratingUserGroupProvider());
 
-        final Set<Group> groups = Stream.of(
-                new Group.Builder().identifier(GROUP_1_IDENTIFIER).name(GROUP_1_NAME).addUser(USER_1_IDENTIFIER).build()
-        ).collect(Collectors.toSet());
+        // users and groups
+        assertEquals(4, userGroupProvider.getUsers().size());
+        assertEquals(2, userGroupProvider.getGroups().size());
 
-        return new SimpleUserGroupProvider(users, groups);
-    }
+        // unknown
+        assertNull(userGroupProvider.getUser(NOT_A_REAL_USER_IDENTIFIER));
+        assertNull(userGroupProvider.getUserByIdentity(NOT_A_REAL_USER_IDENTITY));
 
-    protected void testUserGroupProviderOne(final UserGroupProvider userGroupProvider) {
-        // users
-        assertNotNull(userGroupProvider.getUser(USER_1_IDENTIFIER));
-        assertNotNull(userGroupProvider.getUserByIdentity(USER_1_IDENTITY));
+        final UserAndGroups unknownUserAndGroups = userGroupProvider.getUserAndGroups(NOT_A_REAL_USER_IDENTITY);
+        assertNotNull(unknownUserAndGroups);
+        assertNull(unknownUserAndGroups.getUser());
+        assertNull(unknownUserAndGroups.getGroups());
 
-        assertNotNull(userGroupProvider.getUser(USER_2_IDENTIFIER));
-        assertNotNull(userGroupProvider.getUserByIdentity(USER_2_IDENTITY));
+        // providers
+        testUserGroupProviderTwo(userGroupProvider);
 
         final UserAndGroups user1AndGroups = userGroupProvider.getUserAndGroups(USER_1_IDENTITY);
         assertNotNull(user1AndGroups);
         assertNotNull(user1AndGroups.getUser());
-        assertEquals(1, user1AndGroups.getGroups().size());
-
-        final UserAndGroups user2AndGroups = userGroupProvider.getUserAndGroups(USER_2_IDENTITY);
-        assertNotNull(user2AndGroups);
-        assertNotNull(user2AndGroups.getUser());
-        assertTrue(user2AndGroups.getGroups().isEmpty());
-
-        // groups
-        assertNotNull(userGroupProvider.getGroup(GROUP_1_IDENTIFIER));
-        assertEquals(1, userGroupProvider.getGroup(GROUP_1_IDENTIFIER).getUsers().size());
-    }
-
-    protected UserGroupProvider getUserGroupProviderTwo() {
-        final Set<User> users = Stream.of(
-                new User.Builder().identifier(USER_3_IDENTIFIER).identity(USER_3_IDENTITY).build()
-        ).collect(Collectors.toSet());
-
-        final Set<Group> groups = Stream.of(
-                new Group.Builder().identifier(GROUP_2_IDENTIFIER).name(GROUP_2_NAME).addUser(USER_3_IDENTIFIER).build()
-        ).collect(Collectors.toSet());
-
-        return new SimpleUserGroupProvider(users, groups);
-    }
-
-    protected void testUserGroupProviderTwo(final UserGroupProvider userGroupProvider) {
-        // users
-        assertNotNull(userGroupProvider.getUser(USER_3_IDENTIFIER));
-        assertNotNull(userGroupProvider.getUserByIdentity(USER_3_IDENTITY));
-
-        final UserAndGroups user3AndGroups = userGroupProvider.getUserAndGroups(USER_3_IDENTITY);
-        assertNotNull(user3AndGroups);
-        assertNotNull(user3AndGroups.getUser());
-        assertEquals(1, user3AndGroups.getGroups().size());
-
-        // groups
-        assertNotNull(userGroupProvider.getGroup(GROUP_2_IDENTIFIER));
-        assertEquals(1, userGroupProvider.getGroup(GROUP_2_IDENTIFIER).getUsers().size());
-    }
-
-    protected UserGroupProvider getConflictingUserGroupProvider() {
-        final Set<User> users = Stream.of(
-                new User.Builder().identifier(USER_1_IDENTIFIER).identity(USER_1_IDENTITY).build(),
-                new User.Builder().identifier(USER_4_IDENTIFIER).identity(USER_4_IDENTITY).build()
-        ).collect(Collectors.toSet());
-
-        final Set<Group> groups = Stream.of(
-                new Group.Builder().identifier(GROUP_2_IDENTIFIER).name(GROUP_2_NAME).addUser(USER_1_IDENTIFIER).addUser(USER_4_IDENTIFIER).build()
-        ).collect(Collectors.toSet());
-
-        return new SimpleUserGroupProvider(users, groups);
-    }
-
-    protected void testConflictingUserGroupProvider(final UserGroupProvider userGroupProvider) {
-        assertNotNull(userGroupProvider.getUser(USER_4_IDENTIFIER));
-        assertNotNull(userGroupProvider.getUserByIdentity(USER_4_IDENTITY));
-    }
-
-    private void mockProperties(final AuthorizerConfigurationContext configurationContext) {
-        when(configurationContext.getProperties()).then((invocation) -> {
-            final Map<String, String> properties = new HashMap<>();
-
-            int i = 1;
-            while (true) {
-                final String key = PROP_USER_GROUP_PROVIDER_PREFIX + i++;
-                final PropertyValue value = configurationContext.getProperty(key);
-                if (value == null) {
-                    break;
-                } else {
-                    properties.put(key, value.getValue());
-                }
-            }
-
-            return properties;
-        });
-    }
-
-    protected UserGroupProvider initCompositeUserGroupProvider(
-            final CompositeUserGroupProvider compositeUserGroupProvider, final Consumer<UserGroupProviderLookup> lookupConsumer,
-            final Consumer<AuthorizerConfigurationContext> configurationContextConsumer, final UserGroupProvider... providers) {
-
-        // initialization
-        final UserGroupProviderLookup lookup = mock(UserGroupProviderLookup.class);
-
-        for (int i = 1; i <= providers.length; i++) {
-            when(lookup.getUserGroupProvider(eq(String.valueOf(i)))).thenReturn(providers[i - 1]);
-        }
-
-        // allow callers to mock additional providers
-        if (lookupConsumer != null) {
-            lookupConsumer.accept(lookup);
-        }
-
-        final UserGroupProviderInitializationContext initializationContext = mock(UserGroupProviderInitializationContext.class);
-        when(initializationContext.getUserGroupProviderLookup()).thenReturn(lookup);
-
-        compositeUserGroupProvider.initialize(initializationContext);
-
-        // configuration
-        final AuthorizerConfigurationContext configurationContext = mock(AuthorizerConfigurationContext.class);
-
-        for (int i = 1; i <= providers.length; i++) {
-            when(configurationContext.getProperty(eq(PROP_USER_GROUP_PROVIDER_PREFIX + i))).thenReturn(new StandardPropertyValue(String.valueOf(i), null));
-        }
-
-        // allow callers to mock additional properties
-        if (configurationContextConsumer != null) {
-            configurationContextConsumer.accept(configurationContext);
-        }
-
-        mockProperties(configurationContext);
-
-        compositeUserGroupProvider.onConfigured(configurationContext);
-
-        return compositeUserGroupProvider;
+        assertEquals(2, user1AndGroups.getGroups().size()); // from UGP1 and CollaboratingUGP
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/CompositeUserGroupProviderTestBase.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/CompositeUserGroupProviderTestBase.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization;
+
+import org.apache.nifi.attribute.expression.language.StandardPropertyValue;
+import org.apache.nifi.components.PropertyValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.nifi.authorization.CompositeUserGroupProvider.PROP_USER_GROUP_PROVIDER_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CompositeUserGroupProviderTestBase {
+
+    public static final String USER_1_IDENTIFIER = "user-identifier-1";
+    public static final String USER_1_IDENTITY = "user-identity-1";
+
+    public static final String USER_2_IDENTIFIER = "user-identifier-2";
+    public static final String USER_2_IDENTITY = "user-identity-2";
+
+    public static final String USER_3_IDENTIFIER = "user-identifier-3";
+    public static final String USER_3_IDENTITY = "user-identity-3";
+
+    public static final String USER_4_IDENTIFIER = "user-identifier-4";
+    public static final String USER_4_IDENTITY = "user-identity-4";
+
+    public static final String GROUP_1_IDENTIFIER = "group-identifier-1";
+    public static final String GROUP_1_NAME = "group-name-1";
+
+    public static final String GROUP_2_IDENTIFIER = "group-identifier-2";
+    public static final String GROUP_2_NAME = "group-name-2";
+
+    public static final String NOT_A_REAL_USER_IDENTIFIER = "not-a-real-user-identifier";
+    public static final String NOT_A_REAL_USER_IDENTITY = "not-a-real-user-identity";
+
+    protected UserGroupProvider getUserGroupProviderOne() {
+        final Set<User> users = Stream.of(
+                new User.Builder().identifier(USER_1_IDENTIFIER).identity(USER_1_IDENTITY).build(),
+                new User.Builder().identifier(USER_2_IDENTIFIER).identity(USER_2_IDENTITY).build()
+        ).collect(Collectors.toSet());
+
+        final Set<Group> groups = Stream.of(
+                new Group.Builder().identifier(GROUP_1_IDENTIFIER).name(GROUP_1_NAME).addUser(USER_1_IDENTIFIER).build()
+        ).collect(Collectors.toSet());
+
+        return new SimpleUserGroupProvider(users, groups);
+    }
+
+    protected void testUserGroupProviderOne(final UserGroupProvider userGroupProvider) {
+        // users
+        assertNotNull(userGroupProvider.getUser(USER_1_IDENTIFIER));
+        assertNotNull(userGroupProvider.getUserByIdentity(USER_1_IDENTITY));
+
+        assertNotNull(userGroupProvider.getUser(USER_2_IDENTIFIER));
+        assertNotNull(userGroupProvider.getUserByIdentity(USER_2_IDENTITY));
+
+        // When used with ConflictingUserGroupProvider, we expect the line below to throw IllegalStateException
+        final UserAndGroups user1AndGroups = userGroupProvider.getUserAndGroups(USER_1_IDENTITY);
+        assertNotNull(user1AndGroups);
+        assertNotNull(user1AndGroups.getUser());
+        assertEquals(1, user1AndGroups.getGroups().size());
+
+        final UserAndGroups user2AndGroups = userGroupProvider.getUserAndGroups(USER_2_IDENTITY);
+        assertNotNull(user2AndGroups);
+        assertNotNull(user2AndGroups.getUser());
+        assertTrue(user2AndGroups.getGroups().isEmpty());
+
+        // groups
+        assertNotNull(userGroupProvider.getGroup(GROUP_1_IDENTIFIER));
+        assertEquals(1, userGroupProvider.getGroup(GROUP_1_IDENTIFIER).getUsers().size());
+    }
+
+    protected UserGroupProvider getUserGroupProviderTwo() {
+        final Set<User> users = Stream.of(
+                new User.Builder().identifier(USER_3_IDENTIFIER).identity(USER_3_IDENTITY).build()
+        ).collect(Collectors.toSet());
+
+        final Set<Group> groups = Stream.of(
+                new Group.Builder().identifier(GROUP_2_IDENTIFIER).name(GROUP_2_NAME).addUser(USER_3_IDENTIFIER).build()
+        ).collect(Collectors.toSet());
+
+        return new SimpleUserGroupProvider(users, groups);
+    }
+
+    protected void testUserGroupProviderTwo(final UserGroupProvider userGroupProvider) {
+        // users
+        assertNotNull(userGroupProvider.getUser(USER_3_IDENTIFIER));
+        assertNotNull(userGroupProvider.getUserByIdentity(USER_3_IDENTITY));
+
+        final UserAndGroups user3AndGroups = userGroupProvider.getUserAndGroups(USER_3_IDENTITY);
+        assertNotNull(user3AndGroups);
+        assertNotNull(user3AndGroups.getUser());
+        assertEquals(1, user3AndGroups.getGroups().size());
+
+        // groups
+        assertNotNull(userGroupProvider.getGroup(GROUP_2_IDENTIFIER));
+        assertEquals(1, userGroupProvider.getGroup(GROUP_2_IDENTIFIER).getUsers().size());
+    }
+
+    protected UserGroupProvider getConflictingUserGroupProvider() {
+        final Set<User> users = Stream.of(
+                new User.Builder().identifier(USER_1_IDENTIFIER).identity(USER_1_IDENTITY).build(),
+                new User.Builder().identifier(USER_4_IDENTIFIER).identity(USER_4_IDENTITY).build()
+        ).collect(Collectors.toSet());
+
+        final Set<Group> groups = Stream.of(
+                new Group.Builder().identifier(GROUP_2_IDENTIFIER).name(GROUP_2_NAME).addUser(USER_1_IDENTIFIER).addUser(USER_4_IDENTIFIER).build()
+        ).collect(Collectors.toSet());
+
+        return new SimpleUserGroupProvider(users, groups);
+    }
+
+    protected void testConflictingUserGroupProvider(final UserGroupProvider userGroupProvider) {
+        assertNotNull(userGroupProvider.getUser(USER_4_IDENTIFIER));
+        assertNotNull(userGroupProvider.getUserByIdentity(USER_4_IDENTITY));
+
+        assertNotNull(userGroupProvider.getUser(USER_1_IDENTIFIER));
+        assertNotNull(userGroupProvider.getUserByIdentity(USER_1_IDENTITY));
+
+        // When used with UserGroupProviderOne, we expect the line below to throw IllegalStateException
+        final UserAndGroups user1AndGroups = userGroupProvider.getUserAndGroups(USER_1_IDENTITY);
+        assertNotNull(user1AndGroups);
+        assertNotNull(user1AndGroups.getUser());
+        assertEquals(1, user1AndGroups.getGroups().size());
+    }
+
+    protected UserGroupProvider getCollaboratingUserGroupProvider() {
+        final Set<User> users = Stream.of(
+                new User.Builder().identifier(USER_4_IDENTIFIER).identity(USER_4_IDENTITY).build()
+        ).collect(Collectors.toSet());
+
+        final Set<Group> groups = Stream.of(
+                // USER_1_IDENTIFIER is from UserGroupProviderOne
+                new Group.Builder().identifier(GROUP_2_IDENTIFIER).name(GROUP_2_NAME).addUser(USER_1_IDENTIFIER).addUser(USER_4_IDENTIFIER).build()
+        ).collect(Collectors.toSet());
+
+        return new SimpleUserGroupProvider(users, groups);
+    }
+
+    protected void testCollaboratingUserGroupProvider(final UserGroupProvider userGroupProvider) {
+        // users
+        assertNotNull(userGroupProvider.getUser(USER_4_IDENTIFIER));
+        assertNotNull(userGroupProvider.getUserByIdentity(USER_4_IDENTITY));
+
+        final UserAndGroups user4AndGroups = userGroupProvider.getUserAndGroups(USER_4_IDENTITY);
+        assertNotNull(user4AndGroups);
+        assertNotNull(user4AndGroups.getUser());
+        assertEquals(1, user4AndGroups.getGroups().size());
+
+        // groups
+        assertNotNull(userGroupProvider.getGroup(GROUP_2_IDENTIFIER));
+        assertEquals(2, userGroupProvider.getGroup(GROUP_2_IDENTIFIER).getUsers().size());
+    }
+
+    protected void mockProperties(final AuthorizerConfigurationContext configurationContext) {
+        when(configurationContext.getProperties()).then((invocation) -> {
+            final Map<String, String> properties = new HashMap<>();
+
+            int i = 1;
+            while (true) {
+                final String key = PROP_USER_GROUP_PROVIDER_PREFIX + i++;
+                final PropertyValue value = configurationContext.getProperty(key);
+                if (value == null) {
+                    break;
+                } else {
+                    properties.put(key, value.getValue());
+                }
+            }
+
+            return properties;
+        });
+    }
+
+    protected UserGroupProvider initCompositeUserGroupProvider(
+            final CompositeUserGroupProvider compositeUserGroupProvider, final Consumer<UserGroupProviderLookup> lookupConsumer,
+            final Consumer<AuthorizerConfigurationContext> configurationContextConsumer, final UserGroupProvider... providers) {
+
+        // initialization
+        final UserGroupProviderLookup lookup = mock(UserGroupProviderLookup.class);
+
+        for (int i = 1; i <= providers.length; i++) {
+            when(lookup.getUserGroupProvider(eq(String.valueOf(i)))).thenReturn(providers[i - 1]);
+        }
+
+        // allow callers to mock additional providers
+        if (lookupConsumer != null) {
+            lookupConsumer.accept(lookup);
+        }
+
+        final UserGroupProviderInitializationContext initializationContext = mock(UserGroupProviderInitializationContext.class);
+        when(initializationContext.getUserGroupProviderLookup()).thenReturn(lookup);
+
+        compositeUserGroupProvider.initialize(initializationContext);
+
+        // configuration
+        final AuthorizerConfigurationContext configurationContext = mock(AuthorizerConfigurationContext.class);
+
+        for (int i = 1; i <= providers.length; i++) {
+            when(configurationContext.getProperty(eq(PROP_USER_GROUP_PROVIDER_PREFIX + i))).thenReturn(new StandardPropertyValue(String.valueOf(i), null));
+        }
+
+        // allow callers to mock additional properties
+        if (configurationContextConsumer != null) {
+            configurationContextConsumer.accept(configurationContext);
+        }
+
+        mockProperties(configurationContext);
+
+        compositeUserGroupProvider.onConfigured(configurationContext);
+
+        return compositeUserGroupProvider;
+    }
+}


### PR DESCRIPTION
Removes user existence check from FileUserGroupProvider when
group is created or updated. Replaces it with check in the
Authorizer Decorator class created by Authorizer Factory, so
that all providers are used.

Also fixes bug when searching for group membership by user
that returns results across all providers.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
