### PR TITLE
Allow delayed transfer

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
@@ -322,6 +322,8 @@ public interface ProcessSession {
      */
     FlowFile penalize(FlowFile flowFile);
 
+    FlowFile penalize(FlowFile flowFile, long penalizationPeriod);
+
     /**
      * Updates the given FlowFiles attributes with the given key/value pair. If
      * the key is named {@code uuid}, this attribute will be ignored.

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -1303,6 +1303,11 @@ public class MockProcessSession implements ProcessSession {
         return newFlowFile;
     }
 
+    @Override
+    public FlowFile penalize(FlowFile flowFile, long penalizationPeriod) {
+        return penalize(flowFile);
+    }
+
     public byte[] getContentAsByteArray(MockFlowFile flowFile) {
         flowFile = validateState(flowFile);
         return flowFile.getData();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/BatchingSessionFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/BatchingSessionFactory.java
@@ -129,7 +129,13 @@ public class BatchingSessionFactory implements ProcessSessionFactory {
 
         @Override
         public FlowFile penalize(FlowFile flowFile) {
+
             return session.penalize(flowFile);
+        }
+
+        @Override
+        public FlowFile penalize(FlowFile flowFile, long penalizationPeriod) {
+            return session.penalize(flowFile, penalizationPeriod);
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -16,6 +16,33 @@
  */
 package org.apache.nifi.controller.repository;
 
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.connectable.Connection;
@@ -54,33 +81,6 @@ import org.apache.nifi.stream.io.ByteCountingOutputStream;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.Closeable;
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -1734,9 +1734,14 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
 
     @Override
     public FlowFile penalize(FlowFile flowFile) {
+        long penalizationPeriod = context.getConnectable().getPenalizationPeriod(TimeUnit.MILLISECONDS);
+        return penalize(flowFile, penalizationPeriod);
+    }
+
+    public FlowFile penalize(FlowFile flowFile, long penalizationPeriod) {
         flowFile = validateRecordState(flowFile);
         final StandardRepositoryRecord record = records.get(flowFile);
-        final long expirationEpochMillis = System.currentTimeMillis() + context.getConnectable().getPenalizationPeriod(TimeUnit.MILLISECONDS);
+        final long expirationEpochMillis = System.currentTimeMillis() + penalizationPeriod;
         final FlowFileRecord newFile = new StandardFlowFileRecord.Builder().fromFlowFile(record.getCurrent()).penaltyExpirationTime(expirationEpochMillis).build();
         record.setWorking(newFile);
         return newFile;

--- a/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/flow/ProcessSessionWrap.java
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/flow/ProcessSessionWrap.java
@@ -454,6 +454,13 @@ public abstract class ProcessSessionWrap implements ProcessSession {
         return sf;
     }
 
+    @Override
+    public FlowFile penalize(FlowFile flowFile, long penalizationPeriod) {
+        SessionFile sf = wrap(flowFile);
+        sf.flowFile = onMod(s.penalize(sf.flowFile, penalizationPeriod));
+        return sf;
+    }
+
     /**
      * Updates the given FlowFiles attributes with the given key/value pair. If
      * the key is named {@code uuid}, this attribute will be ignored.

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogarithmicallyPenalizeFlowFileProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogarithmicallyPenalizeFlowFileProcessor.java
@@ -1,0 +1,122 @@
+package org.apache.nifi.processors.standard;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.util.StandardValidators;
+
+public class LogarithmicallyPenalizeFlowFileProcessor extends AbstractProcessor {
+
+    private static final PropertyDescriptor INITIAL_RECONNECT_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("initialReconnectTimeout")
+            .displayName("InitialReconnectTimeoutMs")
+            .description("First delay length after first FlowFile arrival in millis")
+            .defaultValue("50")
+            .required(true)
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .build();
+
+    private static final PropertyDescriptor MAXIMAL_RECONNECT_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("maximalReconnectTimeout")
+            .displayName("MaximalReconnectTimeoutMs")
+            .description("Maximal delay length after first FlowFile arrival in millis")
+            .defaultValue(""+10*60*1000)//10 minutes
+            .required(true)
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .build();
+
+    private static final PropertyDescriptor MAXIMAL_NUMBER_OF_RETRIES = new PropertyDescriptor.Builder()
+            .name("maximalNumberOfRetries")
+            .displayName("maximalNumberOfRetries")
+            .description("Maximal number of retries to allow")
+            .defaultValue("10")
+            .required(true)
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .build();
+
+    private static final PropertyDescriptor RETRY_COUNT_PROPERTY = new PropertyDescriptor.Builder()
+            .name("retryCountProperty")
+            .displayName("RetryCountProperty")
+            .description("Name of attribute in which number of retries should be stored.")
+            .required(true)
+            .expressionLanguageSupported(false)
+            .addValidator(new Validator() {
+                @Override
+                public ValidationResult validate(String subject, String input, ValidationContext context) {
+                    return new ValidationResult.Builder().valid(true).build();
+                }
+            })
+            .build();
+
+    private final Relationship REL_RETRY = new Relationship.Builder().name("retry").description("FlowFiles that were successfully processed are routed here").build();
+
+    private final Relationship REL_MAX_RETRIES_REACHED = new Relationship.Builder().name("maxRetriesReached").description("FlowFiles that failed more than allowed times, given FlowFile will be routed here.").build();
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return new HashSet<>(Arrays.asList(REL_RETRY, REL_MAX_RETRIES_REACHED));
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Arrays.asList(RETRY_COUNT_PROPERTY,
+                INITIAL_RECONNECT_TIMEOUT,
+                MAXIMAL_RECONNECT_TIMEOUT,
+                MAXIMAL_NUMBER_OF_RETRIES);
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        String retryCountAttributeName = context.getProperty(RETRY_COUNT_PROPERTY).getValue();
+        int maximalNumberOfRetries = context.getProperty(MAXIMAL_NUMBER_OF_RETRIES).asInteger();
+
+
+        String retriesCountAsString = flowFile.getAttribute(retryCountAttributeName);
+        int retriesCount = retriesCountAsString == null ? 1 : Integer.parseInt(retriesCountAsString) + 1;
+        session.putAttribute(flowFile, retryCountAttributeName, Integer.toString(retriesCount));
+
+        if (retriesCount > maximalNumberOfRetries) {
+           session.transfer(flowFile, REL_MAX_RETRIES_REACHED);
+           return;
+        }
+
+        int initialReconnectTimeout = context.getProperty(INITIAL_RECONNECT_TIMEOUT).asInteger();
+        int maximalReconnectTimeout = context.getProperty(MAXIMAL_RECONNECT_TIMEOUT).asInteger();
+
+        double delay = getBackoffDelay(initialReconnectTimeout, maximalReconnectTimeout, retriesCount);
+        session.penalize(flowFile, (long)Math.ceil(delay));
+        session.transfer(flowFile, REL_RETRY);
+    }
+
+    // Exponential Backoff Formula by Prof. Douglas Thain
+    // http://dthain.blogspot.co.uk/2009/02/exponential-backoff-in-distributed.html
+    private double getBackoffDelay(int initialReconnectTimeout, int maxReconnectTimeout, int retryAttempts) {
+        double R = Math.random() + 1;
+        int T = initialReconnectTimeout;
+        int F = 2;
+        int N = retryAttempts;
+        int M = maxReconnectTimeout;
+
+        return Math.floor(Math.min(R * T * Math.pow(F, N), M));
+    };
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -113,3 +113,4 @@ org.apache.nifi.processors.standard.ListFTP
 org.apache.nifi.processors.standard.FetchFTP
 org.apache.nifi.processors.standard.UpdateCounter
 org.apache.nifi.processors.standard.UpdateRecord
+org.apache.nifi.processors.standard.LogarithmicallyPenalizeFlowFileProcessor


### PR DESCRIPTION
Nifi has concept of penalization, but this penalization has fixed delay, and there isn't way how to change it dynamically. 

If we want to implement retry flow, where FlowFile flows in loop, we can either lower performance of Processor via yielding it, or we can do active waiting. And this is actually recommended as a correct way how to do that.

It seems, that we can easily implement better RetryProcessor, all we missing is `session.penalize` which accepts `penalizationPeriod`. Processor then can gradually prolong waiting time after each failure.

---
Pull request providing both core changes + exemplary processor
