### PR TITLE
NIFI-4826 Fixed azure.blobname in ListAzureBlobStorage

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage.java
@@ -106,7 +106,8 @@ public class ListAzureBlobStorage extends AbstractListProcessor<BlobInfo> {
         attributes.put("azure.etag", entity.getEtag());
         attributes.put("azure.primaryUri", entity.getPrimaryUri());
         attributes.put("azure.secondaryUri", entity.getSecondaryUri());
-        attributes.put("azure.blobname", entity.getName());
+        attributes.put("azure.blobname", entity.getBlobName());
+        attributes.put("filename", entity.getName());
         attributes.put("azure.blobtype", entity.getBlobType());
         attributes.put("azure.length", String.valueOf(entity.getLength()));
         attributes.put("azure.timestamp", String.valueOf(entity.getTimestamp()));
@@ -163,6 +164,7 @@ public class ListAzureBlobStorage extends AbstractListProcessor<BlobInfo> {
 
                     Builder builder = new BlobInfo.Builder()
                                               .primaryUri(uri.getPrimaryUri().toString())
+                                              .blobName(cloudBlob.getName())
                                               .containerName(containerName)
                                               .contentType(properties.getContentType())
                                               .contentLanguage(properties.getContentLanguage())

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/BlobInfo.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/BlobInfo.java
@@ -31,6 +31,7 @@ public class BlobInfo implements Comparable<BlobInfo>, Serializable, ListableEnt
     private final long lastModifiedTime;
     private final long length;
     private final String blobType;
+    private final String blobName;
     private final String containerName;
 
     public static long getSerialversionuid() {
@@ -55,6 +56,10 @@ public class BlobInfo implements Comparable<BlobInfo>, Serializable, ListableEnt
 
     public String getContainerName() {
         return containerName;
+    }
+
+    public String getBlobName() {
+        return blobName;
     }
 
     public String getEtag() {
@@ -83,6 +88,7 @@ public class BlobInfo implements Comparable<BlobInfo>, Serializable, ListableEnt
         private long length;
         private String blobType;
         private String containerName;
+        private String blobName;
 
         public Builder primaryUri(String primaryUri) {
             this.primaryUri = primaryUri;
@@ -126,6 +132,11 @@ public class BlobInfo implements Comparable<BlobInfo>, Serializable, ListableEnt
 
         public Builder blobType(String blobType) {
             this.blobType = blobType;
+            return this;
+        }
+
+        public Builder blobName(String blobName) {
+            this.blobName = blobName;
             return this;
         }
 
@@ -180,6 +191,7 @@ public class BlobInfo implements Comparable<BlobInfo>, Serializable, ListableEnt
         this.lastModifiedTime = builder.lastModifiedTime;
         this.length = builder.length;
         this.blobType = builder.blobType;
+        this.blobName = builder.blobName;
     }
 
     @Override


### PR DESCRIPTION
- azure.blobname now has the value returned by CloudBlob.getName().
- Tested for blobs located in a multiple hierarchy directory structure by connecting ListAzureBlobStorage with FetchAzureBlobStorage with the latter processor's "Blob" property set to ${azure.blobname}
- Also fixed filename which was previously having timestamp with the blob's partial name.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
