### PR TITLE
NIFI-4837: Addressing thread leak in HandleHTTPRequest

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -485,7 +485,15 @@ public class HandleHttpRequest extends AbstractProcessor {
             }
         } catch (Exception e) {
             context.yield();
-            throw new ProcessException("Failed to initialize the server",e);
+
+            try {
+                // shutdown to release any resources allocated during the failed initialization
+                shutdown();
+            } catch (final Exception shutdownException) {
+                getLogger().debug("Failed to shutdown following a failed initialization: " + shutdownException);
+            }
+
+            throw new ProcessException("Failed to initialize the server", e);
         }
 
         HttpRequestContainer container;


### PR DESCRIPTION
NIFI-4837:
- When Jetty initializes fails, performing a shutdown sequence to ensure all allocated resources are released.