### PR TITLE
NIFI-4856 Removed deprecated ByteArrayInputStream references in ByteC…

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/stream/io/ByteCountingInputStream.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/stream/io/ByteCountingInputStream.java
@@ -107,4 +107,9 @@ public class ByteCountingInputStream extends InputStream {
     public void close() throws IOException {
         in.close();
     }
+
+    @Override
+    public int available() throws IOException {
+        return in.available();
+    }
 }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/ByteCountingInputStreamTest.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/ByteCountingInputStreamTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.nifi.stream.io;
 
+import java.io.ByteArrayInputStream;
 import junit.framework.TestCase;
 
 public class ByteCountingInputStreamTest extends TestCase {
 
-    final ByteArrayInputStream reader = new ByteArrayInputStream("abcdefghijklmnopqrstuvwxyz".getBytes());
+    final java.io.ByteArrayInputStream reader = new java.io.ByteArrayInputStream("abcdefghijklmnopqrstuvwxyz".getBytes());
 
     public void testReset() throws Exception {
 
@@ -51,5 +52,31 @@ public class ByteCountingInputStreamTest extends TestCase {
         /* verify that the reset bug has been fixed (bug would reduce bytes read count) */
         bcis.reset();
         assertEquals(bytesAtMark, bcis.getBytesRead());
+    }
+
+    public void testAvailableShouldReturnCorrectCount() throws Exception {
+        // Arrange
+        final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(ALPHABET.getBytes());
+        final ByteCountingInputStream bcis = new ByteCountingInputStream(inputStream);
+        int tmp;
+        int initialAvailableBytes = bcis.available();
+        assertEquals(ALPHABET.length(), initialAvailableBytes);
+
+        // Act
+        /* verify first 2 bytes */
+        tmp = bcis.read();
+        assertEquals(tmp, 97);
+        tmp = bcis.read();
+        assertEquals(tmp, 98);
+
+        int availableBytes = bcis.available();
+        assertEquals(ALPHABET.length() - 2, availableBytes);
+
+        bcis.skip(24);
+
+        // Assert
+        int finalAvailableBytes = bcis.available();
+        assertEquals(0, finalAvailableBytes);
     }
 }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/ByteCountingInputStreamTest.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/ByteCountingInputStreamTest.java
@@ -17,15 +17,14 @@
 package org.apache.nifi.stream.io;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import junit.framework.TestCase;
 
 public class ByteCountingInputStreamTest extends TestCase {
 
-    final java.io.ByteArrayInputStream reader = new java.io.ByteArrayInputStream("abcdefghijklmnopqrstuvwxyz".getBytes());
-
     public void testReset() throws Exception {
 
-        final ByteArrayInputStream reader = new ByteArrayInputStream("abcdefghijklmnopqrstuvwxyz".getBytes());
+        final ByteArrayInputStream reader = new ByteArrayInputStream("abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
         final ByteCountingInputStream bcis = new ByteCountingInputStream(reader);
         int tmp;
 
@@ -57,7 +56,7 @@ public class ByteCountingInputStreamTest extends TestCase {
     public void testAvailableShouldReturnCorrectCount() throws Exception {
         // Arrange
         final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(ALPHABET.getBytes());
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(ALPHABET.getBytes(StandardCharsets.UTF_8));
         final ByteCountingInputStream bcis = new ByteCountingInputStream(inputStream);
         int tmp;
         int initialAvailableBytes = bcis.available();


### PR DESCRIPTION
…ountingInputStreamTest.

Added failing unit test for #available() at various states (initial, during read, after read).
Implemented #available() delegation.
All tests pass.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
