### PR TITLE
NIFI-4910 Fixing slight spelling mistake in error message, needs a space

### DIFF
--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2520,7 +2520,7 @@ Sometimes it may be desirable to deprecate a component. Whenever this occurs the
 
 [source, java]
 ----
- @DeprecationNotice(alternatives = {ListenSyslog.class}, classNames = {"org.apache.nifi.processors.standard.ListenRELP"}, reason = "Technologyhas been superseded",  )
+ @DeprecationNotice(alternatives = {ListenSyslog.class}, classNames = {"org.apache.nifi.processors.standard.ListenRELP"}, reason = "Technology has been superseded",  )
  public class ListenOldProtocol extends AbstractProcessor {
 ----
 As you can see, the alternatives can be used to define and array of alternative Components, while classNames can be


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NIFI-4910

The file: nifi-docs/src/main/asciidoc/developer-guide.adoc

The is a spelling error in the message: reason = "Technologyhas been superseded"

The patch just provides the space required between the two words. 