### PR TITLE
NIFI-4936: Fix ranger version definition

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -986,6 +986,7 @@ language governing permissions and limitations under the License. -->
                 <dependency>
                     <groupId>org.apache.ranger</groupId>
                     <artifactId>credentialbuilder</artifactId>
+                    <version>${ranger.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
@@ -26,7 +26,6 @@
     <packaging>jar</packaging>
     <properties>
         <hadoop.version>2.7.3</hadoop.version>
-        <ranger.version>0.7.1</ranger.version>        
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <org.slf4j.version>1.7.25</org.slf4j.version>
+        <ranger.version>0.7.1</ranger.version>
         <jetty.version>9.4.3.v20170317</jetty.version>
     </properties>
 


### PR DESCRIPTION
NIFI-4936:
- Moving definition of ranger version into root pom.