### PR TITLE
NIFI-4962 FlattenJson processor add unexpected backslash after flatten

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FlattenJson.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FlattenJson.java
@@ -18,8 +18,11 @@
 package org.apache.nifi.processors.standard;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.wnameless.json.flattener.CharSequenceTranslatorFactory;
 import com.github.wnameless.json.flattener.FlattenMode;
 import com.github.wnameless.json.flattener.JsonFlattener;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.text.translate.CharSequenceTranslator;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -160,6 +163,7 @@ public class FlattenJson extends AbstractProcessor {
             final String flattened = new JsonFlattener(raw)
                     .withFlattenMode(flattenMode)
                     .withSeparator(separator.charAt(0))
+                    .withStringEscapePolicy(() -> StringEscapeUtils.ESCAPE_JAVA)
                     .flatten();
 
             flowFile = session.write(flowFile, os -> os.write(flattened.getBytes()));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestFlattenJson.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestFlattenJson.groovy
@@ -172,4 +172,23 @@ class TestFlattenJson {
             Assert.assertEquals("Separator not applied.", "one", parsed["first.second.third.0"])
         }
     }
+
+    @Test
+    void testFlattenSlash() {
+        def testRunner = TestRunners.newTestRunner(FlattenJson.class)
+        def json = prettyPrint(toJson([
+                first: [
+                        second: [
+                                third: [
+                                        "http://localhost/value1", "http://localhost/value2"
+                                ]
+                        ]
+                ]
+        ]))
+
+        testRunner.setProperty(FlattenJson.FLATTEN_MODE, FlattenJson.FLATTEN_MODE_NORMAL)
+        baseTest(testRunner, json,2) { parsed ->
+            Assert.assertEquals("Separator not applied.", "http://localhost/value1", parsed["first.second.third[0]"])
+        }
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -329,7 +329,7 @@
             <dependency>
                 <groupId>com.github.wnameless</groupId>
                 <artifactId>json-flattener</artifactId>
-                <version>0.4.1</version>
+                <version>0.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.bval</groupId>


### PR DESCRIPTION
Upgrade json flatten library version to newest one to deal with StringEscapePolicy.
Add unit test code to verify solution.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
