### PR TITLE
NIFI-4864: Improvements to PR #2470

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractConfiguredComponent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractConfiguredComponent.java
@@ -307,6 +307,12 @@ public abstract class AbstractConfiguredComponent implements ConfigurableCompone
      */
     @Override
     public synchronized void reloadAdditionalResourcesIfNecessary() {
+        // Components that don't have any PropertyDescriptors marked `dynamicallyModifiesClasspath`
+        // won't have the fingerprint i.e. will be null, in such cases do nothing
+        if (additionalResourcesFingerprint == null) {
+            return;
+        }
+
         final List<PropertyDescriptor> descriptors = new ArrayList<>(this.getProperties().keySet());
         final Set<URL> additionalUrls = this.getAdditionalClasspathResources(descriptors);
 


### PR DESCRIPTION
The original PR #2470 had an unhandled situation wherein the components that don't have any `PropertyDescriptor` marked as `dynamicallyModifiesClasspath(true)` won't have the `additionalResourcesFingerprint` set i.e. it will be null so the framework will attempt to reload the resources. This caused an unexpected scenario especially when using Schema Registry services which @bbende explained in the [Release Apache NiFi 1.6.0 Dev thread](http://apache-nifi-developer-list.39713.n7.nabble.com/VOTE-Release-Apache-NiFi-1-6-0-td18236.html#a18259) 

I have tested both the scenarios:

1. The actual reason why this ticket was raised i.e. to smartly reload *newly added* additional resources, upon the component's start and stop

1. The unhandled situation that is mentioned above (schema registry situation)

---

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
