### PR TITLE
NIFI-5037 - ConsumeEWS Fails to Read Emtpy Message Body Emails

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
@@ -407,10 +407,15 @@ public class ConsumeEWS extends AbstractProcessor {
         MultiPartEmail mm;
 
         if(ewsMessage.getBody().getBodyType() == BodyType.HTML){
-            mm = new HtmlEmail().setHtmlMsg(bodyText);
+            mm = new HtmlEmail();
+            if(!StringUtils.isEmpty(bodyText)){
+                ((HtmlEmail)mm).setHtmlMsg(bodyText);
+            }
         } else {
             mm = new MultiPartEmail();
-            mm.setMsg(bodyText);
+            if(!StringUtils.isEmpty(bodyText)){
+                mm.setMsg(bodyText);
+            }
         }
         mm.setHostName("NiFi-EWS");
         //from


### PR DESCRIPTION
When an email has no message body, ConsumeEWS fails to read the message.
There is nothing wrong with having no message body, but _setting_ an empty message body in Apache Email Commons is not allowed. Added step to not set the message body if empty. In testing this resolved the issue.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
