### PR TITLE
NIFI-5049 Fix handling of Phonenix datetime columns

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
@@ -429,44 +429,46 @@ public abstract class AbstractDatabaseFetchProcessor extends AbstractSessionFact
     protected static String getLiteralByType(int type, String value, String databaseType) {
         // Format value based on column type. For example, strings and timestamps need to be quoted
         switch (type) {
-        // For string-represented values, put in single quotes
-        case CHAR:
-        case LONGNVARCHAR:
-        case LONGVARCHAR:
-        case NCHAR:
-        case NVARCHAR:
-        case VARCHAR:
-        case ROWID: return "'" + value + "'";
-        case TIME:
-            if (PhoenixDatabaseAdapter.NAME.equals(databaseType)) {
-                return "time '" + value + "'";
-            }
-        case DATE:
-        case TIMESTAMP:
-            // TODO delegate to database adapter the conversion instead of using if in this
-            // class.
-            // TODO (cont) if a new else is added, please refactor the code.
-            // Ideally we should probably have a method on the adapter to get a clause that
-            // coerces a
-            // column to a Timestamp if need be (the generic one can be a no-op)
-            if (!StringUtils.isEmpty(databaseType) && (databaseType.contains("Oracle") || PhoenixDatabaseAdapter.NAME.equals(databaseType))) {
-                // For backwards compatibility, the type might be TIMESTAMP but the state value
-                // is in DATE format. This should be a one-time occurrence as the next maximum
-                // value
-                // should be stored as a full timestamp. Even so, check to see if the value is
-                // missing time-of-day information, and use the "date" coercion rather than the
-                // "timestamp" coercion in that case
-                if (value.matches("\\d{4}-\\d{2}-\\d{2}")) {
-                    return "date '" + value + "'";
-                } else {
-                    return "timestamp '" + value + "'";
-                }
-            } else {
+            // For string-represented values, put in single quotes
+            case CHAR:
+            case LONGNVARCHAR:
+            case LONGVARCHAR:
+            case NCHAR:
+            case NVARCHAR:
+            case VARCHAR:
+            case ROWID:
                 return "'" + value + "'";
-            }
-            // Else leave as is (numeric types, e.g.)
-        default:
-            return value;
+            case TIME:
+                if (PhoenixDatabaseAdapter.NAME.equals(databaseType)) {
+                    return "time '" + value + "'";
+                }
+            case DATE:
+            case TIMESTAMP:
+                // TODO delegate to database adapter the conversion instead of using if in this
+                // class.
+                // TODO (cont) if a new else is added, please refactor the code.
+                // Ideally we should probably have a method on the adapter to get a clause that
+                // coerces a
+                // column to a Timestamp if need be (the generic one can be a no-op)
+                if (!StringUtils.isEmpty(databaseType)
+                        && (databaseType.contains("Oracle") || PhoenixDatabaseAdapter.NAME.equals(databaseType))) {
+                    // For backwards compatibility, the type might be TIMESTAMP but the state value
+                    // is in DATE format. This should be a one-time occurrence as the next maximum
+                    // value
+                    // should be stored as a full timestamp. Even so, check to see if the value is
+                    // missing time-of-day information, and use the "date" coercion rather than the
+                    // "timestamp" coercion in that case
+                    if (value.matches("\\d{4}-\\d{2}-\\d{2}")) {
+                        return "date '" + value + "'";
+                    } else {
+                        return "timestamp '" + value + "'";
+                    }
+                } else {
+                    return "'" + value + "'";
+                }
+                // Else leave as is (numeric types, e.g.)
+            default:
+                return value;
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
@@ -30,6 +30,7 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+import org.apache.nifi.processors.standard.db.impl.PhoenixDatabaseAdapter;
 import org.apache.nifi.util.StringUtils;
 
 import java.io.IOException;
@@ -428,33 +429,44 @@ public abstract class AbstractDatabaseFetchProcessor extends AbstractSessionFact
     protected static String getLiteralByType(int type, String value, String databaseType) {
         // Format value based on column type. For example, strings and timestamps need to be quoted
         switch (type) {
-            // For string-represented values, put in single quotes
-            case CHAR:
-            case LONGNVARCHAR:
-            case LONGVARCHAR:
-            case NCHAR:
-            case NVARCHAR:
-            case VARCHAR:
-            case ROWID:
-            case DATE:
-            case TIME:
-                return "'" + value + "'";
-            case TIMESTAMP:
-                if (!StringUtils.isEmpty(databaseType) && databaseType.contains("Oracle")) {
-                    // For backwards compatibility, the type might be TIMESTAMP but the state value is in DATE format. This should be a one-time occurrence as the next maximum value
-                    // should be stored as a full timestamp. Even so, check to see if the value is missing time-of-day information, and use the "date" coercion rather than the
-                    // "timestamp" coercion in that case
-                    if (value.matches("\\d{4}-\\d{2}-\\d{2}")) {
-                        return "date '" + value + "'";
-                    } else {
-                        return "timestamp '" + value + "'";
-                    }
+        // For string-represented values, put in single quotes
+        case CHAR:
+        case LONGNVARCHAR:
+        case LONGVARCHAR:
+        case NCHAR:
+        case NVARCHAR:
+        case VARCHAR:
+        case ROWID: return "'" + value + "'";
+        case TIME:
+            if (PhoenixDatabaseAdapter.NAME.equals(databaseType)) {
+                return "time '" + value + "'";
+            }
+        case DATE:
+        case TIMESTAMP:
+            // TODO delegate to database adapter the conversion instead of using if in this
+            // class.
+            // TODO (cont) if a new else is added, please refactor the code.
+            // Ideally we should probably have a method on the adapter to get a clause that
+            // coerces a
+            // column to a Timestamp if need be (the generic one can be a no-op)
+            if (!StringUtils.isEmpty(databaseType) && (databaseType.contains("Oracle") || PhoenixDatabaseAdapter.NAME.equals(databaseType))) {
+                // For backwards compatibility, the type might be TIMESTAMP but the state value
+                // is in DATE format. This should be a one-time occurrence as the next maximum
+                // value
+                // should be stored as a full timestamp. Even so, check to see if the value is
+                // missing time-of-day information, and use the "date" coercion rather than the
+                // "timestamp" coercion in that case
+                if (value.matches("\\d{4}-\\d{2}-\\d{2}")) {
+                    return "date '" + value + "'";
                 } else {
-                    return "'" + value + "'";
+                    return "timestamp '" + value + "'";
                 }
-                // Else leave as is (numeric types, e.g.)
-            default:
-                return value;
+            } else {
+                return "'" + value + "'";
+            }
+            // Else leave as is (numeric types, e.g.)
+        default:
+            return value;
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
@@ -303,7 +303,9 @@ public class QueryDatabaseTable extends AbstractDatabaseFetchProcessor {
 
             final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions().asTimePeriod(TimeUnit.SECONDS).intValue();
             st.setQueryTimeout(queryTimeout); // timeout in seconds
-            logger.debug("Executing query {}", new Object[]{selectQuery});
+            if (logger.isDebugEnabled()) {
+                logger.debug("Executing query {}", new Object[] { selectQuery });
+            }
             try (final ResultSet resultSet = st.executeQuery(selectQuery)) {
                 int fragmentIndex=0;
                 while(true) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
@@ -303,9 +303,8 @@ public class QueryDatabaseTable extends AbstractDatabaseFetchProcessor {
 
             final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions().asTimePeriod(TimeUnit.SECONDS).intValue();
             st.setQueryTimeout(queryTimeout); // timeout in seconds
-            try {
-                logger.debug("Executing query {}", new Object[]{selectQuery});
-                final ResultSet resultSet = st.executeQuery(selectQuery);
+            logger.debug("Executing query {}", new Object[]{selectQuery});
+            try (final ResultSet resultSet = st.executeQuery(selectQuery)) {
                 int fragmentIndex=0;
                 while(true) {
                     final AtomicLong nrOfRows = new AtomicLong(0L);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PhoenixDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PhoenixDatabaseAdapter.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.processors.standard.db.DatabaseAdapter;
 
 /**
- * A generic database adapter that generates ANSI SQL.
+ * A Apache Phoenix database adapter that generates ANSI SQL.
  */
 public final class PhoenixDatabaseAdapter implements DatabaseAdapter {
     public static final String NAME = "Phoenix";

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PhoenixDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PhoenixDatabaseAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.db.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+
+/**
+ * A generic database adapter that generates ANSI SQL.
+ */
+public final class PhoenixDatabaseAdapter implements DatabaseAdapter {
+    public static final String NAME = "Phoenix";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates Phoenix compliant SQL";
+    }
+
+    @Override
+    public String getSelectStatement(String tableName, String columnNames, String whereClause, String orderByClause,
+            Long limit, Long offset) {
+        if (StringUtils.isEmpty(tableName)) {
+            throw new IllegalArgumentException("Table name cannot be null or empty");
+        }
+        final StringBuilder query = new StringBuilder("SELECT ");
+        if (StringUtils.isEmpty(columnNames) || columnNames.trim().equals("*")) {
+            query.append("*");
+        } else {
+            query.append(columnNames);
+        }
+        query.append(" FROM ");
+        query.append(tableName);
+
+        if (!StringUtils.isEmpty(whereClause)) {
+            query.append(" WHERE ");
+            query.append(whereClause);
+        }
+        if (!StringUtils.isEmpty(orderByClause)) {
+            query.append(" ORDER BY ");
+            query.append(orderByClause);
+        }
+        if (limit != null) {
+            query.append(" LIMIT ");
+            query.append(limit);
+        }
+        if (offset != null && offset > 0) {
+            query.append(" OFFSET ");
+            query.append(offset);
+        }
+
+        return query.toString();
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableTest.java
@@ -30,6 +30,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.standard.db.DatabaseAdapter;
 import org.apache.nifi.processors.standard.db.impl.GenericDatabaseAdapter;
 import org.apache.nifi.processors.standard.db.impl.OracleDatabaseAdapter;
+import org.apache.nifi.processors.standard.db.impl.PhoenixDatabaseAdapter;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -159,6 +160,35 @@ public class QueryDatabaseTableTest {
         dbAdapter = new OracleDatabaseAdapter();
         query = processor.getQuery(dbAdapter, "myTable", null, Arrays.asList("id", "DATE_CREATED"), "type = \"CUSTOMER\"", stateManager.getState(Scope.CLUSTER).toMap());
         assertEquals("SELECT * FROM myTable WHERE id > 509 AND DATE_CREATED >= timestamp '2016-03-07 12:34:56' AND (type = \"CUSTOMER\")", query);
+
+        // Test time.
+        processor.putColumnType("mytable" + AbstractDatabaseFetchProcessor.NAMESPACE_DELIMITER + "time_created", Types.TIME);
+        maxValues.clear();
+        maxValues.put("id", "509");
+        maxValues.put("time_created", "12:34:57");
+        maxValues.put("date_created", "2016-03-07 12:34:56");
+        stateManager = runner.getStateManager();
+        stateManager.clear(Scope.CLUSTER);
+        stateManager.setState(maxValues, Scope.CLUSTER);
+        query = processor.getQuery(dbAdapter, "myTable", null, Arrays.asList("id", "DATE_CREATED", "TIME_CREATED"), "type = \"CUSTOMER\"", stateManager.getState(Scope.CLUSTER).toMap());
+        assertEquals("SELECT * FROM myTable WHERE id > 509 AND DATE_CREATED >= timestamp '2016-03-07 12:34:56' AND TIME_CREATED >= timestamp '12:34:57' AND (type = \"CUSTOMER\")", query);
+        dbAdapter = new GenericDatabaseAdapter();
+        query = processor.getQuery(dbAdapter, "myTable", null, Arrays.asList("id", "DATE_CREATED", "TIME_CREATED"), "type = \"CUSTOMER\"", stateManager.getState(Scope.CLUSTER).toMap());
+        assertEquals("SELECT * FROM myTable WHERE id > 509 AND DATE_CREATED >= '2016-03-07 12:34:56' AND TIME_CREATED >= '12:34:57' AND (type = \"CUSTOMER\")", query);
+
+        // Test Phoenix strategy
+        dbAdapter = new PhoenixDatabaseAdapter();
+        query = processor.getQuery(dbAdapter, "myTable", null, Arrays.asList("id", "DATE_CREATED", "TIME_CREATED"), "type = \"CUSTOMER\"", stateManager.getState(Scope.CLUSTER).toMap());
+        assertEquals("SELECT * FROM myTable WHERE id > 509 AND DATE_CREATED >= timestamp '2016-03-07 12:34:56' AND TIME_CREATED >= time '12:34:57' AND (type = \"CUSTOMER\")", query);
+
+        maxValues.clear();
+        maxValues.put("id", "509");
+        maxValues.put("time_created", "12:34:57");
+        stateManager = runner.getStateManager();
+        stateManager.clear(Scope.CLUSTER);
+        stateManager.setState(maxValues, Scope.CLUSTER);
+        query = processor.getQuery(dbAdapter, "myTable", null, Arrays.asList("id", "TIME_CREATED"), "type = \"CUSTOMER\"", stateManager.getState(Scope.CLUSTER).toMap());
+        assertEquals("SELECT * FROM myTable WHERE id > 509 AND TIME_CREATED >= time '12:34:57' AND (type = \"CUSTOMER\")", query);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Fixed Error: ERROR 203 (22005): Type mismatch. TIMESTAMP
and VARCHAR for <COLUMN_NAME> = '2015-09-12 18:19:43.293'
(sample date).

The fix consists on applying the same fix added to Oracle DB,
based on NIFI-2323 approach. The changes introduced were:

1) A Phoenix database adapter.
2) Handling timestamp, date and time in Phoenix.
3) Added a close to result set in QueryDatabaseTable processor
   (not related to this bug, but I think it will be useful to
    fix).

The changes don't break existing code.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
