### PR TITLE
NIFI-5070 Fix java.sql.SQLException: ERROR 1101 (XCL01): ResultSet is…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JdbcCommon.java
@@ -858,7 +858,6 @@ public class JdbcCommon {
      * See also
      * <a href="https://issues.apache.org/jira/browse/NIFI-5070">NIFI-5070</a>.
      * </p>
-     * 
      * @param rs the resultSet
      * @return <code>rs.next()</code> or false if the result set is close.
      * @throws SQLException if a database access error ocurrs.

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJdbcCommon.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJdbcCommon.java
@@ -635,7 +635,6 @@ public class TestJdbcCommon {
      * </p>
      * See <a href="https://issues.apache.org/jira/browse/NIFI-5070">NIFI-5070</a>
      * for more information.
-     * 
      * @throws SQLException it is expected the exception be thrown.
      */
     @Test
@@ -674,7 +673,6 @@ public class TestJdbcCommon {
      * </p>
      * See <a href="https://issues.apache.org/jira/browse/NIFI-5070">NIFI-5070</a>
      * for more information.
-     * 
      * @throws SQLException it is expected the exception be thrown.
      */
     @Test


### PR DESCRIPTION
… closed

Discovered on Phoenix Database by using QueryDatabaseTable processor. The fix consists
on applying Matt Burgess' suggestion:

"I think we'd need a try/catch around the next() only to see if the result set is closed,
and an inner try/catch around everything else, to catch other errors not related to
this behavior. "

The solution was verified against Phoenix DB. Also added unit tests to cover the
change.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
