### PR TITLE
NIFI-5062: Removed hbase-client dependecy from hbase bundle

### DIFF
--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/pom.xml
@@ -78,18 +78,6 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock-record-utils</artifactId>

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/TestPutHBaseRecord.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/TestPutHBaseRecord.java
@@ -17,9 +17,9 @@
 
 package org.apache.nifi.hbase;
 
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.nifi.hbase.put.PutColumn;
 import org.apache.nifi.hbase.put.PutFlowFile;
+import org.apache.nifi.hbase.util.Bytes;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.record.MockRecordParser;
 import org.apache.nifi.serialization.record.RecordFieldType;

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/util/Bytes.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/util/Bytes.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.hbase.util;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class Bytes {
+
+    public static String toString(byte[] b) {
+        return b == null ? null : toString(b, 0, b.length);
+    }
+
+    public static String toString(byte[] b1, String sep, byte[] b2) {
+        return toString(b1, 0, b1.length) + sep + toString(b2, 0, b2.length);
+    }
+
+    public static String toString(byte[] b, int off, int len) {
+        if (b == null) {
+            return null;
+        } else {
+            return len == 0 ? "" : new String(b, off, len, Charset.forName("UTF-8"));
+        }
+    }
+
+    public static long toLong(byte[] bytes) {
+        return toLong(bytes, 0, 8);
+    }
+
+    private static long toLong(byte[] bytes, int offset, int length) {
+        if (length == 8 && offset + length <= bytes.length) {
+            if (theUnsafe != null) {
+                return toLongUnsafe(bytes, offset);
+            } else {
+                long l = 0L;
+
+                for(int i = offset; i < offset + length; ++i) {
+                    l <<= 8;
+                    l ^= (long)(bytes[i] & 255);
+                }
+
+                return l;
+            }
+        } else {
+            throw explainWrongLengthOrOffset(bytes, offset, length, 8);
+        }
+    }
+
+    private static long toLongUnsafe(byte[] bytes, int offset) {
+        final boolean littleEndian = ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
+        final int BYTE_ARRAY_BASE_OFFSET = theUnsafe.arrayBaseOffset(byte[].class);
+
+        if (littleEndian) {
+            return Long.reverseBytes(theUnsafe.getLong(bytes,
+                    (long) offset + BYTE_ARRAY_BASE_OFFSET));
+        } else {
+            return theUnsafe.getLong(bytes,
+                    (long) offset + BYTE_ARRAY_BASE_OFFSET);
+        }
+    }
+
+    private static IllegalArgumentException explainWrongLengthOrOffset(byte[] bytes, int offset, int length, int expectedLength) {
+        String reason;
+        if (length != expectedLength) {
+            reason = "Wrong length: " + length + ", expected " + expectedLength;
+        } else {
+            reason = "offset (" + offset + ") + length (" + length + ") exceed the" + " capacity of the array: " + bytes.length;
+        }
+
+        return new IllegalArgumentException(reason);
+    }
+
+    private static final Unsafe theUnsafe = (Unsafe) AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        public Object run() {
+            try {
+                Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                return f.get((Object)null);
+            } catch (NoSuchFieldException | IllegalAccessException var2) {
+                throw new Error();
+            }
+        }
+    });
+
+}

--- a/nifi-nar-bundles/nifi-hbase-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hbase-bundle/pom.xml
@@ -37,11 +37,6 @@
                 <artifactId>nifi-hbase-processors</artifactId>
                 <version>1.7.0-SNAPSHOT</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.hbase</groupId>
-                <artifactId>hbase-client</artifactId>
-                <version>1.1.2</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/pom.xml
@@ -24,6 +24,9 @@
 
     <artifactId>nifi-hbase_1_1_2-client-service</artifactId>
     <packaging>jar</packaging>
+    <properties>
+        <hbase.version>1.1.2</hbase.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -70,7 +73,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>1.1.2</version>
+            <version>${hbase.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Since the `MockHBaseClientService` and `TestPutHBaseRecord` extensively uses the `Bytes` from `hbase-client` class, I have created a new class with the same name and literally copied the necessary methods from the actual `Bytes` class to this one.

---
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
