### PR TITLE
NIFI-5097 add client-side HTTP redirect to error index.jsp

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/src/main/webapp/index.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/src/main/webapp/index.jsp
@@ -32,6 +32,7 @@
     <link rel="stylesheet" href="<%= contextPath %>/nifi/assets/font-awesome/css/font-awesome.min.css" type="text/css"/>
     <link rel="stylesheet" href="<%= contextPath %>/nifi/css/message-pane.css" type="text/css"/>
     <link rel="stylesheet" href="<%= contextPath %>/nifi/css/message-page.css" type="text/css"/>
+    <meta http-equiv="Refresh" content="5; url=<%= contextPath %>/nifi/">
 </head>
 
 <body class="message-pane">
@@ -39,7 +40,7 @@
     <p class="message-pane-title">
         Did you mean: <a href="<%= contextPath %>/nifi/">/nifi</a>
     </p>
-    <p class="message-pane-content">You may have mistyped...</p>
+    <p class="message-pane-content">You may have mistyped... but we'll try to redirect you in 5 seconds.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Existing web error index page suggests user may have meant /nifi/ and crafts a contextPath link, may as well redirect them automatically. Non-human (i.e. curl/wget) can still retrieve the original source without being redirected.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [Y] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [Y] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [N] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [Y] Is your initial contribution a single, squashed commit?

### For code changes:
- [N] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [N] Have you written or updated unit tests to verify your changes?
- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [N/A] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [N/A] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [N/A] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [N/A] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
