### PR TITLE
NIFI-5044 SelectHiveQL accept only one statement

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
@@ -342,7 +342,7 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
         ) {
             Pair<String,SQLException> failure = executeConfigStatements(con, preQueries);
             if (failure != null) {
-                // In case of failure, assigning config query to "hqlStatement"  to follow current error handling 
+                // In case of failure, assigning config query to "hqlStatement"  to follow current error handling
                 hqlStatement = failure.getLeft();
                 flowfile = (fileToProcess == null) ? session.create() : fileToProcess;
                 fileToProcess = null;

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
@@ -529,7 +529,7 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
 
         for (String confSQL : configQueries) {
             try(final Statement st = con.createStatement()){
-                st.executeQuery(confSQL);
+                st.execute(confSQL);
             } catch (SQLException e) {
                 return Pair.of(confSQL, e);
             }

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
@@ -111,7 +111,7 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
             .displayName("HiveQL Pre-Query")
             .description("HiveQL pre-query to execute. Semicolon-delimited list of queries. "
                     + "Example: 'set tez.queue.name=queue1; set hive.exec.orc.split.strategy=ETL; set hive.exec.reducers.bytes.per.reducer=1073741824'. "
-                    + "Note, the results/outputs of these queries will be suppressed if successful executed.")
+                    + "Note, the results/outputs of these queries will be suppressed if successfully executed.")
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -130,8 +130,7 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
             .name("hive-post-query")
             .displayName("HiveQL Post-Query")
             .description("HiveQL post-query to execute. Semicolon-delimited list of queries. "
-                    + "Example: 'set tez.queue.name=default; set hive.exec.orc.split.strategy=HYBRID; set hive.exec.reducers.bytes.per.reducer=258998272'. "
-                    + "Note, the results/outputs of these queries will be suppressed if successful executed.")
+                    + "Note, the results/outputs of these queries will be suppressed if successfully executed.")
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)


### PR DESCRIPTION
SelectHiveQL support only single SELECT statement.
This change adds support for pre- and post- select statements.
It will be useful for configuration queries, i.e. "set tez.queue.name=default", and others.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [X] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
