### PR TITLE
NIFI-5077 ExtractGrok support for `keep empty captures`

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractGrok.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractGrok.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @EventDriven
 @SupportsBatching
@@ -101,6 +102,15 @@ public class ExtractGrok extends AbstractProcessor {
         .required(false)
         .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
         .build();
+
+    public static final PropertyDescriptor KEEP_EMPTY_CAPTURES = new PropertyDescriptor.Builder()
+            .name("Keep Empty Captures")
+            .description("If true, then empty capture values will be included in the returned capture map.")
+            .required(false)
+            .defaultValue("true")
+            .allowableValues("true","false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
 
     public static final PropertyDescriptor DESTINATION = new PropertyDescriptor.Builder()
         .name("Destination")
@@ -156,6 +166,8 @@ public class ExtractGrok extends AbstractProcessor {
     private volatile Grok grok;
     private final BlockingQueue<byte[]> bufferQueue = new LinkedBlockingQueue<>();
 
+    private final AtomicBoolean keepEmptyCaputures = new AtomicBoolean(true);
+
     static {
         final Set<Relationship> _relationships = new HashSet<>();
         _relationships.add(REL_MATCH);
@@ -169,6 +181,7 @@ public class ExtractGrok extends AbstractProcessor {
         _descriptors.add(CHARACTER_SET);
         _descriptors.add(MAX_BUFFER_SIZE);
         _descriptors.add(NAMED_CAPTURES_ONLY);
+        _descriptors.add(KEEP_EMPTY_CAPTURES);
         descriptors = Collections.unmodifiableList(_descriptors);
     }
 
@@ -234,6 +247,11 @@ public class ExtractGrok extends AbstractProcessor {
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) throws GrokException, IOException {
+
+        if (context.getProperty(KEEP_EMPTY_CAPTURES).isSet()) {
+            keepEmptyCaputures.set(context.getProperty(KEEP_EMPTY_CAPTURES).asBoolean());
+        }
+
         for (int i = 0; i < context.getMaxConcurrentTasks(); i++) {
             final int maxBufferSize = context.getProperty(MAX_BUFFER_SIZE).asDataSize(DataUnit.B).intValue();
             final byte[] buffer = new byte[maxBufferSize];
@@ -254,6 +272,7 @@ public class ExtractGrok extends AbstractProcessor {
             }
         }
         grok = grokCompiler.compile(context.getProperty(GROK_EXPRESSION).getValue(), context.getProperty(NAMED_CAPTURES_ONLY).asBoolean());
+
     }
 
     @Override
@@ -286,6 +305,7 @@ public class ExtractGrok extends AbstractProcessor {
         }
 
         final Match gm = grok.match(contentString);
+        gm.setKeepEmptyCaptures(keepEmptyCaputures.get());
         final Map<String,Object> captureMap = gm.capture();
 
         if (captureMap.isEmpty()) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExtractGrok.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExtractGrok.java
@@ -66,6 +66,30 @@ public class TestExtractGrok {
     }
 
     @Test
+    public void testExtractGrokKeepEmptyCaptures() throws Exception {
+        String expression = "%{NUMBER}|%{NUMBER}";
+        testRunner.setProperty(ExtractGrok.GROK_EXPRESSION,expression);
+        testRunner.enqueue("-42");
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(ExtractGrok.REL_MATCH);
+        final MockFlowFile matched = testRunner.getFlowFilesForRelationship(ExtractGrok.REL_MATCH).get(0);
+        matched.assertAttributeEquals("grok.NUMBER","[-42, null]");
+    }
+
+    @Test
+    public void testExtractGrokDoNotKeepEmptyCaptures() throws Exception {
+        String expression = "%{NUMBER}|%{NUMBER}";
+        testRunner.setProperty(ExtractGrok.GROK_EXPRESSION,expression);
+        testRunner.setProperty(ExtractGrok.KEEP_EMPTY_CAPTURES,"false");
+        testRunner.enqueue("-42");
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(ExtractGrok.REL_MATCH);
+        final MockFlowFile matched = testRunner.getFlowFilesForRelationship(ExtractGrok.REL_MATCH).get(0);
+        matched.assertAttributeEquals("grok.NUMBER","-42");
+    }
+
+
+    @Test
     public void testExtractGrokWithUnMatchedContent() throws IOException {
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{URI}");
         testRunner.setProperty(ExtractGrok.GROK_PATTERN_FILE, "src/test/resources/TestExtractGrok/patterns");


### PR DESCRIPTION
Support for the new option to keep empty captures.  I did not add to the GrokReader because I am not sure of the effect on
the schema extraction.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [-] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

I did not, in keeping with the current file 

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.