### PR TITLE
NIFI-5225: Purge event data from event repository when Connectable is removed

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/repository/FlowFileEventRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/repository/FlowFileEventRepository.java
@@ -42,4 +42,12 @@ public interface FlowFileEventRepository extends Closeable {
      * @param cutoffEpochMilliseconds cutoff
      */
     void purgeTransferEvents(long cutoffEpochMilliseconds);
+
+    /**
+     * Causes any flow file events of the given component to be purged from the
+     * repository
+     *
+     * @param componentIdentifier Identifier of the component
+     */
+    void purgeTransferEvents(String componentIdentifier);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -2652,7 +2652,9 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     }
 
     public void onProcessorRemoved(final ProcessorNode procNode) {
-        allProcessors.remove(procNode.getIdentifier());
+        String identifier = procNode.getIdentifier();
+        flowFileEventRepository.purgeTransferEvents(identifier);
+        allProcessors.remove(identifier);
     }
 
     public ProcessorNode getProcessorNode(final String id) {
@@ -2664,7 +2666,9 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     }
 
     public void onConnectionRemoved(final Connection connection) {
-        allConnections.remove(connection.getIdentifier());
+        String identifier = connection.getIdentifier();
+        flowFileEventRepository.purgeTransferEvents(identifier);
+        allConnections.remove(identifier);
     }
 
     public Connection getConnection(final String id) {
@@ -2676,7 +2680,9 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     }
 
     public void onInputPortRemoved(final Port inputPort) {
-        allInputPorts.remove(inputPort.getIdentifier());
+        String identifier = inputPort.getIdentifier();
+        flowFileEventRepository.purgeTransferEvents(identifier);
+        allInputPorts.remove(identifier);
     }
 
     public Port getInputPort(final String id) {
@@ -2688,7 +2694,9 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     }
 
     public void onOutputPortRemoved(final Port outputPort) {
-        allOutputPorts.remove(outputPort.getIdentifier());
+        String identifier = outputPort.getIdentifier();
+        flowFileEventRepository.purgeTransferEvents(identifier);
+        allOutputPorts.remove(identifier);
     }
 
     public Port getOutputPort(final String id) {
@@ -2700,7 +2708,9 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
     }
 
     public void onFunnelRemoved(final Funnel funnel) {
-        allFunnels.remove(funnel.getIdentifier());
+        String identifier = funnel.getIdentifier();
+        flowFileEventRepository.purgeTransferEvents(identifier);
+        allFunnels.remove(identifier);
     }
 
     public Funnel getFunnel(final String id) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/metrics/RingBufferEventRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/metrics/RingBufferEventRepository.java
@@ -64,4 +64,9 @@ public class RingBufferEventRepository implements FlowFileEventRepository {
         }
     }
 
+    @Override
+    public void purgeTransferEvents(String componentIdentifier) {
+        componentEventMap.remove(componentIdentifier);
+    }
+
 }


### PR DESCRIPTION
### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
_Clean install ran through just fine, but contrib-check complained about an unrelated package_
- [x] Have you written or updated unit tests to verify your changes?
- [ ] ~~If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?~~ 
- [ ] ~~If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?~~
- [ ] ~~If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?~~
- [ ] ~~If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?~~

### For documentation related changes:
- ~~[ ] Have you ensured that format looks appropriate for the output in which it is rendered?~~

I introduced the option to purge data from the FlowFileEventRepository (the 5 min ring buffer) to fix this:
https://issues.apache.org/jira/browse/NIFI-5225

And it works for our setup.
