### PR TITLE
NIFI-5258 - Changed addHeader to setHeader which stops X-Frame-Option…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
@@ -194,6 +194,12 @@
             <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.0.6.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -534,7 +534,6 @@ public class JettyServer implements NiFiServer {
 
 
             // The below ServletContext and Servlet API usage was derived from https://stackoverflow.com/a/34277268.
-            // Thanks go to Stack Overflow user Joakim Erdfelt.
 
             // We create a servlet context handler to encapsulate the static docs resources we want served.
             ServletContextHandler docsHandler = new ServletContextHandler();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/JettyServerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/JettyServerTest.java
@@ -17,20 +17,30 @@
 
 package org.apache.nifi.web.server;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.nifi.security.util.KeystoreType;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.apache.nifi.util.NiFiProperties;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.Filter;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.Test;
-
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletResponse;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
 public class JettyServerTest {
     @Test
@@ -141,5 +151,30 @@ public class JettyServerTest {
 
         verify(contextFactory).setTrustStoreType(trustStoreType);
         verify(contextFactory).setTrustStoreProvider(BouncyCastleProvider.PROVIDER_NAME);
+    }
+
+    @Test
+    public void testNoDuplicateXFrameOptions() throws NoSuchFieldException, IllegalAccessException, ServletException, IOException {
+        Field xOptionsFilter = JettyServer.class.getDeclaredField("FRAME_OPTIONS_FILTER");
+        xOptionsFilter.setAccessible(true);
+        Filter filter = (Filter) xOptionsFilter.get(xOptionsFilter);
+
+        HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(mockRequest.getRequestURI()).thenReturn("/");
+
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        FilterChain mockFilterChain = Mockito.mock(FilterChain.class);
+        ServletContext mockContext = Mockito.mock(ServletContext.class);
+        FilterConfig mockFilterConfig = Mockito.mock(FilterConfig.class);
+
+        when(mockFilterConfig.getServletContext()).thenReturn(mockContext);
+
+        filter.init(mockFilterConfig);
+
+        // Call doFilter twice, then check the header only appears once.
+        filter.doFilter(mockRequest, mockResponse, mockFilterChain);
+        filter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertEquals(1, mockResponse.getHeaders("X-Frame-Options").size());
     }
 }


### PR DESCRIPTION
…s being added twice to responses. Changed the way docs webapp is created to allow adding the X-Frame-Options header to docs resources too. Added test to check response header.

NIFI-5258 - Added unit test to check header returns as expected.

NIFI-5258 - Fixed * import.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
