### PR TITLE
NIFI-5266: Sanitize ES parameters in PutElasticsearchHttp processors

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/pom.xml
@@ -62,8 +62,8 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <artifactId>commons-text</artifactId>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttp.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttp.java
@@ -142,6 +142,8 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
     private static final Set<Relationship> relationships;
     private static final List<PropertyDescriptor> propertyDescriptors;
 
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     static {
         final Set<Relationship> _rels = new HashSet<>();
         _rels.add(REL_SUCCESS);
@@ -228,7 +230,7 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
         final StringBuilder sb = new StringBuilder();
         final String baseUrl = context.getProperty(ES_URL).evaluateAttributeExpressions().getValue().trim();
         if (StringUtils.isEmpty(baseUrl)) {
-            throw new ProcessException("Elasticsearch URL is not valid: " + baseUrl);
+            throw new ProcessException("Elasticsearch URL is empty or null, this indicates an invalid Expression (missing variables, e.g.)");
         }
         HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder().addPathSegment("_bulk");
 
@@ -295,7 +297,6 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
 
             // Ensure the JSON body is well-formed
             try {
-                final ObjectMapper mapper = new ObjectMapper();
                 mapper.readTree(jsonString);
             } catch (IOException e) {
                 logger.error("Flow file content is not valid JSON, penalizing and transferring to failure.",

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttp.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttp.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processors.elasticsearch;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -60,8 +61,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
@@ -227,7 +226,10 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
         List<FlowFile> flowFilesToTransfer = new LinkedList<>(flowFiles);
 
         final StringBuilder sb = new StringBuilder();
-        final String baseUrl = trimToEmpty(context.getProperty(ES_URL).evaluateAttributeExpressions().getValue());
+        final String baseUrl = context.getProperty(ES_URL).evaluateAttributeExpressions().getValue().trim();
+        if (StringUtils.isEmpty(baseUrl)) {
+            throw new ProcessException("Elasticsearch URL is not valid: " + baseUrl);
+        }
         HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder().addPathSegment("_bulk");
 
         // Find the user-added properties and set them as query parameters on the URL
@@ -288,42 +290,23 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
             session.read(file, in -> {
                 json.append(IOUtils.toString(in, charset).replace("\r\n", " ").replace('\n', ' ').replace('\r', ' '));
             });
-            if (indexOp.equalsIgnoreCase("index")) {
-                sb.append("{\"index\": { \"_index\": \"");
-                sb.append(index);
-                sb.append("\", \"_type\": \"");
-                sb.append(docType);
-                sb.append("\"");
-                if (!StringUtils.isEmpty(id)) {
-                    sb.append(", \"_id\": \"");
-                    sb.append(id);
-                    sb.append("\"");
-                }
-                sb.append("}}\n");
-                sb.append(json);
-                sb.append("\n");
-            } else if (indexOp.equalsIgnoreCase("upsert") || indexOp.equalsIgnoreCase("update")) {
-                sb.append("{\"update\": { \"_index\": \"");
-                sb.append(index);
-                sb.append("\", \"_type\": \"");
-                sb.append(docType);
-                sb.append("\", \"_id\": \"");
-                sb.append(id);
-                sb.append("\" }\n");
-                sb.append("{\"doc\": ");
-                sb.append(json);
-                sb.append(", \"doc_as_upsert\": ");
-                sb.append(indexOp.equalsIgnoreCase("upsert"));
-                sb.append(" }\n");
-            } else if (indexOp.equalsIgnoreCase("delete")) {
-                sb.append("{\"delete\": { \"_index\": \"");
-                sb.append(index);
-                sb.append("\", \"_type\": \"");
-                sb.append(docType);
-                sb.append("\", \"_id\": \"");
-                sb.append(id);
-                sb.append("\" }\n");
+
+            String jsonString = json.toString();
+
+            // Ensure the JSON body is well-formed
+            try {
+                final ObjectMapper mapper = new ObjectMapper();
+                mapper.readTree(jsonString);
+            } catch (IOException e) {
+                logger.error("Flow file content is not valid JSON, penalizing and transferring to failure.",
+                        new Object[]{indexOp, file});
+                flowFilesToTransfer.remove(file);
+                file = session.penalize(file);
+                session.transfer(file, REL_FAILURE);
+                continue;
             }
+
+            buildBulkCommand(sb, index, docType, indexOp, id, jsonString);
         }
         if (!flowFilesToTransfer.isEmpty()) {
             RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), sb.toString());
@@ -364,10 +347,10 @@ public class PutElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
                                     if (!isSuccess(status)) {
                                         if (errorReason == null) {
                                             // Use "result" if it is present; this happens for status codes like 404 Not Found, which may not have an error/reason
-                                            String reason = itemNode.findPath("//result").asText();
+                                            String reason = itemNode.findPath("result").asText();
                                             if (StringUtils.isEmpty(reason)) {
                                                 // If there was no result, we expect an error with a string description in the "reason" field
-                                                reason = itemNode.findPath("//error/reason").asText();
+                                                reason = itemNode.findPath("reason").asText();
                                             }
                                             errorReason = reason;
                                             logger.error("Failed to process {} due to {}, transferring to failure",

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
@@ -80,8 +80,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.apache.commons.lang3.StringUtils.trimToEmpty;
-
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @EventDriven
@@ -261,7 +259,10 @@ public class PutElasticsearchHttpRecord extends AbstractElasticsearchHttpProcess
         OkHttpClient okHttpClient = getClient();
         final ComponentLog logger = getLogger();
 
-        final String baseUrl = trimToEmpty(context.getProperty(ES_URL).evaluateAttributeExpressions().getValue());
+        final String baseUrl = context.getProperty(ES_URL).evaluateAttributeExpressions().getValue().trim();
+        if (StringUtils.isEmpty(baseUrl)) {
+            throw new ProcessException("Elasticsearch URL is not valid: " + baseUrl);
+        }
         HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder().addPathSegment("_bulk");
 
         // Find the user-added properties and set them as query parameters on the URL
@@ -339,42 +340,7 @@ public class PutElasticsearchHttpRecord extends AbstractElasticsearchHttpProcess
                 generator.close();
                 json.append(out.toString());
 
-                if (indexOp.equalsIgnoreCase("index")) {
-                    sb.append("{\"index\": { \"_index\": \"");
-                    sb.append(index);
-                    sb.append("\", \"_type\": \"");
-                    sb.append(docType);
-                    sb.append("\"");
-                    if (!StringUtils.isEmpty(id)) {
-                        sb.append(", \"_id\": \"");
-                        sb.append(id);
-                        sb.append("\"");
-                    }
-                    sb.append("}}\n");
-                    sb.append(json);
-                    sb.append("\n");
-                } else if (indexOp.equalsIgnoreCase("upsert") || indexOp.equalsIgnoreCase("update")) {
-                    sb.append("{\"update\": { \"_index\": \"");
-                    sb.append(index);
-                    sb.append("\", \"_type\": \"");
-                    sb.append(docType);
-                    sb.append("\", \"_id\": \"");
-                    sb.append(id);
-                    sb.append("\" }\n");
-                    sb.append("{\"doc\": ");
-                    sb.append(json);
-                    sb.append(", \"doc_as_upsert\": ");
-                    sb.append(indexOp.equalsIgnoreCase("upsert"));
-                    sb.append(" }\n");
-                } else if (indexOp.equalsIgnoreCase("delete")) {
-                    sb.append("{\"delete\": { \"_index\": \"");
-                    sb.append(index);
-                    sb.append("\", \"_type\": \"");
-                    sb.append(docType);
-                    sb.append("\", \"_id\": \"");
-                    sb.append(id);
-                    sb.append("\" }\n");
-                }
+                buildBulkCommand(sb, index, docType, indexOp, id, json.toString());
             }
         } catch (IdentifierNotFoundException infe) {
             logger.error(infe.getMessage(), new Object[]{flowFile});
@@ -422,10 +388,10 @@ public class PutElasticsearchHttpRecord extends AbstractElasticsearchHttpProcess
                             if (!isSuccess(status)) {
                                 if (errorReason == null) {
                                     // Use "result" if it is present; this happens for status codes like 404 Not Found, which may not have an error/reason
-                                    String reason = itemNode.findPath("//result").asText();
+                                    String reason = itemNode.findPath("result").asText();
                                     if (StringUtils.isEmpty(reason)) {
                                         // If there was no result, we expect an error with a string description in the "reason" field
-                                        reason = itemNode.findPath("//error/reason").asText();
+                                        reason = itemNode.findPath("reason").asText();
                                     }
                                     errorReason = reason;
                                     logger.error("Failed to process {} due to {}, transferring to failure",

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
@@ -261,7 +261,7 @@ public class PutElasticsearchHttpRecord extends AbstractElasticsearchHttpProcess
 
         final String baseUrl = context.getProperty(ES_URL).evaluateAttributeExpressions().getValue().trim();
         if (StringUtils.isEmpty(baseUrl)) {
-            throw new ProcessException("Elasticsearch URL is not valid: " + baseUrl);
+            throw new ProcessException("Elasticsearch URL is empty or null, this indicates an invalid Expression (missing variables, e.g.)");
         }
         HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder().addPathSegment("_bulk");
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecordIT.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecordIT.java
@@ -205,7 +205,7 @@ public class PutElasticsearchHttpRecordIT {
     }
 
     @Test
-    public void testBadIndexName() throws Exception {
+    public void testIllegalIndexName() throws Exception {
         // Undo some stuff from setup()
         runner.setProperty(PutElasticsearchHttpRecord.INDEX, "people\"test");
         runner.setProperty(PutElasticsearchHttpRecord.TYPE, "person");
@@ -225,6 +225,29 @@ public class PutElasticsearchHttpRecordIT {
         runner.assertTransferCount(PutElasticsearchHttpRecord.REL_FAILURE, 1);
         runner.assertTransferCount(PutElasticsearchHttpRecord.REL_RETRY, 0);
         runner.assertTransferCount(PutElasticsearchHttpRecord.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testIndexNameWithJsonChar() throws Exception {
+        // Undo some stuff from setup()
+        runner.setProperty(PutElasticsearchHttpRecord.INDEX, "people}test");
+        runner.setProperty(PutElasticsearchHttpRecord.TYPE, "person");
+        recordReader.addRecord(1, new MapRecord(personSchema, new HashMap<String,Object>() {{
+            put("name", "John Doe");
+            put("age", 48);
+            put("sport", null);
+        }}));
+
+        List<Map<String, String>> attrs = new ArrayList<>();
+        Map<String, String> attr = new HashMap<>();
+        attr.put("doc_id", "1");
+        attrs.add(attr);
+
+        runner.enqueue("");
+        runner.run(1, true, true);
+        runner.assertTransferCount(PutElasticsearchHttpRecord.REL_FAILURE, 0);
+        runner.assertTransferCount(PutElasticsearchHttpRecord.REL_RETRY, 0);
+        runner.assertTransferCount(PutElasticsearchHttpRecord.REL_SUCCESS, 1);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecordIT.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecordIT.java
@@ -89,7 +89,6 @@ public class PutElasticsearchHttpRecordIT {
 
     private void setupPut() {
         runner.enqueue("");
-        runner.setValidateExpressionUsage(false);
         runner.run(1, true, true);
         runner.assertTransferCount(PutElasticsearchHttpRecord.REL_FAILURE, 0);
         runner.assertTransferCount(PutElasticsearchHttpRecord.REL_RETRY, 0);
@@ -203,6 +202,48 @@ public class PutElasticsearchHttpRecordIT {
             Assert.assertFalse(p1.containsKey("sport"));
             Assert.assertFalse(p2.containsKey("sport"));
         });
+    }
+
+    @Test
+    public void testBadIndexName() throws Exception {
+        // Undo some stuff from setup()
+        runner.setProperty(PutElasticsearchHttpRecord.INDEX, "people\"test");
+        runner.setProperty(PutElasticsearchHttpRecord.TYPE, "person");
+        recordReader.addRecord(1, new MapRecord(personSchema, new HashMap<String,Object>() {{
+            put("name", "John Doe");
+            put("age", 48);
+            put("sport", null);
+        }}));
+
+        List<Map<String, String>> attrs = new ArrayList<>();
+        Map<String, String> attr = new HashMap<>();
+        attr.put("doc_id", "1");
+        attrs.add(attr);
+
+        runner.enqueue("");
+        runner.run(1, true, true);
+        runner.assertTransferCount(PutElasticsearchHttpRecord.REL_FAILURE, 1);
+        runner.assertTransferCount(PutElasticsearchHttpRecord.REL_RETRY, 0);
+        runner.assertTransferCount(PutElasticsearchHttpRecord.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testTypeNameWithSpecialChars() throws Exception {
+        // Undo some stuff from setup()
+        runner.setProperty(PutElasticsearchHttpRecord.INDEX, "people_test2");
+        runner.setProperty(PutElasticsearchHttpRecord.TYPE, "per\"son");
+        recordReader.addRecord(1, new MapRecord(personSchema, new HashMap<String,Object>() {{
+            put("name", "John Doe");
+            put("age", 48);
+            put("sport", null);
+        }}));
+
+        List<Map<String, String>> attrs = new ArrayList<>();
+        Map<String, String> attr = new HashMap<>();
+        attr.put("doc_id", "1");
+        attrs.add(attr);
+
+        setupPut();
     }
 
     private interface SharedPostTest {

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttp.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttp.java
@@ -553,4 +553,20 @@ public class TestPutElasticsearchHttp {
         runner.run(1, true, true);
         runner.assertAllFlowFilesTransferred(PutElasticsearchHttp.REL_SUCCESS, 1);
     }
+
+    @Test(expected = AssertionError.class)
+    public void testPutElasticSearchBadHostInEL() throws IOException {
+        runner = TestRunners.newTestRunner(new PutElasticsearchTestProcessor(false)); // no failures
+        runner.setProperty(AbstractElasticsearchHttpProcessor.ES_URL, "${es.url}");
+
+        runner.setProperty(PutElasticsearchHttp.INDEX, "doc");
+        runner.setProperty(PutElasticsearchHttp.TYPE, "status");
+        runner.setProperty(PutElasticsearchHttp.BATCH_SIZE, "1");
+        runner.setProperty(PutElasticsearchHttp.ID_ATTRIBUTE, "doc_id");
+
+        runner.enqueue(docExample, new HashMap<String, String>() {{
+            put("doc_id", "28039652140");
+        }});
+        runner.run(1, true, true);
+    }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
@@ -486,6 +486,23 @@ public class TestPutElasticsearchHttpRecord {
         runner.assertAllFlowFilesTransferred(PutElasticsearchHttpRecord.REL_SUCCESS, 100);
     }
 
+    @Test(expected = AssertionError.class)
+    public void testPutElasticSearchBadHostInEL() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutElasticsearchHttpRecord());
+
+        runner.setProperty(AbstractElasticsearchHttpProcessor.ES_URL, "${es.url}");
+        runner.setProperty(PutElasticsearchHttpRecord.INDEX, "doc");
+        runner.setProperty(PutElasticsearchHttpRecord.TYPE, "status");
+        runner.setProperty(PutElasticsearchHttpRecord.ID_RECORD_PATH, "/id");
+        runner.assertValid();
+
+        runner.enqueue(new byte[0], new HashMap<String, String>() {{
+            put("doc_id", "1");
+        }});
+
+        runner.run();
+    }
+
     private void generateTestData() throws IOException {
 
         final MockRecordParser parser = new MockRecordParser();


### PR DESCRIPTION
I ran the PutESHttp integration tests as well (after adding new ones to test this behavior). Also fixed a couple of minor issues while I was in here, such as adding unit tests around Expression Language for the ES URL, fixing the result/reason error handling to return the right string, etc.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
