### PR TITLE
NIFI-5237: Considering proxy headers following OIDC login

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
@@ -266,7 +266,7 @@ public class AccessResource extends ApplicationResource {
             }
 
             // redirect to the name page
-            httpServletResponse.sendRedirect("../../../nifi");
+            httpServletResponse.sendRedirect(getNiFiUri());
         } else {
             // remove the oidc request cookie
             removeOidcRequestCookie(httpServletResponse);
@@ -369,7 +369,7 @@ public class AccessResource extends ApplicationResource {
             return;
         }
 
-        httpServletResponse.sendRedirect("../../../nifi");
+        httpServletResponse.sendRedirect(getNiFiUri());
     }
 
     /**
@@ -738,6 +738,12 @@ public class AccessResource extends ApplicationResource {
 
     private String getOidcCallback() {
         return generateResourceUri("access", "oidc", "callback");
+    }
+
+    private String getNiFiUri() {
+        final String nifiApiUrl = generateResourceUri();
+        final String baseUrl = StringUtils.substringBeforeLast(nifiApiUrl,"/nifi-api");
+        return baseUrl + "/nifi";
     }
 
     private void removeOidcRequestCookie(final HttpServletResponse httpServletResponse) {


### PR DESCRIPTION
NIFI-5237:
- Ensuring the proxy headers are considered when redirecting the user following a OIDC or Knox login exchange.