### PR TITLE
NIFI-3217: Preventing editor close on window resize

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/slick-nifi-theme.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/slick-nifi-theme.css
@@ -91,6 +91,10 @@
     text-align: center;
 }
 
+.slick-header.ui-state-default {
+    background-color: #728E9B;
+}
+
 .slick-header.ui-state-default, .slick-headerrow.ui-state-default {
     font-family: Roboto;
     font-weight: 500;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1492,6 +1492,14 @@
             }
         });
 
+        if (options.readOnly !== true) {
+            propertyGrid.onBeforeCellEditorDestroy.subscribe(function (e, args) {
+                setTimeout(function() {
+                    propertyGrid.resizeCanvas();
+                }, 50);
+            });
+        }
+
         // wire up the dataview to the grid
         propertyData.onRowCountChanged.subscribe(function (e, args) {
             propertyGrid.updateRowCount();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas.js
@@ -667,9 +667,13 @@
                     // resize grids when appropriate
                     var gridElements = $('*[class*="slickgrid_"]');
                     for (var j = 0, len = gridElements.length; j < len; j++) {
-                        if ($(gridElements[j]).is(':visible')){
-                            setTimeout(function(gridElement){
-                                gridElement.data('gridInstance').resizeCanvas();
+                        if ($(gridElements[j]).is(':visible')) {
+                            setTimeout(function(gridElement) {
+                                var grid = gridElement.data('gridInstance');
+                                var editorLock = grid.getEditorLock();
+                                if (!editorLock.isActive()) {
+                                    grid.resizeCanvas();
+                                }
                             }, 50, $(gridElements[j]));
                         }
                     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-variable-registry.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-variable-registry.js
@@ -585,6 +585,11 @@
                 }
             }
         });
+        variablesGrid.onBeforeCellEditorDestroy.subscribe(function (e, args) {
+            setTimeout(function() {
+                variablesGrid.resizeCanvas();
+            }, 50);
+        });
 
         // wire up the dataview to the grid
         variableData.onRowCountChanged.subscribe(function (e, args) {

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/src/main/webapp/js/application.js
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/src/main/webapp/js/application.js
@@ -68,8 +68,15 @@ var ua = {
         // enable grid resizing
         $(window).resize(function (e) {
             if (e.target === window) {
-                conditionsGrid.resizeCanvas();
-                actionsGrid.resizeCanvas();
+                var conditionsLock = conditionsGrid.getEditorLock();
+                if (!conditionsLock.isActive()) {
+                    conditionsGrid.resizeCanvas();
+                }
+
+                var actionsLock = actionsGrid.getEditorLock();
+                if (!actionsLock.isActive()) {
+                    actionsGrid.resizeCanvas();
+                }
 
                 // toggle .scrollable when appropriate
                 toggleScrollable($('#rule-details-panel').get(0));
@@ -766,6 +773,17 @@ var ua = {
             e.stopImmediatePropagation();
         });
 
+        if (ua.editable) {
+            conditionsGrid.onBeforeCellEditorDestroy.subscribe(function (e, args) {
+                setTimeout(function() {
+                    conditionsGrid.resizeCanvas();
+
+                    var actionsGrid = $('#selected-rule-actions').data('gridInstance');
+                    actionsGrid.resizeCanvas();
+                }, 50);
+            });
+        }
+
         // wire up the dataview to the grid
         conditionsData.onRowCountChanged.subscribe(function (e, args) {
             conditionsGrid.updateRowCount();
@@ -843,6 +861,17 @@ var ua = {
             // prevents standard edit logic
             e.stopImmediatePropagation();
         });
+
+        if (ua.editable) {
+            actionsGrid.onBeforeCellEditorDestroy.subscribe(function (e, args) {
+                setTimeout(function() {
+                    actionsGrid.resizeCanvas();
+
+                    var conditionsGrid = $('#selected-rule-conditions').data('gridInstance');
+                    conditionsGrid.resizeCanvas();
+                }, 50);
+            });
+        }
 
         // wire up the dataview to the grid
         actionsData.onRowCountChanged.subscribe(function (e, args) {


### PR DESCRIPTION
NIFI-3217: 
- Disabling the resize of SlickGrid when there is an active edit occuring. This will prevent the accidental closure of the current edit.
- Triggering a resize when the active editor closes.