### PR TITLE
NIFI-5278: fixes JSON escaping of code parameter in Execute Spark Interactive processor

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -291,6 +291,11 @@ The following binary components are provided under the Apache Software License v
       This product includes software from the Spring Framework,
       under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 
+  (ASLv2) Apache Commons Text
+    The following NOTICE information applies:
+      Apache Commons Text
+      Copyright 2001-2018 The Apache Software Foundation
+
   (ASLv2) Apache Commons Configuration
     The following NOTICE information applies:
       Apache Commons Configuration

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-nar/src/main/resources/META-INF/NOTICE
@@ -53,6 +53,11 @@ The following binary components are provided under the Apache Software License v
       Apache Commons IO
       Copyright 2002-2016 The Apache Software Foundation
 
+  (ASLv2) Apache Commons Text
+    The following NOTICE information applies:
+      Apache Commons Text
+      Copyright 2001-2018 The Apache Software Foundation
+
   (ASLv2) Jackson JSON processor
     The following NOTICE information applies:
       # Jackson JSON processor

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/pom.xml
@@ -98,5 +98,10 @@
             <version>1.7.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/main/java/org/apache/nifi/processors/livy/ExecuteSparkInteractive.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/main/java/org/apache/nifi/processors/livy/ExecuteSparkInteractive.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -207,7 +207,7 @@ public class ExecuteSparkInteractive extends AbstractProcessor {
             }
         }
 
-        code = StringEscapeUtils.escapeJavaScript(code);
+        code = StringEscapeUtils.escapeJson(code);
         String payload = "{\"code\":\"" + code + "\"}";
         try {
             final JSONObject result = submitAndHandleJob(livyUrl, livySessionService, sessionId, payload, statusCheckInterval);

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/ExecuteSparkInteractiveTestBase.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/ExecuteSparkInteractiveTestBase.java
@@ -16,10 +16,12 @@
  */
 package org.apache.nifi.processors.livy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -32,21 +34,21 @@ public class ExecuteSparkInteractiveTestBase {
         int session1Requests = 0;
 
         @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
             baseRequest.setHandled(true);
 
-            response.setStatus(200);
+            int responseStatus = 404;
+            String responseContentType = "text/plain";
+            String responseBody = "Not found";
 
             if ("GET".equalsIgnoreCase(request.getMethod())) {
-
-                String responseBody = "{}";
-                response.setContentType("application/json");
-
+                responseStatus = 200;
+                responseBody = "{}";
+                responseContentType = "application/json";
                 if ("/sessions".equalsIgnoreCase(target)) {
                     responseBody = "{\"sessions\": [{\"id\": 1, \"kind\": \"spark\", \"state\": \"idle\"}]}";
                 } else if (target.startsWith("/sessions/") && !target.contains("statement")) {
                     responseBody = "{\"id\": 1, \"kind\": \"spark\", \"state\": \"idle\"}";
-
                 } else if ("/sessions/1/statements/7".equalsIgnoreCase(target)) {
                     switch (session1Requests) {
                         case 0:
@@ -64,33 +66,37 @@ public class ExecuteSparkInteractiveTestBase {
                     }
                     session1Requests++;
                 }
-
-                response.setContentLength(responseBody.length());
-
-                try (PrintWriter writer = response.getWriter()) {
-                    writer.print(responseBody);
-                    writer.flush();
-                }
-
             } else if ("POST".equalsIgnoreCase(request.getMethod())) {
+                String requestBody = IOUtils.toString(request.getReader());
+                try {
+                    System.out.println("requestBody: " + requestBody);
 
-                String responseBody = "{}";
-                response.setContentType("application/json");
+                    new ObjectMapper().readTree(requestBody);
 
-                if ("/sessions".equalsIgnoreCase(target)) {
-                    responseBody = "{\"id\": 1, \"kind\": \"spark\", \"state\": \"idle\"}";
-                } else if ("/sessions/1/statements".equalsIgnoreCase(target)) {
-                    responseBody = "{\"id\": 7}";
+                    responseStatus = 200;
+                    responseBody = "{}";
+                    responseContentType = "application/json";
+                    if ("/sessions".equalsIgnoreCase(target)) {
+                        responseBody = "{\"id\": 1, \"kind\": \"spark\", \"state\": \"idle\"}";
+                    } else if ("/sessions/1/statements".equalsIgnoreCase(target)) {
+                        responseBody = "{\"id\": 7}";
+                    }
+                } catch (JsonProcessingException e) {
+                    responseStatus = 400;
+                    responseContentType = "text/plain";
+                    responseBody = "Bad request";
                 }
-
-                response.setContentLength(responseBody.length());
-
-                try (PrintWriter writer = response.getWriter()) {
-                    writer.print(responseBody);
-                    writer.flush();
-                }
-
             }
+
+            response.setStatus(responseStatus);
+            response.setContentType(responseContentType);
+            response.setContentLength(responseBody.length());
+
+            try (PrintWriter writer = response.getWriter()) {
+                writer.print(responseBody);
+                writer.flush();
+            }
+
         }
     }
 }

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractive.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractive.java
@@ -17,26 +17,18 @@
 package org.apache.nifi.processors.livy;
 
 import org.apache.nifi.controller.livy.LivySessionController;
-import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.nifi.web.util.TestServer;
-import org.eclipse.jetty.server.Handler;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.List;
-
 public class TestExecuteSparkInteractive extends ExecuteSparkInteractiveTestBase {
 
-    public static TestServer server;
-    public static String url;
-
-    public TestRunner runner;
+    private static TestServer server;
+    private static String url;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -50,10 +42,6 @@ public class TestExecuteSparkInteractive extends ExecuteSparkInteractiveTestBase
 
         // this is the base url with the random port
         url = server.getUrl();
-    }
-
-    public void addHandler(Handler handler) {
-        server.addHandler(handler);
     }
 
     @AfterClass
@@ -79,26 +67,17 @@ public class TestExecuteSparkInteractive extends ExecuteSparkInteractiveTestBase
         runner.shutdown();
     }
 
-    private static TestServer createServer() throws IOException {
+    private static TestServer createServer() {
         return new TestServer();
     }
 
     @Test
     public void testSparkSession() throws Exception {
-        addHandler(new LivyAPIHandler());
+        testCode(server, "print \"hello world\"");
+    }
 
-        String code = "print \"hello world\" //'?!<>[]{}()$&*=%;.|_-\\";
-
-        runner.enqueue(code);
-        runner.run();
-        List<MockFlowFile> waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
-        while (!waitingFlowfiles.isEmpty()) {
-            Thread.sleep(1000);
-            runner.clearTransferState();
-            runner.enqueue(code);
-            runner.run();
-            waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
-        }
-        runner.assertTransferCount(ExecuteSparkInteractive.REL_SUCCESS, 1);
+    @Test
+    public void testSparkSessionWithSpecialChars() throws Exception {
+        testCode(server, "print \"/'?!<>[]{}()$&*=%;.|_-\\\"");
     }
 }

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractive.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractive.java
@@ -85,16 +85,17 @@ public class TestExecuteSparkInteractive extends ExecuteSparkInteractiveTestBase
 
     @Test
     public void testSparkSession() throws Exception {
-
         addHandler(new LivyAPIHandler());
 
-        runner.enqueue("print \"hello world\"");
+        String code = "print \"hello world\" //'?!<>[]{}()$&*=%;.|_-\\";
+
+        runner.enqueue(code);
         runner.run();
         List<MockFlowFile> waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
         while (!waitingFlowfiles.isEmpty()) {
             Thread.sleep(1000);
             runner.clearTransferState();
-            runner.enqueue("print \"hello world\"");
+            runner.enqueue(code);
             runner.run();
             waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
         }

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractiveSSL.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractiveSSL.java
@@ -18,30 +18,23 @@ package org.apache.nifi.processors.livy;
 
 import org.apache.nifi.controller.livy.LivySessionController;
 import org.apache.nifi.ssl.StandardSSLContextService;
-import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.nifi.web.util.TestServer;
-import org.eclipse.jetty.server.Handler;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class TestExecuteSparkInteractiveSSL extends ExecuteSparkInteractiveTestBase {
 
     private static Map<String, String> sslProperties;
 
-    public static TestServer server;
-    public static String url;
-
-    public TestRunner runner;
+    private static TestServer server;
+    private static String url;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -62,10 +55,6 @@ public class TestExecuteSparkInteractiveSSL extends ExecuteSparkInteractiveTestB
 
         // this is the base url with the random port
         url = server.getSecureUrl();
-    }
-
-    public void addHandler(Handler handler) {
-        server.addHandler(handler);
     }
 
     @AfterClass
@@ -101,27 +90,13 @@ public class TestExecuteSparkInteractiveSSL extends ExecuteSparkInteractiveTestB
         runner.shutdown();
     }
 
-    private static TestServer createServer() throws IOException {
+    private static TestServer createServer() {
         return new TestServer(sslProperties);
     }
 
     @Test
-    public void testSslSparkSession() throws Exception {
-        addHandler(new LivyAPIHandler());
-
-        String code = "print \"hello world\" //'?!<>[]{}()$&*=%;.|_-\\";
-
-        runner.enqueue(code);
-        runner.run();
-        List<MockFlowFile> waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
-        while (!waitingFlowfiles.isEmpty()) {
-            Thread.sleep(1000);
-            runner.clearTransferState();
-            runner.enqueue(code);
-            runner.run();
-            waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
-        }
-        runner.assertTransferCount(ExecuteSparkInteractive.REL_SUCCESS, 1);
+    public void testSparkSession() throws Exception {
+      testCode(server,"print \"hello world\"");
     }
 
     private static Map<String, String> createSslProperties() {

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractiveSSL.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-processors/src/test/java/org/apache/nifi/processors/livy/TestExecuteSparkInteractiveSSL.java
@@ -109,13 +109,15 @@ public class TestExecuteSparkInteractiveSSL extends ExecuteSparkInteractiveTestB
     public void testSslSparkSession() throws Exception {
         addHandler(new LivyAPIHandler());
 
-        runner.enqueue("print \"hello world\"");
+        String code = "print \"hello world\" //'?!<>[]{}()$&*=%;.|_-\\";
+
+        runner.enqueue(code);
         runner.run();
         List<MockFlowFile> waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
         while (!waitingFlowfiles.isEmpty()) {
             Thread.sleep(1000);
             runner.clearTransferState();
-            runner.enqueue("print \"hello world\"");
+            runner.enqueue(code);
             runner.run();
             waitingFlowfiles = runner.getFlowFilesForRelationship(ExecuteSparkInteractive.REL_WAIT);
         }


### PR DESCRIPTION
Change-Id: I2cb0e6c658d4a0f2aad9c4aab9201a3334ee54df

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
