### PR TITLE
NIFI-4508: Update ConsumeAMQP to use basicConsume API instead of basicGet in order to provide better performance

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPConsumer.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPConsumer.java
@@ -17,13 +17,19 @@
 package org.apache.nifi.amqp.processors;
 
 import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.nifi.processor.exception.ProcessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.GetResponse;
 
 /**
@@ -34,12 +40,37 @@ final class AMQPConsumer extends AMQPWorker {
 
     private final static Logger logger = LoggerFactory.getLogger(AMQPConsumer.class);
     private final String queueName;
+    private final BlockingQueue<GetResponse> responseQueue;
+    private final boolean autoAcknowledge;
 
-    AMQPConsumer(Connection connection, String queueName) {
+    private volatile boolean closed = false;
+
+
+    AMQPConsumer(final Connection connection, final String queueName, final boolean autoAcknowledge) throws IOException {
         super(connection);
         this.validateStringProperty("queueName", queueName);
         this.queueName = queueName;
+        this.autoAcknowledge = autoAcknowledge;
+        this.responseQueue = new LinkedBlockingQueue<>(10);
+
         logger.info("Successfully connected AMQPConsumer to " + connection.toString() + " and '" + queueName + "' queue");
+
+        final Channel channel = getChannel();
+        channel.basicConsume(queueName, autoAcknowledge, new DefaultConsumer(channel) {
+            @Override
+            public void handleDelivery(final String consumerTag, final Envelope envelope, final BasicProperties properties, final byte[] body) throws IOException {
+                if (!autoAcknowledge && closed) {
+                    channel.basicReject(envelope.getDeliveryTag(), true);
+                    return;
+                }
+
+                try {
+                    responseQueue.put(new GetResponse(envelope, properties, body, Integer.MAX_VALUE));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
     }
 
     /**
@@ -53,12 +84,29 @@ final class AMQPConsumer extends AMQPWorker {
      * @return instance of {@link GetResponse}
      */
     public GetResponse consume() {
-        try {
-            return getChannel().basicGet(this.queueName, true);
-        } catch (IOException e) {
-            logger.error("Failed to receive message from AMQP; " + this + ". Possible reasons: Queue '" + this.queueName
-                    + "' may not have been defined", e);
-            throw new ProcessException(e);
+        return responseQueue.poll();
+    }
+
+    public void acknowledge(final GetResponse response) throws IOException {
+        if (autoAcknowledge) {
+            return;
+        }
+
+        getChannel().basicAck(response.getEnvelope().getDeliveryTag(), true);
+    }
+
+    @Override
+    public void close() throws TimeoutException, IOException {
+        closed = true;
+
+        GetResponse lastMessage = null;
+        GetResponse response;
+        while ((response = responseQueue.poll()) != null) {
+            lastMessage = response;
+        }
+
+        if (lastMessage != null) {
+            getChannel().basicNack(lastMessage.getEnvelope().getDeliveryTag(), true, true);
         }
     }
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPWorker.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPWorker.java
@@ -35,6 +35,7 @@ abstract class AMQPWorker implements AutoCloseable {
 
     private final static Logger logger = LoggerFactory.getLogger(AMQPWorker.class);
     private final Channel channel;
+    private boolean closed = false;
 
     /**
      * Creates an instance of this worker initializing it with AMQP
@@ -58,20 +59,21 @@ abstract class AMQPWorker implements AutoCloseable {
         return channel;
     }
 
-    /**
-     * Closes {@link Channel} created when instance of this class was created.
-     */
+
     @Override
     public void close() throws TimeoutException, IOException {
+        if (closed) {
+            return;
+        }
+
         if (logger.isDebugEnabled()) {
             logger.debug("Closing AMQP channel for " + this.channel.getConnection().toString());
         }
+
         this.channel.close();
+        closed = true;
     }
 
-    /**
-     *
-     */
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + ":" + this.channel.getConnection().toString();
@@ -80,10 +82,8 @@ abstract class AMQPWorker implements AutoCloseable {
     /**
      * Validates that a String property has value (not null nor empty)
      *
-     * @param propertyName
-     *            the name of the property
-     * @param value
-     *            the value of the property
+     * @param propertyName the name of the property
+     * @param value the value of the property
      */
     void validateStringProperty(String propertyName, String value) {
         if (value == null || value.trim().length() == 0) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -142,6 +142,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
 
     private final BlockingQueue<AMQPResource<T>> resourceQueue = new LinkedBlockingQueue<>();
 
+
     /**
      * Will builds target resource ({@link AMQPPublisher} or {@link AMQPConsumer}) upon first invocation and will delegate to the
      * implementation of {@link #processResource(ProcessContext, ProcessSession)} method for further processing.

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -18,22 +18,37 @@ package org.apache.nifi.amqp.processors;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
-import org.apache.nifi.processor.exception.ProcessException;
-import org.junit.Ignore;
 import org.junit.Test;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.GetResponse;
 
-@Ignore
 public class AMQPConsumerTest {
+
+
+    @Test
+    public void testUnconsumedMessagesNacked() throws TimeoutException, IOException {
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1", "queue2"));
+        final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
+
+        final TestConnection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
+        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true);
+        consumer.getChannel().basicPublish("myExchange", "key1", new BasicProperties(), new byte[0]);
+
+        consumer.close();
+        assertTrue(((TestChannel) consumer.getChannel()).isNack(0));
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void failOnNullConnection() throws IOException {
@@ -52,7 +67,7 @@ public class AMQPConsumerTest {
         new AMQPConsumer(conn, " ", true);
     }
 
-    @Test(expected = ProcessException.class)
+    @Test(expected = IOException.class)
     public void failOnNonExistingQueue() throws Exception {
         Connection conn = new TestConnection(null, null);
         try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello", true)) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -19,43 +19,43 @@ package org.apache.nifi.amqp.processors;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.nifi.processor.exception.ProcessException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.GetResponse;
 
+@Ignore
 public class AMQPConsumerTest {
 
-    @SuppressWarnings("resource")
     @Test(expected = IllegalArgumentException.class)
-    public void failOnNullConnection() {
-        new AMQPConsumer(null, null);
+    public void failOnNullConnection() throws IOException {
+        new AMQPConsumer(null, null, true);
     }
 
-    @SuppressWarnings("resource")
     @Test(expected = IllegalArgumentException.class)
     public void failOnNullQueueName() throws Exception {
         Connection conn = new TestConnection(null, null);
-        new AMQPConsumer(conn, null);
+        new AMQPConsumer(conn, null, true);
     }
 
-    @SuppressWarnings("resource")
     @Test(expected = IllegalArgumentException.class)
     public void failOnEmptyQueueName() throws Exception {
         Connection conn = new TestConnection(null, null);
-        new AMQPConsumer(conn, " ");
+        new AMQPConsumer(conn, " ", true);
     }
 
     @Test(expected = ProcessException.class)
     public void failOnNonExistingQueue() throws Exception {
         Connection conn = new TestConnection(null, null);
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello")) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello", true)) {
             consumer.consume();
         }
     }
@@ -68,7 +68,7 @@ public class AMQPConsumerTest {
         exchangeToRoutingKeymap.put("", "queue1");
 
         Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1")) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true)) {
             GetResponse response = consumer.consume();
             assertNull(response);
         }
@@ -83,7 +83,7 @@ public class AMQPConsumerTest {
 
         Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
         conn.createChannel().basicPublish("myExchange", "key1", null, "hello Joe".getBytes());
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1")) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true)) {
             GetResponse response = consumer.consume();
             assertNotNull(response);
         }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -19,6 +19,7 @@ package org.apache.nifi.amqp.processors;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -26,14 +27,17 @@ import java.util.Map;
 
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.MessageProperties;
 
+@Ignore
 public class ConsumeAMQPTest {
 
 
@@ -68,7 +72,11 @@ public class ConsumeAMQPTest {
 
         @Override
         protected AMQPConsumer createAMQPWorker(ProcessContext context, Connection connection) {
-            return new AMQPConsumer(connection, context.getProperty(QUEUE).getValue());
+            try {
+                return new AMQPConsumer(connection, context.getProperty(QUEUE).getValue(), context.getProperty(AUTO_ACKNOWLEDGE).asBoolean());
+            } catch (IOException e) {
+                throw new ProcessException(e);
+            }
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.nifi.amqp.processors;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -24,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
@@ -31,15 +34,120 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Ignore;
 import org.junit.Test;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.MessageProperties;
 
-@Ignore
 public class ConsumeAMQPTest {
 
+    @Test
+    public void testMessageAcked() throws TimeoutException, IOException {
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
+
+        final Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
+
+        try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
+            sender.publish("hello".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+            sender.publish("world".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+
+            ConsumeAMQP proc = new LocalConsumeAMQP(connection);
+            TestRunner runner = TestRunners.newTestRunner(proc);
+            runner.setProperty(ConsumeAMQP.HOST, "injvm");
+            runner.setProperty(ConsumeAMQP.QUEUE, "queue1");
+            runner.setProperty(ConsumeAMQP.AUTO_ACKNOWLEDGE, "false");
+
+            runner.run();
+
+            runner.assertTransferCount(PublishAMQP.REL_SUCCESS, 2);
+
+            final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+            helloFF.assertContentEquals("hello");
+
+            final MockFlowFile worldFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(1);
+            worldFF.assertContentEquals("world");
+
+            // A single cumulative ack should be used
+            assertFalse(((TestChannel) connection.createChannel()).isAck(0));
+            assertTrue(((TestChannel) connection.createChannel()).isAck(1));
+        }
+    }
+
+    @Test
+    public void testBatchSizeAffectsAcks() throws TimeoutException, IOException {
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
+
+        final Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
+
+        try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
+            sender.publish("hello".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+            sender.publish("world".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+
+            ConsumeAMQP proc = new LocalConsumeAMQP(connection);
+            TestRunner runner = TestRunners.newTestRunner(proc);
+            runner.setProperty(ConsumeAMQP.HOST, "injvm");
+            runner.setProperty(ConsumeAMQP.QUEUE, "queue1");
+            runner.setProperty(ConsumeAMQP.BATCH_SIZE, "1");
+
+            runner.run(2);
+
+            runner.assertTransferCount(PublishAMQP.REL_SUCCESS, 2);
+
+            final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+            helloFF.assertContentEquals("hello");
+
+            final MockFlowFile worldFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(1);
+            worldFF.assertContentEquals("world");
+
+            // A single cumulative ack should be used
+            assertTrue(((TestChannel) connection.createChannel()).isAck(0));
+            assertTrue(((TestChannel) connection.createChannel()).isAck(1));
+        }
+    }
+
+    @Test
+    public void testMessagesRejectedOnStop() throws TimeoutException, IOException {
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
+
+        final Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
+
+        try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
+            sender.publish("hello".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+            sender.publish("world".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+            sender.publish("good-bye".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
+
+            LocalConsumeAMQP proc = new LocalConsumeAMQP(connection);
+            TestRunner runner = TestRunners.newTestRunner(proc);
+            runner.setProperty(ConsumeAMQP.HOST, "injvm");
+            runner.setProperty(ConsumeAMQP.QUEUE, "queue1");
+            runner.setProperty(ConsumeAMQP.BATCH_SIZE, "1");
+
+            runner.run();
+            proc.close();
+
+            runner.assertTransferCount(PublishAMQP.REL_SUCCESS, 1);
+
+            final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+            helloFF.assertContentEquals("hello");
+
+
+            // A single cumulative ack should be used
+            assertTrue(((TestChannel) connection.createChannel()).isAck(0));
+
+            // Messages 1 and 2 will have been delivered but on stop should be rejected. They will be rejected
+            // cumulatively, though, so only delivery Tag 2 will be nack'ed explicitly
+            assertTrue(((TestChannel) connection.createChannel()).isNack(2));
+
+            // Any newly delivered messages should also be immediately nack'ed.
+            proc.getAMQPWorker().getConsumer().handleDelivery("123", new Envelope(3, false, "myExchange", "key1"), new BasicProperties(), new byte[0]);
+            assertTrue(((TestChannel) connection.createChannel()).isNack(3));
+        }
+    }
 
     @Test
     public void validateSuccessfullConsumeAndTransferToSuccess() throws Exception {
@@ -51,8 +159,8 @@ public class ConsumeAMQPTest {
         try (AMQPPublisher sender = new AMQPPublisher(connection, mock(ComponentLog.class))) {
             sender.publish("hello".getBytes(), MessageProperties.PERSISTENT_TEXT_PLAIN, "key1", "myExchange");
 
-            ConsumeAMQP pubProc = new LocalConsumeAMQP(connection);
-            TestRunner runner = TestRunners.newTestRunner(pubProc);
+            ConsumeAMQP proc = new LocalConsumeAMQP(connection);
+            TestRunner runner = TestRunners.newTestRunner(proc);
             runner.setProperty(ConsumeAMQP.HOST, "injvm");
             runner.setProperty(ConsumeAMQP.QUEUE, "queue1");
 
@@ -60,11 +168,11 @@ public class ConsumeAMQPTest {
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
         }
-
     }
 
     public static class LocalConsumeAMQP extends ConsumeAMQP {
         private final Connection connection;
+        private AMQPConsumer consumer;
 
         public LocalConsumeAMQP(Connection connection) {
             this.connection = connection;
@@ -73,10 +181,19 @@ public class ConsumeAMQPTest {
         @Override
         protected AMQPConsumer createAMQPWorker(ProcessContext context, Connection connection) {
             try {
-                return new AMQPConsumer(connection, context.getProperty(QUEUE).getValue(), context.getProperty(AUTO_ACKNOWLEDGE).asBoolean());
+                if (consumer != null) {
+                    throw new IllegalStateException("Consumer already created");
+                }
+
+                consumer = new AMQPConsumer(connection, context.getProperty(QUEUE).getValue(), context.getProperty(AUTO_ACKNOWLEDGE).asBoolean());
+                return consumer;
             } catch (IOException e) {
                 throw new ProcessException(e);
             }
+        }
+
+        public AMQPConsumer getAMQPWorker() {
+            return consumer;
         }
 
         @Override


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
