### PR TITLE
NIFI-5231: CalculateRecordCount should use 'record.count'

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CalculateRecordStats.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CalculateRecordStats.java
@@ -64,7 +64,7 @@ import java.util.stream.Collectors;
                     "Total number of top N value counts to be added is defined by the limit configuration.")
 })
 public class CalculateRecordStats extends AbstractProcessor {
-    static final String RECORD_COUNT_ATTR = "record_count";
+    static final String RECORD_COUNT_ATTR = "record.count";
 
     static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
         .name("record-stats-reader")

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestCalculateRecordStats.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestCalculateRecordStats.groovy
@@ -63,7 +63,7 @@ class TestCalculateRecordStats {
             "recordStats.sport.Football": "2",
             "recordStats.sport.Basketball": "1",
             "recordStats.sport": "6",
-            "record_count": "6"
+            "record.count": "6"
         ]
 
         commonTest([ "sport": "/person/sport"], sports, expectedAttributes)
@@ -77,7 +77,7 @@ class TestCalculateRecordStats {
             "recordStats.sport.Football": "1",
             "recordStats.sport.Basketball": "1",
             "recordStats.sport": "3",
-            "record_count": "6"
+            "record.count": "6"
         ]
 
         commonTest([ "sport": "/person/sport"], sports, expectedAttributes)
@@ -90,7 +90,7 @@ class TestCalculateRecordStats {
             "recordStats.sport.Soccer": "3",
             "recordStats.sport.Basketball": "1",
             "recordStats.sport": "4",
-            "record_count": "6"
+            "record.count": "6"
         ]
 
         def propz = [
@@ -112,7 +112,7 @@ class TestCalculateRecordStats {
             "recordStats.sport.Soccer": "3",
             "recordStats.sport.Baseball": "4",
             "recordStats.sport": String.valueOf(sports.size()),
-            "record_count": String.valueOf(sports.size())
+            "record.count": String.valueOf(sports.size())
         ]
 
         def propz = [


### PR DESCRIPTION
Hi @MikeThomsen , would you review this?

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
