### PR TITLE
 NIFI-5309 update the logger message to get the output format from outputFormat Variable

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/SelectHiveQL.java
@@ -407,7 +407,7 @@ public class SelectHiveQL extends AbstractHiveQLProcessor {
 
                         flowfile = session.putAllAttributes(flowfile, attributes);
 
-                        logger.info("{} contains {} Avro records; transferring to 'success'",
+                        logger.info("{} contains {} " + outputFormat + " records; transferring to 'success'",
                                 new Object[]{flowfile, nrOfRows.get()});
 
                         if (context.hasIncomingConnection()) {


### PR DESCRIPTION
Updated the info message of logger printing the output format of flow files records.

This change will print the output format in the logs of selectHiveQl processor based on the outputFormat variable value