### PR TITLE
NIFI-5319 Utilize NiFi Registry 0.2.0 client

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -23,7 +23,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <nifi.registry.version>0.1.0</nifi.registry.version>
+        <nifi.registry.version>0.2.0</nifi.registry.version>
         <jersey.version>2.26</jersey.version>
         <spring.version>4.3.10.RELEASE</spring.version>
         <spring.security.version>4.2.4.RELEASE</spring.security.version>    

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-client</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/AbstractNiFiRegistryCommand.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/AbstractNiFiRegistryCommand.java
@@ -18,7 +18,6 @@ package org.apache.nifi.toolkit.cli.impl.command.registry;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.nifi.registry.bucket.BucketItem;
 import org.apache.nifi.registry.client.FlowSnapshotClient;
 import org.apache.nifi.registry.client.NiFiRegistryClient;
 import org.apache.nifi.registry.client.NiFiRegistryException;
@@ -33,7 +32,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -71,28 +69,10 @@ public abstract class AbstractNiFiRegistryCommand<R extends Result> extends Abst
     public abstract R doExecute(final NiFiRegistryClient client, final Properties properties)
             throws IOException, NiFiRegistryException, ParseException;
 
-    /*
-     * NOTE: This will bring back every item in the registry. We should create an end-point on the registry side
-     * to retrieve a flow by id and remove this later.
-     */
-    protected String getBucketId(final NiFiRegistryClient client, final String flowId) throws IOException, NiFiRegistryException {
-        final List<BucketItem> items = client.getItemsClient().getAll();
-
-        final Optional<BucketItem> matchingItem = items.stream()
-                .filter(i ->  i.getIdentifier().equals(flowId))
-                .findFirst();
-
-        if (!matchingItem.isPresent()) {
-            throw new NiFiRegistryException("Versioned flow does not exist with id " + flowId);
-        }
-
-        return matchingItem.get().getBucketIdentifier();
-    }
-
-    protected List<Integer> getVersions(final NiFiRegistryClient client, final String bucketId, final String flowId)
+    protected List<Integer> getVersions(final NiFiRegistryClient client, final String flowId)
             throws NiFiRegistryException, IOException {
         final FlowSnapshotClient srcSnapshotClient = client.getFlowSnapshotClient();
-        final List<VersionedFlowSnapshotMetadata> srcVersionMetadata = srcSnapshotClient.getSnapshotMetadata(bucketId, flowId);
+        final List<VersionedFlowSnapshotMetadata> srcVersionMetadata = srcSnapshotClient.getSnapshotMetadata(flowId);
         return srcVersionMetadata.stream().map(s -> s.getVersion()).collect(Collectors.toList());
     }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/flow/ExportFlowVersion.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/flow/ExportFlowVersion.java
@@ -53,15 +53,12 @@ public class ExportFlowVersion extends AbstractNiFiRegistryCommand<VersionedFlow
         final String flowId = getRequiredArg(properties, CommandOption.FLOW_ID);
         final Integer version = getIntArg(properties, CommandOption.FLOW_VERSION);
 
-        // determine the bucket for the provided flow id
-        final String bucketId = getBucketId(client, flowId);
-
         // if no version was provided then export the latest, otherwise use specific version
         final VersionedFlowSnapshot versionedFlowSnapshot;
         if (version == null) {
-            versionedFlowSnapshot = client.getFlowSnapshotClient().getLatest(bucketId, flowId);
+            versionedFlowSnapshot = client.getFlowSnapshotClient().getLatest(flowId);
         } else {
-            versionedFlowSnapshot = client.getFlowSnapshotClient().get(bucketId, flowId, version);
+            versionedFlowSnapshot = client.getFlowSnapshotClient().get(flowId, version);
         }
 
         versionedFlowSnapshot.setFlow(null);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/flow/ListFlowVersions.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/flow/ListFlowVersions.java
@@ -53,10 +53,9 @@ public class ListFlowVersions extends AbstractNiFiRegistryCommand<VersionedFlowS
     public VersionedFlowSnapshotMetadataResult doExecute(final NiFiRegistryClient client, final Properties properties)
             throws ParseException, IOException, NiFiRegistryException {
         final String flow = getRequiredArg(properties, CommandOption.FLOW_ID);
-        final String bucket = getBucketId(client, flow);
 
         final FlowSnapshotClient snapshotClient = client.getFlowSnapshotClient();
-        final List<VersionedFlowSnapshotMetadata> snapshotMetadata = snapshotClient.getSnapshotMetadata(bucket, flow);
+        final List<VersionedFlowSnapshotMetadata> snapshotMetadata = snapshotClient.getSnapshotMetadata(flow);
         return new VersionedFlowSnapshotMetadataResult(getResultType(properties), snapshotMetadata);
     }
 


### PR DESCRIPTION
NOTE: This should only be merged after the NiFi Registry 0.2.0 release is complete and the 0.2.0 artifacts are available in Maven central.
