### PR TITLE
NIFI-539 and  NIFI-3698: Add SCP and SSH Processors

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
@@ -402,7 +402,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
         final long currentRunTimeMillis = System.currentTimeMillis();
         try {
             // track of when this last executed for consideration of the lag nanos
-            entityList = performListing(context, minTimestampToListMillis);
+            entityList = performListing(context, null, minTimestampToListMillis);
         } catch (final IOException e) {
             getLogger().error("Failed to perform listing on remote host due to {}", e);
             context.yield();
@@ -608,7 +608,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
      * @param minTimestamp the minimum timestamp of entities that should be returned.
      * @return a Listing of entities that have a timestamp >= minTimestamp
      */
-    protected abstract List<T> performListing(final ProcessContext context, final Long minTimestamp) throws IOException;
+    protected abstract List<T> performListing(final ProcessContext context, final FlowFile flowFile, final Long minTimestamp) throws IOException;
 
     /**
      * Determines whether or not the listing must be reset if the value of the given property is changed

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/test/java/org/apache/nifi/processor/util/list/TestAbstractListProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/test/java/org/apache/nifi/processor/util/list/TestAbstractListProcessor.java
@@ -275,7 +275,7 @@ public class TestAbstractListProcessor {
         }
 
         @Override
-        protected List<ListableEntity> performListing(final ProcessContext context, final Long minTimestamp) throws IOException {
+        protected List<ListableEntity> performListing(ProcessContext context, FlowFile flowFile, Long minTimestamp) throws IOException {
             return Collections.unmodifiableList(entities);
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -281,6 +281,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.mina</groupId>
+            <artifactId>mina-core</artifactId>
+            <version>2.0.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-core</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteRemoteProcess.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteRemoteProcess.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.standard.util.ArgumentUtils;
+import org.apache.nifi.processors.standard.util.SSHExec;
+import org.apache.nifi.processors.standard.util.SSHTransfer;
+import org.apache.nifi.util.StringUtils;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Tags({"command", "process", "source", "ssh", "external", "invoke", "script"})
+@CapabilityDescription("Runs an operating system command over SSH specified by the user and writes the output of that command to a FlowFile.")
+
+@WritesAttributes({
+    @WritesAttribute(attribute = "command", description = "Executed command"),
+    @WritesAttribute(attribute = "command.arguments", description = "Arguments of the command")
+})
+public class ExecuteRemoteProcess extends AbstractProcessor {
+
+    final static String ATTRIBUTE_COMMAND = "command";
+    final static String ATTRIBUTE_COMMAND_ARGS = "command.arguments";
+
+    public static final PropertyDescriptor COMMAND = new PropertyDescriptor.Builder()
+    .name("Command")
+    .description("Specifies the command to be executed; if just the name of an executable is provided, it must be in the user's environment PATH.")
+    .required(true)
+    .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+    .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+    .build();
+
+    public static final PropertyDescriptor COMMAND_ARGUMENTS = new PropertyDescriptor.Builder()
+    .name("Command Arguments")
+    .description("The arguments to supply to the executable delimited by white space. White space can be escaped by enclosing it in double-quotes.")
+    .required(false)
+    .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+    .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+    .build();
+
+    public static final PropertyDescriptor WORKING_DIR = new PropertyDescriptor.Builder()
+    .name("Working Directory")
+    .description("The directory to use as the current working directory when executing the command")
+    .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+    .addValidator(StandardValidators.createDirectoryExistsValidator(false, true))
+    .required(false)
+    .build();
+
+    public static final PropertyDescriptor REDIRECT_ERROR_STREAM = new PropertyDescriptor.Builder()
+    .name("Redirect Error Stream")
+    .description("If true will redirect any error stream output of the process to the output stream. "
+            + "This is particularly helpful for processes which write extensively to the error stream or for troubleshooting.")
+            .required(false)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+
+    private static final Validator characterValidator = new StandardValidators.StringLengthValidator(1, 1);
+
+    static final PropertyDescriptor ARG_DELIMITER = new PropertyDescriptor.Builder()
+      .name("Argument Delimiter")
+      .description("Delimiter to use to separate arguments for a command [default: space]. Must be a single character.")
+      .addValidator(Validator.VALID)
+      .addValidator(characterValidator)
+      .required(true)
+      .defaultValue(" ")
+      .build();
+
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+        .name("success")
+        .description("FlowFile containing output is routed to this relationship")
+        .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+        .name("failure")
+        .description("Command ended in error. Error message is written to the FlowFile if available.")
+        .build();
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        Set<Relationship> relationships = new HashSet<>();
+        relationships.add(REL_SUCCESS);
+        relationships.add(REL_FAILURE);
+
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(COMMAND);
+        properties.add(COMMAND_ARGUMENTS);
+        properties.add(REDIRECT_ERROR_STREAM);
+        properties.add(WORKING_DIR);
+        properties.add(ARG_DELIMITER);
+        properties.add(SSHTransfer.HOSTNAME);
+        properties.add(SSHTransfer.PORT);
+        properties.add(SSHTransfer.USERNAME);
+        properties.add(SSHTransfer.PASSWORD);
+        properties.add(SSHTransfer.PRIVATE_KEY_PATH);
+        properties.add(SSHTransfer.PRIVATE_KEY_PASSPHRASE);
+        properties.add(SSHTransfer.CONNECTION_TIMEOUT);
+        properties.add(SSHTransfer.DATA_TIMEOUT);
+        properties.add(SSHTransfer.HOST_KEY_FILE);
+        properties.add(SSHTransfer.STRICT_HOST_KEY_CHECKING);
+        properties.add(SSHTransfer.USE_KEEPALIVE_ON_TIMEOUT);
+        properties.add(SSHTransfer.USE_COMPRESSION);
+        properties.add(SSHTransfer.PROXY_CONFIGURATION_SERVICE);
+        return properties;
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            flowFile = session.create();
+        }
+
+        final String command = context.getProperty(COMMAND).evaluateAttributeExpressions(flowFile).getValue();
+        final String arguments = context.getProperty(COMMAND_ARGUMENTS).isSet()
+          ? context.getProperty(COMMAND_ARGUMENTS).evaluateAttributeExpressions(flowFile).getValue()
+          : null;
+
+        final String workingDirectory = context.getProperty(WORKING_DIR).evaluateAttributeExpressions(flowFile).getValue();
+
+        // add command and arguments as attribute
+        flowFile = session.putAttribute(flowFile, ATTRIBUTE_COMMAND, command);
+        if(arguments != null) {
+            flowFile = session.putAttribute(flowFile, ATTRIBUTE_COMMAND_ARGS, arguments);
+        }
+
+        final List<String> commandStrings = createCommandStrings(context, command, arguments, workingDirectory);
+        final String commandString = StringUtils.join(commandStrings, " ");
+
+        // Write to and set the OutputStream for the FlowFile
+        // as the delegate for the OuptutStream, then wait until the process finishes
+        final FlowFile finalFlowFile = flowFile;
+        session.write(finalFlowFile, flowFileOut -> {
+            try (final OutputStream out = new BufferedOutputStream(flowFileOut)) {
+                SSHExec sshExec = new SSHExec();
+                sshExec.setCommand(commandString);
+
+                final String executeOutput = sshExec.execute(SSHTransfer.getSession(context, finalFlowFile));
+
+                out.write(executeOutput.getBytes("UTF-8"));
+                out.flush();
+
+                // All was good. Transfer FlowFile.
+                session.getProvenanceReporter().create(finalFlowFile, "Created from command: " + commandString);
+                getLogger().info("Created {} and routed to success", new Object[] {finalFlowFile});
+                session.transfer(finalFlowFile, REL_SUCCESS);
+            } catch (IOException e){
+                session.transfer(finalFlowFile, REL_FAILURE);
+            }
+        });
+
+        // Commit the session so that the FlowFile is transferred to the next processor
+        session.commit();
+    }
+
+    protected List<String> createCommandStrings(final ProcessContext context, final String command, final String arguments, final String workingDirectory) {
+        final List<String> args = ArgumentUtils.splitArgs(arguments, context.getProperty(ARG_DELIMITER).getValue().charAt(0));
+        final List<String> commandStrings = new ArrayList<>(args.size() + 1);
+
+        if(!StringUtils.isEmpty(workingDirectory)){
+            commandStrings.add("cd \"" + workingDirectory + "\" ;");
+        }
+
+        commandStrings.add(command);
+        commandStrings.addAll(args);
+        return commandStrings;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFileTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFileTransfer.java
@@ -326,7 +326,7 @@ public abstract class FetchFileTransfer extends AbstractProcessor {
                     final File targetFile = new File(absoluteTargetDirPath, simpleFilename);
                     if (context.getProperty(MOVE_CREATE_DIRECTORY).asBoolean()) {
                         // Create the target directory if necessary.
-                        transfer.ensureDirectoryExists(flowFile, targetFile.getParentFile());
+                        transfer.ensureDirectoryExists(flowFile, targetFile.getParentFile().getAbsolutePath());
                     }
 
                     transfer.rename(flowFile, filename, targetFile.getAbsolutePath());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSCP.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.standard.util.FTPTransfer;
+import org.apache.nifi.processors.standard.util.FileTransfer;
+import org.apache.nifi.processors.standard.util.SCPTransfer;
+import org.apache.nifi.processors.standard.util.SFTPTransfer;
+import org.apache.nifi.processors.standard.util.SSHTransfer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+// Note that we do not use @SupportsBatching annotation. This processor cannot support batching because it must ensure that session commits happen before remote files are deleted.
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@Tags({"scp", "get", "retrieve", "files", "fetch", "remote", "ingest", "source", "input"})
+@CapabilityDescription("Fetches the content of a file from a remote SCP server and overwrites the contents of an incoming FlowFile with the content of the remote file.")
+@SeeAlso({GetSCP.class, PutSCP.class, ListRemoteFiles.class})
+@WritesAttributes({
+    @WritesAttribute(attribute = "ssh.remote.host", description = "The hostname or IP address from which the file was pulled"),
+    @WritesAttribute(attribute = "ssh.remote.port", description = "The port that was used to communicate with the remote SFTP server"),
+    @WritesAttribute(attribute = "ssh.remote.filename", description = "The name of the remote file that was pulled"),
+    @WritesAttribute(attribute = "filename", description = "The filename is updated to point to the filename fo the remote file"),
+    @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute")
+})
+public class FetchSCP extends FetchFileTransfer {
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        final PropertyDescriptor port = new PropertyDescriptor.Builder().fromPropertyDescriptor(UNDEFAULTED_PORT).defaultValue("22").build();
+
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(HOSTNAME);
+        properties.add(port);
+        properties.add(USERNAME);
+        properties.add(SSHTransfer.PASSWORD);
+        properties.add(SSHTransfer.PRIVATE_KEY_PATH);
+        properties.add(SSHTransfer.PRIVATE_KEY_PASSPHRASE);
+        properties.add(REMOTE_FILENAME);
+        properties.add(COMPLETION_STRATEGY);
+        properties.add(MOVE_DESTINATION_DIR);
+        properties.add(MOVE_CREATE_DIRECTORY);
+        properties.add(SSHTransfer.CONNECTION_TIMEOUT);
+        properties.add(SSHTransfer.DATA_TIMEOUT);
+        properties.add(SSHTransfer.USE_KEEPALIVE_ON_TIMEOUT);
+        properties.add(SSHTransfer.HOST_KEY_FILE);
+        properties.add(SSHTransfer.STRICT_HOST_KEY_CHECKING);
+        properties.add(SSHTransfer.USE_COMPRESSION);
+        properties.add(SSHTransfer.PROXY_CONFIGURATION_SERVICE);
+        return properties;
+    }
+
+    @Override
+    protected FileTransfer createFileTransfer(final ProcessContext context) {
+        return new SCPTransfer(context, getLogger());
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        final Collection<ValidationResult> results = new ArrayList<>();
+        SSHTransfer.validateProxySpec(validationContext, results);
+        return results;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileTransfer.java
@@ -281,7 +281,7 @@ public abstract class GetFileTransfer extends AbstractProcessor {
         }
 
         final StopWatch stopWatch = new StopWatch(true);
-        final List<FileInfo> listing = transfer.getListing();
+        final List<FileInfo> listing = transfer.getListing(null);
         final long millis = stopWatch.getElapsed(TimeUnit.MILLISECONDS);
 
         int newItems = 0;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetSCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetSCP.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processors.standard.util.FTPTransfer;
+import org.apache.nifi.processors.standard.util.FileTransfer;
+import org.apache.nifi.processors.standard.util.SCPTransfer;
+import org.apache.nifi.processors.standard.util.SFTPTransfer;
+import org.apache.nifi.processors.standard.util.SSHTransfer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@InputRequirement(Requirement.INPUT_FORBIDDEN)
+@Tags({"scp", "get", "retrieve", "files", "fetch", "remote", "ingest", "source", "input"})
+@CapabilityDescription("Fetches files from an SSH Server using SCP and creates FlowFiles from them")
+@WritesAttributes({
+    @WritesAttribute(attribute = "filename", description = "The filename is set to the name of the file on the remote server"),
+    @WritesAttribute(attribute = "path", description = "The path is set to the path of the file's directory on the remote server. "
+            + "For example, if the <Remote Path> property is set to /tmp, files picked up from /tmp will have the path attribute set "
+            + "to /tmp. If the <Search Recursively> property is set to true and a file is picked up from /tmp/abc/1/2/3, then the path "
+            + "attribute will be set to /tmp/abc/1/2/3"),
+    @WritesAttribute(attribute = "file.lastModifiedTime", description = "The date and time that the source file was last modified"),
+    @WritesAttribute(attribute = "file.owner", description = "The numeric owner id of the source file"),
+    @WritesAttribute(attribute = "file.group", description = "The numeric group id of the source file"),
+    @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the source file"),
+    @WritesAttribute(attribute = "absolute.path", description = "The full/absolute path from where a file was picked up. The current 'path' "
+            + "attribute is still populated, but may be a relative path")})
+@SeeAlso(PutSCP.class)
+public class GetSCP extends GetFileTransfer {
+
+    private List<PropertyDescriptor> properties;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(SFTPTransfer.HOSTNAME);
+        properties.add(SFTPTransfer.PORT);
+        properties.add(SFTPTransfer.USERNAME);
+        properties.add(SFTPTransfer.PASSWORD);
+        properties.add(SFTPTransfer.PRIVATE_KEY_PATH);
+        properties.add(SFTPTransfer.PRIVATE_KEY_PASSPHRASE);
+        properties.add(SFTPTransfer.REMOTE_PATH);
+        properties.add(SFTPTransfer.FILE_FILTER_REGEX);
+        properties.add(SFTPTransfer.PATH_FILTER_REGEX);
+        properties.add(SFTPTransfer.POLLING_INTERVAL);
+        properties.add(SFTPTransfer.RECURSIVE_SEARCH);
+        properties.add(SFTPTransfer.IGNORE_DOTTED_FILES);
+        properties.add(SFTPTransfer.DELETE_ORIGINAL);
+        properties.add(SFTPTransfer.CONNECTION_TIMEOUT);
+        properties.add(SFTPTransfer.DATA_TIMEOUT);
+        properties.add(SFTPTransfer.HOST_KEY_FILE);
+        properties.add(SFTPTransfer.MAX_SELECTS);
+        properties.add(SFTPTransfer.REMOTE_POLL_BATCH_SIZE);
+        properties.add(SFTPTransfer.STRICT_HOST_KEY_CHECKING);
+        properties.add(SFTPTransfer.USE_KEEPALIVE_ON_TIMEOUT);
+        properties.add(SFTPTransfer.USE_COMPRESSION);
+        properties.add(SFTPTransfer.USE_NATURAL_ORDERING);
+        properties.add(SFTPTransfer.PROXY_CONFIGURATION_SERVICE);
+        this.properties = Collections.unmodifiableList(properties);
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(final ValidationContext context) {
+        final List<ValidationResult> results = new ArrayList<>(super.customValidate(context));
+        final boolean passwordSpecified = context.getProperty(SFTPTransfer.PASSWORD).getValue() != null;
+        final boolean privateKeySpecified = context.getProperty(SFTPTransfer.PRIVATE_KEY_PATH).evaluateAttributeExpressions().getValue() != null;
+
+        if (!passwordSpecified && !privateKeySpecified) {
+            results.add(new ValidationResult.Builder().subject("Password")
+                    .explanation("Either the Private Key Passphrase or the Password must be supplied")
+                    .valid(false)
+                    .build());
+        }
+
+        SSHTransfer.validateProxySpec(context, results);
+
+        return results;
+    }
+
+    @Override
+    protected FileTransfer getFileTransfer(final ProcessContext context) {
+        return new SCPTransfer(context, getLogger());
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -31,6 +31,7 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
@@ -327,7 +328,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
     }
 
     @Override
-    protected List<FileInfo> performListing(final ProcessContext context, final Long minTimestamp) throws IOException {
+    protected List<FileInfo> performListing(ProcessContext context, FlowFile flowFile, Long minTimestamp) throws IOException {
         final File path = new File(getPath(context));
         final Boolean recurse = context.getProperty(RECURSE).asBoolean();
         return scanDirectory(path, fileFilterRef.get(), recurse, minTimestamp);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFileTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFileTransfer.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -99,11 +100,11 @@ public abstract class ListFileTransfer extends AbstractListProcessor<FileInfo> {
     }
 
     @Override
-    protected List<FileInfo> performListing(final ProcessContext context, final Long minTimestamp) throws IOException {
+    protected List<FileInfo> performListing(final ProcessContext context, final FlowFile flowFile, final Long minTimestamp) throws IOException {
         final FileTransfer transfer = getFileTransfer(context);
         final List<FileInfo> listing;
         try {
-            listing = transfer.getListing();
+            listing = transfer.getListing(flowFile);
         } finally {
             IOUtils.closeQuietly(transfer);
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListRemoteFiles.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListRemoteFiles.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.PrimaryNodeOnly;
+import org.apache.nifi.annotation.behavior.Stateful;
+import org.apache.nifi.annotation.behavior.TriggerSerially;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.standard.util.FTPTransfer;
+import org.apache.nifi.processors.standard.util.FileTransfer;
+import org.apache.nifi.processors.standard.util.SCPTransfer;
+import org.apache.nifi.processors.standard.util.SFTPTransfer;
+import org.apache.nifi.processors.standard.util.SSHTransfer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@PrimaryNodeOnly
+@TriggerSerially
+@InputRequirement(Requirement.INPUT_FORBIDDEN)
+@Tags({"list", "ssh", "remote", "ingest", "source", "input", "files"})
+@CapabilityDescription("Performs a listing of the files residing on a server using SSH. For each file that is found on the remote server, a new FlowFile will be created with the filename attribute "
+    + "set to the name of the file on the remote server. This can then be used in conjunction with FetchSCP in order to fetch those files.")
+@SeeAlso({FetchSCP.class, GetSCP.class, PutSCP.class})
+@WritesAttributes({
+    @WritesAttribute(attribute = "ssh.remote.host", description = "The hostname of the SSH Server"),
+    @WritesAttribute(attribute = "ssh.remote.port", description = "The port that was connected to on the SSH Server"),
+    @WritesAttribute(attribute = "ssh.listing.user", description = "The username of the user that performed the Listing"),
+    @WritesAttribute(attribute = ListFile.FILE_OWNER_ATTRIBUTE, description = "The numeric owner id of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_GROUP_ATTRIBUTE, description = "The numeric group id of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_PERMISSIONS_ATTRIBUTE, description = "The read/write/execute permissions of the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_SIZE_ATTRIBUTE, description = "The number of bytes in the source file"),
+    @WritesAttribute(attribute = ListFile.FILE_LAST_MODIFY_TIME_ATTRIBUTE, description = "The timestamp of when the file in the filesystem was" +
+                  "last modified as 'yyyy-MM-dd'T'HH:mm:ssZ'"),
+    @WritesAttribute(attribute = "filename", description = "The name of the file on the Server"),
+    @WritesAttribute(attribute = "path", description = "The fully qualified name of the directory on the Server from which the file was pulled"),
+})
+@Stateful(scopes = {Scope.CLUSTER}, description = "After performing a listing of files, the timestamp of the newest file is stored. "
+    + "This allows the Processor to list only files that have been added or modified after "
+    + "this date the next time that the Processor is run. State is stored across the cluster so that this Processor can be run on Primary Node only and if "
+    + "a new Primary Node is selected, the new node will not duplicate the data that was listed by the previous Primary Node.")
+public class ListRemoteFiles extends ListFileTransfer {
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        final PropertyDescriptor port = new PropertyDescriptor.Builder().fromPropertyDescriptor(UNDEFAULTED_PORT).defaultValue("22").build();
+
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(HOSTNAME);
+        properties.add(port);
+        properties.add(USERNAME);
+        properties.add(SSHTransfer.PASSWORD);
+        properties.add(SSHTransfer.PRIVATE_KEY_PATH);
+        properties.add(SSHTransfer.PRIVATE_KEY_PASSPHRASE);
+        properties.add(REMOTE_PATH);
+        properties.add(DISTRIBUTED_CACHE_SERVICE);
+        properties.add(SSHTransfer.RECURSIVE_SEARCH);
+        properties.add(SSHTransfer.FILE_FILTER_REGEX);
+        properties.add(SSHTransfer.PATH_FILTER_REGEX);
+        properties.add(SSHTransfer.IGNORE_DOTTED_FILES);
+        properties.add(SSHTransfer.STRICT_HOST_KEY_CHECKING);
+        properties.add(SSHTransfer.HOST_KEY_FILE);
+        properties.add(SSHTransfer.CONNECTION_TIMEOUT);
+        properties.add(SSHTransfer.DATA_TIMEOUT);
+        properties.add(SSHTransfer.USE_KEEPALIVE_ON_TIMEOUT);
+        properties.add(TARGET_SYSTEM_TIMESTAMP_PRECISION);
+        properties.add(SSHTransfer.PROXY_CONFIGURATION_SERVICE);
+        return properties;
+    }
+
+    @Override
+    protected FileTransfer getFileTransfer(final ProcessContext context) {
+        return new SCPTransfer(context, getLogger());
+    }
+
+    @Override
+    protected String getProtocolName() {
+        return "ssh";
+    }
+
+    @Override
+    protected Scope getStateScope(final ProcessContext context) {
+        // Use cluster scope so that component can be run on Primary Node Only and can still
+        // pick up where it left off, even if the Primary Node changes.
+        return Scope.CLUSTER;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        final Collection<ValidationResult> results = new ArrayList<>();
+        SSHTransfer.validateProxySpec(validationContext, results);
+        return results;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFTP.java
@@ -32,6 +32,8 @@ import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -49,6 +51,9 @@ import org.apache.nifi.processors.standard.util.FTPTransfer;
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"remote", "copy", "egress", "put", "ftp", "archive", "files"})
 @CapabilityDescription("Sends FlowFiles to an FTP Server")
+@WritesAttributes({
+        @WritesAttribute(attribute = "filename", description = "The filename is set to the name of the file on the remote server"),
+        @WritesAttribute(attribute = "absolute.path", description = "The full/absolute path where the file was uploaded to.")})
 @SeeAlso(GetFTP.class)
 @DynamicProperties({
     @DynamicProperty(name = "pre.cmd._____", value = "Not used", description = "The command specified in the key will be executed before doing a put.  You may add these optional properties "

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSCP.java
@@ -16,12 +16,6 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
@@ -35,57 +29,53 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessorInitializationContext;
-import org.apache.nifi.processors.standard.util.FTPTransfer;
-import org.apache.nifi.processors.standard.util.SFTPTransfer;
+import org.apache.nifi.processors.standard.util.SCPTransfer;
 import org.apache.nifi.processors.standard.util.SSHTransfer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
-@Tags({"remote", "copy", "egress", "put", "sftp", "archive", "files"})
-@CapabilityDescription("Sends FlowFiles to an SFTP Server")
+@Tags({"remote", "copy", "egress", "put", "scp", "archive", "files"})
+@CapabilityDescription("Sends FlowFiles to an SSH Server via SCP")
 @WritesAttributes({
         @WritesAttribute(attribute = "filename", description = "The filename is set to the name of the file on the remote server"),
         @WritesAttribute(attribute = "absolute.path", description = "The full/absolute path where the file was uploaded to.")})
-@SeeAlso(GetSFTP.class)
-@DynamicProperty(name = "Disable Directory Listing", value = "true or false",
-        description = "Disables directory listings before operations which might fail, such as configurations which create directory structures.")
-public class PutSFTP extends PutFileTransfer<SFTPTransfer> {
+@SeeAlso(GetSCP.class)
+public class PutSCP extends PutFileTransfer<SCPTransfer> {
 
     private List<PropertyDescriptor> properties;
 
     @Override
     protected void init(final ProcessorInitializationContext context) {
         final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(SFTPTransfer.HOSTNAME);
-        properties.add(SFTPTransfer.PORT);
-        properties.add(SFTPTransfer.USERNAME);
-        properties.add(SFTPTransfer.PASSWORD);
-        properties.add(SFTPTransfer.PRIVATE_KEY_PATH);
-        properties.add(SFTPTransfer.PRIVATE_KEY_PASSPHRASE);
-        properties.add(SFTPTransfer.REMOTE_PATH);
-        properties.add(SFTPTransfer.CREATE_DIRECTORY);
-        properties.add(SFTPTransfer.DISABLE_DIRECTORY_LISTING);
-        properties.add(SFTPTransfer.BATCH_SIZE);
-        properties.add(SFTPTransfer.CONNECTION_TIMEOUT);
-        properties.add(SFTPTransfer.DATA_TIMEOUT);
-        properties.add(SFTPTransfer.CONFLICT_RESOLUTION);
-        properties.add(SFTPTransfer.REJECT_ZERO_BYTE);
-        properties.add(SFTPTransfer.DOT_RENAME);
-        properties.add(SFTPTransfer.TEMP_FILENAME);
-        properties.add(SFTPTransfer.HOST_KEY_FILE);
-        properties.add(SFTPTransfer.LAST_MODIFIED_TIME);
-        properties.add(SFTPTransfer.PERMISSIONS);
-        properties.add(SFTPTransfer.REMOTE_OWNER);
-        properties.add(SFTPTransfer.REMOTE_GROUP);
-        properties.add(SFTPTransfer.STRICT_HOST_KEY_CHECKING);
-        properties.add(SFTPTransfer.USE_KEEPALIVE_ON_TIMEOUT);
-        properties.add(SFTPTransfer.USE_COMPRESSION);
-        properties.add(SFTPTransfer.PROXY_CONFIGURATION_SERVICE);
-        properties.add(FTPTransfer.PROXY_TYPE);
-        properties.add(FTPTransfer.PROXY_HOST);
-        properties.add(FTPTransfer.PROXY_PORT);
-        properties.add(FTPTransfer.HTTP_PROXY_USERNAME);
-        properties.add(FTPTransfer.HTTP_PROXY_PASSWORD);
+        properties.add(SSHTransfer.HOSTNAME);
+        properties.add(SSHTransfer.PORT);
+        properties.add(SSHTransfer.USERNAME);
+        properties.add(SSHTransfer.PASSWORD);
+        properties.add(SSHTransfer.PRIVATE_KEY_PATH);
+        properties.add(SSHTransfer.PRIVATE_KEY_PASSPHRASE);
+        properties.add(SSHTransfer.REMOTE_PATH);
+        properties.add(SSHTransfer.CREATE_DIRECTORY);
+        properties.add(SSHTransfer.BATCH_SIZE);
+        properties.add(SSHTransfer.CONNECTION_TIMEOUT);
+        properties.add(SSHTransfer.DATA_TIMEOUT);
+        properties.add(SSHTransfer.CONFLICT_RESOLUTION);
+        properties.add(SSHTransfer.REJECT_ZERO_BYTE);
+        properties.add(SSHTransfer.DOT_RENAME);
+        properties.add(SSHTransfer.TEMP_FILENAME);
+        properties.add(SSHTransfer.HOST_KEY_FILE);
+        properties.add(SSHTransfer.LAST_MODIFIED_TIME);
+        properties.add(SSHTransfer.PERMISSIONS);
+        properties.add(SSHTransfer.REMOTE_OWNER);
+        properties.add(SSHTransfer.REMOTE_GROUP);
+        properties.add(SSHTransfer.STRICT_HOST_KEY_CHECKING);
+        properties.add(SSHTransfer.USE_KEEPALIVE_ON_TIMEOUT);
+        properties.add(SSHTransfer.USE_COMPRESSION);
+        properties.add(SSHTransfer.PROXY_CONFIGURATION_SERVICE);
         this.properties = Collections.unmodifiableList(properties);
     }
 
@@ -95,8 +85,8 @@ public class PutSFTP extends PutFileTransfer<SFTPTransfer> {
     }
 
     @Override
-    protected SFTPTransfer getFileTransfer(final ProcessContext context) {
-        return new SFTPTransfer(context, getLogger());
+    protected SCPTransfer getFileTransfer(final ProcessContext context) {
+        return new SCPTransfer(context, getLogger());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileInfo.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileInfo.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.processors.standard.util;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.nifi.processor.util.list.ListableEntity;
 
@@ -32,6 +34,11 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
     private final String permissions;
     private final String owner;
     private final String group;
+    private final Map<String,String> attributes;
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
 
     public String getFileName() {
         return fileName;
@@ -109,6 +116,7 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
         this.permissions = builder.permissions;
         this.owner = builder.owner;
         this.group = builder.group;
+        this.attributes = builder.attributes==null?new HashMap<>():builder.attributes;
     }
 
     public static final class Builder {
@@ -121,6 +129,7 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
         private String permissions;
         private String owner;
         private String group;
+        private Map<String,String> attributes;
 
         public FileInfo build() {
             return new FileInfo(this);
@@ -163,6 +172,12 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
 
         public Builder group(String group) {
             this.group = group;
+            return this;
+        }
+
+
+        public Builder setAttributes(Map<String, String> attributes) {
+            this.attributes = attributes;
             return this;
         }
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SCPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SCPTransfer.java
@@ -1,0 +1,484 @@
+package org.apache.nifi.processors.standard.util;
+
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.Session;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.exception.ProcessException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class SCPTransfer extends SSHTransfer {
+    private static final int DEFAULT_FILE_MODE = 0700;
+    private static final int BUFFER_SIZE = 100 * 1024;
+    private static final byte LINE_FEED = 0x0a;
+
+    private final DateFormat informat = new SimpleDateFormat(FILE_MODIFY_DATE_ATTR_FORMAT, Locale.US);
+
+    private ChannelExec execChannel;
+    protected final ByteArrayOutputStream errout = new ByteArrayOutputStream();
+
+    public SCPTransfer(final ProcessContext processContext, final ComponentLog logger) {
+        super(processContext, logger);
+
+    }
+
+    @Override
+    public String getSSHProtocolName() {
+        return "exec";
+    }
+
+    @Override
+    public String getHomeDirectory(FlowFile flowFile) throws IOException {
+        //output from console will have line return after path.
+        return executeCommand(flowFile, "pwd").trim();
+    }
+
+    @Override
+    public List<FileInfo> getListing(final FlowFile flowFile) throws IOException {
+        final String path = ctx.getProperty(FileTransfer.REMOTE_PATH).evaluateAttributeExpressions().getValue();
+        final int depth = 0;
+
+        final int maxResults;
+        final PropertyValue batchSizeValue = ctx.getProperty(FileTransfer.REMOTE_POLL_BATCH_SIZE);
+        if (batchSizeValue == null) {
+            maxResults = Integer.MAX_VALUE;
+        } else {
+            final Integer configuredValue = batchSizeValue.asInteger();
+            maxResults = configuredValue == null ? Integer.MAX_VALUE : configuredValue;
+        }
+
+        final List<FileInfo> listing = new ArrayList<>(1000);
+        getListing(flowFile, path, depth, maxResults, listing);
+        return listing;
+    }
+
+    @Override
+    public List<FileInfo> getDirectoryListing(final FlowFile flowFile, final String remoteFileName) throws IOException {
+        String searchPath = remoteFileName;
+        if (remoteFileName == null || remoteFileName.trim().isEmpty()) {
+            searchPath = ".";
+        }
+
+        //A, don't print . and .. entries
+        //l, long list
+        //t, sort by modification time
+        //1, print one file per line; there are very few limits on filenames, which can include line returns
+        //n, output group/user information as numbers rather than names
+        //p, puts a slash after directory names so we can identify them
+        //--time-style, used to get time format in parsable way
+        String listing = executeCommand(flowFile, "ls -Alt1np --time-style=full-iso \"" + searchPath + "\"");
+        String[] fileListings = listing.split("\\n");
+
+        List<FileInfo> files = new ArrayList<>();
+
+        if(fileListings.length > 1){
+            //start with 1 to skip Totals row from `ls` command
+            for (int i = 1; i < fileListings.length; i++) {
+                final String fileString = fileListings[i];
+                final String[] fileListParts = fileString.split("\\s+");
+
+                final String fileDate = fileListParts[5];
+                final String fileTime = fileListParts[6];
+                //add colon to time zone offset for parsing
+                final String fileTimeZoneOffset = fileListParts[7].substring(0,3) + ":" + fileListParts[7].substring(3);
+
+                final String fileDateTimeString = fileDate + "T" + fileTime + fileTimeZoneOffset;
+
+                final String filenameRaw = fileListParts[8];
+                final Boolean isDirectory = filenameRaw.endsWith("/");
+                final String filename = isDirectory?filenameRaw.replace("/", ""):filenameRaw;
+
+                if (filename.equals(".") || filename.equals("..")) {
+                    continue;
+                }
+
+                files.add(new FileInfo.Builder()
+                        .directory(isDirectory)
+                        .permissions(fileListParts[0])
+                        .owner(fileListParts[2])
+                        .group(fileListParts[3])
+                        .size(Long.parseLong(fileListParts[4]))
+                        .lastModifiedTime(OffsetDateTime.parse(fileDateTimeString).toInstant().getEpochSecond())
+                        .filename(filename)
+                        .fullPathFileName(searchPath.endsWith("/") ? searchPath + filename : searchPath + "/" + filename).build());
+            }
+        }
+
+        return files;
+    }
+
+    private void getListing(final FlowFile flowFile, final String path, final int depth, final int maxResults, final List<FileInfo> listing) throws IOException {
+        if (maxResults < 1 || listing.size() >= maxResults) {
+            return;
+        }
+
+        if (depth >= 100) {
+            logger.warn(this + " had to stop recursively searching directories at a recursive depth of " + depth + " to avoid memory issues");
+            return;
+        }
+
+        // check if this directory path matches the PATH_FILTER_REGEX
+        boolean pathFilterMatches = FileTransfer.isPathMatch(ctx, flowFile, path);
+
+        final boolean recurse = ctx.getProperty(FileTransfer.RECURSIVE_SEARCH).asBoolean();
+        final List<FileInfo> subDirs = new ArrayList<>();
+
+        //create FileInfo filter
+        FileInfoFilter fileInfoFilter = FileTransfer.createFileInfoFilter(ctx, flowFile);
+
+        try {
+            final List<FileInfo> files = getDirectoryListing(flowFile, path);
+
+            //filter files based on rules, get list of sub directories for recursion
+            for (FileInfo f:files) {
+                if(!fileInfoFilter.accept(null,f)){
+                    continue;
+                }
+
+                // if is a directory and we're supposed to recurse
+                if (recurse && f.isDirectory()) {
+                    subDirs.add(f);
+                    continue;
+                }
+
+                // if is not a directory and is not a link and it matches
+                // FILE_FILTER_REGEX - then let's add it
+
+                //TODO: how to identify if this file is a link? SFTP code has !entry.getAttrs().isLink()
+                if(!f.isDirectory() && pathFilterMatches) {
+                    listing.add(f);
+                }
+
+                if (listing.size() >= maxResults) {
+                    break;
+                }
+            }
+        } catch (final IOException e) {
+            final String pathDesc = path == null ? "current directory" : path;
+            throw new IOException("Failed to obtain file listing for " + pathDesc, e);
+        }
+
+        for (final FileInfo entry : subDirs) {
+            try {
+                getListing(flowFile, entry.getFullPathFileName(), depth + 1, maxResults, listing);
+            } catch (final IOException e) {
+                logger.error("Unable to get listing from " + entry.getFullPathFileName() + "; skipping this subdirectory", e);
+            }
+        }
+    }
+
+    @Override
+    public InputStream getInputStream(String remoteFileName, FlowFile flowFile) throws IOException {
+        ensureChannel(flowFile, "scp -f " + remoteFileName);
+        sendAck(out);
+
+        PipedInputStream pipedInputStream = new PipedInputStream();
+        OutputStream fos = new PipedOutputStream(pipedInputStream);
+
+
+        try {
+            // C0644 filesize filename - header for a regular file
+            // T time 0 time 0\n - present if perserve time.
+            // D directory - this is the header for a directory.
+            final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            while (true) {
+                final int read = in.read();
+                if (read < 0) {
+                    return null;
+                }
+                if ((byte) read == LINE_FEED) {
+                    break;
+                }
+                stream.write(read);
+            }
+
+            final String serverResponse = stream.toString("UTF-8");
+            if (serverResponse.charAt(0) == 'C') {
+                final byte[] buf = new byte[BUFFER_SIZE];
+                sendAck(out);
+
+                int start = 0;
+                int end = serverResponse.indexOf(' ', start + 1);
+                start = end + 1;
+                end = serverResponse.indexOf(' ', start + 1);
+
+                long filesize = Long.parseLong(serverResponse.substring(start, end));
+                final String filename = serverResponse.substring(end + 1);
+
+                int length;
+
+                try {
+                    while (true) {
+                        length = in.read(buf, 0,
+                                BUFFER_SIZE < filesize ? BUFFER_SIZE
+                                        : (int) filesize);
+                        if (length < 0) {
+                            throw new EOFException("Unexpected end of stream.");
+                        }
+                        fos.write(buf, 0, length);
+                        filesize -= length;
+                        if (filesize == 0) {
+                            break;
+                        }
+                    }
+                } finally {
+                    fos.flush();
+                    fos.close();
+                }
+
+                waitForAck(in);
+                sendAck(out);
+            } else if (serverResponse.charAt(0) == '\01'
+                    || serverResponse.charAt(0) == '\02') {
+                // this indicates an error.
+                throw new IOException(serverResponse.substring(1));
+            } else {
+                throw new IOException("Unknown SCP transfer type " + serverResponse.substring(1));
+            }
+        } finally {
+            close();
+        }
+
+        return pipedInputStream;
+    }
+
+    @Override
+    public FileInfo getRemoteFileInfo(FlowFile flowFile, String path, String remoteFileName) throws IOException {
+
+        return null;
+    }
+
+    @Override
+    public String put(FlowFile flowFile, String path, String filename, InputStream content) throws IOException {
+        //path cleanup
+        path = (path == null) ? "" : (path.endsWith("/")) ? path : path + "/";
+
+        // destination path + filename
+        final String fullPath = path + filename;
+
+        // temporary path + filename
+        String tempFilename = ctx.getProperty(TEMP_FILENAME).evaluateAttributeExpressions(flowFile).getValue();
+        if (tempFilename == null) {
+            final boolean dotRename = ctx.getProperty(DOT_RENAME).asBoolean();
+            tempFilename = dotRename ? "." + filename : filename;
+        }
+
+        final String tempFullPath = path + tempFilename;
+
+        ensureChannel(flowFile, "scp -t " + path);
+        waitForAck(in);
+
+        final String lastModifiedTime = ctx.getProperty(LAST_MODIFIED_TIME).evaluateAttributeExpressions(flowFile).getValue();
+        if (lastModifiedTime != null && !lastModifiedTime.trim().isEmpty()) {
+            try {
+                Date dtFileModifyTime = informat.parse(lastModifiedTime);
+                long fileModifyTime = dtFileModifyTime.getTime();
+
+                String command = "T" + (fileModifyTime / 1000) + " 0";
+                command += " " + (fileModifyTime / 1000) + " 0\n";
+                out.write(command.getBytes());
+                out.flush();
+
+                waitForAck(in);
+            } catch (ParseException e) {
+                logger.warn("Could not set lastModifiedTime on {} to {}", new Object[] {flowFile, lastModifiedTime});
+            }
+        }
+
+        String command = "C0";
+        final String permissions = ctx.getProperty(PERMISSIONS).evaluateAttributeExpressions(flowFile).getValue();
+        if (permissions != null && !permissions.trim().isEmpty()) {
+            try {
+                int perms = numberPermissions(permissions);
+                if (perms == -1) {
+                    //File mode is REQUIRED by SCP protcol. Defaulting to 700 if not specified.
+                    perms = DEFAULT_FILE_MODE;
+                }
+
+                command += Integer.toOctalString(perms);
+            } catch (final Exception e) {
+                logger.error("Failed to set permission on {} to {} due to {}", new Object[] {path, permissions, e});
+            }
+        } else {
+            command += Integer.toOctalString(DEFAULT_FILE_MODE);
+        }
+
+        command += " " + flowFile.getSize() + " ";
+        command += tempFilename;
+        command += "\n";
+
+        out.write(command.getBytes());
+        out.flush();
+
+        waitForAck(in);
+
+        // send a content of file
+        final byte[] buf = new byte[BUFFER_SIZE];
+
+        while (true) {
+            final int len = content.read(buf, 0, buf.length);
+            if (len <= 0) {
+                break;
+            }
+            out.write(buf, 0, len);
+        }
+        out.flush();
+        sendAck(out);
+        waitForAck(in);
+
+        if (!filename.equals(tempFilename)) {
+            rename(flowFile, tempFullPath, fullPath);
+        }
+
+        return fullPath;
+    }
+
+    @Override
+    public void rename(FlowFile flowFile, String source, String target) throws IOException {
+        String command = "mv \"" + source + "\" \"" + target + "\"";
+
+        executeCommand(flowFile, command);
+    }
+
+    @Override
+    public void deleteFile(FlowFile flowFile, String path, String remoteFileName) throws IOException {
+        final String fullPath = (path == null) ? remoteFileName : (path.endsWith("/")) ? path + remoteFileName : path + "/" + remoteFileName;
+
+        String command = "rm \"" + fullPath + "\"";
+
+        executeCommand(flowFile, command);
+    }
+
+    @Override
+    public void deleteDirectory(FlowFile flowFile, String remoteDirectoryName) throws IOException {
+        String command = "rm -r \"" + remoteDirectoryName + "\"";
+
+        executeCommand(flowFile, command);
+    }
+
+    @Override
+    public String getProtocolName() {
+        return "ssh";
+    }
+
+    @Override
+    public void ensureDirectoryExists(FlowFile flowFile, String remoteDirectory) throws IOException {
+        String command = "mkdir -p \"" + remoteDirectory + "\"";
+
+        executeCommand(flowFile, command);
+    }
+
+    protected String executeCommand(FlowFile flowFile, String command) throws IOException {
+        closeChannel();
+        if(!sessionIsValid(flowFile)){
+            this.session = SSHTransfer.getSession(ctx, flowFile);
+        }
+
+        SSHExec executor = new SSHExec();
+        executor.setCommand(command);
+
+        return executor.execute(session);
+    }
+
+    protected void ensureChannel(FlowFile flowFile, String command) throws IOException {
+        //close existing channel if open.
+        //all requests are executed using exec channel, since user may not have permission for shell channel
+        closeChannel();
+
+        execChannel = (ChannelExec) getChannel(flowFile, new SetCommandHandler(command));
+    }
+
+    /**
+     * Reads the response, throws a BuildException if the response
+     * indicates an error.
+     * @param in the input stream to use
+     * @throws IOException on I/O error
+     */
+    protected void waitForAck(final InputStream in)
+            throws IOException, ProcessException {
+        final int b = in.read();
+
+        // b may be 0 for success,
+        //          1 for error,
+        //          2 for fatal error,
+
+        if (b == -1) {
+            // didn't receive any response
+            throw new ProcessException("No response from server");
+        }
+        if (b != 0) {
+            final StringBuilder sb = new StringBuilder();
+
+            int c = in.read();
+            while (c > 0 && c != '\n') {
+                sb.append((char) c);
+                c = in.read();
+            }
+
+            if (b == 1) {
+                throw new ProcessException("server indicated an error: "
+                        + sb.toString());
+            } else if (b == 2) {
+                throw new ProcessException("server indicated a fatal error: "
+                        + sb.toString());
+            } else {
+                throw new ProcessException("unknown response, code " + b
+                        + " message: " + sb.toString());
+            }
+        }
+    }
+
+    /**
+     * Send an ack.
+     * @param out the output stream to use
+     * @throws IOException on error
+     */
+    protected void sendAck(final OutputStream out) throws IOException {
+        final byte[] buf = new byte[1];
+        buf[0] = 0;
+        out.write(buf);
+        out.flush();
+    }
+
+
+    protected class SetCommandHandler implements PreConnectHandler {
+        private final String command;
+
+        public SetCommandHandler(String command){
+            this.command = command;
+        }
+
+        @Override
+        public void OnPreConnect(Channel channel, FlowFile flowFile) throws IOException {
+            ChannelExec execChannel = (ChannelExec) channel;
+
+            execChannel.setCommand(this.command);
+
+            execChannel.setErrStream(errout);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SSHExec.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SSHExec.java
@@ -1,0 +1,181 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.nifi.processors.standard.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.StringReader;
+
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import org.apache.nifi.processor.exception.ProcessException;
+
+/**
+ * Executes a command on a remote machine via ssh.
+ */
+public class SSHExec {
+
+    private static final int BUFFER_SIZE = 8192;
+    private static final int RETRY_INTERVAL = 500;
+
+    /** the command to execute via ssh */
+    private String command = null;
+
+    /** units are milliseconds, default is 0=infinite */
+    private long maxwait = 0;
+
+    /** for waiting for the command to finish */
+    private Thread thread = null;
+
+    private boolean usePty = false;
+
+    private static final String TIMEOUT_MESSAGE =
+            "Timeout period exceeded, connection dropped.";
+
+    /**
+     * Sets the command to execute on the remote host.
+     *
+     * @param command  The new command value
+     */
+    public void setCommand(final String command) {
+        this.command = command;
+    }
+
+    /**
+     * The connection can be dropped after a specified number of
+     * milliseconds. This is sometimes useful when a connection may be
+     * flaky. Default is 0, which means &quot;wait forever&quot;.
+     *
+     * @param timeout  The new timeout value in seconds
+     */
+    public void setTimeout(final long timeout) {
+        maxwait = timeout;
+    }
+
+    /**
+     * Whether a pseudo-tty should be allocated.
+     * @param b boolean
+     */
+    public void setUsePty(final boolean b) {
+        usePty = b;
+    }
+
+    /**
+     * Execute the command on the remote host.
+     *
+     * @exception IOException  Most likely a network error or bad parameter.
+     */
+    public String execute(Session session) throws ProcessException,IOException {
+        if (command == null ) {
+            throw new ProcessException("Command or commandResource is required.");
+        }
+
+        final StringBuilder output = new StringBuilder();
+        try {
+            executeCommand(session, command, output);
+
+            return output.toString();
+        } catch (final ProcessException e) {
+            throw e;
+        }
+    }
+
+    private void executeCommand(final Session session, final String cmd, final StringBuilder sb)
+            throws ProcessException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errout = new ByteArrayOutputStream();
+
+        try {
+            final ChannelExec channel;
+            /* execute the command */
+            channel = (ChannelExec) session.openChannel("exec");
+            channel.setCommand(cmd);
+            channel.setOutputStream(out);
+            channel.setExtOutputStream(out);
+            channel.setErrStream(errout);
+
+            channel.setPty(usePty);
+            channel.connect();
+            // wait for it to finish
+            thread =
+                    new Thread(() -> {
+                        while (!channel.isClosed()) {
+                            if (thread == null) {
+                                return;
+                            }
+                            try {
+                                Thread.sleep(RETRY_INTERVAL);
+                            } catch (final Exception e) {
+                                // ignored
+                            }
+                        }
+                    });
+
+            thread.start();
+            thread.join(maxwait);
+
+            if (thread.isAlive()) {
+                // ran out of time
+                thread = null;
+                throw new ProcessException(TIMEOUT_MESSAGE);
+            }
+        } catch (final ProcessException e) {
+            throw e;
+        } catch (final JSchException e) {
+            if (e.getMessage().contains("session is down")) {
+                throw new ProcessException(TIMEOUT_MESSAGE, e);
+            } else {
+                throw new ProcessException(e);
+            }
+        } catch (final Exception e) {
+            throw new ProcessException(e);
+        } finally {
+            //Save output for return to requestor
+            sb.append(out.toString());
+        }
+    }
+
+    /**
+     * Writes a string to a file. If destination file exists, it may be
+     * overwritten depending on the "append" value.
+     *
+     * @param from           string to write
+     * @param to             file to write to
+     * @param append         if true, append to existing file, else overwrite
+     */
+    private void writeToFile(final String from, final boolean append, final File to)
+            throws IOException {
+        try (FileWriter out = new FileWriter(to.getAbsolutePath(), append)) {
+            final StringReader in = new StringReader(from);
+            final char[] buffer = new char[BUFFER_SIZE];
+            while (true) {
+                int bytesRead = in.read(buffer);
+                if (bytesRead == -1) {
+                    break;
+                }
+                out.write(buffer, 0, bytesRead);
+            }
+            out.flush();
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SSHTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SSHTransfer.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.ProxyHTTP;
+import com.jcraft.jsch.ProxySOCKS5;
+import com.jcraft.jsch.Session;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.apache.nifi.proxy.ProxySpec;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static org.apache.nifi.processors.standard.util.FTPTransfer.createComponentProxyConfigSupplier;
+
+public abstract class SSHTransfer implements FileTransfer {
+
+    public static final PropertyDescriptor PRIVATE_KEY_PATH = new PropertyDescriptor.Builder()
+        .name("Private Key Path")
+        .description("The fully qualified path to the Private Key file")
+        .required(false)
+        .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .build();
+    public static final PropertyDescriptor PRIVATE_KEY_PASSPHRASE = new PropertyDescriptor.Builder()
+        .name("Private Key Passphrase")
+        .description("Password for the private key")
+        .required(false)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .sensitive(true)
+        .build();
+    public static final PropertyDescriptor HOST_KEY_FILE = new PropertyDescriptor.Builder()
+        .name("Host Key File")
+        .description("If supplied, the given file will be used as the Host Key; otherwise, no use host key file will be used")
+        .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+        .required(false)
+        .build();
+    public static final PropertyDescriptor STRICT_HOST_KEY_CHECKING = new PropertyDescriptor.Builder()
+        .name("Strict Host Key Checking")
+        .description("Indicates whether or not strict enforcement of hosts keys should be applied")
+        .allowableValues("true", "false")
+        .defaultValue("false")
+        .required(true)
+        .build();
+    public static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
+        .name("Port")
+        .description("The port that the remote system is listening on for file transfers")
+        .addValidator(StandardValidators.PORT_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .required(true)
+        .defaultValue("22")
+        .build();
+    public static final PropertyDescriptor USE_KEEPALIVE_ON_TIMEOUT = new PropertyDescriptor.Builder()
+        .name("Send Keep Alive On Timeout")
+        .description("Indicates whether or not to send a single Keep Alive message when SSH socket times out")
+        .allowableValues("true", "false")
+        .defaultValue("true")
+        .required(true)
+        .build();
+
+
+    protected static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP_AUTH, ProxySpec.SOCKS_AUTH};
+    public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE
+            = ProxyConfiguration.createProxyConfigPropertyDescriptor(true, PROXY_SPECS);
+
+    protected final ComponentLog logger;
+    protected final ProcessContext ctx;
+    protected Channel channel;
+    protected Session session;
+    protected InputStream in;
+    protected OutputStream out;
+
+    protected boolean closed = false;
+
+    public SSHTransfer(final ProcessContext processContext, final ComponentLog logger) {
+        this.ctx = processContext;
+        this.logger = logger;
+    }
+
+    public static void validateProxySpec(ValidationContext context, Collection<ValidationResult> results) {
+        ProxyConfiguration.validateProxySpec(context, results, PROXY_SPECS);
+    }
+
+    public abstract String getSSHProtocolName();
+
+    @Override
+    public InputStream getInputStream(final String remoteFileName) throws IOException {
+        return getInputStream(remoteFileName, null);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // nothing needed here
+    }
+
+    @Override
+    public boolean flush(final FlowFile flowFile) throws IOException {
+        return true;
+    }
+
+    protected boolean sessionIsValid(final FlowFile flowFile){
+        if(session == null || !session.isConnected()) return false;
+
+        //confirm we are connected to the correct server
+        final String sessionhost = session.getHost();
+        final int sessionport = session.getPort();
+
+        final String desthost = ctx.getProperty(HOSTNAME).evaluateAttributeExpressions(flowFile).getValue();
+        final int destport = ctx.getProperty(PORT).evaluateAttributeExpressions(flowFile).asInteger();
+
+        return (sessionhost.equals(desthost) && sessionport == destport);
+    }
+
+    protected void establishSession(final FlowFile flowFile) throws IOException {
+        if(sessionIsValid(flowFile)) return;
+
+        //establish new SSH session
+        this.close();
+        this.session = getSession(ctx, flowFile);
+        this.closed=false;
+    }
+
+    public static Session getSession(final ProcessContext processContext, final FlowFile flowFile) throws IOException {
+        final JSch jsch = new JSch();
+        try{
+            final String username = processContext.getProperty(USERNAME).evaluateAttributeExpressions(flowFile).getValue();
+            final Session session = jsch.getSession(username,
+                    processContext.getProperty(HOSTNAME).evaluateAttributeExpressions(flowFile).getValue(),
+                    processContext.getProperty(PORT).evaluateAttributeExpressions(flowFile).asInteger().intValue());
+
+            final ProxyConfiguration proxyConfig = ProxyConfiguration.getConfiguration(processContext,
+                    createComponentProxyConfigSupplier(processContext));
+            switch (proxyConfig.getProxyType()) {
+                case HTTP:
+                    final ProxyHTTP proxyHTTP = new ProxyHTTP(proxyConfig.getProxyServerHost(), proxyConfig.getProxyServerPort());
+                    // Check if Username is set and populate the proxy accordingly
+                    if (proxyConfig.hasCredential()) {
+                        proxyHTTP.setUserPasswd(proxyConfig.getProxyUserName(), proxyConfig.getProxyUserPassword());
+                    }
+                    session.setProxy(proxyHTTP);
+                    break;
+                case SOCKS:
+                    final ProxySOCKS5 proxySOCKS5 = new ProxySOCKS5(proxyConfig.getProxyServerHost(), proxyConfig.getProxyServerPort());
+                    if (proxyConfig.hasCredential()) {
+                        proxySOCKS5.setUserPasswd(proxyConfig.getProxyUserName(), proxyConfig.getProxyUserPassword());
+                    }
+                    session.setProxy(proxySOCKS5);
+                    break;
+
+            }
+
+            final String hostKeyVal = processContext.getProperty(HOST_KEY_FILE).getValue();
+            if (hostKeyVal != null) {
+                jsch.setKnownHosts(hostKeyVal);
+            }
+
+            final Properties properties = new Properties();
+            properties.setProperty("StrictHostKeyChecking", processContext.getProperty(STRICT_HOST_KEY_CHECKING).asBoolean() ? "yes" : "no");
+            properties.setProperty("PreferredAuthentications", "publickey,password,keyboard-interactive");
+
+            final PropertyValue compressionValue = processContext.getProperty(FileTransfer.USE_COMPRESSION);
+            if (compressionValue != null && "true".equalsIgnoreCase(compressionValue.getValue())) {
+                properties.setProperty("compression.s2c", "zlib@openssh.com,zlib,none");
+                properties.setProperty("compression.c2s", "zlib@openssh.com,zlib,none");
+            } else {
+                properties.setProperty("compression.s2c", "none");
+                properties.setProperty("compression.c2s", "none");
+            }
+
+            session.setConfig(properties);
+
+            final String privateKeyFile = processContext.getProperty(PRIVATE_KEY_PATH).evaluateAttributeExpressions(flowFile).getValue();
+            if (privateKeyFile != null) {
+                jsch.addIdentity(privateKeyFile, processContext.getProperty(PRIVATE_KEY_PASSPHRASE).evaluateAttributeExpressions(flowFile).getValue());
+            }
+
+            final String password = processContext.getProperty(FileTransfer.PASSWORD).evaluateAttributeExpressions(flowFile).getValue();
+            if (password != null) {
+                session.setPassword(password);
+            }
+
+            final int connectionTimeoutMillis = processContext.getProperty(FileTransfer.CONNECTION_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
+            session.setTimeout(connectionTimeoutMillis);
+            session.connect();
+
+            return session;
+        } catch (JSchException e) {
+            throw new IOException(e);
+        }
+    }
+
+    protected Channel getChannel(final FlowFile flowFile) throws IOException {
+        return getChannel(flowFile, null);
+    }
+
+    protected Channel getChannel(final FlowFile flowFile, final PreConnectHandler preConnectHandler) throws IOException {
+        if (sessionIsValid(flowFile) && channel != null && channel.isConnected()) {
+            return channel;
+        }
+
+        try {
+            if(!sessionIsValid(flowFile)){
+                establishSession(flowFile);
+            }
+
+            channel = session.openChannel(this.getSSHProtocolName());
+
+            in = channel.getInputStream();
+            out = channel.getOutputStream();
+
+            if(preConnectHandler != null){
+                preConnectHandler.OnPreConnect(channel, flowFile);
+            }
+
+            final int connectionTimeoutMillis = ctx.getProperty(FileTransfer.CONNECTION_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
+            channel.connect(connectionTimeoutMillis);
+            session.setTimeout(ctx.getProperty(FileTransfer.DATA_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue());
+            if (!ctx.getProperty(USE_KEEPALIVE_ON_TIMEOUT).asBoolean()) {
+                session.setServerAliveCountMax(0); // do not send keepalive message on SocketTimeoutException
+            }
+
+            return channel;
+        } catch (JSchException e) {
+            throw new IOException("Failed to obtain connection to remote host due to " + e.toString(), e);
+        }
+    }
+
+    public interface PreConnectHandler{
+        void OnPreConnect(Channel channel, FlowFile flowFile) throws IOException;
+    }
+
+    public void closeChannel(){
+        try {
+            if (null != channel) {
+                channel.disconnect();
+            }
+        } catch (final Exception ex) {
+            logger.warn("Failed to close Channel due to {}", new Object[] {ex.toString()}, ex);
+        }
+        channel = null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        closeChannel();
+
+        try {
+            if (null != session) {
+                session.disconnect();
+            }
+        } catch (final Exception ex) {
+            logger.warn("Failed to close session due to {}", new Object[] {ex.toString()}, ex);
+        }
+        session = null;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    protected int numberPermissions(String perms) {
+        int number = -1;
+        final Pattern rwxPattern = Pattern.compile("^[rwx-]{9}$");
+        final Pattern numPattern = Pattern.compile("\\d+");
+        if (rwxPattern.matcher(perms).matches()) {
+            number = 0;
+            if (perms.charAt(0) == 'r') {
+                number |= 0x100;
+            }
+            if (perms.charAt(1) == 'w') {
+                number |= 0x80;
+            }
+            if (perms.charAt(2) == 'x') {
+                number |= 0x40;
+            }
+            if (perms.charAt(3) == 'r') {
+                number |= 0x20;
+            }
+            if (perms.charAt(4) == 'w') {
+                number |= 0x10;
+            }
+            if (perms.charAt(5) == 'x') {
+                number |= 0x8;
+            }
+            if (perms.charAt(6) == 'r') {
+                number |= 0x4;
+            }
+            if (perms.charAt(7) == 'w') {
+                number |= 0x2;
+            }
+            if (perms.charAt(8) == 'x') {
+                number |= 0x1;
+            }
+        } else if (numPattern.matcher(perms).matches()) {
+            try {
+                number = Integer.parseInt(perms, 8);
+            } catch (NumberFormatException ignore) {
+            }
+        }
+        return number;
+    }
+
+    static {
+        JSch.setLogger(new com.jcraft.jsch.Logger() {
+            @Override
+            public boolean isEnabled(int level) {
+                return true;
+            }
+
+            @Override
+            public void log(int level, String message) {
+                LoggerFactory.getLogger(SSHTransfer.class).debug("JSch Log: {}", message);
+            }
+        });
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -43,6 +43,7 @@ org.apache.nifi.processors.standard.GetFile
 org.apache.nifi.processors.standard.GetFTP
 org.apache.nifi.processors.standard.GetHTTP
 org.apache.nifi.processors.standard.GetSFTP
+org.apache.nifi.processors.standard.GetSCP
 org.apache.nifi.processors.standard.HandleHttpRequest
 org.apache.nifi.processors.standard.HandleHttpResponse
 org.apache.nifi.processors.standard.HashAttribute
@@ -85,6 +86,7 @@ org.apache.nifi.processors.standard.PutFile
 org.apache.nifi.processors.standard.PutFTP
 org.apache.nifi.processors.standard.PutJMS
 org.apache.nifi.processors.standard.PutSFTP
+org.apache.nifi.processors.standard.PutSCP
 org.apache.nifi.processors.standard.PutSQL
 org.apache.nifi.processors.standard.PutSyslog
 org.apache.nifi.processors.standard.PutTCP

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchFileTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchFileTransfer.java
@@ -280,7 +280,12 @@ public class TestFetchFileTransfer {
                 }
 
                 @Override
-                public List<FileInfo> getListing() throws IOException {
+                public List<FileInfo> getListing(FlowFile flowFile) throws IOException {
+                    return null;
+                }
+
+                @Override
+                public List<FileInfo> getDirectoryListing(FlowFile flowFile, String path) throws IOException {
                     return null;
                 }
 
@@ -365,7 +370,7 @@ public class TestFetchFileTransfer {
                 }
 
                 @Override
-                public void ensureDirectoryExists(FlowFile flowFile, File remoteDirectory) throws IOException {
+                public void ensureDirectoryExists(FlowFile flowFile, String remoteDirectory) throws IOException {
                     if (!allowCreateDir) {
                         throw new PermissionDeniedException("test permission denied");
                     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetSFTP.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.nifi.processors.standard.util.SFTPTransfer;
+import org.apache.nifi.processors.standard.util.SSHTestServer;
+import org.apache.nifi.processors.standard.util.SSHTransfer;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestGetSFTP {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestGetSFTP.class);
+
+    private TestRunner getSFTPRunner;
+    private static SSHTestServer sshTestServer;
+
+    @BeforeClass
+    public static void setupSSHD() throws IOException {
+        sshTestServer = new SSHTestServer();
+        sshTestServer.startServer();
+    }
+
+    @AfterClass
+    public static void cleanupSSHD() throws IOException {
+        sshTestServer.stopServer();
+    }
+
+    @Before
+    public void setup(){
+        getSFTPRunner = TestRunners.newTestRunner(GetSFTP.class);
+        getSFTPRunner.setProperty(SSHTransfer.HOSTNAME, "localhost");
+        getSFTPRunner.setProperty(SSHTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
+        getSFTPRunner.setProperty(SSHTransfer.USERNAME, sshTestServer.getUsername());
+        getSFTPRunner.setProperty(SSHTransfer.PASSWORD, sshTestServer.getPassword());
+        getSFTPRunner.setProperty(SSHTransfer.STRICT_HOST_KEY_CHECKING, "false");
+        getSFTPRunner.setProperty(SSHTransfer.DATA_TIMEOUT, "30 sec");
+        getSFTPRunner.setProperty(SSHTransfer.REMOTE_PATH, "/");
+        getSFTPRunner.setProperty(SFTPTransfer.FILE_FILTER_REGEX, "");
+        getSFTPRunner.setProperty(SFTPTransfer.PATH_FILTER_REGEX, "");
+        getSFTPRunner.setProperty(SFTPTransfer.POLLING_INTERVAL, "60 sec");
+        getSFTPRunner.setProperty(SFTPTransfer.RECURSIVE_SEARCH, "false");
+        getSFTPRunner.setProperty(SFTPTransfer.IGNORE_DOTTED_FILES, "true");
+        getSFTPRunner.setProperty(SFTPTransfer.DELETE_ORIGINAL, "true");
+        getSFTPRunner.setProperty(SFTPTransfer.MAX_SELECTS, "100");
+        getSFTPRunner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "5000");
+        
+        getSFTPRunner.setValidateExpressionUsage(false);
+    }
+
+    @Test
+    public void testGetSFTPFileBasicRead() throws IOException {
+        emptyTestDirectory();
+
+        touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile1.txt");
+        touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile2.txt");
+        touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile3.txt");
+        touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile4.txt");
+
+        getSFTPRunner.run();
+
+        getSFTPRunner.assertTransferCount(GetSFTP.REL_SUCCESS, 4);
+
+        //Verify files deleted
+        for(int i=1;i<5;i++){
+            Path file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/testFile" + i + ".txt");
+            Assert.assertTrue("File not deleted.", !file1.toAbsolutePath().toFile().exists());
+        }
+
+        getSFTPRunner.clearTransferState();
+    }
+
+    @Test
+    public void testGetSFTPIgnoreDottedFiles() throws IOException {
+        emptyTestDirectory();
+
+        touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile1.txt");
+        touchFile(sshTestServer.getVirtualFileSystemPath() + ".testFile2.txt");
+        touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile3.txt");
+        touchFile(sshTestServer.getVirtualFileSystemPath() + ".testFile4.txt");
+
+        getSFTPRunner.run();
+
+        getSFTPRunner.assertTransferCount(GetSFTP.REL_SUCCESS, 2);
+
+        //Verify non-dotted files were deleted and dotted files were not deleted
+        Path file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/testFile1.txt");
+        Assert.assertTrue("File not deleted.", !file1.toAbsolutePath().toFile().exists());
+
+        file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/testFile3.txt");
+        Assert.assertTrue("File not deleted.", !file1.toAbsolutePath().toFile().exists());
+
+        file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/.testFile2.txt");
+        Assert.assertTrue("File deleted.", file1.toAbsolutePath().toFile().exists());
+
+        file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/.testFile4.txt");
+        Assert.assertTrue("File deleted.", file1.toAbsolutePath().toFile().exists());
+
+        getSFTPRunner.clearTransferState();
+    }
+
+    private void touchFile(String file) throws IOException {
+        FileUtils.writeStringToFile(new File(file), "", "UTF-8");
+    }
+
+    private void emptyTestDirectory() throws IOException {
+        //Delete Virtual File System folder
+        Path dir = Paths.get(sshTestServer.getVirtualFileSystemPath());
+        FileUtils.cleanDirectory(dir.toFile());
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.nifi.processors.standard.util.FileTransfer;
+import org.apache.nifi.processors.standard.util.SSHTestServer;
+import org.apache.nifi.processors.standard.util.SSHTransfer;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.AssertTrue;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.nifi.processors.standard.FetchFileTransfer.REMOTE_FILENAME;
+
+public class TestPutSFTP {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestPutSFTP.class);
+
+    private TestRunner putSFTPRunner;
+    private static SSHTestServer sshTestServer;
+
+    private final String testFile = "src" + File.separator + "test" + File.separator + "resources" + File.separator + "hello.txt";
+
+    @BeforeClass
+    public static void setupSSHD() throws IOException {
+        sshTestServer = new SSHTestServer();
+        sshTestServer.startServer();
+    }
+
+    @AfterClass
+    public static void cleanupSSHD() throws IOException {
+        sshTestServer.stopServer();
+    }
+
+    @Before
+    public void setup(){
+        putSFTPRunner = TestRunners.newTestRunner(PutSFTP.class);
+        putSFTPRunner.setProperty(SSHTransfer.HOSTNAME, "localhost");
+        putSFTPRunner.setProperty(SSHTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
+        putSFTPRunner.setProperty(SSHTransfer.USERNAME, sshTestServer.getUsername());
+        putSFTPRunner.setProperty(SSHTransfer.PASSWORD, sshTestServer.getPassword());
+        putSFTPRunner.setProperty(SSHTransfer.STRICT_HOST_KEY_CHECKING, "false");
+        putSFTPRunner.setProperty(SSHTransfer.BATCH_SIZE, "2");
+        putSFTPRunner.setProperty(SSHTransfer.REMOTE_PATH, "nifi_test/");
+        putSFTPRunner.setProperty(SSHTransfer.REJECT_ZERO_BYTE, "true");
+        putSFTPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, FileTransfer.CONFLICT_RESOLUTION_REPLACE);
+        putSFTPRunner.setProperty(SSHTransfer.CREATE_DIRECTORY, "true");
+        putSFTPRunner.setProperty(SSHTransfer.DATA_TIMEOUT, "30 sec");
+        putSFTPRunner.setValidateExpressionUsage(false);
+    }
+
+    @Test
+    public void testPutSFTPFile() throws IOException {
+        emptyTestDirectory();
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put("filename", "testfile.txt");
+
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+
+        //verify directory exists
+        Path newDirectory = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/");
+        Path newFile = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/testfile.txt");
+        Assert.assertTrue("New directory not created.", newDirectory.toAbsolutePath().toFile().exists());
+        Assert.assertTrue("New File not created.", newFile.toAbsolutePath().toFile().exists());
+        putSFTPRunner.clearTransferState();
+    }
+
+    @Test
+    public void testPutSFTPFileZeroByte() throws IOException {
+        emptyTestDirectory();
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put("filename", "testfile.txt");
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile1.txt");
+        putSFTPRunner.enqueue("", attributes);
+
+        putSFTPRunner.run();
+
+        //Two files in batch, should have only 1 transferred to sucess, 1 to failure
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 1);
+        putSFTPRunner.clearTransferState();
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile1.txt");
+        putSFTPRunner.enqueue("", attributes);
+
+        putSFTPRunner.run();
+
+        //One files in batch, should have 0 transferred to output since it's zero byte
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 1);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 0);
+        putSFTPRunner.clearTransferState();
+
+        //allow zero byte files
+        putSFTPRunner.setProperty(SSHTransfer.REJECT_ZERO_BYTE, "false");
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile1.txt");
+        putSFTPRunner.enqueue("", attributes);
+
+        putSFTPRunner.run();
+
+        //should have 1 transferred to sucess
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+
+        //revert settings
+        putSFTPRunner.setProperty(SSHTransfer.REJECT_ZERO_BYTE, "true");
+        putSFTPRunner.clearTransferState();
+    }
+
+    @Test
+    public void testPutSFTPFileConflictResolution() throws IOException {
+        emptyTestDirectory();
+
+        //Try transferring file with the same name as a directory, should fail in all cases
+        // except RESOLUTION of NONE
+        Path dir = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test" );
+        Path dir2 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/testfile" );
+        Files.createDirectory(dir);
+        Files.createDirectory(dir2);
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put("filename", "testfile");
+
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 0);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 1);
+
+        //Prepare by uploading test file
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile.txt");
+
+        putSFTPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, FileTransfer.CONFLICT_RESOLUTION_REPLACE);
+
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+        putSFTPRunner.clearTransferState();
+
+        //set conflict resolution mode to REJECT
+        putSFTPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, FileTransfer.CONFLICT_RESOLUTION_REJECT);
+
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 0);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 1);
+        putSFTPRunner.clearTransferState();
+
+        //set conflict resolution mode to RENAME
+        putSFTPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, FileTransfer.CONFLICT_RESOLUTION_RENAME);
+
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 0);
+
+        //verify filename
+        Assert.assertEquals("File name does not match", "1.testfile.txt", putSFTPRunner.getFlowFilesForRelationship(PutSFTP.REL_SUCCESS).get(0).getAttribute("filename"));
+        putSFTPRunner.clearTransferState();
+
+        //set conflict resolution mode to IGNORE
+        putSFTPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, FileTransfer.CONFLICT_RESOLUTION_IGNORE);
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 0);
+
+        putSFTPRunner.clearTransferState();
+
+        //set conflict resolution mode to FAIL
+        putSFTPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, FileTransfer.CONFLICT_RESOLUTION_FAIL);
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 0);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_REJECT, 0);
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_FAILURE, 1);
+
+        putSFTPRunner.clearTransferState();
+    }
+
+    @Test
+    public void testPutSFTPBatching() throws IOException {
+        emptyTestDirectory();
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put("filename", "testfile.txt");
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile2.txt");
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile3.txt");
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile4.txt");
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+
+        attributes = new HashMap<>();
+        attributes.put("filename", "testfile5.txt");
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+
+        putSFTPRunner.run();
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 2);
+
+        putSFTPRunner.clearTransferState();
+
+        putSFTPRunner.run();
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 2);
+
+        putSFTPRunner.clearTransferState();
+
+        putSFTPRunner.run();
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+        putSFTPRunner.clearTransferState();
+    }
+
+    private void emptyTestDirectory() throws IOException {
+        //Delete Virtual File System folder
+        Path dir = Paths.get(sshTestServer.getVirtualFileSystemPath());
+        FileUtils.cleanDirectory(dir.toFile());
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/ExternalProcessCommandFactory.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/ExternalProcessCommandFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.sshd.common.util.OsUtils;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.CommandFactory;
+import org.apache.sshd.server.shell.ProcessShellFactory;
+
+public class ExternalProcessCommandFactory implements CommandFactory {
+    @Override
+    public Command createCommand(String s) {
+        if (OsUtils.isUNIX()) {
+            return new ProcessShellFactory(new String[] { "/bin/sh", "-c", s }).create();
+        } else {
+            return new ProcessShellFactory(new String[] { "C:\\Windows\\System32\\bash.exe -c \"" + s.replace("\"", "\"\"") + "\"" }).create();
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/SSHTestServer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/SSHTestServer.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.common.util.OsUtils;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.scp.ScpCommandFactory;
+import org.apache.sshd.server.shell.ProcessShellFactory;
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystem;
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SSHTestServer {
+    public int getSSHPort(){
+        return sshd.getPort();
+    }
+
+    public String getVirtualFileSystemPath() {
+        return virtualFileSystemPath;
+    }
+
+    public void setVirtualFileSystemPath(String virtualFileSystemPath) {
+        this.virtualFileSystemPath = virtualFileSystemPath;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    private static SshServer sshd;
+    private String virtualFileSystemPath = "ssh_vfs/";
+
+    private String username = "nifiuser";
+    private String password = "nifipassword";
+
+    public void SSHTestServer(){
+
+    }
+
+    public void startServer() throws IOException {
+        sshd = SshServer.setUpDefaultServer();
+        sshd.setHost("localhost");
+
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+
+        //Accept all keys for authentication
+        sshd.setPublickeyAuthenticator((s, publicKey, serverSession) -> true);
+
+        //Allow username/password authentication using pre-defined credentials
+        sshd.setPasswordAuthenticator((username, password, serverSession) ->  this.username.equals(username) && this.password.equals(password));
+
+        //Add SCP support
+        ScpCommandFactory scpCommandFactory = new ScpCommandFactory();
+        scpCommandFactory.setDelegateCommandFactory(new ExternalProcessCommandFactory());
+        sshd.setCommandFactory(scpCommandFactory);
+
+        //Allow Shell access
+        sshd.setShellFactory(getShellFactory());
+
+        //Setup Virtual File System (VFS)
+        //Ensure VFS folder exists
+        Path dir = Paths.get(getVirtualFileSystemPath());
+        Files.createDirectories(dir);
+        sshd.setFileSystemFactory(new VirtualFileSystemFactory(dir.toAbsolutePath()));
+
+        //Add SFTP support
+        List<NamedFactory<Command>> sftpCommandFactory = new ArrayList<>();
+        sftpCommandFactory.add(new SftpSubsystemFactory());
+        sshd.setSubsystemFactories(sftpCommandFactory);
+
+        sshd.start();
+    }
+
+    public void stopServer() throws IOException {
+        if(sshd == null) return;
+        sshd.stop(true);
+
+        //Delete Virtual File System folder
+        Path dir = Paths.get(getVirtualFileSystemPath());
+        FileUtils.deleteDirectory(dir.toFile());
+    }
+
+    private static ProcessShellFactory getShellFactory() {
+        if (OsUtils.isUNIX()) {
+            return new ProcessShellFactory(new String[]{"/bin/sh", "-i", "-s"});
+        } else {
+            return new ProcessShellFactory(new String[]{"C:\\cygwin64\\bin\\bash.exe", "--login", "-i"});
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestSCPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestSCPTransfer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.nifi.processors.standard.FetchSCP;
+import org.apache.nifi.processors.standard.GetSCP;
+import org.apache.nifi.processors.standard.ListRemoteFiles;
+import org.apache.nifi.processors.standard.PutSCP;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import static org.apache.nifi.processors.standard.FetchFileTransfer.REMOTE_FILENAME;
+
+public class TestSCPTransfer {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestSCPTransfer.class);
+
+    private TestRunner putSCPRunner;
+
+
+    private static SSHTestServer sshTestServer;
+
+    @BeforeClass
+    public static void setupSSHD() throws IOException {
+        sshTestServer = new SSHTestServer();
+        sshTestServer.startServer();
+    }
+
+    @AfterClass
+    public static void cleanupSSHD() throws IOException {
+        sshTestServer.stopServer();
+    }
+
+    @Before
+    public void setup(){
+        putSCPRunner = TestRunners.newTestRunner(PutSCP.class);
+        putSCPRunner.setProperty(SSHTransfer.HOSTNAME, "localhost");
+        putSCPRunner.setProperty(SSHTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
+        putSCPRunner.setProperty(SSHTransfer.USERNAME, sshTestServer.getUsername());
+        putSCPRunner.setProperty(SSHTransfer.PASSWORD, sshTestServer.getPassword());
+        putSCPRunner.setProperty(SSHTransfer.STRICT_HOST_KEY_CHECKING, "false");
+        putSCPRunner.setProperty(SSHTransfer.BATCH_SIZE, "2");
+        putSCPRunner.setProperty(SSHTransfer.REMOTE_PATH, "/");
+        putSCPRunner.setProperty(SSHTransfer.TEMP_FILENAME, "${filename}");
+        putSCPRunner.setProperty(SSHTransfer.REJECT_ZERO_BYTE, "true");
+        putSCPRunner.setProperty(SSHTransfer.CONFLICT_RESOLUTION, "NONE");
+        putSCPRunner.setProperty(SSHTransfer.CREATE_DIRECTORY, "false");
+        putSCPRunner.setProperty(SSHTransfer.DATA_TIMEOUT, "30 sec");
+        putSCPRunner.setValidateExpressionUsage(false);
+    }
+
+    @Test
+    public void testPutSCPFile() throws IOException {
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put("filename", "testfile.txt");
+
+        String testFile = "src" + File.separator + "test" + File.separator + "resources" + File.separator + "hello.txt";
+        putSCPRunner.enqueue(Paths.get(testFile), attributes);
+        putSCPRunner.run();
+
+        putSCPRunner.assertTransferCount(PutSCP.REL_SUCCESS, 1);
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestSFTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestSFTPTransfer.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -48,12 +47,12 @@ public class TestSFTPTransfer {
 
     private static final Logger logger = LoggerFactory.getLogger(TestSFTPTransfer.class);
 
-    private SFTPTransfer createSftpTransfer(ProcessContext processContext, ChannelSftp channel) {
+    private SFTPTransfer createSftpTransfer(ProcessContext processContext, ChannelSftp sftchannel) {
         final ComponentLog componentLog = mock(ComponentLog.class);
         return new SFTPTransfer(processContext, componentLog) {
             @Override
             protected ChannelSftp getChannel(FlowFile flowFile) throws IOException {
-                return channel;
+                return sftchannel;
             }
         };
     }
@@ -64,8 +63,7 @@ public class TestSFTPTransfer {
         final ChannelSftp channel = mock(ChannelSftp.class);
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
-        sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+        sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
 
         // Dir existence check should be done by stat
         verify(channel).stat(eq("/dir1/dir2/dir3"));
@@ -80,9 +78,8 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
         try {
-            sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+            sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
             fail("Should fail");
         } catch (IOException e) {
             assertEquals("Failed to determine if remote directory exists at /dir1/dir2/dir3 due to 4: Failure", e.getMessage());
@@ -101,8 +98,7 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
-        sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+        sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
 
         // Dir existence check should be done by stat
         verify(channel).stat(eq("/dir1/dir2/dir3")); // dir3 was not found
@@ -120,8 +116,7 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
-        sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+        sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
 
         // Dir existence check should be done by stat
         verify(channel).stat(eq("/dir1/dir2/dir3")); // dir3 was not found
@@ -142,9 +137,8 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
         try {
-            sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+            sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
             fail("Should fail");
         } catch (IOException e) {
             assertEquals("Failed to create remote directory /dir1/dir2/dir3 due to 4: Failed", e.getMessage());
@@ -164,8 +158,7 @@ public class TestSFTPTransfer {
         final ChannelSftp channel = mock(ChannelSftp.class);
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
-        sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+        sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
 
         // stat should not be called.
         verify(channel, times(0)).stat(eq("/dir1/dir2/dir3"));
@@ -192,8 +185,7 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
-        sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+        sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
 
         // stat should not be called.
         verify(channel, times(0)).stat(eq("/dir1/dir2/dir3"));
@@ -213,8 +205,7 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
-        sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+        sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
 
         // stat should not be called.
         verify(channel, times(0)).stat(eq("/dir1/dir2/dir3"));
@@ -231,9 +222,8 @@ public class TestSFTPTransfer {
 
         final SFTPTransfer sftpTransfer = createSftpTransfer(processContext, channel);
         final MockFlowFile flowFile = new MockFlowFile(0);
-        final File remoteDir = new File("/dir1/dir2/dir3");
         try {
-            sftpTransfer.ensureDirectoryExists(flowFile, remoteDir);
+            sftpTransfer.ensureDirectoryExists(flowFile, "/dir1/dir2/dir3");
             fail("Should fail");
         } catch (IOException e) {
             assertEquals("Could not blindly create remote directory due to Permission denied", e.getMessage());


### PR DESCRIPTION
Combination of NIFI-539 and NIFI-3698. Adds functionality for SCP and SSH remote execution processors.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
