### PR TITLE
NIFI-5361: When submitting many processors to start, calculate the 't…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -1481,11 +1481,15 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         final Processor processor = getProcessor();
         final ComponentLog procLog = new SimpleProcessLogger(StandardProcessorNode.this.getIdentifier(), processor);
 
-        final long completionTimestamp = System.currentTimeMillis() + onScheduleTimeoutMillis;
+        // Completion Timestamp is set to MAX_VALUE because we don't want to timeout until the task has a chance to run.
+        final AtomicLong completionTimestampRef = new AtomicLong(Long.MAX_VALUE);
 
         // Create a task to invoke the @OnScheduled annotation of the processor
         final Callable<Void> startupTask = () -> {
             LOG.debug("Invoking @OnScheduled methods of {}", processor);
+
+            // Now that the task has been scheduled, set the timeout
+            completionTimestampRef.set(System.currentTimeMillis() + onScheduleTimeoutMillis);
 
             try (final NarCloseable nc = NarCloseable.withComponentNarLoader(processor.getClass(), processor.getIdentifier())) {
                 try {
@@ -1571,7 +1575,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                     return;
                 }
 
-                monitorAsyncTask(taskFuture, monitoringFuture, completionTimestamp);
+                monitorAsyncTask(taskFuture, monitoringFuture, completionTimestampRef.get());
             }
         };
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -319,7 +319,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
             @Override
             public Future<?> scheduleTask(final Callable<?> task) {
                 lifecycleState.incrementActiveThreadCount(null);
-                return componentMonitoringThreadPool.submit(task);
+                return componentLifeCycleThreadPool.submit(task);
             }
 
             @Override


### PR DESCRIPTION
…imeout timestamp' immediately before calling @OnScheduled method, after the task has been scheduled to run, instead of before the task has a chance to run.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
