### PR TITLE
fix copy paste bug in documentation for ldap auth

### DIFF
--- a/nifi-docker/dockerhub/README.md
+++ b/nifi-docker/dockerhub/README.md
@@ -97,7 +97,7 @@ volume to provide certificates on the host system to the container instance.
     docker run --name nifi \
       -v /User/dreynolds/certs/localhost:/opt/certs \
       -p 8443:8443 \
-      -e AUTH=tls \
+      -e AUTH=ldap \
       -e KEYSTORE_PATH=/opt/certs/keystore.jks \
       -e KEYSTORE_TYPE=JKS \
       -e KEYSTORE_PASSWORD=QKZv1hSWAFQYZ+WU1jjF5ank+l4igeOfQRp+OSbkkrs \


### PR DESCRIPTION
Trivial fix for example docker launch using LDAP authentication
