### PR TITLE
NIFI-5318 Implement NiFi test harness: initial commit of nifi-test

### DIFF
--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2296,6 +2296,32 @@ threads that should be used to run the Processor can
 be set via the `setThreadCount(int)` method.
 
 
+=== Experimental NiFi Flow test harness
+
+NiFi now has an experimental feature for full end-to-end testing of flows. This allows us
+to take a NiFi flow, install it to a test NiFi instance, run it and make Java unit test
+like asserts regarding its behaviour.
+
+The class `org.apache.nifi.test.TestNiFiInstance` is a thin wrapper that allows us
+to manipulate a NiFi installation and deploy a flow with some adjustments
+to its configuration, including changing processor properties and replacing processor
+classes with mocks.
+
+In order to add the necessary classes to your project,
+you can use the Maven dependency:
+
+[source]
+----
+<dependency>
+	<groupId>org.apache.nifi</groupId>
+	<artifactId>nifi-test</artifactId>
+	<version>${nifi version}</version>
+</dependency>
+----
+
+For further documentation, please consult the JavaDoc of
+`org.apache.nifi.test.TestNiFiInstance`. For samples, please take a look at
+link:https://github.com/apache/nifi/tree/master/nifi-test/src/test/java/org/apache/test/samples[samples on GitHub^].
 
 
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/DocGenerator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/DocGenerator.java
@@ -57,6 +57,9 @@ public class DocGenerator {
      * @param extensionMapping extension mapping
      */
     public static void generate(final NiFiProperties properties, final ExtensionMapping extensionMapping) {
+
+
+
         final File explodedNiFiDocsDir = properties.getComponentDocumentationWorkingDirectory();
 
         logger.debug("Generating documentation for: " + extensionMapping.size() + " components in: " + explodedNiFiDocsDir);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/mock/GetHTTPMock.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/mock/GetHTTPMock.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.nifi.test.mock;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessSessionFactory;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.util.StopWatch;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class GetHTTPMock extends MockProcessor {
+
+    private final String contentType;
+    private final Supplier<InputStream> inputStreamSupplier;
+
+    public GetHTTPMock(String contentType, Supplier<InputStream> inputStreamSupplier) {
+        super("org.apache.nifi.processors.standard.GetHTTP");
+
+        this.contentType = contentType;
+        this.inputStreamSupplier = inputStreamSupplier;
+    }
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("All files are transferred to the success relationship")
+            .build();
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSessionFactory processSessionFactory) {
+
+        final ComponentLog logger = getLogger();
+
+        final StopWatch stopWatch = new StopWatch(true);
+
+        final ProcessSession session = processSessionFactory.createSession();
+
+        final String url = context.getProperty("URL").evaluateAttributeExpressions().getValue();
+        final URI uri;
+        String source = url;
+        try {
+            uri = new URI(url);
+            source = uri.getHost();
+        } catch (final URISyntaxException swallow) {
+            // this won't happen as the url has already been validated
+        }
+
+        FlowFile flowFile = session.create();
+
+        flowFile = session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), context.getProperty("Filename").evaluateAttributeExpressions().getValue());
+        flowFile = session.putAttribute(flowFile, this.getClass().getSimpleName().toLowerCase() + ".remote.source", source);
+        flowFile = session.importFrom(inputStreamSupplier.get(), flowFile);
+
+        flowFile = session.putAttribute(flowFile, CoreAttributes.MIME_TYPE.key(), contentType);
+
+        final long flowFileSize = flowFile.getSize();
+        stopWatch.stop();
+        session.getProvenanceReporter().receive(flowFile, url, stopWatch.getDuration(TimeUnit.MILLISECONDS));
+        session.transfer(flowFile, REL_SUCCESS);
+
+        final String dataRate = stopWatch.calculateDataRate(flowFileSize);
+        logger.info("Successfully received {} from {} at a rate of {}; transferred to success", new Object[]{flowFile, url, dataRate});
+        session.commit();
+
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/mock/MockProcessor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/mock/MockProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.nifi.test.mock;
+
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.*;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public abstract class MockProcessor implements Processor {
+
+    private final Processor delegate;
+    private ComponentLog logger;
+
+    protected MockProcessor(String delegateClassName) {
+        try {
+
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            final Class<?> delegateClass = Class.forName(delegateClassName, true, contextClassLoader);
+
+            delegate = (Processor) delegateClass.newInstance();
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+            throw new RuntimeException(e);
+        }
+
+
+    }
+
+    protected Processor getDelegate() {
+        return delegate;
+
+    }
+
+    protected final ComponentLog getLogger() {
+        return logger;
+    }
+
+    @Override
+    public void initialize(ProcessorInitializationContext processorInitializationContext) {
+        getDelegate().initialize(processorInitializationContext);
+        logger = processorInitializationContext.getLogger();
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return getDelegate().getRelationships();
+    }
+
+    @Override
+    public abstract void onTrigger(ProcessContext processContext, ProcessSessionFactory processSessionFactory);
+
+    @Override
+    public Collection<ValidationResult> validate(ValidationContext validationContext) {
+        return getDelegate().validate(validationContext);
+    }
+
+    @Override
+    public PropertyDescriptor getPropertyDescriptor(String s) {
+        return getDelegate().getPropertyDescriptor(s);
+    }
+
+    @Override
+    public void onPropertyModified(PropertyDescriptor propertyDescriptor, String s, String s1) {
+        getDelegate().onPropertyModified(propertyDescriptor, s, s1);
+    }
+
+    @Override
+    public List<PropertyDescriptor> getPropertyDescriptors() {
+        return getDelegate().getPropertyDescriptors();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return getDelegate().getIdentifier();
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/samples/Constants.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/samples/Constants.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.nifi.test.samples;
+
+import java.io.File;
+
+public class Constants {
+
+    private static final String USER_HOME = System.getProperty("user.home");
+    static final File OUTPUT_DIR = new File(USER_HOME + "/NiFiTest/NiFiReadTest");
+    static final File NIFI_ZIP_DIR = new File("../../nifi-assembly/target");
+    static final File FLOW_XML_FILE = new File(NiFiMockFlowTest.class.getResource("/flow.xml").getFile());
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/samples/NiFiFlowTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/samples/NiFiFlowTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.nifi.test.samples;
+
+
+
+import org.apache.nifi.test.TestNiFiInstance;
+import org.apache.nifi.test.util.FileUtils;
+import org.apache.nifi.test.SimpleNiFiFlowDefinitionEditor;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.testng.annotations.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * This test demonstrates how to mock the source data by starting a mock HTTP server (using Jetty)
+ * and rewrite the URL in flow definition.
+ * <p>
+ * NOTE: this test is disabled for now: see @Test(enabled = false)
+ */
+@Test(enabled=false) // this is a sample for now
+public class NiFiFlowTest {
+
+    private static final SimpleNiFiFlowDefinitionEditor CONFIGURE_MOCKS_IN_NIFI_FLOW = SimpleNiFiFlowDefinitionEditor.builder()
+            .setSingleProcessorProperty("GetHTTP", "URL", "http://localhost:12345")
+            .build();
+
+    // used by mocked GetHTTP; serves test data
+    private static Server testJettyServer;
+
+    private final TestNiFiInstance testNiFiInstance;
+
+
+    public NiFiFlowTest() {
+
+        File nifiZipFile = getBinaryDistributionZipFile(Constants.NIFI_ZIP_DIR);
+
+        this.testNiFiInstance = TestNiFiInstance.builder()
+                .setNiFiBinaryDistributionZip(nifiZipFile)
+                .setFlowXmlToInstallForTesting(Constants.FLOW_XML_FILE)
+                .modifyFlowXmlBeforeInstalling(CONFIGURE_MOCKS_IN_NIFI_FLOW)
+                .build();
+    }
+
+    private static File getBinaryDistributionZipFile(File binaryDistributionZipDir) {
+
+        File[] files = binaryDistributionZipDir.listFiles((dir, name) ->
+                name.startsWith("nifi-") && name.endsWith("-bin.zip"));
+
+        if (files.length == 0) {
+            throw new IllegalStateException(
+                    "No NiFi distribution ZIP file is found in: " + binaryDistributionZipDir);
+        }
+
+        if (files.length != 1) {
+            throw new IllegalStateException(
+                    "MultipleNiFi distribution ZIP files are found in: " + binaryDistributionZipDir);
+        }
+
+        return files[0];
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        NiFiFlowTest.testJettyServer = new Server(12345);
+
+
+        Handler handler = new TestHandler();
+        NiFiFlowTest.testJettyServer.setHandler(handler);
+        NiFiFlowTest.testJettyServer.start();
+    }
+
+
+    @BeforeMethod
+    public void bootstrapNiFi() throws Exception {
+
+        if (Constants.OUTPUT_DIR.exists()) {
+            FileUtils.deleteDirectoryRecursive(Constants.OUTPUT_DIR.toPath());
+        }
+
+        testNiFiInstance.install();
+        testNiFiInstance.start();
+    }
+
+    // test disabled for now: apparenlt NiFi does not like being started
+    // multiple times in the same JVM
+    @Test
+    public void testFlowCreatesFilesInCorrectLocation() throws IOException {
+
+        // We deleted the output directory: our NiFi flow should create it
+
+        assertTrue(Constants.OUTPUT_DIR.exists(), "Output directory not found: " + Constants.OUTPUT_DIR);
+
+        File outputFile = new File(Constants.OUTPUT_DIR, "bbc-world.rss.xml");
+
+        assertTrue(outputFile.exists(), "Output file not found: " + outputFile);
+
+        List<String> strings = Files.readAllLines(outputFile.toPath());
+
+        boolean atLeastOneLineContainsBBC = strings.stream().anyMatch(line -> line.toLowerCase().contains("bbc"));
+
+        assertTrue(atLeastOneLineContainsBBC, "There was no line containing BBC");
+
+        boolean atLeastOneLineContainsIPhone = strings.stream().anyMatch(line -> line.toLowerCase().contains("iphone"));
+
+        assertTrue(atLeastOneLineContainsIPhone, "There was no line containing IPhone");
+
+    }
+
+    @AfterMethod
+    public void shutdownNiFi() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        testNiFiInstance.stopAndCleanup();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        NiFiFlowTest.testJettyServer.stop();
+    }
+
+
+    private static class TestHandler extends org.eclipse.jetty.server.handler.AbstractHandler {
+        @Override
+        public void handle(
+                String target,
+                Request baseRequest,
+                HttpServletRequest httpServletRequest,
+                HttpServletResponse response) throws IOException, ServletException {
+
+            response.setContentType("text/html;charset=utf-8");
+            response.setStatus(HttpServletResponse.SC_OK);
+            baseRequest.setHandled(true);
+
+            InputStream resource = TestHandler.class.getResourceAsStream("/sample_technology_rss.xml");
+            ServletOutputStream outputStream = response.getOutputStream();
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = resource.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, len);
+            }
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/samples/NiFiMockFlowTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/samples/NiFiMockFlowTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.nifi.test.samples;
+
+
+import org.apache.nifi.test.TestNiFiInstance;
+import org.apache.nifi.test.mock.GetHTTPMock;
+import org.apache.nifi.test.util.FileUtils;
+import org.apache.nifi.test.SimpleNiFiFlowDefinitionEditor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * This test demonstrates how to mock the source data by mocking the processor
+ * itself in the flow definition.
+ */
+@Test(enabled=false) // this is a sample for now
+public class NiFiMockFlowTest {
+
+    private static final InputStream DEMO_DATA_AS_STREAM =
+            NiFiFlowTest.class.getResourceAsStream("/sample_technology_rss.xml");
+
+
+    // We have a dedicated class. It has to be public static
+    // so that NiFi engine can instantiate it.
+    public static class MockedGetHTTP extends GetHTTPMock {
+
+        public MockedGetHTTP() {
+            super("text/xml; charset=utf-8", () -> DEMO_DATA_AS_STREAM);
+        }
+    }
+
+
+    private static final SimpleNiFiFlowDefinitionEditor CONFIGURE_MOCKS_IN_NIFI_FLOW = SimpleNiFiFlowDefinitionEditor.builder()
+            .setClassOfSingleProcessor("GetHTTP", MockedGetHTTP.class)
+            .build();
+
+
+    private final TestNiFiInstance testNiFiInstance;
+
+
+    public NiFiMockFlowTest() {
+        try {
+            if (!Constants.NIFI_ZIP_DIR.exists()) {
+                throw new IllegalStateException("NiFi distribution ZIP file not found at the expected location: "
+                        + Constants.NIFI_ZIP_DIR.getCanonicalPath());
+            }
+
+            this.testNiFiInstance = TestNiFiInstance.builder()
+                    .setNiFiBinaryDistributionZip(Constants.NIFI_ZIP_DIR)
+                    .setFlowXmlToInstallForTesting(Constants.FLOW_XML_FILE)
+                    .modifyFlowXmlBeforeInstalling(CONFIGURE_MOCKS_IN_NIFI_FLOW)
+                    .build();
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeMethod
+    public void bootstrapNiFi() throws Exception {
+
+        if (Constants.OUTPUT_DIR.exists()) {
+            FileUtils.deleteDirectoryRecursive(Constants.OUTPUT_DIR.toPath());
+        }
+
+        testNiFiInstance.install();
+        testNiFiInstance.start();
+    }
+
+    @Test
+    public void testFlowCreatesFilesInCorrectLocation() throws IOException {
+
+        // We deleted the output directory: our NiFi flow should create it
+
+        assertTrue(Constants.OUTPUT_DIR.exists(), "Output directory not found: " + Constants.OUTPUT_DIR);
+
+        File outputFile = new File(Constants.OUTPUT_DIR, "bbc-world.rss.xml");
+
+        assertTrue(outputFile.exists(), "Output file not found: " + outputFile);
+
+        List<String> strings = Files.readAllLines(outputFile.toPath());
+
+        boolean atLeastOneLineContainsBBC = strings.stream().anyMatch(line -> line.toLowerCase().contains("bbc"));
+
+        assertTrue(atLeastOneLineContainsBBC, "There was no line containing BBC");
+
+        boolean atLeastOneLineContainsIPhone = strings.stream().anyMatch(line -> line.toLowerCase().contains("iphone"));
+
+        assertTrue(atLeastOneLineContainsIPhone, "There was no line containing IPhone");
+
+    }
+
+    @AfterMethod
+    public void shutdownNiFi() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        testNiFiInstance.stopAndCleanup();
+    }
+}

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/test/resources/flow.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/test/resources/flow.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<flowController encoding-version="1.1">
+  <maxTimerDrivenThreadCount>10</maxTimerDrivenThreadCount>
+  <maxEventDrivenThreadCount>5</maxEventDrivenThreadCount>
+  <rootGroup>
+    <id>b895989d-015e-1000-6ace-31c53901f9e7</id>
+    <name>NiFi Flow</name>
+    <position x="0.0" y="0.0"/>
+    <comment/>
+    <processor>
+      <id>bd4ba8b0-015e-1000-d3ee-28f5484892b4</id>
+      <name>GetHTTP</name>
+      <position x="337.0" y="107.0"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.GetHTTP</class>
+      <bundle>
+        <group>org.apache.nifi</group>
+        <artifact>nifi-standard-nar</artifact>
+        <version>1.6.0</version>
+      </bundle>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <executionNode>ALL</executionNode>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>URL</name>
+        <value>http://feeds.bbci.co.uk/news/technology/rss.xml?edition=uk#</value>
+      </property>
+      <property>
+        <name>Filename</name>
+        <value>bbc-world.rss.xml</value>
+      </property>
+      <property>
+        <name>SSL Context Service</name>
+      </property>
+      <property>
+        <name>Username</name>
+      </property>
+      <property>
+        <name>Password</name>
+      </property>
+      <property>
+        <name>Connection Timeout</name>
+        <value>30 sec</value>
+      </property>
+      <property>
+        <name>Data Timeout</name>
+        <value>30 sec</value>
+      </property>
+      <property>
+        <name>User Agent</name>
+      </property>
+      <property>
+        <name>Accept Content-Type</name>
+      </property>
+      <property>
+        <name>Follow Redirects</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>redirect-cookie-policy</name>
+        <value>default</value>
+      </property>
+      <property>
+        <name>Proxy Host</name>
+      </property>
+      <property>
+        <name>Proxy Port</name>
+      </property>
+    </processor>
+    <processor>
+      <id>bd4d98aa-015e-1000-72cb-f10194e94546</id>
+      <name>PutFile</name>
+      <position x="333.0" y="312.0"/>
+      <styles/>
+      <comment/>
+      <class>org.apache.nifi.processors.standard.PutFile</class>
+      <bundle>
+        <group>org.apache.nifi</group>
+        <artifact>nifi-standard-nar</artifact>
+        <version>1.6.0</version>
+      </bundle>
+      <maxConcurrentTasks>1</maxConcurrentTasks>
+      <schedulingPeriod>0 sec</schedulingPeriod>
+      <penalizationPeriod>30 sec</penalizationPeriod>
+      <yieldPeriod>1 sec</yieldPeriod>
+      <bulletinLevel>WARN</bulletinLevel>
+      <lossTolerant>false</lossTolerant>
+      <scheduledState>RUNNING</scheduledState>
+      <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+      <executionNode>ALL</executionNode>
+      <runDurationNanos>0</runDurationNanos>
+      <property>
+        <name>Directory</name>
+        <value>${"user.home"}/NiFiTest/NiFiReadTest</value>
+      </property>
+      <property>
+        <name>Conflict Resolution Strategy</name>
+        <value>ignore</value>
+      </property>
+      <property>
+        <name>Create Missing Directories</name>
+        <value>true</value>
+      </property>
+      <property>
+        <name>Maximum File Count</name>
+      </property>
+      <property>
+        <name>Last Modified Time</name>
+      </property>
+      <property>
+        <name>Permissions</name>
+      </property>
+      <property>
+        <name>Owner</name>
+      </property>
+      <property>
+        <name>Group</name>
+      </property>
+      <autoTerminatedRelationship>success</autoTerminatedRelationship>
+      <autoTerminatedRelationship>failure</autoTerminatedRelationship>
+    </processor>
+    <connection>
+      <id>bd4e54a4-015e-1000-3b0f-19d24756ce1c</id>
+      <name/>
+      <bendPoints/>
+      <labelIndex>1</labelIndex>
+      <zIndex>0</zIndex>
+      <sourceId>bd4ba8b0-015e-1000-d3ee-28f5484892b4</sourceId>
+      <sourceGroupId>b895989d-015e-1000-6ace-31c53901f9e7</sourceGroupId>
+      <sourceType>PROCESSOR</sourceType>
+      <destinationId>bd4d98aa-015e-1000-72cb-f10194e94546</destinationId>
+      <destinationGroupId>b895989d-015e-1000-6ace-31c53901f9e7</destinationGroupId>
+      <destinationType>PROCESSOR</destinationType>
+      <relationship>success</relationship>
+      <maxWorkQueueSize>10000</maxWorkQueueSize>
+      <maxWorkQueueDataSize>1 GB</maxWorkQueueDataSize>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+    </connection>
+  </rootGroup>
+  <controllerServices/>
+  <reportingTasks/>
+</flowController>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/test/resources/logback-test.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration debug="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/test/resources/sample_technology_rss.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/test/resources/sample_technology_rss.xml
@@ -1,0 +1,28 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet title="XSL_formatting" type="text/xsl" href="/shared/bsp/xsl/rss/nolsol.xsl"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+        <title><![CDATA[BBC News - Technology]]></title>
+        <description><![CDATA[BBC News - Technology]]></description>
+        <link>http://www.bbc.co.uk/news/</link>
+        <image>
+            <url>http://news.bbcimg.co.uk/nol/shared/img/bbc_news_120x60.gif</url>
+            <title>BBC News - Technology</title>
+            <link>http://www.bbc.co.uk/news/</link>
+        </image>
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Fri, 29 Sep 2017 07:38:08 GMT</lastBuildDate>
+        <copyright><![CDATA[Copyright: (C) British Broadcasting Corporation, see http://news.bbc.co.uk/2/hi/help/rss/4498287.stm for terms and conditions of reuse.]]></copyright>
+        <language><![CDATA[en-gb]]></language>
+        <ttl>15</ttl>
+        <item>
+            <title><![CDATA[IPhone X to use 'black box' anti-spoof Face ID tech]]></title>
+            <description><![CDATA[Even Apple will be unable to explain how its anti-spoof facial recognition technology works.]]></description>
+            <link>http://www.bbc.co.uk/news/technology-41412560</link>
+            <guid isPermaLink="true">http://www.bbc.co.uk/news/technology-41412560</guid>
+            <pubDate>Wed, 27 Sep 2017 16:37:39 GMT</pubDate>
+            <media:thumbnail width="2048" height="1152" url="http://c.files.bbci.co.uk/13384/production/_98042787_mediaitem98042786.jpg"/>
+        </item>
+    </channel>
+</rss>

--- a/nifi-test/nifi_test_nifi_home/NIFI_TEST_README.txt
+++ b/nifi-test/nifi_test_nifi_home/NIFI_TEST_README.txt
@@ -1,0 +1,3 @@
+This directory is used to mimic NiFi's own home directory: the JVM hosting the
+TestNiFiInstance has to be started here. Once started, TestNiFiInstance then
+creates symlinks to the actual NiFi installation directory.

--- a/nifi-test/pom.xml
+++ b/nifi-test/pom.xml
@@ -1,0 +1,145 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>nifi</artifactId>
+        <groupId>org.apache.nifi</groupId>
+        <version>1.8.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.thinkbiganalytics</groupId>
+    <artifactId>nifi-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <workingDirectory>nifi_test_nifi_home</workingDirectory>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+    <packaging>jar</packaging>
+
+    <name>nifi-test</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <org.slf4j.version>1.7.25</org.slf4j.version>
+        <jetty.version>9.4.3.v20170317</jetty.version>
+        <nifi.version>1.6.0</nifi.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-runtime</artifactId>
+            <version>${nifi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-api</artifactId>
+            <version>${nifi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-core</artifactId>
+            <version>${nifi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-bootstrap</artifactId>
+            <version>${nifi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <version>${nifi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>3.4</version>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymockclassextension</artifactId>
+            <version>3.2</version>
+            <scope>test</scope>
+        </dependency>
+
+
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-easymock</artifactId>
+            <version>1.7.1</version>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>1.7.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.11</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/SimpleNiFiFlowDefinitionEditor.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/SimpleNiFiFlowDefinitionEditor.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test;
+
+import org.apache.nifi.test.api.FlowFileEditorCallback;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.util.LinkedList;
+
+
+/**
+ * <p>
+ * A facility to describe simple, common changes to a NiFi flow before it is installed to the test
+ * NiFi instance. Intended to be used by
+ * {@link TestNiFiInstance.Builder#modifyFlowXmlBeforeInstalling(FlowFileEditorCallback)}
+ * </p>
+ *
+ * <p>
+ * The desired edits can be configured via the {@link Builder} object returned by the {@link #builder()}
+ * method. Once fully configured, the {@link Builder#build()} emits a {@code FlowFileEditorCallback}
+ * object that can be passed to
+ * {@link TestNiFiInstance.Builder#modifyFlowXmlBeforeInstalling(FlowFileEditorCallback)}.
+ * </p>
+ *
+ * <p>
+ * <strong>CAUTION: THIS IS AN EXPERIMENTAL API: EXPECT CHANGES!</strong>
+ * Efforts will be made to retain backwards API compatibility, but
+ * no guarantee is given.
+ * </p>
+ *
+ * @see TestNiFiInstance.Builder#modifyFlowXmlBeforeInstalling(FlowFileEditorCallback)
+ *
+ * @author Peter G. Horvath
+ */
+
+public final class SimpleNiFiFlowDefinitionEditor implements FlowFileEditorCallback {
+
+
+    private final LinkedList<FlowFileEditorCallback> delegateActions;
+
+    private SimpleNiFiFlowDefinitionEditor(LinkedList<FlowFileEditorCallback> delegateActions) {
+        this.delegateActions = delegateActions;
+    }
+
+    @Override
+    public Document edit(Document document) throws Exception {
+
+        for (FlowFileEditorCallback change : delegateActions) {
+            document = change.edit(document);
+        }
+
+        return document;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Builder() {
+            // no external instance
+        }
+
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        private final LinkedList<FlowFileEditorCallback> actions = new LinkedList<>();
+
+        public Builder rawXmlChange(FlowFileEditorCallback flowFileEditorCallback) {
+            actions.addLast(flowFileEditorCallback);
+            return this;
+        }
+
+        public Builder setSingleProcessorProperty(String processorName, String propertyName, String newValue) {
+
+            return rawXmlChange(document -> {
+                String xpathString = "//processor[name/text() = '" + processorName
+                        + "']/property[name/text() = '" + propertyName + "']/value";
+
+                Node propertyValueNode = (Node) xpath.evaluate(xpathString, document, XPathConstants.NODE);
+
+                if (propertyValueNode == null) {
+                    throw new IllegalArgumentException("Reference to processor '"+ processorName +"' with property '"
+                            + propertyName + "' not found: " + xpathString);
+                }
+
+                propertyValueNode.setTextContent(newValue);
+
+                return document;
+            });
+
+
+        }
+
+        public Builder setClassOfSingleProcessor(String processorName, Class<?> mockProcessor) {
+
+            return setClassOfSingleProcessor(processorName, mockProcessor.getName());
+        }
+
+        public Builder setClassOfSingleProcessor(String processorName, String newFullyQualifiedClassName) {
+
+            return rawXmlChange(document -> {
+                String xpathString = "//processor[name/text() = '" + processorName + "']/class";
+
+                Node classNameNode = (Node) xpath.evaluate(xpathString, document, XPathConstants.NODE);
+
+                if (classNameNode == null) {
+                    throw new IllegalArgumentException("Reference to processor '"+ processorName +" not found: " +
+                            xpathString);
+                }
+
+                classNameNode.setTextContent(newFullyQualifiedClassName);
+
+                return document;
+            });
+        }
+
+
+        public SimpleNiFiFlowDefinitionEditor build() {
+            return new SimpleNiFiFlowDefinitionEditor(actions);
+        }
+
+    }
+}

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/TestNiFiInstance.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/TestNiFiInstance.java
@@ -1,0 +1,476 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test;
+
+import org.apache.nifi.test.api.FlowFileEditorCallback;
+import org.apache.nifi.test.util.*;
+import org.apache.nifi.EmbeddedNiFi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.zip.ZipEntry;
+
+/**
+ * <p>
+ * An API wrapper of a "test" NiFi instance to which a flow definition is installed for testing.</p>
+ *
+ * <p>
+ * Due to NiFi design restrictions, {@code TestNiFiInstance} has to take <i>full command</i>
+ * of the current working directory: it installs a full NiFi installation to there. To ensure
+ * this is desired, <strong>it will only run if the current directory is called
+ * "nifi_test_nifi_home"</strong>. As such the JVM process has to be started inside a directory
+ * called "nifi_test_nifi_home" so that the following is true:
+ *
+ * <pre><tt>
+ *     new File(System.getProperty("user.dir")).getName().equals("nifi_test_nifi_home")
+ * </tt></pre>
+ * </p>
+ *
+ * <p>
+ * Before {@code TestNiFiInstance} can be used, it has to be configured via its builder
+ * interface:
+ * <ul>
+ *     <li>
+ *      {@link Builder#setFlowXmlToInstallForTesting(File)} specifies the location of the NiFi binary
+ *      distribution ZIP file to be used.
+ *     </li>
+ *      <li>
+ *      {@link Builder#setFlowXmlToInstallForTesting(File)} specifies the location of the NiFi flow
+ *      to install.
+ *     </li>
+ *     <li>
+ *      {@link Builder#modifyFlowXmlBeforeInstalling(FlowFileEditorCallback)} allows on-the-fly
+ *      changes to be performed to the Flow file before it is actually installed.
+ *     </li>
+ * </ul>
+ *
+ * <h5>Sample</h5>
+ * <pre><tt>
+ * TestNiFiInstance testNiFiInstance = TestNiFiInstance.builder()
+ *      .setNiFiBinaryDistributionZip(YourConstants.NIFI_ZIP_FILE)
+ *      .setFlowXmlToInstallForTesting(YourConstants.FLOW_XML_FILE)
+ *      .modifyFlowXmlBeforeInstalling(YourConstants.FLOW_FILE_CHANGES_FOR_TESTS)
+ *      .build();
+ * </tt></pre>
+ *
+ * </p>
+ *
+ * <p>
+ * If the current working directory is called "nifi_test_nifi_home", the caller can
+ * {@link #install()} this {@code TestNiFiInstance}, which will
+ * <ol>
+ *  <li>
+ *      (as a first cleanup step) erase all content of the current working directory.
+ *      (NOTE: this potentially destructive operation is the reason why we have the
+ *      "nifi_test_nifi_home" directory name guard in place!)
+ *  </li>
+ *  <li>
+ *      Extracts the contents of the NiFi binary distribution ZIP file specified in
+ *      the configuration to a to a temporary directory.
+ *  <li>
+ *      Symlinks all files from the temporary directory to the current working
+ *      directory, causing the to hold a fully functional
+ *      NiFi installation.
+ *  </li>
+ *  <li>
+ *      Installs the flow definition files(s) to the NiFi instance specified in
+ *      the configuration.
+ *  </li>
+ * </ol>
+ * </p>
+ *
+ * <p>
+ *
+ * The caller then can proceed to {@link #start()}} this {@code TestNiFiInstance},
+ * which will bootstrap the NiFi engine, which in turn will pick up and start processing
+ * the flow definition supplied by the caller in the configuration.
+ * </p>
+ *
+ * <p>
+ * Once the previous step is done, the caller can perform asserts regarding the observed behaviour
+ * of the NiFi flow, just like one would do it with standard Java test cases.
+ * </p>
+ *
+ * <p>
+ * To perform a clean shutdown of the hosted NiFi instance, the caller is required to call
+ * {@link #stopAndCleanup()}, which will shut down NiFi and remove all temporary files, including
+ * the symlinks created int current working directory.
+ * </p>
+ *
+ *
+ * <h4>NOTES</h4>
+ * <ul>
+ *  <li>
+ *      {@code TestNiFiInstance} is NOT thread safe: if more than one thread uses it,
+ *      external synchronisation is required.
+ *  </li>
+ *   <li>
+ *      Only one {@code TestNiFiInstance} can be started in the same "nifi_test_nifi_home"
+ *      directory at the same time.
+ *  </li>
+ *  <li>
+ *      Currently, due to NiFi limitations, one {@TestNiFiInstance} can be started per JVM process.
+ *      If multiple test cases are required, launch a new JVM process per test case
+ *      (in sequence, see the point above).
+ *  </li>
+ * </ul>
+ *
+ * <p>
+ * <strong>CAUTION: THIS IS AN EXPERIMENTAL API: EXPECT CHANGES!</strong>
+ * Efforts will be made to retain backwards API compatibility, but
+ * no guarantee is given.
+ * </p>
+ *
+ *
+ * @see TestNiFiInstance#builder()
+ *
+ * @author Peter G. Horvath
+ *
+ */
+public class TestNiFiInstance {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestNiFiInstance.class);
+
+
+    private EmbeddedNiFi testNiFi;
+
+    private final File nifiHomeDir;
+    private final File bootstrapLibDir;
+
+    private File nifiProperties;
+
+    private final File flowXmlGz;
+
+    private final File placeholderNiFiHomeDir;
+
+
+    private enum State {
+        STOPPED,
+        STOP_FAILED,
+        START_FAILED(STOPPED),
+        STARTED(STOPPED, STOP_FAILED),
+        INSTALLATION_FAILED(),
+        INSTALLED(STARTED, START_FAILED),
+        CREATED(INSTALLED, INSTALLATION_FAILED);
+
+
+        private final Set<State> allowedTransitions;
+
+        State(State... allowedTransitions) {
+            this.allowedTransitions = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(allowedTransitions)));
+        }
+
+        private State checkCanTransition(State newState) {
+            if (!this.allowedTransitions.contains(newState)) {
+                throw new IllegalStateException("Cannot transition from " + this + " to " + newState);
+            }
+
+            return newState;
+        }
+    }
+
+    private State currentState = State.CREATED;
+
+    private final File nifiBinaryZip;
+    private final File flowXml;
+    private final FlowFileEditorCallback editCallback;
+
+    private TestNiFiInstance(File nifiBinaryZip, File flowXml, FlowFileEditorCallback editCallback) {
+        this.nifiBinaryZip = Objects.requireNonNull(nifiBinaryZip, "nifiBinaryZip");
+        this.flowXml = Objects.requireNonNull(flowXml, "flowXml");
+        this.editCallback = editCallback;
+
+        nifiHomeDir = requireCurrentWorkingDirectoryIsCorrect();
+
+        final File configDir = new File(nifiHomeDir, "conf");
+        final File libDir = new File(nifiHomeDir, "lib");
+
+        bootstrapLibDir = new File(libDir, "bootstrap");
+
+        nifiProperties = new File(configDir, "nifi.properties");
+
+        flowXmlGz = new File(configDir, "flow.xml.gz");
+
+        placeholderNiFiHomeDir = requireCurrentWorkingDirectoryIsCorrect();
+    }
+
+    public void install() throws IOException {
+
+        currentState.checkCanTransition(State.INSTALLED);
+
+        File[] staleInstallations = placeholderNiFiHomeDir.listFiles((dir, name) -> name.startsWith("nifi-"));
+        Arrays.stream(staleInstallations).forEach(TestNiFiInstance::deleteFileOrDirectoryRecursively);
+
+        Path tempDirectory = null;
+        try {
+            tempDirectory = Files.createTempDirectory("installable-flow");
+
+            File installableFlowFile = createInstallableFlowFile(tempDirectory);
+
+            LOGGER.info("Uncompressing NiFi archive {} to {} ...", nifiBinaryZip, placeholderNiFiHomeDir);
+
+            Zip.unzipFile(nifiBinaryZip, placeholderNiFiHomeDir, new Zip.StatusListenerAdapter() {
+                @Override
+                public void onUncompressDone(ZipEntry ze) {
+                    LOGGER.debug("Uncompressed {}", ze.getName());
+                }
+            });
+
+            LOGGER.info("Uncompressing DONE");
+
+            File actualNiFiHomeDir = getActualNiFiHomeDir(placeholderNiFiHomeDir);
+
+            FileUtils.createSymlinks(placeholderNiFiHomeDir, actualNiFiHomeDir);
+
+            installFlowFile(installableFlowFile);
+        } catch (Exception e) {
+
+            currentState = State.INSTALLATION_FAILED;
+
+            throw new RuntimeException("Installation failed: " + e.getMessage(), e);
+
+        } finally {
+            if (tempDirectory != null) {
+                FileUtils.deleteDirectoryRecursive(tempDirectory);
+            }
+        }
+
+        currentState = State.INSTALLED;
+    }
+
+    private File createInstallableFlowFile(Path tempDirectory) throws IOException {
+
+        File flowXmlFile = new File(tempDirectory.toFile(), "flow.xml");
+
+        if (editCallback == null) {
+            Files.copy(flowXml.toPath(), flowXmlFile.toPath());
+        } else {
+            XmlUtils.editXml(flowXml, flowXmlFile, editCallback);
+        }
+
+        return flowXmlFile;
+    }
+
+    private void installFlowFile(File fileToIncludeInGz) throws IOException {
+        Zip.gzipFile(fileToIncludeInGz, flowXmlGz);
+    }
+
+    public void start() {
+
+        currentState.checkCanTransition(State.STARTED);
+
+        try {
+            if (!bootstrapLibDir.exists()) {
+                throw new IllegalStateException("Not found: " + bootstrapLibDir);
+            }
+
+
+
+            System.setProperty("org.apache.jasper.compiler.disablejsr199", "true");
+            System.setProperty("java.security.egd", "file:/dev/urandom");
+            System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+            System.setProperty("java.net.preferIPv4Stack", "true");
+            System.setProperty("java.awt.headless", "true");
+            System.setProperty("java.protocol.handler.pkgs", "sun.net.www.protocol");
+
+            System.setProperty("nifi.properties.file.path", nifiProperties.getAbsolutePath());
+            System.setProperty("app", "NiFi");
+            System.setProperty("org.apache.nifi.bootstrap.config.log.dir", "./logs");
+
+            ClassLoader coreClassLoader = new NiFiCoreLibClassLoader(nifiHomeDir, ClassLoader.getSystemClassLoader());
+            Thread.currentThread().setContextClassLoader(coreClassLoader);
+
+
+
+            this.testNiFi = new EmbeddedNiFi(new String[0], coreClassLoader);
+
+        } catch (Exception ex) {
+
+            currentState = State.START_FAILED;
+
+            throw new RuntimeException("Startup failed", ex);
+
+        }
+
+        currentState = State.STARTED;
+
+
+    }
+
+
+    public void stopAndCleanup() {
+        currentState.checkCanTransition(State.STOPPED);
+
+        try {
+            testNiFi.shutdown();
+
+            removeNiFiFilesCreatedForTemporaryInstallation(placeholderNiFiHomeDir);
+
+        } catch (Exception e) {
+            currentState = State.STOP_FAILED;
+
+            throw new RuntimeException(e);
+        }
+
+        currentState = State.STOPPED;
+    }
+
+    private static File requireCurrentWorkingDirectoryIsCorrect() {
+
+        File currentWorkDir = new File(System.getProperty("user.dir"));
+        if (!currentWorkDir.getName().equals("nifi_test_nifi_home")) {
+
+            throw new IllegalStateException(
+                    "The test's working directory has to be set to nifi_test_nifi_home, but was: " + currentWorkDir);
+        }
+        return currentWorkDir;
+    }
+
+    private static File getActualNiFiHomeDir(File currentDir) {
+        File[] files = currentDir.listFiles((dir, name) -> name.startsWith("nifi-"));
+
+        if (files.length == 0) {
+            throw new IllegalStateException(
+                    "No \"nifi-*\" directory found in temporary NiFi home directory container: " + currentDir);
+        }
+
+        if (files.length != 1) {
+            throw new IllegalStateException(
+                    "Multiple \"nifi-*\" directories found in temporary NiFi home directory container: " + currentDir);
+        }
+
+        return files[0];
+    }
+
+    private static void removeNiFiFilesCreatedForTemporaryInstallation(File directoryToClear) {
+
+        Arrays.stream(directoryToClear.listFiles())
+                .filter(file -> !"NIFI_TEST_README.txt".equals(file.getName()))
+                .forEach(file -> {
+                    deleteFileOrDirectoryRecursively(file);
+
+
+                });
+    }
+
+    private static void deleteFileOrDirectoryRecursively(File file) {
+        if (file.isDirectory()) {
+            FileUtils.deleteDirectoryRecursive(file);
+        }
+        else {
+            file.delete();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "NiFi test instance(" + Integer.toHexString(hashCode())
+                + ") state: " + currentState + ", home: " + nifiHomeDir;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+
+    public static class Builder {
+
+        private boolean isDisposed = false;
+
+        private File nifiBinaryZip;
+        private File flowXml;
+        private FlowFileEditorCallback editCallback;
+
+        /**
+         * Sets the location of the NiFi binary distribution file, from which the test instance
+         * will be uncompressed and built.
+         *
+         * @param nifiBinaryZip
+         *      the NiFi binary distribution file, from which the test instance will be built (never {@code null})
+         * @return {@code this} (for method chaining)
+         */
+        public Builder setNiFiBinaryDistributionZip(File nifiBinaryZip) {
+            if (!nifiBinaryZip.exists()) {
+                throw new IllegalArgumentException("File not found: " + nifiBinaryZip);
+            }
+
+            this.nifiBinaryZip = nifiBinaryZip;
+            return this;
+        }
+
+        /**
+         * Sets the NiFi flow XML, which will be installed to the NiFi instance for testing.
+         *
+         * @param flowXml the NiFi flow file to install to the test instance for testing (never {@code null})
+         *
+         * @return {@code this} (for method chaining)
+         */
+        public Builder setFlowXmlToInstallForTesting(File flowXml) {
+            if (!flowXml.exists()) {
+                throw new IllegalArgumentException("File not found: " + flowXml);
+            }
+
+            this.flowXml = flowXml;
+            return this;
+        }
+
+        /**
+         * <p>
+         * An <strong>optional</strong> callback to change the flow definition read from
+         * {@link #setFlowXmlToInstallForTesting(File)}, before it is actually installed for testing.
+         * (NOTE: The original file remains unchanged: changes are applied to a copy of it.)</p>
+         *
+         * <p>
+         * NOTE: {@link SimpleNiFiFlowDefinitionEditor} provides various common flow definition changes
+         * useful for testing.
+         * </p>
+         *
+         * @param callback an <strong>optional</strong> callback to change the flow definition
+         *
+         * @return {@code this} (for method chaining)
+         *
+         * @see SimpleNiFiFlowDefinitionEditor
+         */
+        public Builder modifyFlowXmlBeforeInstalling(FlowFileEditorCallback callback) {
+            this.editCallback = callback;
+            return this;
+        }
+
+
+
+        public TestNiFiInstance build() {
+            if (isDisposed) {
+                throw new IllegalStateException("builder can only be used once");
+            }
+            isDisposed = true;
+
+            return new TestNiFiInstance(nifiBinaryZip, flowXml, editCallback);
+        }
+
+
+    }
+
+
+}

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/api/FlowFileEditorCallback.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/api/FlowFileEditorCallback.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test.api;
+
+import org.w3c.dom.Document;
+
+/**
+ * <p>
+ * An interface that allows programmatic access to the contents of a NiFi XML
+ * resource (e.g. {@code flow.xml}), allowing changes to be performed before it
+ * is actually installed to the NiFi instance.</p>
+ *
+ * <p>
+ * <strong>CAUTION: THIS IS AN EXPERIMENTAL API: EXPECT CHANGES!</strong>
+ * Efforts will be made to retain backwards API compatibility, but
+ * no guarantee is given.
+ * </p>
+ *
+ */
+public interface FlowFileEditorCallback {
+
+    /**
+     *
+     * @param document the document to change document (never {@code null})
+     * @return the changed document (never {@code null})
+     * @throws Exception in case the editing fails
+     */
+    Document edit(Document document) throws Exception;
+}

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/FileUtils.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/FileUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+
+public final class FileUtils {
+
+
+    private static final String MAC_DS_STORE_NAME = ".DS_Store";
+
+    private FileUtils() {
+        // no instances
+    }
+
+    public static void deleteDirectoryRecursive(Path directory) throws IOException {
+        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    public static void deleteDirectoryRecursive(File dir) {
+        try {
+            deleteDirectoryRecursive(dir.toPath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void createLink(Path newLink, Path existingFile)  {
+        try {
+            Files.createSymbolicLink(newLink, existingFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void createSymlinks(File newLinkDir, File existingDir) {
+        Arrays.stream(existingDir.list())
+                .filter(fileName -> !MAC_DS_STORE_NAME.equals(fileName))
+                .forEach(fileName -> {
+                    Path newLink = Paths.get(newLinkDir.getAbsolutePath(), fileName);
+                    Path existingFile = Paths.get(existingDir.getAbsolutePath(), fileName);
+
+                    File symlinkFile = newLink.toFile();
+                    if (symlinkFile.exists()) {
+                        symlinkFile.delete();
+                    }
+
+                    createLink(newLink, existingFile);
+                });
+    }
+}

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/NiFiCoreLibClassLoader.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/NiFiCoreLibClassLoader.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class NiFiCoreLibClassLoader extends URLClassLoader {
+
+
+    public NiFiCoreLibClassLoader(File nifiHomeDir, ClassLoader parent) {
+        super(getURls(nifiHomeDir), parent);
+    }
+
+    private static URL[] getURls(File nifiHomeDir) {
+
+        try {
+            File libDir = new File(nifiHomeDir, "lib");
+            File bootstrapLibDir = new File(libDir, "bootstrap");
+
+
+            List<URL> libs = Files.list(libDir.toPath())
+                    .filter(NiFiCoreLibClassLoader::isJarOrNarFile)
+                    .map(NiFiCoreLibClassLoader::toURL)
+                    .collect(Collectors.toList());
+            List<URL> bootstrapLibs = Files.list(bootstrapLibDir.toPath())
+                    .filter(NiFiCoreLibClassLoader::isJarOrNarFile)
+                    .map(NiFiCoreLibClassLoader::toURL)
+                    .collect(Collectors.toList());
+
+            LinkedList<URL> urls = new LinkedList<>();
+            urls.addAll(libs);
+            urls.addAll(bootstrapLibs);
+
+            return urls.toArray(new URL[urls.size()]);
+        } catch (IOException ioEx) {
+            throw new RuntimeException(ioEx);
+        }
+
+
+    }
+
+    private static URL toURL(Path path) {
+        try {
+            return path.toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private static boolean isJarOrNarFile(Path path) {
+        String fullPathString = path.getFileName().toString();
+
+        return path.toFile().isFile() && fullPathString.endsWith(".jar");
+    }
+
+
+}

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/XmlUtils.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/XmlUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test.util;
+
+import org.apache.nifi.test.api.FlowFileEditorCallback;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.io.FileInputStream;
+
+public final class XmlUtils {
+
+    public static void editXml(File inputFile, File outputFile, FlowFileEditorCallback editCallback) {
+
+      try(FileInputStream inputStream = new FileInputStream(inputFile)) {
+
+          DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+          DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+          Document document = documentBuilder.parse(new InputSource(inputStream));
+
+          document = editCallback.edit(document);
+
+          // save the result
+          TransformerFactory transformerFactory = TransformerFactory.newInstance();
+          Transformer transformer = transformerFactory.newTransformer();
+          transformer.transform(new DOMSource(document), new StreamResult(outputFile));
+
+      } catch (Exception e) {
+          throw new RuntimeException("Failed to change XML document: " + e.getMessage(), e);
+      }
+  }
+}

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/Zip.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/test/util/Zip.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.nifi.test.util;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public final class Zip {
+
+    private Zip() {
+        // no external instances allowed
+    }
+
+
+    public interface StatusListener {
+        void onUncompressStarted(ZipEntry ze);
+
+        void onUncompressDone(ZipEntry ze);
+    }
+
+    public static class StatusListenerAdapter implements StatusListener {
+
+        @Override
+        public void onUncompressStarted(ZipEntry ze) {
+
+        }
+
+        @Override
+        public void onUncompressDone(ZipEntry ze) {
+
+        }
+    }
+
+    private static final StatusListener NO_OP_STATUS_LISTENER = new StatusListenerAdapter();
+
+    public static void unzipFile(File zipFile, File targetDirectory) throws IOException {
+        unzipFile(zipFile, targetDirectory, NO_OP_STATUS_LISTENER);
+
+    }
+
+
+    public static void unzipFile(File zipFile, File targetDirectory,
+                                 StatusListener statusListener) throws IOException {
+
+        if (!targetDirectory.exists()) {
+            boolean mkdirs = targetDirectory.mkdirs();
+            if (!mkdirs) {
+                throw new IOException("Failed to create directory: " + targetDirectory);
+            }
+        }
+
+        try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(zipFile))) {
+
+            ZipEntry ze = zipInputStream.getNextEntry();
+
+            while (ze != null) {
+
+                if(ze.isDirectory()) {
+                    ze = zipInputStream.getNextEntry();
+                    continue;
+                }
+
+                statusListener.onUncompressStarted(ze);
+
+                String fileName = ze.getName();
+                File outputFile = new File(targetDirectory, fileName);
+
+
+                File parentDir = new File(outputFile.getParent());
+                if (!parentDir.exists()) {
+                    boolean couldCreateParentDir = parentDir.mkdirs();
+                    if (!couldCreateParentDir) {
+                        throw new IllegalStateException("Could not create: " + parentDir);
+
+                    }
+                }
+
+
+
+                Files.copy(zipInputStream, outputFile.toPath());
+
+                statusListener.onUncompressDone(ze);
+
+
+                ze = zipInputStream.getNextEntry();
+            }
+
+            zipInputStream.closeEntry();
+
+
+        }
+
+
+    }
+
+
+    public static void gzipFile(File inputFile, File gzipFile) throws IOException {
+
+        try (GZIPOutputStream gzos =
+                     new GZIPOutputStream(new FileOutputStream(gzipFile))) {
+
+
+            Files.copy(inputFile.toPath(), gzos);
+
+            gzos.finish();
+        }
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>nifi-mock</module>
         <module>nifi-nar-bundles</module>
         <module>nifi-assembly</module>
+        <module>nifi-test</module>
         <module>nifi-docs</module>
         <module>nifi-maven-archetypes</module>
         <module>nifi-external</module>


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ x Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
At the moment, the build fails with unit **test failures unrelated to this commit**:
```
[INFO] Running org.apache.nifi.csv.TestCSVValidators
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.apache.nifi.csv.TestCSVValidators
[INFO] Running org.apache.nifi.csv.TestJacksonCSVRecordReader
[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.033 s <<< FAILURE! - in org.apache.nifi.csv.TestJacksonCSVRecordReader
[ERROR] testUTF8(org.apache.nifi.csv.TestJacksonCSVRecordReader)  Time elapsed: 0.002 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[黃凱揚]> but was:<[???]>
	at org.apache.nifi.csv.TestJacksonCSVRecordReader.testUTF8(TestJacksonCSVRecordReader.java:81)

[INFO] Running org.apache.nifi.csv.TestCSVHeaderSchemaStrategy
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.apache.nifi.csv.TestCSVHeaderSchemaStrategy
[INFO] Running org.apache.nifi.csv.TestCSVRecordReader
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.apache.nifi.csv.TestCSVRecordReader
[INFO] Running org.apache.nifi.csv.TestWriteCSVResult
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.apache.nifi.csv.TestWriteCSVResult
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJacksonCSVRecordReader.testUTF8:81 expected:<[黃凱揚]> but was:<[???]>
[ERROR]   TestXMLReader.testAttributePrefix:133 expected:<... ATTR_ID=P3, NAME=Am[é]lie Bonfils, AGE=74}...> but was:<... ATTR_ID=P3, NAME=Am[?]lie Bonfils, AGE=74}...>
[ERROR]   TestXMLReader.testContentField:156 expected:<...apRecord[{CONTENT=Am[é]lie Bonfils, ATTR=at...> but was:<...apRecord[{CONTENT=Am[?]lie Bonfils, ATTR=at...>
[INFO] 
[ERROR] Tests run: 221, Failures: 3, Errors: 0, Skipped: 2
[INFO] 
[INFO] ------------------------------------------------------------------------
```

- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
