### PR TITLE
NIFI-5384 FlowFile's queued in batches should all have the same Queue…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -1861,10 +1861,14 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
         return newFile;
     }
 
-    private void updateLastQueuedDate(final StandardRepositoryRecord record) {
+    private void updateLastQueuedDate(final StandardRepositoryRecord record, final Long lastQueueDate) {
         final FlowFileRecord newFile = new StandardFlowFileRecord.Builder().fromFlowFile(record.getCurrent())
-            .lastQueued(System.currentTimeMillis(), enqueuedIndex.getAndIncrement()).build();
+                .lastQueued(lastQueueDate, enqueuedIndex.getAndIncrement()).build();
         record.setWorking(newFile);
+    }
+
+    private void updateLastQueuedDate(final StandardRepositoryRecord record) {
+        updateLastQueuedDate(record, System.currentTimeMillis());
     }
 
     @Override
@@ -1938,11 +1942,12 @@ public final class StandardProcessSession implements ProcessSession, ProvenanceE
 
         final int multiplier = Math.max(1, numDestinations);
 
+        final long queuedTime = System.currentTimeMillis();
         long contentSize = 0L;
         for (final FlowFile flowFile : flowFiles) {
             final StandardRepositoryRecord record = records.get(flowFile);
             record.setTransferRelationship(relationship);
-            updateLastQueuedDate(record);
+            updateLastQueuedDate(record, queuedTime);
 
             contentSize += flowFile.getSize();
         }


### PR DESCRIPTION
… time

While building some batching unit tests I started making the assumption that FlowFile's sent to session.Transfer in batches should all have the same Queued time. Only to find out that wasn't true.

Updating batch queuing of FlowFile's so that FlowFile's transferred together all have the same queue time.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
