### PR TITLE
NIFI-5355 ResizeImage Fails to read PNG type on some OS's

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ResizeImage.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ResizeImage.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.image;
 
 import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -174,7 +175,13 @@ public class ResizeImage extends AbstractProcessor {
                         if (scaledImage instanceof BufferedImage) {
                             scaledBufferedImg = (BufferedImage) scaledImage;
                         } else {
-                            scaledBufferedImg = new BufferedImage(scaledImage.getWidth(null), scaledImage.getHeight(null), image.getType());
+                            // Determine image type, since calling image.getType may return 0
+                            int imageType = BufferedImage.TYPE_INT_ARGB;
+                            if(image.getTransparency() == Transparency.OPAQUE) {
+                                imageType = BufferedImage.TYPE_INT_RGB;
+                            }
+
+                            scaledBufferedImg = new BufferedImage(scaledImage.getWidth(null), scaledImage.getHeight(null), imageType);
                             final Graphics2D graphics = scaledBufferedImg.createGraphics();
                             try {
                                 graphics.drawImage(scaledImage, 0, 0, null);

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/image/TestResizeImage.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/image/TestResizeImage.java
@@ -44,14 +44,73 @@ public class TestResizeImage {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ResizeImage.REL_SUCCESS, 1);
+        MockFlowFile mff = runner.getFlowFilesForRelationship(ResizeImage.REL_SUCCESS).get(0);
+        byte[] data = mff.toByteArray();
+
+        BufferedImage img = ImageIO.read(new ByteArrayInputStream(data));
+        assertEquals(64, img.getWidth());
+        assertEquals(64, img.getHeight());
+        File out = new File("target/smooth.jpg");
+        ImageIO.write(img, "JPG", out);
+
+        runner.clearTransferState();
+
+        runner.setProperty(ResizeImage.SCALING_ALGORITHM, ResizeImage.RESIZE_FAST);
+
+        runner.enqueue(Paths.get("src/test/resources/simple.jpg"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ResizeImage.REL_SUCCESS, 1);
+        mff = runner.getFlowFilesForRelationship(ResizeImage.REL_SUCCESS).get(0);
+        data = mff.toByteArray();
+
+        img = ImageIO.read(new ByteArrayInputStream(data));
+        assertEquals(64, img.getWidth());
+        assertEquals(64, img.getHeight());
+        out = new File("target/fast.jpg");
+        ImageIO.write(img, "JPG", out);
+    }
+
+    @Test
+    public void testEnlarge() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new ResizeImage());
+        runner.setProperty(ResizeImage.IMAGE_HEIGHT, "600");
+        runner.setProperty(ResizeImage.IMAGE_WIDTH, "600");
+        runner.setProperty(ResizeImage.SCALING_ALGORITHM, ResizeImage.RESIZE_SMOOTH);
+
+        runner.enqueue(Paths.get("src/test/resources/photoshop-8x12-32colors-alpha.gif"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ResizeImage.REL_SUCCESS, 1);
+        MockFlowFile mff = runner.getFlowFilesForRelationship(ResizeImage.REL_SUCCESS).get(0);
+        byte[] data = mff.toByteArray();
+
+        BufferedImage img = ImageIO.read(new ByteArrayInputStream(data));
+        assertEquals(600, img.getWidth());
+        assertEquals(600, img.getHeight());
+        File out = new File("target/enlarge.png");
+        ImageIO.write(img, "PNG", out);
+    }
+
+
+    @Test
+    public void testResizePNG() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new ResizeImage());
+        runner.setProperty(ResizeImage.IMAGE_HEIGHT, "64");
+        runner.setProperty(ResizeImage.IMAGE_WIDTH, "64");
+        runner.setProperty(ResizeImage.SCALING_ALGORITHM, ResizeImage.RESIZE_SMOOTH);
+
+        runner.enqueue(Paths.get("src/test/resources/mspaint-8x10.png"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ResizeImage.REL_SUCCESS, 1);
         final MockFlowFile mff = runner.getFlowFilesForRelationship(ResizeImage.REL_SUCCESS).get(0);
         final byte[] data = mff.toByteArray();
 
         final BufferedImage img = ImageIO.read(new ByteArrayInputStream(data));
         assertEquals(64, img.getWidth());
         assertEquals(64, img.getHeight());
-        final File out = new File("target/simple.jpg");
-        ImageIO.write(img, "JPG", out);
+        final File out = new File("target/mspaint-8x10resized.png");
+        ImageIO.write(img, "PNG", out);
     }
-
 }


### PR DESCRIPTION
Updated ResizeImage to better support PNG file format on all platforms.
Updated resize logic to provide a higher performance/faster experience. Unfortunately `Hint` values are not exactly the same. I mapped them as best as possible to avoid any breaking changes. 

Added in Unit tests for these changes, and also for if the requested resize size is larger than the original image.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
