### PR TITLE
NIFI-4654: Support reporting RAS S2S lineage to Atlas

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/flowfile/attributes/SiteToSiteAttributes.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/flowfile/attributes/SiteToSiteAttributes.java
@@ -23,7 +23,9 @@ public enum SiteToSiteAttributes implements FlowFileAttributeKey {
 
     S2S_HOST("s2s.host"),
 
-    S2S_ADDRESS("s2s.address");
+    S2S_ADDRESS("s2s.address"),
+
+    S2S_PORT_ID("s2s.port.id");
 
     private final String key;
 

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/provenance/analyzer/NiFiRootGroupPort.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/provenance/analyzer/NiFiRootGroupPort.java
@@ -54,7 +54,7 @@ public class NiFiRootGroupPort extends NiFiS2S {
         final String type = isInputPort ? TYPE_NIFI_INPUT_PORT : TYPE_NIFI_OUTPUT_PORT;
         final String rootPortId = event.getComponentId();
 
-        final S2STransitUrl s2sUrl = parseTransitURL(event.getTransitUri(), context.getClusterResolver());
+        final S2SPort s2SPort = analyzeS2SPort(event, context.getClusterResolver());
 
         // Find connections connecting to/from the remote port.
         final List<ConnectionStatus> connections = isInputPort
@@ -69,7 +69,7 @@ public class NiFiRootGroupPort extends NiFiS2S {
         final ConnectionStatus connection = connections.get(0);
         final Referenceable ref = new Referenceable(type);
         ref.set(ATTR_NAME, isInputPort ? connection.getSourceName() : connection.getDestinationName());
-        ref.set(ATTR_QUALIFIED_NAME, toQualifiedName(s2sUrl.clusterName, rootPortId));
+        ref.set(ATTR_QUALIFIED_NAME, toQualifiedName(s2SPort.clusterName, rootPortId));
 
         return singleDataSetRef(event.getComponentId(), event.getEventType(), ref);
     }
@@ -77,5 +77,10 @@ public class NiFiRootGroupPort extends NiFiS2S {
     @Override
     public String targetComponentTypePattern() {
         return "^(In|Out)put Port$";
+    }
+
+    @Override
+    protected String getRawProtocolPortId(ProvenanceEventRecord event) {
+        return event.getComponentId();
     }
 }

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/resources/docs/org.apache.nifi.atlas.reporting.ReportLineageToAtlas/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/resources/docs/org.apache.nifi.atlas.reporting.ReportLineageToAtlas/additionalDetails.html
@@ -329,7 +329,7 @@ Processor 3</pre>
                 </td>
                 <td>rootGroupPortGUID@clusterName
                     (e.g. 35dbc0ab-015e-1000-144c-a8d71255027d@cl1)</td>
-                <td rowspan="4"><strong>NOTE:</strong>Only HTTP S2S protocol is supported. RAW support may be added in the future as it needs NiFi code modification. See <a href="https://issues.apache.org/jira/browse/NIFI-4654">NIFI-4654</a> for detail.</td>
+                <td></td>
             </tr>
             <tr>
                 <td>
@@ -345,6 +345,7 @@ upstream (nifi_flow_path)
                 </td>
                 <td>remoteInputPortGUID@clusterName<br/>(e.g. f31a6b53-3077-4c59-144c-a8d71255027d@cl1)
                     <p>NOTE: The remoteInputPortGUID is the client side component ID and different from the remote target port GUID. Multiple Remote Input Ports can send to the same target remote input port.</p></td>
+                <td></td>
             </tr>
             <tr>
                 <td rowspan="2">
@@ -364,6 +365,7 @@ upstream (nifi_flow_path)
                 </td>
                 <td>rootGroupPortGUID@clusterName
                     (e.g. 45dbc0ab-015e-1000-144c-a8d71255027d@cl1)</td>
+                <td></td>
             </tr>
             <tr>
                 <td>
@@ -385,6 +387,7 @@ remote target port
                         <li>For 'nifi_queue': downstreamPathGUID@clusterName<br/>(e.g. bb530e58-ee14-3cac-144c-a8d71255027d@cl1)</li>
                     </ul>
                 </td>
+                <td></td>
             </tr>
             <tr>
                 <td>NiFiRootGroupPort</td>

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/java/org/apache/nifi/atlas/provenance/analyzer/TestNiFiRootGroupPort.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/java/org/apache/nifi/atlas/provenance/analyzer/TestNiFiRootGroupPort.java
@@ -24,7 +24,6 @@ import org.apache.nifi.atlas.provenance.NiFiProvenanceEventAnalyzerFactory;
 import org.apache.nifi.atlas.reporting.ITReportLineageToAtlas;
 import org.apache.nifi.atlas.resolver.ClusterResolvers;
 import org.apache.nifi.controller.status.ConnectionStatus;
-import org.apache.nifi.flowfile.attributes.SiteToSiteAttributes;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.junit.Test;
@@ -44,17 +43,56 @@ import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for RemotePorts.
+ * Tests for RootGroupPorts.
  * More complex and detailed tests are available at {@link ITReportLineageToAtlas}.
  */
-public class TestNiFiRemotePort {
+public class TestNiFiRootGroupPort {
 
     @Test
-    public void testRemoteInputPortHTTP() {
-        final String componentType = "Remote Input Port";
+    public void testInputPortHTTP() {
+        final String componentType = "Input Port";
         final String transitUri = "http://0.example.com:8080/nifi-api/data-transfer/input-ports/port-guid/transactions/tx-guid/flow-files";
+        final ProvenanceEventRecord receiveEvent = Mockito.mock(ProvenanceEventRecord.class);
+        when(receiveEvent.getEventId()).thenReturn(123L);
+        when(receiveEvent.getComponentId()).thenReturn("port-guid");
+        when(receiveEvent.getComponentType()).thenReturn(componentType);
+        when(receiveEvent.getTransitUri()).thenReturn(transitUri);
+        when(receiveEvent.getEventType()).thenReturn(ProvenanceEventType.RECEIVE);
+
+        final ClusterResolvers clusterResolvers = Mockito.mock(ClusterResolvers.class);
+        when(clusterResolvers.fromHostNames(matches(".+\\.example\\.com"))).thenReturn("cluster1");
+
+        final List<ConnectionStatus> connections = new ArrayList<>();
+        final ConnectionStatus connection = new ConnectionStatus();
+        connection.setSourceId("port-guid");
+        connection.setSourceName("inputPortA");
+        connections.add(connection);
+
+        final AnalysisContext context = Mockito.mock(AnalysisContext.class);
+        when(context.getClusterResolver()).thenReturn(clusterResolvers);
+        when(context.findConnectionFrom(matches("port-guid"))).thenReturn(connections);
+
+        final NiFiProvenanceEventAnalyzer analyzer = NiFiProvenanceEventAnalyzerFactory.getAnalyzer(componentType, transitUri, receiveEvent.getEventType());
+        assertNotNull(analyzer);
+
+        final DataSetRefs refs = analyzer.analyze(context, receiveEvent);
+        assertEquals(1, refs.getInputs().size());
+        assertEquals(0, refs.getOutputs().size());
+        assertEquals(1, refs.getComponentIds().size());
+        // Should report connected componentId.
+        assertTrue(refs.getComponentIds().contains("port-guid"));
+
+        Referenceable ref = refs.getInputs().iterator().next();
+        assertEquals(TYPE_NIFI_INPUT_PORT, ref.getTypeName());
+        assertEquals("inputPortA", ref.get(ATTR_NAME));
+        assertEquals("port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
+    }
+
+    @Test
+    public void testRemoteOutputPortHTTP() {
+        final String componentType = "Output Port";
+        final String transitUri = "http://0.example.com:8080/nifi-api/data-transfer/output-ports/port-guid/transactions/tx-guid/flow-files";
         final ProvenanceEventRecord sendEvent = Mockito.mock(ProvenanceEventRecord.class);
-        when(sendEvent.getEventId()).thenReturn(123L);
         when(sendEvent.getComponentId()).thenReturn("port-guid");
         when(sendEvent.getComponentType()).thenReturn(componentType);
         when(sendEvent.getTransitUri()).thenReturn(transitUri);
@@ -66,7 +104,7 @@ public class TestNiFiRemotePort {
         final List<ConnectionStatus> connections = new ArrayList<>();
         final ConnectionStatus connection = new ConnectionStatus();
         connection.setDestinationId("port-guid");
-        connection.setDestinationName("inputPortA");
+        connection.setDestinationName("outputPortA");
         connections.add(connection);
 
         final AnalysisContext context = Mockito.mock(AnalysisContext.class);
@@ -79,46 +117,7 @@ public class TestNiFiRemotePort {
         final DataSetRefs refs = analyzer.analyze(context, sendEvent);
         assertEquals(0, refs.getInputs().size());
         assertEquals(1, refs.getOutputs().size());
-        assertEquals(1, refs.getComponentIds().size());
-        // Should report connected componentId.
-        assertTrue(refs.getComponentIds().contains("port-guid"));
-
         Referenceable ref = refs.getOutputs().iterator().next();
-        assertEquals(TYPE_NIFI_INPUT_PORT, ref.getTypeName());
-        assertEquals("inputPortA", ref.get(ATTR_NAME));
-        assertEquals("port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
-    }
-
-    @Test
-    public void testRemoteOutputPortHTTP() {
-        final String componentType = "Remote Output Port";
-        final String transitUri = "http://0.example.com:8080/nifi-api/data-transfer/output-ports/port-guid/transactions/tx-guid/flow-files";
-        final ProvenanceEventRecord record = Mockito.mock(ProvenanceEventRecord.class);
-        when(record.getComponentId()).thenReturn("port-guid");
-        when(record.getComponentType()).thenReturn(componentType);
-        when(record.getTransitUri()).thenReturn(transitUri);
-        when(record.getEventType()).thenReturn(ProvenanceEventType.RECEIVE);
-
-        final ClusterResolvers clusterResolvers = Mockito.mock(ClusterResolvers.class);
-        when(clusterResolvers.fromHostNames(matches(".+\\.example\\.com"))).thenReturn("cluster1");
-
-        final List<ConnectionStatus> connections = new ArrayList<>();
-        final ConnectionStatus connection = new ConnectionStatus();
-        connection.setSourceId("port-guid");
-        connection.setSourceName("outputPortA");
-        connections.add(connection);
-
-        final AnalysisContext context = Mockito.mock(AnalysisContext.class);
-        when(context.getClusterResolver()).thenReturn(clusterResolvers);
-        when(context.findConnectionFrom(matches("port-guid"))).thenReturn(connections);
-
-        final NiFiProvenanceEventAnalyzer analyzer = NiFiProvenanceEventAnalyzerFactory.getAnalyzer(componentType, transitUri, record.getEventType());
-        assertNotNull(analyzer);
-
-        final DataSetRefs refs = analyzer.analyze(context, record);
-        assertEquals(1, refs.getInputs().size());
-        assertEquals(0, refs.getOutputs().size());
-        Referenceable ref = refs.getInputs().iterator().next();
         assertEquals(TYPE_NIFI_OUTPUT_PORT, ref.getTypeName());
         assertEquals("outputPortA", ref.get(ATTR_NAME));
         assertEquals("port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
@@ -126,30 +125,68 @@ public class TestNiFiRemotePort {
 
     @Test
     public void testRemoteInputPortRAW() {
-        final String componentType = "Remote Input Port";
+        final String componentType = "Input Port";
         // The UUID in a Transit Uri is a FlowFile UUID
         final String transitUri = "nifi://0.example.com:8081/580b7989-a80b-4089-b25b-3f5e0103af82";
-        final ProvenanceEventRecord sendEvent = Mockito.mock(ProvenanceEventRecord.class);
-        when(sendEvent.getEventId()).thenReturn(123L);
-        // Component Id is an UUID of the RemoteGroupPort instance acting as a S2S client.
-        when(sendEvent.getComponentId()).thenReturn("s2s-client-component-guid");
-        when(sendEvent.getComponentType()).thenReturn(componentType);
-        when(sendEvent.getTransitUri()).thenReturn(transitUri);
-        when(sendEvent.getEventType()).thenReturn(ProvenanceEventType.SEND);
-        when(sendEvent.getAttribute(SiteToSiteAttributes.S2S_PORT_ID.key())).thenReturn("remote-port-guid");
+        final ProvenanceEventRecord receiveEvent = Mockito.mock(ProvenanceEventRecord.class);
+        when(receiveEvent.getEventId()).thenReturn(123L);
+        when(receiveEvent.getComponentId()).thenReturn("port-guid");
+        when(receiveEvent.getComponentType()).thenReturn(componentType);
+        when(receiveEvent.getTransitUri()).thenReturn(transitUri);
+        when(receiveEvent.getEventType()).thenReturn(ProvenanceEventType.RECEIVE);
 
         final ClusterResolvers clusterResolvers = Mockito.mock(ClusterResolvers.class);
         when(clusterResolvers.fromHostNames(matches(".+\\.example\\.com"))).thenReturn("cluster1");
 
         final List<ConnectionStatus> connections = new ArrayList<>();
         final ConnectionStatus connection = new ConnectionStatus();
-        connection.setDestinationId("s2s-client-component-guid");
-        connection.setDestinationName("inputPortA");
+        connection.setSourceId("port-guid");
+        connection.setSourceName("inputPortA");
         connections.add(connection);
 
         final AnalysisContext context = Mockito.mock(AnalysisContext.class);
         when(context.getClusterResolver()).thenReturn(clusterResolvers);
-        when(context.findConnectionTo(matches("s2s-client-component-guid"))).thenReturn(connections);
+        when(context.findConnectionFrom(matches("port-guid"))).thenReturn(connections);
+
+        final NiFiProvenanceEventAnalyzer analyzer = NiFiProvenanceEventAnalyzerFactory.getAnalyzer(componentType, transitUri, receiveEvent.getEventType());
+        assertNotNull(analyzer);
+
+        final DataSetRefs refs = analyzer.analyze(context, receiveEvent);
+        assertEquals(1, refs.getInputs().size());
+        assertEquals(0, refs.getOutputs().size());
+        assertEquals(1, refs.getComponentIds().size());
+        // Should report connected componentId.
+        assertTrue(refs.getComponentIds().contains("port-guid"));
+
+        Referenceable ref = refs.getInputs().iterator().next();
+        assertEquals(TYPE_NIFI_INPUT_PORT, ref.getTypeName());
+        assertEquals("inputPortA", ref.get(ATTR_NAME));
+        assertEquals("port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
+    }
+
+    @Test
+    public void testRemoteOutputPortRAW() {
+        final String componentType = "Output Port";
+        // The UUID in a Transit Uri is a FlowFile UUID
+        final String transitUri = "nifi://0.example.com:8081/232018cc-a147-40c6-b148-21f9f814e93c";
+        final ProvenanceEventRecord sendEvent = Mockito.mock(ProvenanceEventRecord.class);
+        when(sendEvent.getComponentId()).thenReturn("port-guid");
+        when(sendEvent.getComponentType()).thenReturn(componentType);
+        when(sendEvent.getTransitUri()).thenReturn(transitUri);
+        when(sendEvent.getEventType()).thenReturn(ProvenanceEventType.SEND);
+
+        final ClusterResolvers clusterResolvers = Mockito.mock(ClusterResolvers.class);
+        when(clusterResolvers.fromHostNames(matches(".+\\.example\\.com"))).thenReturn("cluster1");
+
+        final List<ConnectionStatus> connections = new ArrayList<>();
+        final ConnectionStatus connection = new ConnectionStatus();
+        connection.setDestinationId("port-guid");
+        connection.setDestinationName("outputPortA");
+        connections.add(connection);
+
+        final AnalysisContext context = Mockito.mock(AnalysisContext.class);
+        when(context.getClusterResolver()).thenReturn(clusterResolvers);
+        when(context.findConnectionTo(matches("port-guid"))).thenReturn(connections);
 
         final NiFiProvenanceEventAnalyzer analyzer = NiFiProvenanceEventAnalyzerFactory.getAnalyzer(componentType, transitUri, sendEvent.getEventType());
         assertNotNull(analyzer);
@@ -157,52 +194,10 @@ public class TestNiFiRemotePort {
         final DataSetRefs refs = analyzer.analyze(context, sendEvent);
         assertEquals(0, refs.getInputs().size());
         assertEquals(1, refs.getOutputs().size());
-        assertEquals(1, refs.getComponentIds().size());
-        // Should report connected componentId.
-        assertTrue(refs.getComponentIds().contains("s2s-client-component-guid"));
-
         Referenceable ref = refs.getOutputs().iterator().next();
-        assertEquals(TYPE_NIFI_INPUT_PORT, ref.getTypeName());
-        assertEquals("inputPortA", ref.get(ATTR_NAME));
-        assertEquals("remote-port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
-    }
-
-    @Test
-    public void testRemoteOutputPortRAW() {
-        final String componentType = "Remote Output Port";
-        // The UUID in a Transit Uri is a FlowFile UUID
-        final String transitUri = "nifi://0.example.com:8081/232018cc-a147-40c6-b148-21f9f814e93c";
-        final ProvenanceEventRecord record = Mockito.mock(ProvenanceEventRecord.class);
-        // Component Id is an UUID of the RemoteGroupPort instance acting as a S2S client.
-        when(record.getComponentId()).thenReturn("s2s-client-component-guid");
-        when(record.getComponentType()).thenReturn(componentType);
-        when(record.getTransitUri()).thenReturn(transitUri);
-        when(record.getEventType()).thenReturn(ProvenanceEventType.RECEIVE);
-        when(record.getAttribute(SiteToSiteAttributes.S2S_PORT_ID.key())).thenReturn("remote-port-guid");
-
-        final ClusterResolvers clusterResolvers = Mockito.mock(ClusterResolvers.class);
-        when(clusterResolvers.fromHostNames(matches(".+\\.example\\.com"))).thenReturn("cluster1");
-
-        final List<ConnectionStatus> connections = new ArrayList<>();
-        final ConnectionStatus connection = new ConnectionStatus();
-        connection.setSourceId("s2s-client-component-guid");
-        connection.setSourceName("outputPortA");
-        connections.add(connection);
-
-        final AnalysisContext context = Mockito.mock(AnalysisContext.class);
-        when(context.getClusterResolver()).thenReturn(clusterResolvers);
-        when(context.findConnectionFrom(matches("s2s-client-component-guid"))).thenReturn(connections);
-
-        final NiFiProvenanceEventAnalyzer analyzer = NiFiProvenanceEventAnalyzerFactory.getAnalyzer(componentType, transitUri, record.getEventType());
-        assertNotNull(analyzer);
-
-        final DataSetRefs refs = analyzer.analyze(context, record);
-        assertEquals(1, refs.getInputs().size());
-        assertEquals(0, refs.getOutputs().size());
-        Referenceable ref = refs.getInputs().iterator().next();
         assertEquals(TYPE_NIFI_OUTPUT_PORT, ref.getTypeName());
         assertEquals("outputPortA", ref.get(ATTR_NAME));
-        assertEquals("remote-port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
+        assertEquals("port-guid@cluster1", ref.get(ATTR_QUALIFIED_NAME));
     }
 
 }

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/resources/flow-templates/S2SGetRAW.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/resources/flow-templates/S2SGetRAW.xml
@@ -1,0 +1,443 @@
+<?xml version="1.0" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<template encoding-version="1.1">
+  <description></description>
+  <groupId>27b7b6b8-015f-1000-0d31-197ae42bab34</groupId>
+  <name>S2SGetRAW</name>
+  <snippet>
+    <processGroups>
+      <id>9fc65d0a-ff54-3c07-0000-000000000000</id>
+      <parentGroupId>c81f8a46-4aa3-313e-0000-000000000000</parentGroupId>
+      <position>
+        <x>0.0</x>
+        <y>0.0</y>
+      </position>
+      <comments></comments>
+      <contents>
+        <connections>
+          <id>8812c40b-5c71-369f-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>9fc65d0a-ff54-3c07-0000-000000000000</groupId>
+            <id>bb530e58-ee14-3cac-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <source>
+            <groupId>c6acb687-616a-3d36-0000-000000000000</groupId>
+            <id>7375f8f6-4604-468d-0000-000000000000</id>
+            <type>REMOTE_OUTPUT_PORT</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>9df33c4b-8c26-33e5-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>9fc65d0a-ff54-3c07-0000-000000000000</groupId>
+            <id>97cc5b27-22f3-3c3b-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <source>
+            <groupId>c6acb687-616a-3d36-0000-000000000000</groupId>
+            <id>7375f8f6-4604-468d-0000-000000000000</id>
+            <type>REMOTE_OUTPUT_PORT</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>1ddd5163-7815-3117-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>9fc65d0a-ff54-3c07-0000-000000000000</groupId>
+            <id>4f3bfa4c-6427-3aac-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <source>
+            <groupId>c6acb687-616a-3d36-0000-000000000000</groupId>
+            <id>7375f8f6-4604-468d-0000-000000000000</id>
+            <type>REMOTE_OUTPUT_PORT</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <labels>
+          <id>12073df1-f38b-3cad-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <position>
+            <x>872.9999891005355</x>
+            <y>296.0000048267144</y>
+          </position>
+          <height>68.00000762939453</height>
+          <label>A FlowFile is passed to every downstream process paths.</label>
+          <style>
+            <entry>
+              <key>font-size</key>
+              <value>12px</value>
+            </entry>
+          </style>
+          <width>338.0</width>
+        </labels>
+        <processors>
+          <id>97cc5b27-22f3-3c3b-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <position>
+            <x>470.9999891005356</x>
+            <y>679.0000048267144</y>
+          </position>
+          <bundle>
+            <artifact>nifi-standard-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>Log Level</key>
+                <value>
+                  <name>Log Level</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Log Payload</key>
+                <value>
+                  <name>Log Payload</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Attributes to Log</key>
+                <value>
+                  <name>Attributes to Log</name>
+                </value>
+              </entry>
+              <entry>
+                <key>attributes-to-log-regex</key>
+                <value>
+                  <name>attributes-to-log-regex</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Attributes to Ignore</key>
+                <value>
+                  <name>Attributes to Ignore</name>
+                </value>
+              </entry>
+              <entry>
+                <key>attributes-to-ignore-regex</key>
+                <value>
+                  <name>attributes-to-ignore-regex</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Log prefix</key>
+                <value>
+                  <name>Log prefix</name>
+                </value>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>
+                  <name>character-set</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>Log Level</key>
+                <value>info</value>
+              </entry>
+              <entry>
+                <key>Log Payload</key>
+                <value>false</value>
+              </entry>
+              <entry>
+                <key>Attributes to Log</key>
+              </entry>
+              <entry>
+                <key>attributes-to-log-regex</key>
+                <value>.*</value>
+              </entry>
+              <entry>
+                <key>Attributes to Ignore</key>
+              </entry>
+              <entry>
+                <key>attributes-to-ignore-regex</key>
+              </entry>
+              <entry>
+                <key>Log prefix</key>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>UTF-8</value>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>0 sec</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>LogAttribute</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.standard.LogAttribute</type>
+        </processors>
+        <processors>
+          <id>bb530e58-ee14-3cac-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <position>
+            <x>150.99998910053557</x>
+            <y>514.0000048267144</y>
+          </position>
+          <bundle>
+            <artifact>nifi-update-attribute-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>Delete Attributes Expression</key>
+                <value>
+                  <name>Delete Attributes Expression</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Store State</key>
+                <value>
+                  <name>Store State</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Stateful Variables Initial Value</key>
+                <value>
+                  <name>Stateful Variables Initial Value</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>Delete Attributes Expression</key>
+              </entry>
+              <entry>
+                <key>Store State</key>
+                <value>Do not store state</value>
+              </entry>
+              <entry>
+                <key>Stateful Variables Initial Value</key>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>0 sec</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>UpdateAttribute</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.attributes.UpdateAttribute</type>
+        </processors>
+        <processors>
+          <id>4f3bfa4c-6427-3aac-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <position>
+            <x>810.9999891005356</x>
+            <y>524.0000048267144</y>
+          </position>
+          <bundle>
+            <artifact>nifi-standard-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>Directory</key>
+                <value>
+                  <name>Directory</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Conflict Resolution Strategy</key>
+                <value>
+                  <name>Conflict Resolution Strategy</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Create Missing Directories</key>
+                <value>
+                  <name>Create Missing Directories</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Maximum File Count</key>
+                <value>
+                  <name>Maximum File Count</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Last Modified Time</key>
+                <value>
+                  <name>Last Modified Time</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Permissions</key>
+                <value>
+                  <name>Permissions</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Owner</key>
+                <value>
+                  <name>Owner</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Group</key>
+                <value>
+                  <name>Group</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>Directory</key>
+              </entry>
+              <entry>
+                <key>Conflict Resolution Strategy</key>
+                <value>fail</value>
+              </entry>
+              <entry>
+                <key>Create Missing Directories</key>
+                <value>true</value>
+              </entry>
+              <entry>
+                <key>Maximum File Count</key>
+              </entry>
+              <entry>
+                <key>Last Modified Time</key>
+              </entry>
+              <entry>
+                <key>Permissions</key>
+              </entry>
+              <entry>
+                <key>Owner</key>
+              </entry>
+              <entry>
+                <key>Group</key>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>0 sec</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>PutFile</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>failure</name>
+          </relationships>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.standard.PutFile</type>
+        </processors>
+        <remoteProcessGroups>
+          <id>c6acb687-616a-3d36-0000-000000000000</id>
+          <parentGroupId>9fc65d0a-ff54-3c07-0000-000000000000</parentGroupId>
+          <position>
+            <x>451.4000360293711</x>
+            <y>231.5999721410119</y>
+          </position>
+          <communicationsTimeout>30 sec</communicationsTimeout>
+          <contents>
+            <inputPorts>
+              <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+              <connected>false</connected>
+              <exists>true</exists>
+              <id>015f101e-dcd7-17bd-8899-1a723733521a</id>
+              <name>input</name>
+              <targetRunning>true</targetRunning>
+              <transmitting>false</transmitting>
+              <useCompression>false</useCompression>
+            </inputPorts>
+            <outputPorts>
+              <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+              <connected>true</connected>
+              <exists>true</exists>
+              <id>7375f8f6-4604-468d-0000-000000000000</id>
+              <targetId>392e7343-3950-329b-0000-000000000000</targetId>
+              <name>output</name>
+              <targetRunning>true</targetRunning>
+              <transmitting>true</transmitting>
+              <useCompression>false</useCompression>
+            </outputPorts>
+          </contents>
+          <proxyHost></proxyHost>
+          <proxyUser></proxyUser>
+          <targetUri>http://localhost:8080/nifi</targetUri>
+          <targetUris>http://localhost:8080/nifi</targetUris>
+          <transportProtocol>RAW</transportProtocol>
+          <yieldDuration>10 sec</yieldDuration>
+        </remoteProcessGroups>
+      </contents>
+      <name>S2SGetRAW</name>
+    </processGroups>
+  </snippet>
+  <timestamp>10/20/2017 13:03:49 JST</timestamp>
+</template>

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/resources/flow-templates/S2SSendRAW.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/resources/flow-templates/S2SSendRAW.xml
@@ -1,0 +1,822 @@
+<?xml version="1.0" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<template encoding-version="1.1">
+  <description></description>
+  <groupId>27b7b6b8-015f-1000-0d31-197ae42bab34</groupId>
+  <name>S2SSendRAW</name>
+  <snippet>
+    <processGroups>
+      <id>b3a9430b-3e40-3a04-0000-000000000000</id>
+      <parentGroupId>c81f8a46-4aa3-313e-0000-000000000000</parentGroupId>
+      <position>
+        <x>0.0</x>
+        <y>0.0</y>
+      </position>
+      <comments></comments>
+      <contents>
+        <connections>
+          <id>af5cc030-abbd-31bb-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>1504e817-9715-35fb-0000-000000000000</id>
+            <type>FUNNEL</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <selectedRelationships>success</selectedRelationships>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>c5392447-e9f1-33ad-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>aff3eea5-0826-338d-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>18474287-6326-311a-0000-000000000000</groupId>
+            <id>f31a6b53-3077-4c59-0000-000000000000</id>
+            <type>REMOTE_INPUT_PORT</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <selectedRelationships>success</selectedRelationships>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>7033f311-ac68-3cab-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>071e7d2a-0680-3d9a-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>c5392447-e9f1-33ad-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <selectedRelationships>success</selectedRelationships>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>c439cdca-e989-3491-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>308a0785-e948-3151-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>18474287-6326-311a-0000-000000000000</groupId>
+            <id>f31a6b53-3077-4c59-0000-000000000000</id>
+            <type>REMOTE_INPUT_PORT</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <selectedRelationships>success</selectedRelationships>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>b775b657-5a5b-3708-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>470d0e2a-6281-3d3b-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>18474287-6326-311a-0000-000000000000</groupId>
+            <id>f31a6b53-3077-4c59-0000-000000000000</id>
+            <type>REMOTE_INPUT_PORT</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>1504e817-9715-35fb-0000-000000000000</id>
+            <type>FUNNEL</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>4dacb06c-5bb8-3318-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>c5392447-e9f1-33ad-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <selectedRelationships>success</selectedRelationships>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>333255b6-eb02-3056-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <connections>
+          <id>7521c9ce-7e0c-34ed-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+          <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+          <destination>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>1504e817-9715-35fb-0000-000000000000</id>
+            <type>FUNNEL</type>
+          </destination>
+          <flowFileExpiration>0 sec</flowFileExpiration>
+          <labelIndex>1</labelIndex>
+          <name></name>
+          <selectedRelationships>success</selectedRelationships>
+          <source>
+            <groupId>b3a9430b-3e40-3a04-0000-000000000000</groupId>
+            <id>ca71e4d9-2a4f-3970-0000-000000000000</id>
+            <type>PROCESSOR</type>
+          </source>
+          <zIndex>0</zIndex>
+        </connections>
+        <funnels>
+          <id>1504e817-9715-35fb-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>353.013200790822</x>
+            <y>106.10680357116347</y>
+          </position>
+        </funnels>
+        <labels>
+          <id>9dbb0346-5ba8-3208-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>615.6071466250744</x>
+            <y>-91.46566086985234</y>
+          </position>
+          <height>82.47064208984375</height>
+          <label>If multiple paths are sending data through the same remote port,
+then we need to fetch previous provenance event from
+the actual SEND event, to report which path passed the data.</label>
+          <style>
+            <entry>
+              <key>font-size</key>
+              <value>12px</value>
+            </entry>
+          </style>
+          <width>467.25079345703125</width>
+        </labels>
+        <labels>
+          <id>4414cff6-9e3d-311f-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>1124.8022214005925</x>
+            <y>87.1594194315544</y>
+          </position>
+          <height>69.47367095947266</height>
+          <label>If a processor has never generated any data,
+then NiFi will not report the lineage to Atlas because it hasn't happened.</label>
+          <style>
+            <entry>
+              <key>font-size</key>
+              <value>12px</value>
+            </entry>
+          </style>
+          <width>416.84210205078125</width>
+        </labels>
+        <processors>
+          <id>b775b657-5a5b-3708-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>711.1157953067149</x>
+            <y>1.67367972157831</y>
+          </position>
+          <bundle>
+            <artifact>nifi-social-media-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>Twitter Endpoint</key>
+                <value>
+                  <name>Twitter Endpoint</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Consumer Key</key>
+                <value>
+                  <name>Consumer Key</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Consumer Secret</key>
+                <value>
+                  <name>Consumer Secret</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Access Token</key>
+                <value>
+                  <name>Access Token</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Access Token Secret</key>
+                <value>
+                  <name>Access Token Secret</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Languages</key>
+                <value>
+                  <name>Languages</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Terms to Filter On</key>
+                <value>
+                  <name>Terms to Filter On</name>
+                </value>
+              </entry>
+              <entry>
+                <key>IDs to Follow</key>
+                <value>
+                  <name>IDs to Follow</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Locations to Filter On</key>
+                <value>
+                  <name>Locations to Filter On</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>Twitter Endpoint</key>
+                <value>Sample Endpoint</value>
+              </entry>
+              <entry>
+                <key>Consumer Key</key>
+              </entry>
+              <entry>
+                <key>Consumer Secret</key>
+              </entry>
+              <entry>
+                <key>Access Token</key>
+              </entry>
+              <entry>
+                <key>Access Token Secret</key>
+              </entry>
+              <entry>
+                <key>Languages</key>
+              </entry>
+              <entry>
+                <key>Terms to Filter On</key>
+              </entry>
+              <entry>
+                <key>IDs to Follow</key>
+              </entry>
+              <entry>
+                <key>Locations to Filter On</key>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>0 sec</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>GetTwitter</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.twitter.GetTwitter</type>
+        </processors>
+        <processors>
+          <id>c439cdca-e989-3491-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>674.1998712344492</x>
+            <y>-474.2524572489417</y>
+          </position>
+          <bundle>
+            <artifact>nifi-standard-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>File Size</key>
+                <value>
+                  <name>File Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>
+                  <name>Batch Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>
+                  <name>Data Format</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>
+                  <name>Unique FlowFiles</name>
+                </value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+                <value>
+                  <name>generate-ff-custom-text</name>
+                </value>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>
+                  <name>character-set</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>File Size</key>
+                <value>0B</value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>1</value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>Text</value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>false</value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>UTF-8</value>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>1d</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>Generate C</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>RUNNING</state>
+          <style></style>
+          <type>org.apache.nifi.processors.standard.GenerateFlowFile</type>
+        </processors>
+        <processors>
+          <id>c5392447-e9f1-33ad-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>350.48686507975015</x>
+            <y>-234.94570552127266</y>
+          </position>
+          <bundle>
+            <artifact>nifi-update-attribute-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>Delete Attributes Expression</key>
+                <value>
+                  <name>Delete Attributes Expression</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Store State</key>
+                <value>
+                  <name>Store State</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Stateful Variables Initial Value</key>
+                <value>
+                  <name>Stateful Variables Initial Value</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>Delete Attributes Expression</key>
+              </entry>
+              <entry>
+                <key>Store State</key>
+                <value>Do not store state</value>
+              </entry>
+              <entry>
+                <key>Stateful Variables Initial Value</key>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>0 sec</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>UpdateAttribute</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>RUNNING</state>
+          <style></style>
+          <type>org.apache.nifi.processors.attributes.UpdateAttribute</type>
+        </processors>
+        <processors>
+          <id>ca71e4d9-2a4f-3970-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>-73.58932859465233</x>
+            <y>-130.67362652994757</y>
+          </position>
+          <bundle>
+            <artifact>nifi-standard-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>File Size</key>
+                <value>
+                  <name>File Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>
+                  <name>Batch Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>
+                  <name>Data Format</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>
+                  <name>Unique FlowFiles</name>
+                </value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+                <value>
+                  <name>generate-ff-custom-text</name>
+                </value>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>
+                  <name>character-set</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>File Size</key>
+                <value>0B</value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>1</value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>Text</value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>false</value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>UTF-8</value>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>1d</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>Generate A</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.standard.GenerateFlowFile</type>
+        </processors>
+        <processors>
+          <id>333255b6-eb02-3056-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>167.93687074616798</x>
+            <y>-480.30510007120733</y>
+          </position>
+          <bundle>
+            <artifact>nifi-standard-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>File Size</key>
+                <value>
+                  <name>File Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>
+                  <name>Batch Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>
+                  <name>Data Format</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>
+                  <name>Unique FlowFiles</name>
+                </value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+                <value>
+                  <name>generate-ff-custom-text</name>
+                </value>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>
+                  <name>character-set</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>File Size</key>
+                <value>0B</value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>1</value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>Text</value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>false</value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>UTF-8</value>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>1d</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>Generate B</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.standard.GenerateFlowFile</type>
+        </processors>
+        <processors>
+          <id>7033f311-ac68-3cab-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>1147.8839837832775</x>
+            <y>171.22101629994745</y>
+          </position>
+          <bundle>
+            <artifact>nifi-standard-nar</artifact>
+            <group>org.apache.nifi</group>
+            <version>1.5.0-SNAPSHOT</version>
+          </bundle>
+          <config>
+            <bulletinLevel>WARN</bulletinLevel>
+            <comments></comments>
+            <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+            <descriptors>
+              <entry>
+                <key>File Size</key>
+                <value>
+                  <name>File Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>
+                  <name>Batch Size</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>
+                  <name>Data Format</name>
+                </value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>
+                  <name>Unique FlowFiles</name>
+                </value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+                <value>
+                  <name>generate-ff-custom-text</name>
+                </value>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>
+                  <name>character-set</name>
+                </value>
+              </entry>
+            </descriptors>
+            <executionNode>ALL</executionNode>
+            <lossTolerant>false</lossTolerant>
+            <penaltyDuration>30 sec</penaltyDuration>
+            <properties>
+              <entry>
+                <key>File Size</key>
+                <value>0B</value>
+              </entry>
+              <entry>
+                <key>Batch Size</key>
+                <value>1</value>
+              </entry>
+              <entry>
+                <key>Data Format</key>
+                <value>Text</value>
+              </entry>
+              <entry>
+                <key>Unique FlowFiles</key>
+                <value>false</value>
+              </entry>
+              <entry>
+                <key>generate-ff-custom-text</key>
+              </entry>
+              <entry>
+                <key>character-set</key>
+                <value>UTF-8</value>
+              </entry>
+            </properties>
+            <runDurationMillis>0</runDurationMillis>
+            <schedulingPeriod>1d</schedulingPeriod>
+            <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+            <yieldDuration>1 sec</yieldDuration>
+          </config>
+          <name>InactiveProcessor</name>
+          <relationships>
+            <autoTerminate>false</autoTerminate>
+            <name>success</name>
+          </relationships>
+          <state>STOPPED</state>
+          <style></style>
+          <type>org.apache.nifi.processors.standard.GenerateFlowFile</type>
+        </processors>
+        <remoteProcessGroups>
+          <id>18474287-6326-311a-0000-000000000000</id>
+          <parentGroupId>b3a9430b-3e40-3a04-0000-000000000000</parentGroupId>
+          <position>
+            <x>534.4000360293711</x>
+            <y>319.5999721410119</y>
+          </position>
+          <communicationsTimeout>30 sec</communicationsTimeout>
+          <contents>
+            <inputPorts>
+              <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+              <connected>true</connected>
+              <exists>true</exists>
+              <id>f31a6b53-3077-4c59-0000-000000000000</id>
+              <targetId>77919f59-533e-35a3-0000-000000000000</targetId>
+              <name>input</name>
+              <targetRunning>true</targetRunning>
+              <transmitting>true</transmitting>
+              <useCompression>false</useCompression>
+            </inputPorts>
+          </contents>
+          <proxyHost></proxyHost>
+          <proxyUser></proxyUser>
+          <targetUri>http://localhost:8080/nifi</targetUri>
+          <targetUris>http://localhost:8080/nifi</targetUris>
+          <transportProtocol>RAW</transportProtocol>
+          <yieldDuration>10 sec</yieldDuration>
+        </remoteProcessGroups>
+      </contents>
+      <name>S2SSendRAW</name>
+    </processGroups>
+  </snippet>
+  <timestamp>10/18/2017 16:02:17 JST</timestamp>
+</template>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -347,6 +347,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
                 logger.debug("{} Sent {} to {}", this, flowFile, transaction.getCommunicant().getUrl());
 
                 final String transitUri = transaction.getCommunicant().createTransitUri(flowFile.getAttribute(CoreAttributes.UUID.key()));
+                flowFile = session.putAttribute(flowFile, SiteToSiteAttributes.S2S_PORT_ID.key(), getTargetIdentifier());
                 session.getProvenanceReporter().send(flowFile, transitUri, "Remote DN=" + userDn, transferMillis, false);
                 session.remove(flowFile);
 
@@ -413,6 +414,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
             final Map<String,String> attributes = new HashMap<>(2);
             attributes.put(SiteToSiteAttributes.S2S_HOST.key(), host);
             attributes.put(SiteToSiteAttributes.S2S_ADDRESS.key(), host + ":" + port);
+            attributes.put(SiteToSiteAttributes.S2S_PORT_ID.key(), getTargetIdentifier());
 
             flowFile = session.putAllAttributes(flowFile, attributes);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/TestStandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/TestStandardRemoteGroupPort.java
@@ -173,6 +173,7 @@ public class TestStandardRemoteGroupPort {
             assertEquals(ProvenanceEventType.SEND, provenanceEvent.getEventType());
             assertEquals(peerUrl + "/" + flowFile.getAttribute(CoreAttributes.UUID.key()), provenanceEvent.getTransitUri());
             assertEquals("Remote DN=nifi.node1.example.com", provenanceEvent.getDetails());
+            assertEquals("remote-group-port-id", provenanceEvent.getAttribute(SiteToSiteAttributes.S2S_PORT_ID.key()));
 
         }
     }
@@ -220,6 +221,7 @@ public class TestStandardRemoteGroupPort {
             final MockFlowFile flowFile = flowFiles.get(0);
             flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_HOST.key(), peer.getHost());
             flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_ADDRESS.key(), peer.getHost() + ":" + peer.getPort());
+            flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_PORT_ID.key(), "remote-group-port-id");
         }
 
     }
@@ -253,6 +255,7 @@ public class TestStandardRemoteGroupPort {
         assertEquals(ProvenanceEventType.SEND, provenanceEvent.getEventType());
         assertEquals(flowFileEndpointUri, provenanceEvent.getTransitUri());
         assertEquals("Remote DN=nifi.node1.example.com", provenanceEvent.getDetails());
+        assertEquals("remote-group-port-id", provenanceEvent.getAttribute(SiteToSiteAttributes.S2S_PORT_ID.key()));
     }
 
     @Test
@@ -436,6 +439,7 @@ public class TestStandardRemoteGroupPort {
         final MockFlowFile flowFile = flowFiles.get(0);
         flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_HOST.key(), peer.getHost());
         flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_ADDRESS.key(), peer.getHost() + ":" + peer.getPort());
+        flowFile.assertAttributeEquals(SiteToSiteAttributes.S2S_PORT_ID.key(), "remote-group-port-id");
 
     }
 }


### PR DESCRIPTION
- Added 's2s.port.id' FlowFile attribute to track target remote Port id
- Use 's2s.port.id' to analyze RAW S2S provenance events

This PR adds support for ReportLineageToAtlas report S2S RAW protocol lineages. Data transfer using RAW S2S protocol can be reported to Atlas as shown in following screenshots:

## Sending data to remote Input Port
![image](https://user-images.githubusercontent.com/1107620/42439098-dddf85b2-839c-11e8-90b6-7855769d1a49.png)

## Getting data from remote Output Port
![image](https://user-images.githubusercontent.com/1107620/42439133-f26a5278-839c-11e8-8c6a-87e8bd171eec.png)

---
Before this change, following error message was logged when Atlas reporting task failed to parse S2S RAW transit URI:

```
2018-07-09 11:45:19,336 ERROR [Timer-Driven Process Thread-6] o.a.n.a.reporting.ReportLineageToAtlas ReportLineageToAtlas[id=7ce9bfa0-0164-1000-b729-c4fedd3
69dc6] Skipping failed analyzing event ProvenanceEventRecord [eventId=1, eventType=SEND, eventTime=Mon Jul 09 11:40:06 JST 2018, uuid=87316f90-41af-4929-bfc
2-4fbef69647f8, fileSize=4, componentId=33a9d769-7263-32df-8957-789e3f503ea7, transitUri=nifi://s2sclient:8081/87316f90-41af-4929-bfc2-4fbef69647f8, sourceS
ystemFlowFileIdentifier=null, parentUuids=[], alternateIdentifierUri=null] due to java.lang.IllegalArgumentException: Failed to parse url nifi://s2sclient:8
081/87316f90-41af-4929-bfc2-4fbef69647f8 due to java.net.MalformedURLException: unknown protocol: nifi.: java.lang.IllegalArgumentException: Failed to parse
url nifi://s2sclient:8081/87316f90-41af-4929-bfc2-4fbef69647f8 due to java.net.MalformedURLException: unknown protocol: nifi
java.lang.IllegalArgumentException: Failed to parse url nifi://s2sclient:8081/87316f90-41af-4929-bfc2-4fbef69647f8 due to java.net.MalformedURLException: un
known protocol: nifi
        at org.apache.nifi.atlas.provenance.AbstractNiFiProvenanceEventAnalyzer.parseUrl(AbstractNiFiProvenanceEventAnalyzer.java:54)
        at org.apache.nifi.atlas.provenance.analyzer.NiFiS2S.parseTransitURL(NiFiS2S.java:36)
        at org.apache.nifi.atlas.provenance.analyzer.NiFiRemotePort.analyze(NiFiRemotePort.java:58)
        at org.apache.nifi.atlas.provenance.lineage.AbstractLineageStrategy.executeAnalyzer(AbstractLineageStrategy.java:70)
        at org.apache.nifi.atlas.provenance.lineage.SimpleFlowPathLineage.processEvent(SimpleFlowPathLineage.java:41)
        at org.apache.nifi.atlas.reporting.ReportLineageToAtlas.lambda$consumeNiFiProvenanceEvents$6(ReportLineageToAtlas.java:716)
        at org.apache.nifi.reporting.util.provenance.ProvenanceEventConsumer.consumeEvents(ProvenanceEventConsumer.java:204)
        at org.apache.nifi.atlas.reporting.ReportLineageToAtlas.consumeNiFiProvenanceEvents(ReportLineageToAtlas.java:713)
        at org.apache.nifi.atlas.reporting.ReportLineageToAtlas.onTrigger(ReportLineageToAtlas.java:665)
        at org.apache.nifi.controller.tasks.ReportingTaskWrapper.run(ReportingTaskWrapper.java:41)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.MalformedURLException: unknown protocol: nifi
        at java.net.URL.<init>(URL.java:600)
        at java.net.URL.<init>(URL.java:490)
        at java.net.URL.<init>(URL.java:439)
        at org.apache.nifi.atlas.provenance.AbstractNiFiProvenanceEventAnalyzer.parseUrl(AbstractNiFiProvenanceEventAnalyzer.java:51)
```

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
