### PR TITLE
NIFI-4407: Updated Expression Language Guide to provide details about…

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/Query.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/Query.java
@@ -16,11 +16,6 @@
  */
 package org.apache.nifi.attribute.expression.language;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.antlr.runtime.tree.Tree;
 import org.apache.nifi.attribute.expression.language.compile.ExpressionCompiler;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
@@ -29,6 +24,11 @@ import org.apache.nifi.attribute.expression.language.exception.AttributeExpressi
 import org.apache.nifi.expression.AttributeExpression.ResultType;
 import org.apache.nifi.expression.AttributeValueDecorator;
 import org.apache.nifi.processor.exception.ProcessException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Class used for creating and evaluating NiFi Expression Language. Once a Query
@@ -248,7 +248,11 @@ public class Query {
         final List<Range> ranges = extractExpressionRanges(query);
 
         if (ranges.isEmpty()) {
-            return new EmptyPreparedQuery(query.replace("$$", "$"));
+            // While in the other cases below, we are simply replacing "$$" with "$", we have to do this
+            // a bit differently. We want to treat $$ as an escaped $ only if it immediately precedes the
+            // start of an Expression, which is the case below. Here, we did not detect the start of an Expression
+            // and as such as must use the #unescape method instead of a simple replace() function.
+            return new EmptyPreparedQuery(unescape(query));
         }
 
         final ExpressionCompiler compiler = new ExpressionCompiler();

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -16,15 +16,19 @@
  */
 package org.apache.nifi.attribute.expression.language;
 
-import static java.lang.Double.NEGATIVE_INFINITY;
-import static java.lang.Double.NaN;
-import static java.lang.Double.POSITIVE_INFINITY;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.antlr.runtime.tree.Tree;
+import org.apache.nifi.attribute.expression.language.Query.Range;
+import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageParsingException;
+import org.apache.nifi.expression.AttributeExpression.ResultType;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.registry.VariableRegistry;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -40,19 +44,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.antlr.runtime.tree.Tree;
-import org.apache.nifi.attribute.expression.language.Query.Range;
-import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
-import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
-import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
-import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageParsingException;
-import org.apache.nifi.expression.AttributeExpression.ResultType;
-import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.registry.VariableRegistry;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.Mockito;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestQuery {
 
@@ -167,14 +167,25 @@ public class TestQuery {
     @Test
     public void testEscape() {
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("attr", "My Value");
+        attributes.put("abc", "xyz");
         attributes.put("${xx}", "hello");
 
-        assertEquals("My Value", evaluateQueryForEscape("${attr}", attributes));
-        assertEquals("${attr}", evaluateQueryForEscape("$${attr}", attributes));
-        assertEquals("$My Value", evaluateQueryForEscape("$$${attr}", attributes));
-        assertEquals("$${attr}", evaluateQueryForEscape("$$$${attr}", attributes));
-        assertEquals("$$My Value", evaluateQueryForEscape("$$$$${attr}", attributes));
+        assertEquals("xyz", evaluateQueryForEscape("${abc}", attributes));
+        assertEquals("${abc}", evaluateQueryForEscape("$${abc}", attributes));
+        assertEquals("$xyz", evaluateQueryForEscape("$$${abc}", attributes));
+        assertEquals("$${abc}", evaluateQueryForEscape("$$$${abc}", attributes));
+        assertEquals("$$xyz", evaluateQueryForEscape("$$$$${abc}", attributes));
+
+        assertEquals( "Unescaped $$${5 because no closing brace", evaluateQueryForEscape("Unescaped $$${5 because no closing brace", attributes));
+        assertEquals( "Unescaped $ because no closing brace", evaluateQueryForEscape("Unescaped $$${'5'} because no closing brace", attributes));
+
+        assertEquals("I owe you $5", evaluateQueryForEscape("I owe you $5", attributes));
+        assertEquals("You owe me $$5 too", evaluateQueryForEscape("You owe me $$5 too", attributes));
+        assertEquals("Unescaped $$${5 because no closing brace", evaluateQueryForEscape("Unescaped $$${5 because no closing brace", attributes));
+        assertEquals("xyz owes me $5", evaluateQueryForEscape("${abc} owes me $5", attributes));
+        assertEquals("xyz owes me ${5", evaluateQueryForEscape("${abc} owes me ${5", attributes));
+        assertEquals("xyz owes me ", evaluateQueryForEscape("${abc} owes me ${'5'}", attributes));
+        assertEquals("xyz owes me $", evaluateQueryForEscape("${abc} owes me $$${'5'}", attributes));
     }
 
     @Test

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -142,24 +142,56 @@ a Property supports the Expression Language is determined by the developer of th
 the Processor is written. However, the application strives to clearly illustrate for each Property
 whether or not the Expression Language is supported.
 
-In the application, when configuring a Processor property, the User Interface provides an Information
+In the application, when configuring a component property, the User Interface provides an Information
 icon (
 image:iconInfo.png["Info"]
 ) next to the name of the Property. Hovering over this icon with the mouse will provide a tooltip that
 provides helpful information about the Property. This information includes a description of the Property,
 the default value (if any), historically configured values (if any), and the evaluation scope of this
-property for expression language. There are three values and the evaluation scope of the expression 
+property for expression language. There are three values and the evaluation scope of the expression
 language is hierarchical: NONE -> VARIABLE_REGISTRY -> FLOWFILE_ATTRIBUTES.
 
 * NONE - expression language is not supported for this property
 * VARIABLE_REGISTRY is hierarchically constructed as below:
-** Variables defined at process group level and then, recursively, up to the higher process group until 
+** Variables defined at process group level and then, recursively, up to the higher process group until
 the root process group.
-** Variables defined in custom properties files through the nifi.variable.registry.properties property 
+** Variables defined in custom properties files through the nifi.variable.registry.properties property
 in nifi.properties file.
 ** Environment variables defined at JVM level and system properties.
-* FLOWFILE_ATTRIBUTES - will use attributes of each individual flow file.
+* FLOWFILE_ATTRIBUTES - will use attributes of each individual flow file, as well as those variables defined
+by the Variable Registry, as described above.
 
+[[escaping]]
+=== Escaping Expression Language
+There may be times when a property supports Expression Language, but the user wishes to use a literal value
+that follows the same syntax as the Expression Language. For example, a user may want to configure a property
+value to be the literal text `Hello ${UserName}`. In such a case, this can be accomplished by using an extra
+`$` (dollar sign symbol) just before the expression to escape it (i.e., `Hello $${UserName}`). Unless the `$`
+character is being used to escape an Expression, it should not be escaped. For example, the value `Hello $$User$$Name`
+should not escape the `$` characters, so the literal value that will be used is `Hello $$User$$Name`.
+
+If more than two `$` characters are encountered sequentially before a `{`, then each pair of `$` characters will
+be considered an escaping of the `$` character. The escaping will be performed from left-to-right.
+To help illustrate this, consider that the variable `abc` contains the value `xyz`. Then, consider the following
+table of Expressions and their corresponding evaluated values:
+
+.Escaping EL Examples
+|========================================================================================
+| Expression | Value | Notes
+| `${abc}` | `xyz` |
+| `$${abc}` | `${abc}` |
+| `$$${abc}` | `$xyz` |
+| `$$$${abc}` | `$${abc}` |
+| `$$$$${abc}` | `$$xyz` |
+| `I owe you $5` | `I owe you $5` | No actual Expression is present here.
+| `You owe me $$5 too` | `You owe me $$5 too` | The $ character is not escaped because it does not immediately precede an Expression.
+| `Unescaped $$${5 because no closing brace` | `Unescaped $$${5 because no closing brace` | Because there is no closing brace here, there is no actual Expression and hence the $ characters are not
+escaped.
+| `Unescaped $$${5} because no closing brace` | <Error> | This expression is not valid because it equates to an escaped $, followed by `${5}` and the `${5}` is not a valid Expression. The number
+must be escaped.
+| `Unescaped $$${'5'} because no closing brace` | `Unescaped $ because no closing brace` | There is no attribute named `5` so the Expression evaluates to an empty string. The `$$` evaluates to a
+single (escaped) `$` because it immediately precedes an Expression.
+|========================================================================================
 
 [[editor]]
 === Expression Language Editor


### PR DESCRIPTION
… how escaping $ is accomplished, and when the $ character should and should not be escaped. Fixed bug in the Query compiler that mistakenly would blindly replace 484 with $ even when the 484 did not precede an Expression. Added additional test cases.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
