### PR TITLE
Remove two reference markers from jsonPath docs

### DIFF
--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -1522,7 +1522,7 @@ Expressions will provide the following results:
   path expression. An empty string is generated if the Subject does not contain valid JSON, the _jsonPath_ is invalid, or the path
 	does not exist in the Subject.  If the evaluation results in a scalar value, the string representation of scalar value is
 	generated.  Otherwise a string representation of the JSON result is generated.  A JSON array of length 1 is special cased
-	when `[0]` is a scalar, the string representation of `[0]` is generated.^1^#
+	when `[0]` is a scalar, the string representation of `[0]` is generated.#
 
 *Subject Type*: [.subject]#String#
 
@@ -1565,7 +1565,7 @@ Expressions will provide the following results:
 | Expression | Value
 | `${myJson:jsonPath('$.firstName')}` | `John`
 | `${myJson:jsonPath('$.address.postalCode')}` | `10021-3100`
-| `${myJson:jsonPath('$.phoneNumbers[?(@.type=="home")].number')}`^1^ | `212 555-1234`
+| `${myJson:jsonPath('$.phoneNumbers[?(@.type=="home")].number')}` | `212 555-1234`
 | `${myJson:jsonPath('$.phoneNumbers')}` | `[{"type":"home","number":"212 555-1234"},{"type":"office","number":"646 555-4567"}]`
 | `${myJson:jsonPath('$.missing-path')}` | _empty_
 | `${myJson:jsonPath('$.bad-json-path..')}` | _exception bulletin_


### PR DESCRIPTION
There are two superscript references in the JsonPath documentation that don't seem to mean any thing. They are not clickable and there are no other similar reference markers in the document. This removes them to prevent confusion. 

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
