### PR TITLE
[WIP] NIFI-5508 - support disabling wantClientAuth for use behind reverse proxies

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -174,6 +174,7 @@ public abstract class NiFiProperties {
     public static final String WEB_HTTPS_PORT = "nifi.web.https.port";
     public static final String WEB_HTTPS_PORT_FORWARDING = "nifi.web.https.port.forwarding";
     public static final String WEB_HTTPS_HOST = "nifi.web.https.host";
+    public static final String WEB_HTTPS_WANT_CLIENT_AUTH = "nifi.web.https.want.client.auth";
     public static final String WEB_HTTPS_NETWORK_INTERFACE_PREFIX = "nifi.web.https.network.interface.";
     public static final String WEB_WORKING_DIR = "nifi.web.jetty.working.directory";
     public static final String WEB_THREADS = "nifi.web.jetty.threads";
@@ -1028,6 +1029,14 @@ public abstract class NiFiProperties {
 
         return InetSocketAddress.createUnresolved(host, port);
 
+    }
+
+    public boolean isClientAuthWanted() {
+        String value = getProperty(WEB_HTTPS_WANT_CLIENT_AUTH);
+        if(StringUtils.isBlank(value)) {
+            value = "false";
+        }
+        return Boolean.parseBoolean(value);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -781,7 +781,7 @@ public class JettyServer implements NiFiServer {
         if (props.isClientAuthRequiredForRestApi()) {
             contextFactory.setNeedClientAuth(true);
         } else {
-            contextFactory.setWantClientAuth(true);
+            contextFactory.setWantClientAuth(props.isClientAuthWanted());
         }
 
         /* below code sets JSSE system properties when values are provided */


### PR DESCRIPTION
Before merging need assistance wordsmithing the administration-guide.adoc file.  Specifically the below paragraph.

> Similar to nifi.security.needClientAuth, the web server can be configured to require certificate based client authentication for users accessing the User Interface. In order to do this it must be configured to not support username/password authentication using Lightweight Directory Access Protocol (LDAP) or Kerberos. Either of these options will configure the web server to WANT certificate based client authentication. This will allow it to support users with certificates and those without that may be logging in with their credentials or those accessing anonymously. If username/password authentication and anonymous access are not configured, the web server will REQUIRE certificate based client authentication. See User Authentication for more details.