### PR TITLE
NIFI-5474: When using Regex Replace with ReplaceText, and there are capturing groups, ensure that we populate the 'additionalVariables' map for each match of the regex. This allows Expression Language to reference the back-references properly even when there are multiple matches

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
@@ -18,17 +18,16 @@ package org.apache.nifi.processors.standard;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.SystemResource;
-import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
@@ -80,9 +79,7 @@ import java.util.regex.Pattern;
 @SystemResourceConsideration(resource = SystemResource.MEMORY)
 public class ReplaceText extends AbstractProcessor {
 
-    private static Pattern QUOTED_GROUP_REF_PATTERN = Pattern.compile("\\$\\{\\s*?'\\$\\d+?'.+?\\}");
-    private static Pattern DOUBLE_QUOTED_GROUP_REF_PATTERN = Pattern.compile("\\$\\{\\s*?\"\\$\\d+?\".+?\\}");
-    private static Pattern LITERAL_QUOTED_PATTERN = Pattern.compile("literal\\(('.*?')\\)",Pattern.DOTALL);
+    private static Pattern REPLACEMENT_NORMALIZATION_PATTERN = Pattern.compile("(\\$\\D)");
 
     // Constants
     public static final String LINE_BY_LINE = "Line-by-Line";
@@ -314,8 +311,12 @@ public class ReplaceText extends AbstractProcessor {
 
     // If we find a back reference that is not valid, then we will treat it as a literal string. For example, if we have 3 capturing
     // groups and the Replacement Value has the value is "I owe $8 to him", then we want to treat the $8 as a literal "$8", rather
-    // than attempting to use it as a back reference.  We do this even if there are no capture groups.
+    // than attempting to use it as a back reference.
     private static String escapeLiteralBackReferences(final String unescaped, final int numCapturingGroups) {
+        if (numCapturingGroups == 0) {
+            return unescaped;
+        }
+
         String value = unescaped;
         final Matcher backRefMatcher = unescapedBackReferencePattern.matcher(value); // consider unescaped back references
         while (backRefMatcher.find()) {
@@ -551,18 +552,12 @@ public class ReplaceText extends AbstractProcessor {
                         additionalAttrs.put("$" + i, groupValue);
                     }
 
-                    // prepare the string and do the regex replace first
-                    // then evaluate the EL on the result
-                    String replacement = context.getProperty(REPLACEMENT_VALUE).getValue();
+                    String replacement = context.getProperty(REPLACEMENT_VALUE).evaluateAttributeExpressions(flowFile, additionalAttrs, escapeBackRefDecorator).getValue();
                     replacement = escapeLiteralBackReferences(replacement, numCapturingGroups);
-                    replacement = escapeExpressionDollarSigns(replacement);
-                    replacement = wrapLiterals(replacement);
-                    replacement = contentString.replaceAll(searchRegex, replacement);
-                    replacement = escapeForEvaluation(replacement);
 
-                    PropertyValue tempValue =  context.newPropertyValue(replacement);
-                    final String updatedValue = tempValue.evaluateAttributeExpressions(flowFile, additionalAttrs, null).getValue();
+                    String replacementFinal = normalizeReplacementString(replacement);
 
+                    final String updatedValue = contentString.replaceAll(searchRegex, replacementFinal);
                     updatedFlowFile = session.write(flowFile, new OutputStreamCallback() {
                         @Override
                         public void process(final OutputStream out) throws IOException {
@@ -589,17 +584,12 @@ public class ReplaceText extends AbstractProcessor {
                                         additionalAttrs.put("$" + i, groupValue);
                                     }
 
-                                    // prepare the string and do the regex replace first
-                                    // then evaluate the EL on the result
-                                    String replacement = context.getProperty(REPLACEMENT_VALUE).getValue();
+                                    String replacement = context.getProperty(REPLACEMENT_VALUE).evaluateAttributeExpressions(flowFile, additionalAttrs, escapeBackRefDecorator).getValue();
                                     replacement = escapeLiteralBackReferences(replacement, numCapturingGroups);
-                                    replacement = escapeExpressionDollarSigns(replacement);
-                                    replacement = wrapLiterals(replacement);
-                                    replacement = oneLine.replaceAll(searchRegex, replacement);
-                                    replacement = escapeForEvaluation(replacement);
 
-                                    PropertyValue tempValue =  context.newPropertyValue(replacement);
-                                    final String updatedValue = tempValue.evaluateAttributeExpressions(flowFile, additionalAttrs, null).getValue();
+                                    String replacementFinal = normalizeReplacementString(replacement);
+
+                                    final String updatedValue = oneLine.replaceAll(searchRegex, replacementFinal);
                                     bw.write(updatedValue);
                                 } else {
                                     // No match. Just write out the line as it was.
@@ -679,76 +669,16 @@ public class ReplaceText extends AbstractProcessor {
     }
 
     /**
-     * Wraps '$1' with the {@code literal} function for EL evaluation.
-     * @param possibleLiteral the {@code String} to evaluate.
-     * @return {@code String} with literals wrapped.  If no literals or Expression Lanaguage present the passed string
-     * is returned.
-     */
-    private static String wrapLiterals(String possibleLiteral) {
-        String replacementFinal = possibleLiteral;
-        if (!possibleLiteral.contains("${")) {
-            return possibleLiteral;
-        }
-
-        if (QUOTED_GROUP_REF_PATTERN.matcher(replacementFinal).find()) {
-            replacementFinal = replacementFinal.replaceAll("(\\$\\{\\s*?)('\\$\\d+?')(.*\\})", "$1literal($2)$3");
-        }
-
-        if (DOUBLE_QUOTED_GROUP_REF_PATTERN.matcher(replacementFinal).find()) {
-            replacementFinal = replacementFinal.replaceAll("(\\$\\{\\s*?)(\"\\$\\d+?\")(.*\\})", "$1literal($2)$3");
-        }
-
-        return replacementFinal;
-    }
-
-    /**
      * If we have a '$' followed by anything other than a number, then escape
-     * it if it is not already escaped. E.g., '$d' becomes '\$d' so that it can be used as a literal in a
+     * it. E.g., '$d' becomes '\$d' so that it can be used as a literal in a
      * regex.
      */
-    private static String escapeExpressionDollarSigns(String replacement) {
-
-        // are there expressions or group references
-        if (replacement.indexOf('$') == -1) {
-            return replacement;
+    private static String normalizeReplacementString(String replacement) {
+        String replacementFinal = replacement;
+        if (REPLACEMENT_NORMALIZATION_PATTERN.matcher(replacement).find()) {
+            replacementFinal = Matcher.quoteReplacement(replacement);
         }
-        StringBuilder sb = new StringBuilder();
-        boolean lastWasEscape = false;
-        for (int i=0; i<replacement.length(); i++) {
-            char c = replacement.charAt(i);
-            if (c == '\\' ) {
-                lastWasEscape = true;
-            } else {
-                if ( c == '$') {
-                    if (!lastWasEscape && !Character.isDigit(replacement.charAt(i+1))) {
-                        sb.append('\\');
-                    }
-                }
-                lastWasEscape = false;
-            }
-            sb.append(c);
-        }
-       return sb.toString();
-    }
-
-    /**
-     * Escapes a {@code String} containing literal('') EL values.
-     * @param contentString the {@code String}
-     * @return the escaped {@code String}. If no literal() is present, then the input {@code String} will be returned
-     */
-    private static String escapeForEvaluation(String contentString) {
-        final Matcher matcher = LITERAL_QUOTED_PATTERN.matcher(contentString);
-        String returnString = contentString;
-        while(matcher.find()) {
-            for (int i = 1; i <= matcher.groupCount(); i ++) {
-                String replacement = matcher.group(i)
-                    .replaceAll("\\n","\\\\n")
-                    .replaceAll("\\r","\\\\r")
-                    .replaceAll("\\t","\\\\t");
-                returnString = new StringBuilder(returnString).replace(matcher.start(i),matcher.end(i),replacement).toString();
-            }
-        }
-        return returnString;
+        return replacementFinal;
     }
 
     private interface ReplacementStrategyExecutor {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceText.java
@@ -80,23 +80,9 @@ public class TestReplaceText {
     }
 
     @Test
-    public void testEscapedEnough$InReplacementCanReturnEscaped$() throws IOException {
-        final TestRunner runner = getRunner();
-        runner.setProperty(ReplaceText.SEARCH_VALUE, "(?s)(^.*$)");
-        runner.setProperty(ReplaceText.REPLACEMENT_VALUE, "a\\\\\\$b");
-
-        runner.enqueue("a$a,b,c,d");
-        runner.run();
-
-        runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("a\\$b".getBytes("UTF-8"));
-    }
-
-    @Test
     public void testWithEscaped$InReplacement() throws IOException {
         final TestRunner runner = getRunner();
-        runner.setProperty(ReplaceText.SEARCH_VALUE, "(?s)(^.*$)");
+        runner.setProperty(ReplaceText.SEARCH_VALUE, "(?s:^.*$)");
         runner.setProperty(ReplaceText.REPLACEMENT_VALUE, "a\\$b");
 
         runner.enqueue("a$a,b,c,d");
@@ -104,7 +90,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("a$b".getBytes("UTF-8"));
+        out.assertContentEquals("a\\$b".getBytes("UTF-8"));
     }
 
     @Test
@@ -119,34 +105,6 @@ public class TestReplaceText {
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         out.assertContentEquals("a$b".getBytes("UTF-8"));
-    }
-
-    @Test
-    public void testWithSingleQuotedELInReplacement() throws IOException {
-        final TestRunner runner = getRunner();
-        runner.setProperty(ReplaceText.SEARCH_VALUE, "\"([a-z]+)\":\"(\\w+)\"");
-        runner.setProperty(ReplaceText.REPLACEMENT_VALUE, "\"${'$1':toUpper()}\":\"$2\"");
-        runner.enqueue("{\"name\":\"Smith\",\"middle\":\"nifi\",\"firstname\":\"John\"}");
-        runner.run();
-
-        runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("{\"NAME\":\"Smith\",\"MIDDLE\":\"nifi\",\"FIRSTNAME\":\"John\"}");
-
-    }
-
-    @Test
-    public void testWithDoubleQuotedELInReplacement() throws IOException {
-        final TestRunner runner = getRunner();
-        runner.setProperty(ReplaceText.SEARCH_VALUE, "\"([a-z]+)\":\"(\\w+)\"");
-        runner.setProperty(ReplaceText.REPLACEMENT_VALUE, "\"${\"$1\":toUpper()}\":\"$2\"");
-        runner.enqueue("{\"name\":\"Smith\",\"middle\":\"nifi\",\"firstname\":\"John\"}");
-        runner.run();
-
-        runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("{\"NAME\":\"Smith\",\"MIDDLE\":\"nifi\",\"FIRSTNAME\":\"John\"}");
-
     }
 
     @Test
@@ -1140,22 +1098,6 @@ public class TestReplaceText {
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         out.assertContentEquals("TESTING\n123");
-    }
-
-    @Test
-    public void testRegexWithELAndELSpecialChars() throws Exception {
-        final TestRunner runner = getRunner();
-        runner.setProperty(ReplaceText.SEARCH_VALUE, "(?s)(^.*$)");
-        runner.setProperty(ReplaceText.REPLACEMENT_VALUE, "${'$1':toUpper()}"); // will uppercase group with good Java regex
-        runner.setProperty(ReplaceText.REPLACEMENT_STRATEGY, ReplaceText.REGEX_REPLACE);
-        runner.setProperty(ReplaceText.EVALUATION_MODE, ReplaceText.ENTIRE_TEXT);
-
-        runner.enqueue("testing\n\t\r123".getBytes());
-        runner.run();
-
-        runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("TESTING\n\t\r123");
     }
 
     @Test


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
