### PR TITLE
NIFI-5479: Upgrade Jetty

### DIFF
--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java
@@ -29,6 +29,8 @@ import java.security.Security;
 public class KeyStoreUtils {
     private static final Logger logger = LoggerFactory.getLogger(KeyStoreUtils.class);
 
+    public static final String SUN_PROVIDER_NAME = "SUN";
+
     static {
         Security.addProvider(new BouncyCastleProvider());
     }
@@ -42,6 +44,8 @@ public class KeyStoreUtils {
     public static String getKeyStoreProvider(String keyStoreType) {
         if (KeystoreType.PKCS12.toString().equalsIgnoreCase(keyStoreType)) {
             return BouncyCastleProvider.PROVIDER_NAME;
+        } else if (KeystoreType.JKS.toString().equalsIgnoreCase(keyStoreType)) {
+            return SUN_PROVIDER_NAME;
         }
         return null;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoader.java
@@ -176,21 +176,21 @@ public class NarClassLoader extends URLClassLoader {
 
     /**
      * Adds URLs for the resources unpacked from this NAR:
-     * <ul><li>the root: for classes, <tt>META-INF</tt>, etc.</li>
-     * <li><tt>META-INF/dependencies</tt>: for config files, <tt>.so</tt>s,
+     * <ul><li>the root: for classes, <tt>NAR-INF</tt>, etc.</li>
+     * <li><tt>NAR-INF/bundled-dependencies</tt>: for config files, <tt>.so</tt>s,
      * etc.</li>
-     * <li><tt>META-INF/dependencies/*.jar</tt>: for dependent
+     * <li><tt>NAR-INF/bundled-dependencies/*.jar</tt>: for dependent
      * libraries</li></ul>
      *
      * @param root the root directory of the unpacked NAR.
      * @throws IOException if the URL list could not be updated.
      */
     private void updateClasspath(File root) throws IOException {
-        addURL(root.toURI().toURL()); // for compiled classes, META-INF/, etc.
+        addURL(root.toURI().toURL()); // for compiled classes, WEB-INF, NAR-INF/, etc.
 
-        File dependencies = new File(root, "META-INF/bundled-dependencies");
+        File dependencies = new File(root, "NAR-INF/bundled-dependencies");
         if (!dependencies.isDirectory()) {
-            LOGGER.warn(narWorkingDirectory + " does not contain META-INF/bundled-dependencies!");
+            LOGGER.warn(narWorkingDirectory + " does not contain NAR-INF/bundled-dependencies!");
         }
         addURL(dependencies.toURI().toURL());
         if (dependencies.isDirectory()) {
@@ -206,9 +206,9 @@ public class NarClassLoader extends URLClassLoader {
 
     @Override
     protected String findLibrary(final String libname) {
-        File dependencies = new File(narWorkingDirectory, "META-INF/bundled-dependencies");
+        File dependencies = new File(narWorkingDirectory, "NAR-INF/bundled-dependencies");
         if (!dependencies.isDirectory()) {
-            LOGGER.warn(narWorkingDirectory + " does not contain META-INF/bundled-dependencies!");
+            LOGGER.warn(narWorkingDirectory + " does not contain NAR-INF/bundled-dependencies!");
         }
 
         final File nativeDir = new File(dependencies, "native");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarUnpacker.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarUnpacker.java
@@ -195,7 +195,7 @@ public final class NarUnpacker {
             final File unpackedNar = entry.getKey();
             final BundleCoordinate bundleCoordinate = entry.getValue();
 
-            final File bundledDependencies = new File(unpackedNar, "META-INF/bundled-dependencies");
+            final File bundledDependencies = new File(unpackedNar, "NAR-INF/bundled-dependencies");
 
             unpackBundleDocs(docsDirectory, mapping, bundleCoordinate, bundledDependencies);
         }
@@ -261,6 +261,9 @@ public final class NarUnpacker {
             while (jarEntries.hasMoreElements()) {
                 JarEntry jarEntry = jarEntries.nextElement();
                 String name = jarEntry.getName();
+                if(name.contains("META-INF/bundled-dependencies")){
+                    name = name.replace("META-INF/bundled-dependencies", "NAR-INF/bundled-dependencies");
+                }
                 File f = new File(workingDirectory, name);
                 if (jarEntry.isDirectory()) {
                     FileUtils.ensureDirectoryExistAndCanReadAndWrite(f);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -384,7 +384,7 @@ public class JettyServer implements NiFiServer {
         // consider each nar working directory
         bundles.forEach(bundle -> {
             final BundleDetails details = bundle.getBundleDetails();
-            final File narDependencies = new File(details.getWorkingDirectory(), "META-INF/bundled-dependencies");
+            final File narDependencies = new File(details.getWorkingDirectory(), "NAR-INF/bundled-dependencies");
             if (narDependencies.isDirectory()) {
                 // list the wars from this nar
                 final File[] narDependencyDirs = narDependencies.listFiles(WAR_FILTER);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/JettyServerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/JettyServerTest.java
@@ -37,6 +37,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.nifi.security.util.KeyStoreUtils.SUN_PROVIDER_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -107,7 +108,7 @@ public class JettyServerTest {
         JettyServer.configureSslContextFactory(contextFactory, nifiProperties);
 
         verify(contextFactory).setKeyStoreType(keyStoreType);
-        verify(contextFactory, never()).setKeyStoreProvider(anyString());
+        verify(contextFactory).setKeyStoreProvider(SUN_PROVIDER_NAME);
     }
 
     @Test
@@ -137,7 +138,7 @@ public class JettyServerTest {
         JettyServer.configureSslContextFactory(contextFactory, nifiProperties);
 
         verify(contextFactory).setTrustStoreType(trustStoreType);
-        verify(contextFactory, never()).setTrustStoreProvider(anyString());
+        verify(contextFactory).setTrustStoreProvider(SUN_PROVIDER_NAME);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
@@ -914,6 +914,11 @@
             above.
         -->
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>apache-jstl</artifactId>
+            <scope>provided</scope>
+        </dependency>        
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <inceptionYear>2014</inceptionYear>
         <org.slf4j.version>1.7.25</org.slf4j.version>
         <ranger.version>1.0.0</ranger.version>
-        <jetty.version>9.4.3.v20170317</jetty.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Upgrading Jetty. Including a commit that @joewitt had provided in PR #2933. I have provided an additional commit that addresses a behavioral change in Jetty's SslContextFactory. I have verified various NiFi deployments including (un)secured standalone and clustered instances using both certificate based authentication and our JWT authentication using OpenID Connect.

Once this PR is closed, we can also close #2933.

@markap14 Can you help verify some of our processors that leverage the bundled Jetty server?
@ijokarumawak Can you help verify our web socket processors?

Would also appreciate anyone else willing to deploy this proposed change to ensure there aren't any other regressions.