### PR TITLE
NIFI-5541 - Added OWASP profile for dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -706,6 +706,33 @@
                 </pluginManagement>
             </build>
         </profile>
+	<profile>
+		<!-- Maven Plugin that uses dependency-check-core to detect publicly disclosed
+			vulnerabilities associated with the project's dependencies. The plugin will
+			generate a report listing the dependency, any identified Common Platform
+			Enumeration (CPE) identifiers, and the associated Common Vulnerability and
+			Exposure (CVE) entries. -->
+		<id>owasp</id>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.owasp</groupId>
+					<artifactId>dependency-check-maven</artifactId>
+					<version>3.3.1</version>
+					<configuration>
+						<nspAnalyzerEnabled>false</nspAnalyzerEnabled>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>aggregate</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
         <!-- The following profiles are here as a convenience for folks that 
             want to build against vendor-specific distributions of the various Hadoop 
             ecosystem libraries. These will alter which dependencies are sourced in a 


### PR DESCRIPTION
Added a profile allowing people to run the OWASP maven plugin. I had to add ``<nspAnalyzerEnabled>false</nspAnalyzerEnabled>`` to get things working without failure.

I'm running the following command:
````shell
mvn -Powasp -Dtest=false -DfailIfNoTests=false org.owasp:dependency-check-maven:aggregate
````

````
Project: nifi
org.apache.nifi:nifi:1.8.0-SNAPSHOT
Scan Information (show less):

    dependency-check version: 3.3.1
    Report Generated On: Aug 24, 2018 at 14:27:56 +02:00
    Dependencies Scanned: 1855 (1181 unique)
    Vulnerable Dependencies: 141
    Vulnerabilities Found: 509
    Vulnerabilities Suppressed: 0
    NVD CVE 2002: 23/08/2018 09:24:06
    NVD CVE 2003: 24/08/2018 13:00:49
    NVD CVE 2004: 15/08/2018 10:16:37
    NVD CVE 2005: 15/08/2018 10:14:46
    NVD CVE 2006: 15/08/2018 10:11:39
    NVD CVE 2007: 15/08/2018 10:06:55
    NVD CVE 2008: 15/08/2018 10:02:24
    NVD CVE 2009: 15/08/2018 09:57:28
    NVD CVE 2010: 15/08/2018 09:53:24
    NVD CVE 2011: 24/08/2018 13:00:48
    NVD CVE 2012: 24/08/2018 13:00:48
    NVD CVE 2013: 24/08/2018 13:00:48
    NVD CVE 2014: 24/08/2018 13:00:47
    NVD CVE 2015: 24/08/2018 13:00:47
    NVD CVE 2016: 24/08/2018 13:00:47
    NVD CVE 2017: 24/08/2018 13:00:47
    NVD CVE 2018: 24/08/2018 13:00:48
    NVD CVE Checked: 24/08/2018 13:46:11
    NVD CVE Modified: 24/08/2018 12:01:53
    VersionCheckOn: 1535111171413
````

Full report here: http://jsfiddle.net/4jk90tqo/embedded/result/