### PR TITLE
NIFI-5612: Support JDBC drivers that return Long for unsigned ints

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/JdbcCommonTestUtils.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/JdbcCommonTestUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JdbcCommonTestUtils {
+    static ResultSet resultSetReturningMetadata(ResultSetMetaData metadata) throws SQLException {
+        final ResultSet rs = mock(ResultSet.class);
+        when(rs.getMetaData()).thenReturn(metadata);
+
+        final AtomicInteger counter = new AtomicInteger(1);
+        Mockito.doAnswer(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                return counter.getAndDecrement() > 0;
+            }
+        }).when(rs).next();
+
+        return rs;
+    }
+
+    static InputStream convertResultSetToAvroInputStream(ResultSet rs) throws SQLException, IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        JdbcCommon.convertToAvroStream(rs, baos, false);
+
+        final byte[] serializedBytes = baos.toByteArray();
+
+        return new ByteArrayInputStream(serializedBytes);
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJdbcCommonConvertToAvro.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJdbcCommonConvertToAvro.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static java.sql.Types.INTEGER;
+import static java.sql.Types.SMALLINT;
+import static java.sql.Types.TINYINT;
+import static java.sql.Types.BIGINT;
+import static org.apache.nifi.processors.standard.util.JdbcCommonTestUtils.convertResultSetToAvroInputStream;
+import static org.apache.nifi.processors.standard.util.JdbcCommonTestUtils.resultSetReturningMetadata;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class TestJdbcCommonConvertToAvro {
+
+    private final static boolean SIGNED = true;
+    private final static boolean UNSIGNED = false;
+
+    private static int[] range(int start, int end) {
+        return IntStream.rangeClosed(start, end).toArray();
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<TestParams> data() {
+        Map<Integer, int[]> typeWithPrecisionRange = new HashMap<>();
+        typeWithPrecisionRange.put(TINYINT, range(1,3));
+        typeWithPrecisionRange.put(SMALLINT, range(1,5));
+        typeWithPrecisionRange.put(INTEGER, range(1,9));
+
+        ArrayList<TestParams> params = new ArrayList<>();
+
+        typeWithPrecisionRange.forEach( (sqlType, precisions) -> {
+            for (int precision : precisions) {
+                params.add(new TestParams(sqlType, precision, SIGNED));
+                params.add(new TestParams(sqlType, precision, UNSIGNED));
+            }
+        });
+        // remove cases that we know should fail
+        params.removeIf(param ->
+            param.sqlType == INTEGER
+                    &&
+            param.precision == 9
+                    &&
+            param.signed == UNSIGNED
+        );
+
+        return params;
+    }
+
+    @Parameterized.Parameter
+    public TestParams testParams;
+
+    static class TestParams {
+        int sqlType;
+        int precision;
+        boolean signed;
+
+        TestParams(int sqlType, int precision, boolean signed) {
+            this.sqlType = sqlType;
+            this.precision = precision;
+            this.signed = signed;
+        }
+        private String humanReadableType() {
+            switch(sqlType){
+                case TINYINT:
+                    return "TINYINT";
+                case INTEGER:
+                    return "INTEGER";
+                case SMALLINT:
+                    return "SMALLINT";
+                case BIGINT:
+                    return "BIGINT";
+                default:
+                    return "UNKNOWN - ADD TO LIST";
+            }
+        }
+        private String humanReadableSigned() {
+            if(signed) return "SIGNED";
+            return "UNSIGNED";
+        }
+        public String toString(){
+            return String.format(
+                    "TestParams(SqlType=%s, Precision=%s, Signed=%s)",
+                    humanReadableType(),
+                    precision,
+                    humanReadableSigned());
+        }
+    }
+
+    @Test
+    public void testConvertToAvroStreamForNumbers() throws SQLException, IOException {
+        final ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+        when(metadata.getColumnCount()).thenReturn(1);
+        when(metadata.getColumnType(1)).thenReturn(testParams.sqlType);
+        when(metadata.isSigned(1)).thenReturn(testParams.signed);
+        when(metadata.getPrecision(1)).thenReturn(testParams.precision);
+        when(metadata.getColumnName(1)).thenReturn("t_int");
+        when(metadata.getTableName(1)).thenReturn("table");
+
+        final ResultSet rs = resultSetReturningMetadata(metadata);
+
+        final int ret = 0;
+        when(rs.getObject(Mockito.anyInt())).thenReturn(ret);
+
+        final InputStream instream = convertResultSetToAvroInputStream(rs);
+
+        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
+        try (final DataFileStream<GenericRecord> dataFileReader = new DataFileStream<>(instream, datumReader)) {
+            GenericRecord record = null;
+            while (dataFileReader.hasNext()) {
+                record = dataFileReader.next(record);
+                assertEquals(Integer.toString(ret), record.get("t_int").toString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refactors tests in order to share code repeated in tests and to enable some parameterized testing.

MySQL Connector/J 5.1.x in conjunction with MySQL 5.0.x will return a Long for ResultSet#getObject when the SQL type is an unsigned integer. This change prevents that error from occurring while implementing a more informational exception describing what the failing object's POJO type is in addition to its string value.

---

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root nifi folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] ~~If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?~~
- [ ] ~~If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?~~
- [ ] ~~If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?~~
- [ ] ~~If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?~~

### For documentation related changes:
- [ ] ~~Have you ensured that format looks appropriate for the output in which it is rendered?~~

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
