### PR TITLE
NIFI-5640: Improved efficiency of Avro Reader and some methods of Avr…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ServiceStateTransition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ServiceStateTransition.java
@@ -22,6 +22,9 @@ import org.apache.nifi.controller.ComponentNode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class ServiceStateTransition {
     private ControllerServiceState state = ControllerServiceState.DISABLED;
@@ -29,32 +32,45 @@ public class ServiceStateTransition {
     private final List<CompletableFuture<?>> disabledFutures = new ArrayList<>();
 
     private final ControllerServiceNode serviceNode;
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    private final Lock writeLock = rwLock.writeLock();
+    private final Lock readLock = rwLock.readLock();
 
     public ServiceStateTransition(final ControllerServiceNode serviceNode) {
         this.serviceNode = serviceNode;
     }
 
-    public synchronized boolean transitionToEnabling(final ControllerServiceState expectedState, final CompletableFuture<?> enabledFuture) {
-        if (expectedState != state) {
-            return false;
-        }
+    public boolean transitionToEnabling(final ControllerServiceState expectedState, final CompletableFuture<?> enabledFuture) {
+        writeLock.lock();
+        try {
+            if (expectedState != state) {
+                return false;
+            }
 
-        state = ControllerServiceState.ENABLING;
-        enabledFutures.add(enabledFuture);
-        return true;
+            state = ControllerServiceState.ENABLING;
+            enabledFutures.add(enabledFuture);
+            return true;
+        } finally {
+            writeLock.unlock();
+        }
     }
 
-    public synchronized boolean enable() {
-        if (state != ControllerServiceState.ENABLING) {
-            return false;
+    public boolean enable() {
+        writeLock.lock();
+        try {
+            if (state != ControllerServiceState.ENABLING) {
+                return false;
+            }
+
+            state = ControllerServiceState.ENABLED;
+
+            validateReferences(serviceNode);
+
+            enabledFutures.stream().forEach(future -> future.complete(null));
+            return true;
+        } finally {
+            writeLock.unlock();
         }
-
-        state = ControllerServiceState.ENABLED;
-
-        validateReferences(serviceNode);
-
-        enabledFutures.stream().forEach(future -> future.complete(null));
-        return true;
     }
 
     private void validateReferences(final ControllerServiceNode service) {
@@ -64,22 +80,37 @@ public class ServiceStateTransition {
         }
     }
 
-    public synchronized boolean transitionToDisabling(final ControllerServiceState expectedState, final CompletableFuture<?> disabledFuture) {
-        if (expectedState != state) {
-            return false;
+    public boolean transitionToDisabling(final ControllerServiceState expectedState, final CompletableFuture<?> disabledFuture) {
+        writeLock.lock();
+        try {
+            if (expectedState != state) {
+                return false;
+            }
+
+            state = ControllerServiceState.DISABLING;
+            disabledFutures.add(disabledFuture);
+            return true;
+        } finally {
+            writeLock.unlock();
         }
-
-        state = ControllerServiceState.DISABLING;
-        disabledFutures.add(disabledFuture);
-        return true;
     }
 
-    public synchronized void disable() {
-        state = ControllerServiceState.DISABLED;
-        disabledFutures.stream().forEach(future -> future.complete(null));
+    public void disable() {
+        writeLock.lock();
+        try {
+            state = ControllerServiceState.DISABLED;
+            disabledFutures.stream().forEach(future -> future.complete(null));
+        } finally {
+            writeLock.unlock();
+        }
     }
 
-    public synchronized ControllerServiceState getState() {
-        return state;
+    public ControllerServiceState getState() {
+        readLock.lock();
+        try {
+            return state;
+        } finally {
+            readLock.unlock();
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroReader.java
@@ -17,14 +17,6 @@
 
 package org.apache.nifi.avro;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.apache.avro.Schema;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -35,11 +27,18 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.schema.access.SchemaAccessStrategy;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.schemaregistry.services.SchemaRegistry;
-import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.SchemaRegistryService;
 import org.apache.nifi.serialization.record.RecordSchema;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Tags({"avro", "parse", "record", "row", "reader", "delimited", "comma", "separated", "values"})
 @CapabilityDescription("Parses Avro data and returns each Avro record as an separate Record object. The Avro data may contain the schema itself, "
@@ -83,7 +82,7 @@ public class AvroReader extends SchemaRegistryService implements RecordReaderFac
     }
 
     @Override
-    public RecordReader createRecordReader(final Map<String, String> variables, final InputStream in, final ComponentLog logger) throws MalformedRecordException, IOException, SchemaNotFoundException {
+    public RecordReader createRecordReader(final Map<String, String> variables, final InputStream in, final ComponentLog logger) throws IOException, SchemaNotFoundException {
         final String schemaAccessStrategy = getConfigurationContext().getProperty(getSchemaAcessStrategyDescriptor()).getValue();
         if (EMBEDDED_AVRO_SCHEMA.getValue().equals(schemaAccessStrategy)) {
             return new AvroReaderWithEmbeddedSchema(in);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroReaderWithEmbeddedSchema.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroReaderWithEmbeddedSchema.java
@@ -17,15 +17,13 @@
 
 package org.apache.nifi.avro;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
-import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.record.RecordSchema;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 public class AvroReaderWithEmbeddedSchema extends AvroRecordReader {
     private final DataFileStream<GenericRecord> dataFileStream;
@@ -35,7 +33,7 @@ public class AvroReaderWithEmbeddedSchema extends AvroRecordReader {
 
     public AvroReaderWithEmbeddedSchema(final InputStream in) throws IOException {
         this.in = in;
-        dataFileStream = new DataFileStream<>(in, new GenericDatumReader<GenericRecord>());
+        dataFileStream = new DataFileStream<>(in, new NonCachingDatumReader<>());
         this.avroSchema = dataFileStream.getSchema();
         recordSchema = AvroTypeUtil.createSchema(avroSchema);
     }
@@ -56,7 +54,7 @@ public class AvroReaderWithEmbeddedSchema extends AvroRecordReader {
     }
 
     @Override
-    public RecordSchema getSchema() throws MalformedRecordException {
+    public RecordSchema getSchema() {
         return recordSchema;
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroReaderWithExplicitSchema.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroReaderWithExplicitSchema.java
@@ -17,19 +17,16 @@
 
 package org.apache.nifi.avro;
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
-import org.apache.nifi.schema.access.SchemaNotFoundException;
-import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.record.RecordSchema;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class AvroReaderWithExplicitSchema extends AvroRecordReader {
     private final InputStream in;
@@ -38,11 +35,11 @@ public class AvroReaderWithExplicitSchema extends AvroRecordReader {
     private final BinaryDecoder decoder;
     private GenericRecord genericRecord;
 
-    public AvroReaderWithExplicitSchema(final InputStream in, final RecordSchema recordSchema, final Schema avroSchema) throws IOException, SchemaNotFoundException {
+    public AvroReaderWithExplicitSchema(final InputStream in, final RecordSchema recordSchema, final Schema avroSchema) {
         this.in = in;
         this.recordSchema = recordSchema;
 
-        datumReader = new GenericDatumReader<GenericRecord>(avroSchema);
+        datumReader = new NonCachingDatumReader<>(avroSchema);
         decoder = DecoderFactory.get().binaryDecoder(in, null);
     }
 
@@ -67,7 +64,7 @@ public class AvroReaderWithExplicitSchema extends AvroRecordReader {
     }
 
     @Override
-    public RecordSchema getSchema() throws MalformedRecordException {
+    public RecordSchema getSchema() {
         return recordSchema;
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/NonCachingDatumReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/NonCachingDatumReader.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.Decoder;
+
+import java.io.IOException;
+
+/**
+ * Override the GenericDatumReader to provide a much more efficient implementation of #readString. The one that is provided by
+ * GenericDatumReader performs very poorly in some cases because it uses an IdentityHashMap with the key being the Schema so that
+ * it can stash away the "stringClass" but that performs far worse than just calling JsonNode#getProp. I.e., {@link #readString(Object, Schema, Decoder)}
+ * in GenericDatumReader calls #getStringClass, which uses an IdentityHashMap to cache results in order to avoid calling {@link #findStringClass(Schema)}.
+ * However, {@link #findStringClass(Schema)} is much more efficient than using an IdentityHashMap anyway. Additionally, the performance of {@link #findStringClass(Schema)}}
+ * can be improved slightly and made more readable.
+ */
+public class NonCachingDatumReader<T> extends GenericDatumReader<T> {
+    public NonCachingDatumReader() {
+        super();
+    }
+
+    public NonCachingDatumReader(final Schema schema) {
+        super(schema);
+    }
+
+    @Override
+    protected Object readString(final Object old, final Schema expected, final Decoder in) throws IOException {
+        final Class<?> stringClass = findStringClass(expected);
+        if (stringClass == String.class) {
+            return in.readString();
+        }
+
+        if (stringClass == CharSequence.class) {
+            return readString(old, in);
+        }
+
+        return newInstanceFromString(stringClass, in.readString());
+    }
+
+    protected Class findStringClass(Schema schema) {
+        final String name = schema.getProp(GenericData.STRING_PROP);
+        if ("String".equals(name)) {
+            return String.class;
+        }
+
+        return CharSequence.class;
+    }
+}


### PR DESCRIPTION
…oTypeUtil. Also switched ServiceStateTransition to using read/write locks instead of synchronized blocks because profiling showed that significant time was spent in determining state of a Controller Service when attempting to use it. Switching to a ReadLock should provide better performance there.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
