### PR TITLE
NIFI-5645: Auto reconnect ConsumeWindowsEventLog

### DIFF
--- a/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
@@ -21,8 +21,8 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <jna.version>4.2.2</jna.version>
-        <javassist.version>3.20.0-GA</javassist.version>
+        <jna.version>4.5.2</jna.version>
+        <javassist.version>3.23.1-GA</javassist.version>
     </properties>
 
     <dependencies>

--- a/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
+++ b/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
@@ -230,11 +230,12 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
 
         subscriptionHandle = wEvtApi.EvtSubscribe(null, null, channel, query, null, null,
                 evtSubscribeCallback, WEvtApi.EvtSubscribeFlags.SUBSCRIBE_TO_FUTURE | WEvtApi.EvtSubscribeFlags.EVT_SUBSCRIBE_STRICT);
-        lastActivityTimestamp = System.currentTimeMillis();
 
         if (!isSubscribed()) {
             return UNABLE_TO_SUBSCRIBE + errorLookup.getLastError();
         }
+
+        lastActivityTimestamp = System.currentTimeMillis();
         return null;
     }
 

--- a/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
+++ b/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
@@ -20,6 +20,7 @@ package org.apache.nifi.processors.windows.event.log;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
 import com.sun.jna.platform.win32.WinNT;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.TriggerSerially;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -43,6 +46,7 @@ import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.AbstractSessionFactoryProcessor;
@@ -77,6 +81,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
             .defaultValue(DEFAULT_CHANNEL)
             .description("The Windows Event Log Channel to listen to.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
     public static final PropertyDescriptor QUERY = new PropertyDescriptor.Builder()
@@ -86,6 +91,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
             .defaultValue(DEFAULT_XPATH)
             .description("XPath Query to filter events. (See https://msdn.microsoft.com/en-us/library/windows/desktop/dd996910(v=vs.85).aspx for examples.)")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
     public static final PropertyDescriptor MAX_BUFFER_SIZE = new PropertyDescriptor.Builder()
@@ -108,7 +114,21 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(CHANNEL, QUERY, MAX_BUFFER_SIZE, MAX_EVENT_QUEUE_SIZE));
+    public static final PropertyDescriptor INACTIVE_DURATION_TO_RECONNECT = new PropertyDescriptor.Builder()
+            .name("inactiveDurationToReconnect")
+            .displayName("Inactive duration to reconnect")
+            .description("If no new event logs are processed for the specified time period," +
+                    " this processor will try reconnecting to recover from a state where any further messages cannot be consumed." +
+                    " Such situation can happen if Windows Event Log service is restarted, or ERROR_EVT_QUERY_RESULT_STALE (15011) is returned." +
+                    " Setting no duration, e.g. '0 ms' disables auto-reconnection.")
+            .required(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .defaultValue("10 mins")
+            .addValidator(StandardValidators.createTimePeriodValidator(0, TimeUnit.MILLISECONDS, Long.MAX_VALUE, TimeUnit.MILLISECONDS))
+            .build();
+
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(
+            Arrays.asList(CHANNEL, QUERY, MAX_BUFFER_SIZE, MAX_EVENT_QUEUE_SIZE, INACTIVE_DURATION_TO_RECONNECT));
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
@@ -133,6 +153,9 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
     private WinNT.HANDLE subscriptionHandle;
     private ProcessSessionFactory sessionFactory;
     private String provenanceUri;
+
+    private long inactiveDurationToReconnect = 0;
+    private long lastActivityTimestamp = 0;
 
     /**
      * Framework constructor
@@ -182,12 +205,20 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
      *
      * @param context the process context
      */
-    private String subscribe(ProcessContext context) throws URISyntaxException {
-        String channel = context.getProperty(CHANNEL).getValue();
-        String query = context.getProperty(QUERY).getValue();
+    private String subscribe(ProcessContext context) {
+        final String channel = context.getProperty(CHANNEL).evaluateAttributeExpressions().getValue();
+        final String query = context.getProperty(QUERY).evaluateAttributeExpressions().getValue();
 
         renderedXMLs = new LinkedBlockingQueue<>(context.getProperty(MAX_EVENT_QUEUE_SIZE).asInteger());
-        provenanceUri = new URI("winlog", name, "/" + channel, query, null).toASCIIString();
+
+        try {
+            provenanceUri = new URI("winlog", name, "/" + channel, query, null).toASCIIString();
+        } catch (URISyntaxException e) {
+            getLogger().debug("Failed to construct detailed provenanceUri from channel={}, query={}, use simpler one.", new Object[]{channel, query});
+            provenanceUri = String.format("winlog://%s/%s", name, channel);
+        }
+
+        inactiveDurationToReconnect = context.getProperty(INACTIVE_DURATION_TO_RECONNECT).evaluateAttributeExpressions().asTimePeriod(TimeUnit.MILLISECONDS);
 
         evtSubscribeCallback = new EventSubscribeXmlRenderingCallback(getLogger(), s -> {
             try {
@@ -199,6 +230,8 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
 
         subscriptionHandle = wEvtApi.EvtSubscribe(null, null, channel, query, null, null,
                 evtSubscribeCallback, WEvtApi.EvtSubscribeFlags.SUBSCRIBE_TO_FUTURE | WEvtApi.EvtSubscribeFlags.EVT_SUBSCRIBE_STRICT);
+        lastActivityTimestamp = System.currentTimeMillis();
+
         if (!isSubscribed()) {
             return UNABLE_TO_SUBSCRIBE + errorLookup.getLastError();
         }
@@ -210,7 +243,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
     }
 
     @OnScheduled
-    public void onScheduled(ProcessContext context) throws AlreadySubscribedException, URISyntaxException {
+    public void onScheduled(ProcessContext context) throws AlreadySubscribedException {
         if (isSubscribed()) {
             throw new AlreadySubscribedException(PROCESSOR_ALREADY_SUBSCRIBED);
         }
@@ -225,11 +258,8 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
      */
     @OnStopped
     public void stop() {
-        if (isSubscribed()) {
-            wEvtApi.EvtClose(subscriptionHandle);
-        }
-        subscriptionHandle = null;
-        evtSubscribeCallback = null;
+        unsubscribe();
+
         if (!renderedXMLs.isEmpty()) {
             if (sessionFactory != null) {
                 getLogger().info("Finishing processing leftover events");
@@ -246,29 +276,49 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
         renderedXMLs = null;
     }
 
+    private void unsubscribe() {
+        if (isSubscribed()) {
+            wEvtApi.EvtClose(subscriptionHandle);
+        }
+        subscriptionHandle = null;
+        evtSubscribeCallback = null;
+    }
+
     @Override
     public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
         this.sessionFactory = sessionFactory;
+
         if (!isSubscribed()) {
-            String errorMessage;
-            try {
-                errorMessage = subscribe(context);
-            } catch (URISyntaxException e) {
-                getLogger().error(e.getMessage(), e);
-                context.yield();
-                return;
-            }
+            String errorMessage = subscribe(context);
             if (errorMessage != null) {
                 context.yield();
                 getLogger().error(errorMessage);
                 return;
             }
         }
-        processQueue(sessionFactory.createSession());
+
+        final int flowFileCount = processQueue(sessionFactory.createSession());
+
+        final long now = System.currentTimeMillis();
+        if (flowFileCount > 0) {
+            lastActivityTimestamp = now;
+
+        } else if (inactiveDurationToReconnect > 0) {
+            if ((now - lastActivityTimestamp) > inactiveDurationToReconnect) {
+                getLogger().info("Exceeds configured 'inactive duration to reconnect' {} ms. Unsubscribe to reconnect..", new Object[]{inactiveDurationToReconnect});
+                unsubscribe();
+            }
+        }
     }
 
-    private void processQueue(ProcessSession session) {
+    /**
+     * Create FlowFiles from received logs.
+     * @return the number of created FlowFiles
+     */
+    private int processQueue(ProcessSession session) {
         String xml;
+        int flowFileCount = 0;
+
         while ((xml = renderedXMLs.peek()) != null) {
             FlowFile flowFile = session.create();
             byte[] xmlBytes = xml.getBytes(StandardCharsets.UTF_8);
@@ -277,6 +327,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
             session.getProvenanceReporter().receive(flowFile, provenanceUri);
             session.transfer(flowFile, REL_SUCCESS);
             session.commit();
+            flowFileCount++;
             if (!renderedXMLs.remove(xml) && getLogger().isWarnEnabled()) {
                 getLogger().warn(new StringBuilder("Event ")
                         .append(xml)
@@ -286,6 +337,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
                         .toString());
             }
         }
+        return flowFileCount;
     }
 
     @Override


### PR DESCRIPTION
Following screenshots illustrate before and after for this fix:

The left one is the patched one, right one is the released one ver 1.7.1.
![image](https://user-images.githubusercontent.com/1107620/46198490-8d913c00-c347-11e8-82d9-729346673e53.png)

Both can receive logs normally.
![image](https://user-images.githubusercontent.com/1107620/46198496-92ee8680-c347-11e8-94af-362da822de5e.png)

Now, restart Windows Event Log service.
![image](https://user-images.githubusercontent.com/1107620/46198507-9eda4880-c347-11e8-9b1c-93d3769deebf.png)

Restarting services generated 2 more logs. Both processors were able to get these. However, from this point, no further logs can be consumed. Need to restart processors manually to recover. That is the issue this patch trying to address.
![image](https://user-images.githubusercontent.com/1107620/46198525-a6015680-c347-11e8-8c1c-8085abc88689.png)

The updated processor automatically reconnect after seeing no new logs for the configured time period.
![image](https://user-images.githubusercontent.com/1107620/46198536-ae599180-c347-11e8-9258-988ae4dc061c.png)

Then, logs written after reconnection can be delivered successfully. See the current version misses that.
![image](https://user-images.githubusercontent.com/1107620/46198557-b6b1cc80-c347-11e8-93e9-d7aa6e49e90b.png)


---

This commit also contains following refactoring:
- Catch URISyntaxException inside subscribe when constructing provenance
URI as it does not affect the core responsibility of this processor.
Even if it fails to be a proper URI, if the query works for consuming
logs, the processor should proceed forward.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
