### PR TITLE
NIFI-5665 - Setting zookeeper's io.netty:netty transitive dependency …

### DIFF
--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -37,6 +37,12 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-atlas-reporting-task</artifactId>
                 <version>1.8.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -37,10 +37,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
@@ -30,4 +30,15 @@
 	<module>nifi-mock-record-utils</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
@@ -33,12 +33,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -601,6 +601,12 @@
                 <artifactId>commons-net</artifactId>
                 <version>3.6</version>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -602,10 +602,10 @@
                 <version>3.6</version>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -26,4 +26,14 @@
     <modules>
         <module>nifi-hadoop-libraries-nar</module>
     </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -29,10 +29,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -35,6 +35,17 @@
         <module>nifi-hive3-nar</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <properties>
         <hive.version>1.2.1</hive.version>
         <hive.hadoop.version>2.6.2</hive.hadoop.version>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -38,10 +38,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -77,6 +77,12 @@
                 <artifactId>nifi-kafka-2-0-processors</artifactId>
                 <version>1.8.0-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -78,10 +78,10 @@
                 <version>1.8.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
@@ -288,6 +288,22 @@
 
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-kite-processors</artifactId>
+                <version>1.8.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+    </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
@@ -288,16 +288,6 @@
 
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.nifi</groupId>
-                <artifactId>nifi-kite-processors</artifactId>
-                <version>1.8.0-SNAPSHOT</version>
-            </dependency>
-    </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
@@ -295,12 +295,6 @@
                 <artifactId>nifi-kite-processors</artifactId>
                 <version>1.8.0-SNAPSHOT</version>
             </dependency>
-            <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
-            </dependency>
     </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-kite-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/pom.xml
@@ -38,6 +38,12 @@
                 <artifactId>nifi-kite-processors</artifactId>
                 <version>1.8.0-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.6.9 due to CVE-2014-0193 -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.6.9.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -82,6 +82,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -82,17 +82,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
-        <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/nifi-nar-bundles/nifi-parquet-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/pom.xml
@@ -31,5 +31,14 @@
         <module>nifi-parquet-processors</module>
         <module>nifi-parquet-nar</module>
     </modules>
-
+    <dependencyManagement>
+        <!-- Explicitly force Netty to 3.6.9 due to CVE-2014-0193 -->
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.6.9.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-riemann-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-riemann-bundle/pom.xml
@@ -44,6 +44,12 @@
                 <artifactId>nifi-riemann-processors</artifactId>
                 <version>1.8.0-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-riemann-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-riemann-bundle/pom.xml
@@ -45,10 +45,10 @@
                 <version>1.8.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.6.9 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.6.9.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -63,6 +63,12 @@
                 <artifactId>jersey-client</artifactId>
                 <version>1.19.1</version>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -81,6 +87,5 @@
             <artifactId>nifi-processor-utils</artifactId>
             <version>1.8.0-SNAPSHOT</version>
         </dependency>
-
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -64,10 +64,10 @@
                 <version>1.19.1</version>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.8.2 due to CVE-2014-0193 -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.8.2.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -64,10 +64,10 @@
                 <version>1.19.1</version>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.8.2 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.8.2.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
@@ -82,6 +82,12 @@
                 <artifactId>hadoop-auth</artifactId>
                 <version>${hadoop.version}</version>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
@@ -83,10 +83,10 @@
                 <version>${hadoop.version}</version>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.6.9 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.6.9.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -47,7 +47,14 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
         </dependencies>
+
     </dependencyManagement>
     <dependencies>
         <dependency>

--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -48,10 +48,10 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <!-- Explicitly force Netty to 3.10.6 because versions prior to 3.9.0 had a CVE -->
+                <!-- Explicitly force Netty to 3.7.1 due to CVE-2014-0193 -->
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.6.Final</version>
+                <version>3.7.1.Final</version>
             </dependency>
         </dependencies>
 


### PR DESCRIPTION
…version to 3.10.6.Final.

NIFI-5665 - Setting all transitive io.netty dependencies to 3.10.6.Final.

NIFI-5665 - Added comments.

NIFI-5665 - Missed zookeeper in some spots.

NIFI-5665 - Reverted Flume version. The netty version contained was not listed explicitly as vulnerable.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
