### PR TITLE
NIFI-5604: Added property to allow empty FlowFile when no SQL generated by GenerateTableFetch

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -472,9 +472,8 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
                     Map<String, String> attributesToAdd = new HashMap<>();
 
                     whereClause = maxValueClauses.isEmpty() ? "1=1" : StringUtils.join(maxValueClauses, " AND ");
-                    if (StringUtils.isNotBlank(whereClause)) {
-                        attributesToAdd.put("generatetablefetch.whereClause", whereClause);
-                    }
+                    attributesToAdd.put("generatetablefetch.whereClause", whereClause);
+
                     attributesToAdd.put("generatetablefetch.limit", null);
                     if (partitionSize != 0) {
                         attributesToAdd.put("generatetablefetch.offset", null);
@@ -498,15 +497,13 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
                         whereClause = maxValueClauses.isEmpty() ? "1=1" : StringUtils.join(maxValueClauses, " AND ");
                         Long offset = partitionSize == 0 ? null : i * partitionSize + (useColumnValsForPaging ? minValueForPartitioning : 0);
 
-                           final String query = dbAdapter.getSelectStatement(tableName, columnNames, whereClause, maxColumnNames, limit, offset, columnForPartitioning);
+                        final String query = dbAdapter.getSelectStatement(tableName, columnNames, whereClause, maxColumnNames, limit, offset, columnForPartitioning);
                         FlowFile sqlFlowFile = (fileToProcess == null) ? session.create() : session.create(fileToProcess);
                         sqlFlowFile = session.write(sqlFlowFile, out -> out.write(query.getBytes()));
                         Map<String,String> attributesToAdd = new HashMap<>();
 
-                        if (StringUtils.isNotBlank(whereClause)) {
-                            attributesToAdd.put("generatetablefetch.whereClause", whereClause);
-                        }
-                        attributesToAdd.put("generatetablefetch.limit", String.valueOf(limit));
+                        attributesToAdd.put("generatetablefetch.whereClause", whereClause);
+                        attributesToAdd.put("generatetablefetch.limit", (limit == null) ? null : limit.toString());
                         if (partitionSize != 0) {
                             attributesToAdd.put("generatetablefetch.offset", String.valueOf(offset));
                         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -544,6 +544,37 @@ public class TestGenerateTableFetch {
     }
 
     @Test
+    public void testFlowFileGeneratedOnZeroResults() throws SQLException {
+
+        // load test data to database
+        final Connection con = ((DBCPService) runner.getControllerService("dbcp")).getConnection();
+        Statement stmt = con.createStatement();
+
+        try {
+            stmt.execute("drop table TEST_QUERY_DB_TABLE");
+        } catch (final SQLException sqle) {
+            // Ignore this error, probably a "table does not exist" since Derby doesn't yet support DROP IF EXISTS [DERBY-4842]
+        }
+
+        stmt.execute("create table TEST_QUERY_DB_TABLE (id integer not null, bucket integer not null)");
+
+        runner.setProperty(GenerateTableFetch.TABLE_NAME, "TEST_QUERY_DB_TABLE");
+        runner.setIncomingConnection(false);
+        runner.setProperty(GenerateTableFetch.MAX_VALUE_COLUMN_NAMES, "ID");
+        // Set partition size to 0 so we can see that the flow file gets all rows
+        runner.setProperty(GenerateTableFetch.PARTITION_SIZE, "1");
+        runner.setProperty(GenerateTableFetch.OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS, "false");
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 0);
+        runner.clearTransferState();
+
+        runner.setProperty(GenerateTableFetch.OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS, "true");
+        runner.run();
+        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
+    }
+
+    @Test
     public void testMultiplePartitions() throws ClassNotFoundException, SQLException, InitializationException, IOException {
 
         // load test data to database

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -54,6 +54,7 @@ import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor
 import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.REL_SUCCESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -560,6 +561,7 @@ public class TestGenerateTableFetch {
 
         runner.setProperty(GenerateTableFetch.TABLE_NAME, "TEST_QUERY_DB_TABLE");
         runner.setIncomingConnection(false);
+        runner.setProperty(GenerateTableFetch.COLUMN_NAMES, "ID,BUCKET");
         runner.setProperty(GenerateTableFetch.MAX_VALUE_COLUMN_NAMES, "ID");
         // Set partition size to 0 so we can see that the flow file gets all rows
         runner.setProperty(GenerateTableFetch.PARTITION_SIZE, "1");
@@ -572,6 +574,15 @@ public class TestGenerateTableFetch {
         runner.setProperty(GenerateTableFetch.OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS, "true");
         runner.run();
         runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(GenerateTableFetch.REL_SUCCESS).get(0);
+        assertEquals("TEST_QUERY_DB_TABLE", flowFile.getAttribute("generatetablefetch.tableName"));
+        assertEquals("ID,BUCKET", flowFile.getAttribute("generatetablefetch.columnNames"));
+        assertEquals("1=1", flowFile.getAttribute("generatetablefetch.whereClause"));
+        assertEquals("ID", flowFile.getAttribute("generatetablefetch.maxColumnNames"));
+        assertNull(flowFile.getAttribute("generatetablefetch.limit"));
+        assertNull(flowFile.getAttribute("generatetablefetch.offset"));
+        assertEquals("0", flowFile.getAttribute("fragment.index"));
+        assertEquals("0", flowFile.getAttribute("fragment.count"));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -540,7 +540,10 @@ public class TestGenerateTableFetch {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
-        runner.getFlowFilesForRelationship(GenerateTableFetch.REL_SUCCESS).get(0).assertContentEquals("SELECT * FROM TEST_QUERY_DB_TABLE WHERE ID <= 2 ORDER BY ID");
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(GenerateTableFetch.REL_SUCCESS).get(0);
+        flowFile.assertContentEquals("SELECT * FROM TEST_QUERY_DB_TABLE WHERE ID <= 2 ORDER BY ID");
+        flowFile.assertAttributeExists("generatetablefetch.limit");
+        flowFile.assertAttributeEquals("generatetablefetch.limit", null);
         runner.clearTransferState();
     }
 


### PR DESCRIPTION
Note that this should work with NIFI-5601 (#3074) such that the fragment attributes would be written to the empty flow file as well. Depending on which gets merged first, the other probably needs to be updated.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
