### PR TITLE
NIFI-5737: Removing need client auth property as cluster communications no longer support it

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -139,7 +139,6 @@ public abstract class NiFiProperties {
     public static final String SECURITY_TRUSTSTORE = "nifi.security.truststore";
     public static final String SECURITY_TRUSTSTORE_TYPE = "nifi.security.truststoreType";
     public static final String SECURITY_TRUSTSTORE_PASSWD = "nifi.security.truststorePasswd";
-    public static final String SECURITY_NEED_CLIENT_AUTH = "nifi.security.needClientAuth";
     public static final String SECURITY_USER_AUTHORIZER = "nifi.security.user.authorizer";
     public static final String SECURITY_USER_LOGIN_IDENTITY_PROVIDER = "nifi.security.user.login.identity.provider";
     public static final String SECURITY_OCSP_RESPONDER_URL = "nifi.security.ocsp.responder.url";
@@ -571,20 +570,6 @@ public abstract class NiFiProperties {
         } else {
             return new File(value);
         }
-    }
-
-    /**
-     * Will default to true unless the value is explicitly set to false.
-     *
-     * @return Whether client auth is required
-     */
-    public boolean getNeedClientAuth() {
-        boolean needClientAuth = true;
-        String rawNeedClientAuth = getProperty(SECURITY_NEED_CLIENT_AUTH);
-        if ("false".equalsIgnoreCase(rawNeedClientAuth)) {
-            needClientAuth = false;
-        }
-        return needClientAuth;
     }
 
     // getters for web properties //

--- a/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.blank.properties
+++ b/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.blank.properties
@@ -81,7 +81,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.missing.properties
+++ b/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.missing.properties
@@ -79,7 +79,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.properties
+++ b/nifi-commons/nifi-properties/src/test/resources/NiFiProperties/conf/nifi.properties
@@ -81,7 +81,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-docker/dockerhub/sh/start.sh
+++ b/nifi-docker/dockerhub/sh/start.sh
@@ -53,7 +53,6 @@ case ${AUTH} in
         echo 'Enabling LDAP user authentication'
         # Reference ldap-provider in properties
         prop_replace 'nifi.security.user.login.identity.provider' 'ldap-provider'
-        prop_replace 'nifi.security.needClientAuth' 'WANT'
 
         . "${scripts_dir}/secure.sh"
         . "${scripts_dir}/update_login_providers.sh"

--- a/nifi-docker/dockermaven/sh/start.sh
+++ b/nifi-docker/dockermaven/sh/start.sh
@@ -53,7 +53,6 @@ case ${AUTH} in
         echo 'Enabling LDAP user authentication'
         # Reference ldap-provider in properties
         prop_replace 'nifi.security.user.login.identity.provider' 'ldap-provider'
-        prop_replace 'nifi.security.needClientAuth' 'WANT'
 
         . "${scripts_dir}/secure.sh"
         . "${scripts_dir}/update_login_providers.sh"

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -168,7 +168,6 @@ NiFi provides several different configuration options for security purposes. The
 |`nifi.security.truststore` | Filename of the Truststore that will be used to authorize those connecting to NiFi.  A secured instance with no Truststore will refuse all incoming connections.
 |`nifi.security.truststoreType` | The type of the Truststore. Must be either `PKCS12` or `JKS`.  JKS is the preferred type, PKCS12 files will be loaded with BouncyCastle provider.
 |`nifi.security.truststorePasswd` | The password for the Truststore.
-|`nifi.security.needClientAuth` | Set to `true` to specify that connecting clients must authenticate themselves. This property is used by the NiFi cluster protocol to indicate that nodes in the cluster will be authenticated and must have certificates that are trusted by the Truststores. If not set, the default value is `true`.
 |==================================================================================================================================================
 
 Once the above properties have been configured, we can enable the User Interface to be accessed over HTTPS instead of HTTP. This is accomplished
@@ -179,14 +178,14 @@ properties can be specified.
 
 NOTE: It is important when enabling HTTPS that the `nifi.web.http.port` property be unset. NiFi only supports running on HTTP *or* HTTPS, not both simultaneously.
 
-Similar to `nifi.security.needClientAuth`, the web server can be configured to require certificate based client authentication for users accessing
-the User Interface. In order to do this it must be configured to not support username/password authentication using  <<ldap_login_identity_provider>> or <<kerberos_login_identity_provider>>. Either of these options
-will configure the web server to WANT certificate based client authentication. This will allow it to support users with certificates and those without
-that may be logging in with their credentials or those accessing anonymously. If username/password authentication and anonymous access are not configured,
-the web server will REQUIRE certificate based client authentication. See <<user_authentication>> for more details.
+NiFi's web server will REQUIRE certificate based client authentication for users accessing the User Interface when not configured with an alternative
+authentication mechanism which would require one way SSL (for instance LDAP, OpenId Connect, etc). Enabling an alternative authentication mechanism will
+configure the web server to WANT certificate base client authentication. This will allow it to support users with certificates and those without that
+may be logging in with credentials. See <<user_authentication>> for more details.
 
 Now that the User Interface has been secured, we can easily secure Site-to-Site connections and inner-cluster communications, as well. This is
-accomplished by setting the `nifi.remote.input.secure` and `nifi.cluster.protocol.is.secure` properties, respectively, to `true`.
+accomplished by setting the `nifi.remote.input.secure` and `nifi.cluster.protocol.is.secure` properties, respectively, to `true`. These communications
+will always REQUIRE two way SSL as the nodes will use their configured keystore/truststore for authentication.
 
 [[tls_generation_toolkit]]
 === TLS Generation Toolkit
@@ -3929,7 +3928,6 @@ These properties pertain to various security features in NiFi. Many of these pro
 |`nifi.security.truststore`*|The full path and name of the truststore. It is blank by default.
 |`nifi.security.truststoreType`|The truststore type. It is blank by default.
 |`nifi.security.truststorePasswd`|The truststore password. It is blank by default.
-|`nifi.security.needClientAuth`|This indicates whether client authentication in the cluster protocol. It is blank by default.
 |`nifi.security.user.authorizer`|Specifies which of the configured Authorizers in the _authorizers.xml_ file to use.  By default, it is set to `file-provider`.
 |`nifi.security.user.login.identity.provider`|This indicates what type of login identity provider to use. The default value is blank, can be set to the identifier from a provider
 in the file specified in `nifi.login.identity.provider.configuration.file`. Setting this property will trigger NiFi to support username/password authentication.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/resources/conf/nifi.properties
@@ -82,7 +82,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/spring/ServerSocketConfigurationFactoryBean.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/spring/ServerSocketConfigurationFactoryBean.java
@@ -36,7 +36,7 @@ public class ServerSocketConfigurationFactoryBean implements FactoryBean<ServerS
     public ServerSocketConfiguration getObject() throws Exception {
         if (configuration == null) {
             configuration = new ServerSocketConfiguration();
-            configuration.setNeedClientAuth(properties.getNeedClientAuth());
+            configuration.setNeedClientAuth(true);
 
             final int timeout = (int) FormatUtils.getTimeDuration(properties.getClusterNodeReadTimeout(), TimeUnit.MILLISECONDS);
             configuration.setSocketTimeout(timeout);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/resources/conf/nifi.properties
@@ -95,7 +95,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.authorizedUsers.file=./target/conf/authorized-users.xml
 nifi.security.user.credential.cache.duration=24 hours
 nifi.security.user.authority.provider=nifi.authorization.FileAuthorizationProvider

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -513,7 +513,7 @@ public class FlowController implements EventAccess, ControllerServiceProvider, R
         this.encryptor = encryptor;
         this.nifiProperties = nifiProperties;
         this.heartbeatMonitor = heartbeatMonitor;
-        sslContext = SslContextFactory.createSslContext(nifiProperties, false);
+        sslContext = SslContextFactory.createSslContext(nifiProperties);
         extensionManager = new ExtensionManager();
         this.clusterCoordinator = clusterCoordinator;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/manager/StandardStateManagerProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/manager/StandardStateManagerProvider.java
@@ -194,7 +194,7 @@ public class StandardStateManagerProvider implements StateManagerProvider{
             propertyMap.put(descriptor, new StandardPropertyValue(entry.getValue(),null, variableRegistry));
         }
 
-        final SSLContext sslContext = SslContextFactory.createSslContext(properties, false);
+        final SSLContext sslContext = SslContextFactory.createSslContext(properties);
         final ComponentLog logger = new SimpleProcessLogger(providerId, provider);
         final StateProviderInitializationContext initContext = new StandardStateProviderInitializationContext(providerId, propertyMap, sslContext, logger);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/registry/flow/StandardFlowRegistryClient.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/registry/flow/StandardFlowRegistryClient.java
@@ -17,16 +17,15 @@
 
 package org.apache.nifi.registry.flow;
 
+import org.apache.nifi.framework.security.util.SslContextFactory;
+import org.apache.nifi.util.NiFiProperties;
+
+import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import javax.net.ssl.SSLContext;
-
-import org.apache.nifi.framework.security.util.SslContextFactory;
-import org.apache.nifi.util.NiFiProperties;
 
 public class StandardFlowRegistryClient implements FlowRegistryClient {
     private NiFiProperties nifiProperties;
@@ -76,7 +75,7 @@ public class StandardFlowRegistryClient implements FlowRegistryClient {
 
         final FlowRegistry registry;
         if (uriScheme.equalsIgnoreCase("http") || uriScheme.equalsIgnoreCase("https")) {
-            final SSLContext sslContext = SslContextFactory.createSslContext(nifiProperties, false);
+            final SSLContext sslContext = SslContextFactory.createSslContext(nifiProperties);
             if (sslContext == null && uriScheme.equalsIgnoreCase("https")) {
                 throw new IllegalStateException("Failed to create Flow Registry for URI " + registryUrl
                     + " because this NiFi is not configured with a Keystore/Truststore, so it is not capable of communicating with a secure Registry. "

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/conf/nifi.properties
@@ -80,7 +80,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/flowcontrollertest.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/flowcontrollertest.nifi.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/lifecycletest.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/lifecycletest.nifi.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/nifi-with-remote.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/nifi-with-remote.properties
@@ -80,7 +80,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/standardflowserializertest.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/standardflowserializertest.nifi.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/standardflowsynchronizerspec.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/standardflowsynchronizerspec.nifi.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/standardprocessschedulertest.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/standardprocessschedulertest.nifi.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/test/resources/NarUnpacker/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/test/resources/NarUnpacker/conf/nifi.properties
@@ -83,7 +83,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/test/resources/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/test/resources/nifi.properties
@@ -143,7 +143,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/test/resources/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/test/resources/nifi.properties
@@ -143,7 +143,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/bootstrap_tests/conf/nifi_with_sensitive_properties_protected_aes.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/bootstrap_tests/conf/nifi_with_sensitive_properties_protected_aes.properties
@@ -86,7 +86,6 @@ nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=/X/RSlNr2QCJ1Kwe||dENJevX5P61ix+97airrtoBQoyasMFS6DG6fHbX+SZtw2VAMllSSnDeT97Q=
 nifi.security.truststorePasswd.protected=aes/gcm/256
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi.blank.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi.blank.properties
@@ -81,7 +81,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi.missing.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi.missing.properties
@@ -79,7 +79,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi.properties
@@ -81,7 +81,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_additional_sensitive_keys.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_additional_sensitive_keys.properties
@@ -82,7 +82,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_all_sensitive_properties_protected_aes.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_all_sensitive_properties_protected_aes.properties
@@ -86,7 +86,6 @@ nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=/X/RSlNr2QCJ1Kwe||dENJevX5P61ix+97airrtoBQoyasMFS6DG6fHbX+SZtw2VAMllSSnDeT97Q=
 nifi.security.truststorePasswd.protected=aes/gcm/256
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_recursive_additional_sensitive_keys.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_recursive_additional_sensitive_keys.properties
@@ -82,7 +82,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/256
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_128.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_128.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/128
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_128_password.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_128_password.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/128
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_multiple_malformed.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_multiple_malformed.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/256
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_single_malformed.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_aes_single_malformed.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/256
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_unknown.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_protected_unknown.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=unknown
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_unprotected.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_unprotected.properties
@@ -82,7 +82,6 @@ nifi.security.keyPasswd=thisIsABadKeyPassword
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_unprotected_extra_line.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/conf/nifi_with_sensitive_properties_unprotected_extra_line.properties
@@ -83,7 +83,6 @@ nifi.security.keyPasswd=thisIsABadKeyPassword
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -144,7 +144,6 @@
         <nifi.security.truststore />
         <nifi.security.truststoreType />
         <nifi.security.truststorePasswd />
-        <nifi.security.needClientAuth />
         <nifi.security.user.authorizer>managed-authorizer</nifi.security.user.authorizer>
         <nifi.security.user.login.identity.provider />
         <nifi.security.x509.principal.extractor />

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -158,7 +158,6 @@ nifi.security.keyPasswd=${nifi.security.keyPasswd}
 nifi.security.truststore=${nifi.security.truststore}
 nifi.security.truststoreType=${nifi.security.truststoreType}
 nifi.security.truststorePasswd=${nifi.security.truststorePasswd}
-nifi.security.needClientAuth=${nifi.security.needClientAuth}
 nifi.security.user.authorizer=${nifi.security.user.authorizer}
 nifi.security.user.login.identity.provider=${nifi.security.user.login.identity.provider}
 nifi.security.ocsp.responder.url=${nifi.security.ocsp.responder.url}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi.properties
@@ -141,7 +141,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes.properties
@@ -142,7 +142,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes_128.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes_128.properties
@@ -142,7 +142,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes_different_key.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes_different_key.properties
@@ -145,7 +145,6 @@ nifi.security.keyPasswd.protected=aes/gcm/256
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes_different_key_128.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/test/resources/NiFiProperties/conf/nifi_with_sensitive_properties_protected_aes_different_key_128.properties
@@ -145,7 +145,6 @@ nifi.security.keyPasswd.protected=aes/gcm/128
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-security/src/test/java/org/apache/nifi/framework/security/util/SslContextFactoryTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-security/src/test/java/org/apache/nifi/framework/security/util/SslContextFactoryTest.java
@@ -17,11 +17,13 @@
 package org.apache.nifi.framework.security.util;
 
 import org.apache.nifi.security.util.KeystoreType;
-import java.io.File;
 import org.apache.nifi.util.NiFiProperties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +44,6 @@ public class SslContextFactoryTest {
         when(authProps.getProperty(NiFiProperties.SECURITY_KEYSTORE)).thenReturn(ksFile.getAbsolutePath());
         when(authProps.getProperty(NiFiProperties.SECURITY_KEYSTORE_TYPE)).thenReturn(KeystoreType.JKS.toString());
         when(authProps.getProperty(NiFiProperties.SECURITY_KEYSTORE_PASSWD)).thenReturn("passwordpassword");
-        when(authProps.getNeedClientAuth()).thenReturn(false);
 
         mutualAuthProps = mock(NiFiProperties.class);
         when(mutualAuthProps.getProperty(NiFiProperties.SECURITY_KEYSTORE)).thenReturn(ksFile.getAbsolutePath());
@@ -51,7 +52,6 @@ public class SslContextFactoryTest {
         when(mutualAuthProps.getProperty(NiFiProperties.SECURITY_TRUSTSTORE)).thenReturn(trustFile.getAbsolutePath());
         when(mutualAuthProps.getProperty(NiFiProperties.SECURITY_TRUSTSTORE_TYPE)).thenReturn(KeystoreType.JKS.toString());
         when(mutualAuthProps.getProperty(NiFiProperties.SECURITY_TRUSTSTORE_PASSWD)).thenReturn("passwordpassword");
-        when(mutualAuthProps.getNeedClientAuth()).thenReturn(true);
 
     }
 
@@ -60,9 +60,9 @@ public class SslContextFactoryTest {
         Assert.assertNotNull(SslContextFactory.createSslContext(mutualAuthProps));
     }
 
-    @Test
+    @Test(expected = SslContextCreationException.class)
     public void testCreateSslContextWithNoMutualAuth() {
-        Assert.assertNotNull(SslContextFactory.createSslContext(authProps));
+        SslContextFactory.createSslContext(authProps);
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/resources/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/resources/nifi.properties
@@ -61,7 +61,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=src/test/resources/dummy-certs/localhost-ts.jks
 nifi.security.truststoreType=JKS
 nifi.security.truststorePasswd=localtest
-nifi.security.needClientAuth=true
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi-flow.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi-flow.properties
@@ -96,7 +96,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=target/test-classes/access-control/truststore.jks
 nifi.security.truststoreType=JKS
 nifi.security.truststorePasswd=passwordpassword
-nifi.security.needClientAuth=true
 nifi.security.user.login.identity.provider=test-provider
 nifi.security.user.authorizer=flow-test-provider
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/nifi.properties
@@ -96,7 +96,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=target/test-classes/access-control/truststore.jks
 nifi.security.truststoreType=JKS
 nifi.security.truststorePasswd=passwordpassword
-nifi.security.needClientAuth=true
 nifi.security.user.login.identity.provider=test-provider
 nifi.security.user.authorizer=test-provider
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/site-to-site/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/site-to-site/nifi.properties
@@ -137,7 +137,6 @@ nifi.security.keyPasswd=${nifi.security.keyPasswd}
 nifi.security.truststore=${nifi.security.truststore}
 nifi.security.truststoreType=${nifi.security.truststoreType}
 nifi.security.truststorePasswd=${nifi.security.truststorePasswd}
-nifi.security.needClientAuth=${nifi.security.needClientAuth}
 nifi.security.user.authorizer=${nifi.security.user.authorizer}
 nifi.security.user.login.identity.provider=${nifi.security.user.login.identity.provider}
 nifi.security.ocsp.responder.url=${nifi.security.ocsp.responder.url}

--- a/nifi-toolkit/nifi-toolkit-admin/src/test/resources/notify/conf/nifi-secured.properties
+++ b/nifi-toolkit/nifi-toolkit-admin/src/test/resources/notify/conf/nifi-secured.properties
@@ -62,7 +62,6 @@ nifi.security.keyPasswd=badKeyPass
 nifi.security.truststore=target/tmp/keys/localhost/truststore.jks
 nifi.security.truststoreType=JKS
 nifi.security.truststorePasswd=badTrustPass
-nifi.security.needClientAuth=true
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-admin/src/test/resources/notify/conf/nifi.properties
+++ b/nifi-toolkit/nifi-toolkit-admin/src/test/resources/notify/conf/nifi.properties
@@ -143,7 +143,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=

--- a/nifi-toolkit/nifi-toolkit-admin/src/test/resources/notify/conf_secure/nifi.properties
+++ b/nifi-toolkit/nifi-toolkit-admin/src/test/resources/notify/conf_secure/nifi.properties
@@ -62,7 +62,6 @@ nifi.security.keyPasswd=badKeyPass
 nifi.security.truststore=target/tmp/keys/localhost/truststore.jks
 nifi.security.truststoreType=JKS
 nifi.security.truststorePasswd=badTrustPass
-nifi.security.needClientAuth=true
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_default.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_default.properties
@@ -82,7 +82,6 @@ nifi.security.keyPasswd=
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/256
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes_128.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes_128.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/128
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes_password.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes_password.properties
@@ -85,7 +85,6 @@ nifi.security.keyPasswd.protected=aes/gcm/256
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes_password_128.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_protected_aes_password_128.properties
@@ -86,7 +86,6 @@ nifi.security.keyPasswd.protected=aes/gcm/128
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_unprotected.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_unprotected.properties
@@ -82,7 +82,6 @@ nifi.security.keyPasswd=thisIsABadKeyPassword
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_unprotected_and_empty_protection_schemes.properties
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi_with_sensitive_properties_unprotected_and_empty_protection_schemes.properties
@@ -84,7 +84,6 @@ nifi.security.keyPasswd=thisIsABadKeyPassword
 nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=
 
 # cluster common properties (cluster manager and nodes must have same values) #

--- a/nifi-toolkit/nifi-toolkit-s2s/src/main/java/org/apache/nifi/toolkit/s2s/SiteToSiteCliMain.java
+++ b/nifi-toolkit/nifi-toolkit-s2s/src/main/java/org/apache/nifi/toolkit/s2s/SiteToSiteCliMain.java
@@ -72,7 +72,6 @@ public class SiteToSiteCliMain {
     public static final String PROXY_PASSWORD_OPTION = "proxyPassword";
     public static final String PROXY_PORT_OPTION_DEFAULT = "80";
     public static final String KEYSTORE_TYPE_OPTION_DEFAULT = KeystoreType.JKS.toString();
-    public static final String NEED_CLIENT_AUTH_OPTION = "needClientAuth";
 
     /**
      * Prints the usage to System.out
@@ -141,7 +140,6 @@ public class SiteToSiteCliMain {
         options.addOption(null, TRUST_STORE_OPTION, true, "Truststore");
         options.addOption(null, TRUST_STORE_TYPE_OPTION, true, "Truststore type (default: " + KEYSTORE_TYPE_OPTION_DEFAULT + ")");
         options.addOption(null, TRUST_STORE_PASSWORD_OPTION, true, "Truststore password");
-        options.addOption(null, NEED_CLIENT_AUTH_OPTION, false, "Need client auth");
         options.addOption("c", COMPRESSION_OPTION, false, "Use compression");
         options.addOption(null, PEER_PERSISTENCE_FILE_OPTION, true, "File to write peer information to so it can be recovered on restart");
         options.addOption("p", TRANSPORT_PROTOCOL_OPTION, true, "Site to site transport protocol (default: " + TRANSPORT_PROTOCOL_OPTION_DEFAULT + ")");

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/resources/localhost/nifi.properties
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/resources/localhost/nifi.properties
@@ -140,7 +140,6 @@ nifi.security.keyPasswd=qgs57rmnot6p8gm97pfjutnu5g
 nifi.security.truststore=./conf/truststore.jks
 nifi.security.truststoreType=jks
 nifi.security.truststorePasswd=t7rmn1fg8np2ck1sduqdd85opv
-nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=


### PR DESCRIPTION
NIFI-5737:
- Removing needClientAuth property since cluster comms now requires two way ssl. Jetty client auth settings are based on configured features.
- Removing dead code.
- Updating documentation.
- Removing references to needClientAuth property in all test resources.
- Removing overloaded util method with strict parameter.