### PR TITLE
NIFI-4715: ListS3 produces duplicates in frequently updated buckets

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
@@ -230,7 +230,7 @@ public class ListS3 extends AbstractS3Processor {
         final AmazonS3 client = getClient();
         int listCount = 0;
         int totalListCount = 0;
-        long maxTimestamp = currentTimestamp;
+        long latestListedTimestampInThisCycle = currentTimestamp;
         String delimiter = context.getProperty(DELIMITER).getValue();
         String prefix = context.getProperty(PREFIX).evaluateAttributeExpressions().getValue();
 
@@ -252,6 +252,9 @@ public class ListS3 extends AbstractS3Processor {
         }
 
         VersionListing versionListing;
+        final Set<String> listedKeys = new HashSet<>();
+        getLogger().trace("Start listing, listingTimestamp={}, currentTimestamp={}, currentKeys={}", new Object[]{listingTimestamp, currentTimestamp, currentKeys});
+
         do {
             versionListing = bucketLister.listVersions();
             for (S3VersionSummary versionSummary : versionListing.getVersionSummaries()) {
@@ -261,6 +264,8 @@ public class ListS3 extends AbstractS3Processor {
                         || lastModified > (listingTimestamp - minAgeMilliseconds)) {
                     continue;
                 }
+
+                getLogger().trace("Listed key={}, lastModified={}, currentKeys={}", new Object[]{versionSummary.getKey(), lastModified, currentKeys});
 
                 // Create the attributes
                 final Map<String, String> attributes = new HashMap<>();
@@ -287,14 +292,17 @@ public class ListS3 extends AbstractS3Processor {
                 flowFile = session.putAllAttributes(flowFile, attributes);
                 session.transfer(flowFile, REL_SUCCESS);
 
-                // Update state
-                if (lastModified > maxTimestamp) {
-                    maxTimestamp = lastModified;
-                    currentKeys.clear();
+                // Track the latest lastModified timestamp and keys having that timestamp.
+                // NOTE: Amazon S3 lists objects in UTF-8 character encoding in lexicographical order. Not ordered by timestamps.
+                if (lastModified > latestListedTimestampInThisCycle) {
+                    latestListedTimestampInThisCycle = lastModified;
+                    listedKeys.clear();
+                    listedKeys.add(versionSummary.getKey());
+
+                } else if (lastModified == latestListedTimestampInThisCycle) {
+                    listedKeys.add(versionSummary.getKey());
                 }
-                if (lastModified == maxTimestamp) {
-                    currentKeys.add(versionSummary.getKey());
-                }
+
                 listCount++;
             }
             bucketLister.setNextMarker();
@@ -304,8 +312,14 @@ public class ListS3 extends AbstractS3Processor {
             listCount = 0;
         } while (bucketLister.isTruncated());
 
+        // Update currentKeys.
+        if (latestListedTimestampInThisCycle > currentTimestamp) {
+            currentKeys.clear();
+        }
+        currentKeys.addAll(listedKeys);
+
         // Update stateManger with the most recent timestamp
-        currentTimestamp = maxTimestamp;
+        currentTimestamp = latestListedTimestampInThisCycle;
         persistState(context);
 
         final long listMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);


### PR DESCRIPTION
This PR is based on #2361. To preserve @adamlamar's credit, please do not squash the first commit when merging. Thanks!

The 2nd commit avoids updating `currentKeys` during the listing loop. Before this fix, it's easy to reproduce duplicated list with a small number of objects. E.g 10 objects to S3 uploaded at the same time, ListS3 can produce 27 FlowFiles. Using min age doesn't address the issue.

Please use [the template file attached to the JIRA](https://issues.apache.org/jira/secure/attachment/12946341/ListS3_Duplication.xml) to reproduce.

After applying this fix, I confirmed ListS3 can produce FlowFiles without duplication. I tested 10,000 objects were listed without duplication while those were uploaded by PutS3 and listed by ListS3 simultaneously.


---

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
