### PR TITLE
NIFI-5770 Fix Memory Leak in ExecuteScript on Jython

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/impl/JythonScriptEngineConfigurator.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/impl/JythonScriptEngineConfigurator.java
@@ -41,6 +41,16 @@ public class JythonScriptEngineConfigurator implements ScriptEngineConfigurator 
 
     @Override
     public Object init(ScriptEngine engine, String[] modulePaths) throws ScriptException {
+        if (engine != null) {
+            // Need to import the module path inside the engine, in order to pick up
+            // other Python/Jython modules.
+            engine.eval("import sys");
+            if (modulePaths != null) {
+                for (String modulePath : modulePaths) {
+                    engine.eval("sys.path.append('" + modulePath + "')");
+                }
+            }
+        }
         return null;
     }
 
@@ -48,14 +58,6 @@ public class JythonScriptEngineConfigurator implements ScriptEngineConfigurator 
     public Object eval(ScriptEngine engine, String scriptBody, String[] modulePaths) throws ScriptException {
         Object returnValue = null;
         if (engine != null) {
-            // Need to import the module path inside the engine, in order to pick up
-            // other Python/Jython modules
-            engine.eval("import sys");
-            if (modulePaths != null) {
-                for (String modulePath : modulePaths) {
-                    engine.eval("sys.path.append('" + modulePath + "')");
-                }
-            }
             returnValue = engine.eval(scriptBody);
         }
         return returnValue;


### PR DESCRIPTION
Moved module appending (aka classpath in python) into init stage instead of running each time onTrigger.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
