### PR TITLE
NIFI-5792: Remember created versioned flow information

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -3041,6 +3041,10 @@ public final class StandardProcessGroup implements ProcessGroup {
             }
 
             private boolean isModified() {
+                if (versionControlInformation.getVersion() == 0) {
+                    return true;
+                }
+
                 Set<FlowDifference> differences = versionControlFields.getFlowDifferences();
                 if (differences == null) {
                     differences = getModifications();
@@ -3094,7 +3098,7 @@ public final class StandardProcessGroup implements ProcessGroup {
         final VersionedFlowState flowState = versionControlInformation.getStatus().getState();
         versionControlFields.setStale(flowState == VersionedFlowState.STALE || flowState == VersionedFlowState.LOCALLY_MODIFIED_AND_STALE);
         versionControlFields.setLocallyModified(flowState == VersionedFlowState.LOCALLY_MODIFIED || flowState == VersionedFlowState.LOCALLY_MODIFIED_AND_STALE);
-        versionControlFields.setSyncFailureExplanation(null);
+        versionControlFields.setSyncFailureExplanation(flowState == VersionedFlowState.SYNC_FAILURE ? versionControlInformation.getStatus().getStateExplanation() : null);
 
         writeLock.lock();
         try {
@@ -3255,7 +3259,7 @@ public final class StandardProcessGroup implements ProcessGroup {
         }
 
         final VersionedProcessGroup snapshot = vci.getFlowSnapshot();
-        if (snapshot == null) {
+        if (snapshot == null && vci.getVersion() > 0) {
             // We have not yet obtained the snapshot from the Flow Registry, so we need to request the snapshot of our local version of the flow from the Flow Registry.
             // This allows us to know whether or not the flow has been modified since it was last synced with the Flow Registry.
             try {
@@ -3282,8 +3286,13 @@ public final class StandardProcessGroup implements ProcessGroup {
             vci.setRegistryName(flowRegistry.getName());
 
             if (latestVersion == vci.getVersion()) {
-                LOG.debug("{} is currently at the most recent version ({}) of the flow that is under Version Control", this, latestVersion);
                 versionControlFields.setStale(false);
+                if (latestVersion == 0) {
+                    LOG.debug("{} does not have any version in the Registry", this, latestVersion);
+                    versionControlFields.setLocallyModified(true);
+                } else {
+                    LOG.debug("{} is currently at the most recent version ({}) of the flow that is under Version Control", this, latestVersion);
+                }
             } else {
                 LOG.info("{} is not the most recent version of the flow that is under Version Control; current version is {}; most recent version is {}",
                     new Object[] {this, vci.getVersion(), latestVersion});

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
@@ -421,6 +421,13 @@
             url: '../nifi-api/versions/process-groups/' + encodeURIComponent(processGroupId),
             dataType: 'json',
             contentType: 'application/json'
+        }).done(function (response) {
+            if ('SYNC_FAILURE' === response.versionControlInformation.state) {
+                nfDialog.showOkDialog({
+                    headerText: 'Error',
+                    dialogContent: response.versionControlInformation.stateExplanation
+                });
+            }
         }).fail(nfErrorHandler.handleAjaxError);
     };
 


### PR DESCRIPTION
- Before this fix, NiFi loses information about created versioned flow in case of subsequent snapshot creation failure, and NiFi API returned an error response
- This commit makes:
  - The created versioned Flow information is stored even if subsequent snapshot creation fails
  - NiFi API to return a successful 200 response in that case, but return versioned flow status as SYNC_FAILURE with an explanation. NiFi UI shows a popup error dialog with the explanation.
  - Versioned flow status will be LOCALLY_MODIFIED if the latest version is 0.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
