### PR TITLE
NIFI-5652: Fixed LogMessage when logging level is disabled

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogMessage.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogMessage.java
@@ -156,12 +156,9 @@ public class LogMessage extends AbstractProcessor {
                 break;
         }
 
-        if (!isLogLevelEnabled) {
-            transferChunk(session);
-            return;
+        if (isLogLevelEnabled) {
+            processFlowFile(logger, logLevel, flowFile, context);
         }
-
-        processFlowFile(logger, logLevel, flowFile, context);
         session.transfer(flowFile, REL_SUCCESS);
     }
 
@@ -202,12 +199,4 @@ public class LogMessage extends AbstractProcessor {
                 logger.debug(messageToWrite);
         }
     }
-
-    private void transferChunk(final ProcessSession session) {
-        final List<FlowFile> flowFiles = session.get(CHUNK_SIZE);
-        if (!flowFiles.isEmpty()) {
-            session.transfer(flowFiles, REL_SUCCESS);
-        }
-    }
-
 }


### PR DESCRIPTION
I couldn't write a unit test as I can't change the log level in between unit tests. I reproduced the issue and verified it is no longer present with a live NiFi instance running with this patch.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
