### PR TITLE
NIFI-5826 Fix to escaped backslash

### DIFF
--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/filter/ContainsRegex.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/filter/ContainsRegex.java
@@ -24,6 +24,7 @@ import org.apache.nifi.record.path.FieldValue;
 import org.apache.nifi.record.path.RecordPathEvaluationContext;
 import org.apache.nifi.record.path.paths.LiteralValuePath;
 import org.apache.nifi.record.path.paths.RecordPathSegment;
+import org.apache.nifi.record.path.util.RecordPathUtils;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
 
 public class ContainsRegex extends FunctionFilter {
@@ -39,7 +40,7 @@ public class ContainsRegex extends FunctionFilter {
         if (regexPath instanceof LiteralValuePath) {
             final FieldValue fieldValue = ((LiteralValuePath) regexPath).evaluate((RecordPathEvaluationContext) null).findFirst().get();
             final Object value = fieldValue.getValue();
-            final String regex = DataTypeUtils.toString(value, (String) null);
+            final String regex = RecordPathUtils.unescapeBackslash(DataTypeUtils.toString(value, (String) null));
             compiledPattern = Pattern.compile(regex);
         } else {
             compiledPattern = null;
@@ -60,7 +61,7 @@ public class ContainsRegex extends FunctionFilter {
                 return false;
             }
 
-            final String regex = DataTypeUtils.toString(value, (String) null);
+            final String regex = RecordPathUtils.unescapeBackslash(DataTypeUtils.toString(value, (String) null));
             pattern = Pattern.compile(regex);
         } else {
             pattern = compiledPattern;

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/filter/MatchesRegex.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/filter/MatchesRegex.java
@@ -24,6 +24,7 @@ import org.apache.nifi.record.path.FieldValue;
 import org.apache.nifi.record.path.RecordPathEvaluationContext;
 import org.apache.nifi.record.path.paths.LiteralValuePath;
 import org.apache.nifi.record.path.paths.RecordPathSegment;
+import org.apache.nifi.record.path.util.RecordPathUtils;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
 
 public class MatchesRegex extends FunctionFilter {
@@ -39,7 +40,7 @@ public class MatchesRegex extends FunctionFilter {
         if (regexPath instanceof LiteralValuePath) {
             final FieldValue fieldValue = ((LiteralValuePath) regexPath).evaluate((RecordPathEvaluationContext) null).findFirst().get();
             final Object value = fieldValue.getValue();
-            final String regex = DataTypeUtils.toString(value, (String) null);
+            final String regex = RecordPathUtils.unescapeBackslash(DataTypeUtils.toString(value, (String) null));
             compiledPattern = Pattern.compile(regex);
         } else {
             compiledPattern = null;
@@ -60,7 +61,7 @@ public class MatchesRegex extends FunctionFilter {
                 return false;
             }
 
-            final String regex = DataTypeUtils.toString(value, (String) null);
+            final String regex = RecordPathUtils.unescapeBackslash(DataTypeUtils.toString(value, (String) null));
             pattern = Pattern.compile(regex);
         } else {
             pattern = compiledPattern;

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/ReplaceRegex.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/ReplaceRegex.java
@@ -45,7 +45,8 @@ public class ReplaceRegex extends RecordPathSegment {
         if (searchValue instanceof LiteralValuePath) {
             final FieldValue fieldValue = ((LiteralValuePath) searchValue).evaluate((RecordPathEvaluationContext) null).findFirst().get();
             final Object value = fieldValue.getValue();
-            final String regex = DataTypeUtils.toString(value, (String) null);
+            final String regex = RecordPathUtils.unescapeBackslash(DataTypeUtils.toString(value, (String) null));
+
             compiledPattern = Pattern.compile(regex);
         } else {
             compiledPattern = null;
@@ -79,7 +80,7 @@ public class ReplaceRegex extends RecordPathSegment {
                         return fv;
                     }
 
-                    final String regex = DataTypeUtils.toString(fieldValue, (String) null);
+                    final String regex = RecordPathUtils.unescapeBackslash(DataTypeUtils.toString(fieldValue, (String) null));
                     pattern = Pattern.compile(regex);
                 } else {
                     pattern = compiledPattern;

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/util/RecordPathUtils.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/util/RecordPathUtils.java
@@ -39,4 +39,44 @@ public class RecordPathUtils {
 
         return stringValue;
     }
+
+    public static String unescapeBackslash(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        // need to escape characters after backslashes
+        final StringBuilder sb = new StringBuilder();
+        boolean lastCharIsBackslash = false;
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+
+            if (lastCharIsBackslash) {
+                switch (c) {
+                case 'n':
+                    sb.append("\n");
+                    break;
+                case 'r':
+                    sb.append("\r");
+                    break;
+                case '\\':
+                    sb.append("\\");
+                    break;
+                case 't':
+                    sb.append("\\t");
+                    break;
+                default:
+                    sb.append("\\").append(c);
+                    break;
+                }
+
+                lastCharIsBackslash = false;
+            } else if (c == '\\') {
+                lastCharIsBackslash = true;
+            } else {
+                sb.append(c);
+            }
+        }
+
+        return sb.toString();
+    }
 }

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -1008,12 +1008,16 @@ public class TestRecordPath {
         final List<RecordField> fields = new ArrayList<>();
         fields.add(new RecordField("id", RecordFieldType.INT.getDataType()));
         fields.add(new RecordField("name", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("name1", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("name2", RecordFieldType.STRING.getDataType()));
 
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         final Map<String, Object> values = new HashMap<>();
         values.put("id", 48);
         values.put("name", "John Doe");
+        values.put("name1", "John\\Doe");
+        values.put("name2", "John[]Doe");
         final Record record = new MapRecord(schema, values);
 
         assertEquals("ohn oe", RecordPath.compile("replaceRegex(/name, '[JD]', '')").evaluate(record).getSelectedFields().findFirst().get().getValue());
@@ -1026,6 +1030,11 @@ public class TestRecordPath {
         assertEquals("Jxohn Dxoe", RecordPath.compile("replaceRegex(/name, '(?<hello>[JD])', '${hello}x')").evaluate(record).getSelectedFields().findFirst().get().getValue());
 
         assertEquals("48ohn 48oe", RecordPath.compile("replaceRegex(/name, '(?<hello>[JD])', /id)").evaluate(record).getSelectedFields().findFirst().get().getValue());
+
+        assertEquals("John48Doe", RecordPath.compile("replaceRegex(/name1, '\\\\\\\\', /id)").evaluate(record).getSelectedFields().findFirst().get().getValue());
+        assertEquals("John48Doe", RecordPath.compile("replaceRegex(/name, '\\s', /id)").evaluate(record).getSelectedFields().findFirst().get().getValue());
+        assertEquals("John48Doe", RecordPath.compile("replaceRegex(/name, '\\\\s', /id)").evaluate(record).getSelectedFields().findFirst().get().getValue());
+        assertEquals("John  Doe", RecordPath.compile("replaceRegex(/name2, '[\\\\[\\\\]]', ' ')").evaluate(record).getSelectedFields().findFirst().get().getValue());
     }
 
     @Test


### PR DESCRIPTION
Fixing escaped backslash by unescaping it in java just before compiling regex.
-----
For a consistency with expression language regex-based evaluators, all record path operators will follow the same escape sequence for regex. Single backslash should be defined as double backslash.
Examples:
- replaceRegex(/col1, '\\s', "_") - will replace all whitespaces (spaces, tabs) with underscore.
- replaceRegex(/col1, '\\.', ",") - will replace all a period with
- replaceRegex(/col1, '\\\\', "/") - will replace backslash with forward slash

-----
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
