### PR TITLE
NIFI-5862 MockRecordParser Has Bad Logic for failAfterN

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/MockRecordParser.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/MockRecordParser.java
@@ -79,7 +79,7 @@ public class MockRecordParser extends AbstractControllerService implements Recor
 
             @Override
             public Record nextRecord(final boolean coerceTypes, final boolean dropUnknown) throws IOException, MalformedRecordException {
-                if (failAfterN >= recordCount) {
+                if (failAfterN >= 0 && recordCount >= failAfterN) {
                     throw new MalformedRecordException("Intentional Unit Test Exception because " + recordCount + " records have been read");
                 }
                 recordCount++;


### PR DESCRIPTION
`MockRecordParser` has a function that allows it to throw an exception after a certain number of records have been read. This feature is not working at all, and instead the reader fails immediately without reading any records.

The two unit tests that use this (TestSplitRecord.testReadFailure and TestConvertRecord.testReadFailure) both work because they route to Failure on any error in the read, but you can see the error in the console.

Also, I'm working on a custom processor using this test class for testing. My processor interfaces with an external system and sends batches of data. In some cases a read failure could cause a partial load to a remote system, and we need to be able to check for this.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
