### PR TITLE
NIFI-5875 Improve docs around the PriorityAttributePrioritizer

### DIFF
--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -1095,7 +1095,7 @@ The following prioritizers are available:
 
 NOTE: With a <<load_balance_strategy>> configured, the connection has a queue per node in addition to the local queue. The prioritizer will sort the data in each queue independently.
 
-NOTE: With the PriorityAttributePrioritizer it will attempt to parse the "priority" attribute as a long. If this doesn't work it will use unicode string ordering. For example: "99" and "100" will be ordered so the flowfile with "1" comes first, but "A-99" and "A-100" will sort so the flowfile with "A-100" comes first.
+NOTE: With the PriorityAttributePrioritizer it will attempt to parse the "priority" attribute as a long. If this doesn't work it will use unicode string ordering. For example: "99" and "100" will be ordered so the flowfile with "99" comes first, but "A-99" and "A-100" will sort so the flowfile with "A-100" comes first.
 
 ==== Changing Configuration and Context Menu Options
 After a connection has been drawn between two components, the connection's configuration may be changed, and the connection may be moved to a new destination; however, the processors on either side of the connection must be stopped before a configuration or destination change may be made.

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -1091,9 +1091,11 @@ The following prioritizers are available:
 - *FirstInFirstOutPrioritizer*: Given two FlowFiles, the one that reached the connection first will be processed first.
 - *NewestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is newest in the dataflow will be processed first.
 - *OldestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is oldest in the dataflow will be processed first. 'This is the default scheme that is used if no prioritizers are selected'.
-- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. If only one has that attribute it will go first. If the attributes can be parsed as a long, they will be ordered largest number first. For example 9 will come before 1 and 100 will be selected before 99. If only one of them parses as a long that one will be considered to have the higher priority. Otherwise, they will be ordered in alphanumeric order, where "a" is a higher priority than "z", and "1" is a higher priority than "9", for example.
+- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. If only one has that attribute it will go first. Then they will be ordered smallest first. For example "1" will come before "9", "99" will be selected before "100" and "a" before "b".
 
 NOTE: With a <<load_balance_strategy>> configured, the connection has a queue per node in addition to the local queue. The prioritizer will sort the data in each queue independently.
+
+NOTE: With the PriorityAttributePrioritizer it will attempt to parse the "priority" attribute as a long. If this doesn't work it will use unicode string ordering. For example: "99" and "100" will be ordered so the flowfile with "1" comes first, but "A-99" and "A-100" will sort so the flowfile with "A-100" comes first.
 
 ==== Changing Configuration and Context Menu Options
 After a connection has been drawn between two components, the connection's configuration may be changed, and the connection may be moved to a new destination; however, the processors on either side of the connection must be stopped before a configuration or destination change may be made.

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -1091,7 +1091,7 @@ The following prioritizers are available:
 - *FirstInFirstOutPrioritizer*: Given two FlowFiles, the one that reached the connection first will be processed first.
 - *NewestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is newest in the dataflow will be processed first.
 - *OldestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is oldest in the dataflow will be processed first. 'This is the default scheme that is used if no prioritizers are selected'.
-- *PriorityAttributePrioritizer*: Given two FlowFiles that both have a "priority" attribute, the one that has the highest priority value will be processed first. Note that an UpdateAttribute processor should be used to add the "priority" attribute to the FlowFiles before they reach a connection that has this prioritizer set. Values for the "priority" attribute may be alphanumeric, where "a" is a higher priority than "z", and "1" is a higher priority than "9", for example.
+- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. If only one has that attribute it will go first. If the attributes can be parsed as a long, they will be ordered largest number first. For example 9 will come before 1 and 100 will be selected before 99. If only one of them parses as a long that one will be considered to have the higher priority. Otherwise, they will be ordered in alphanumeric order, where "a" is a higher priority than "z", and "1" is a higher priority than "9", for example.
 
 NOTE: With a <<load_balance_strategy>> configured, the connection has a queue per node in addition to the local queue. The prioritizer will sort the data in each queue independently.
 

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -1091,7 +1091,7 @@ The following prioritizers are available:
 - *FirstInFirstOutPrioritizer*: Given two FlowFiles, the one that reached the connection first will be processed first.
 - *NewestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is newest in the dataflow will be processed first.
 - *OldestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is oldest in the dataflow will be processed first. 'This is the default scheme that is used if no prioritizers are selected'.
-- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. If only one has that attribute it will go first. Then they will be ordered smallest first. For example "1" will come before "9", "99" will be selected before "100" and "a" before "b".
+- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. If only one has that attribute it will go first. Then they will be ordered smallest first. For example "1" will come before "9", "99" will be selected before "100" and "a" before "b". Note that an UpdateAttribute processor should be used to add the "priority" attribute to the FlowFiles before they reach a connection that has this prioritizer set.
 
 NOTE: With a <<load_balance_strategy>> configured, the connection has a queue per node in addition to the local queue. The prioritizer will sort the data in each queue independently.
 

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -1091,11 +1091,13 @@ The following prioritizers are available:
 - *FirstInFirstOutPrioritizer*: Given two FlowFiles, the one that reached the connection first will be processed first.
 - *NewestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is newest in the dataflow will be processed first.
 - *OldestFlowFileFirstPrioritizer*: Given two FlowFiles, the one that is oldest in the dataflow will be processed first. 'This is the default scheme that is used if no prioritizers are selected'.
-- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. If only one has that attribute it will go first. Then they will be ordered smallest first. For example "1" will come before "9", "99" will be selected before "100" and "a" before "b". Note that an UpdateAttribute processor should be used to add the "priority" attribute to the FlowFiles before they reach a connection that has this prioritizer set.
+- *PriorityAttributePrioritizer*: Given two FlowFiles, an attribute called “priority” will be extracted. The one that has the lowest priority value will be processed first.
+** Note that an UpdateAttribute processor should be used to add the "priority" attribute to the FlowFiles before they reach a connection that has this prioritizer set.
+** If only one has that attribute it will go first. 
+** Values for the "priority" attribute can be alphanumeric, where "a" will come before "z" and "1" before "9"
+** If "priority" attribute cannot be parsed as a long, unicode string ordering will be used. For example: "99" and "100" will be ordered so the flowfile with "99" comes first, but "A-99" and "A-100" will sort so the flowfile with "A-100" comes first. 
 
 NOTE: With a <<load_balance_strategy>> configured, the connection has a queue per node in addition to the local queue. The prioritizer will sort the data in each queue independently.
-
-NOTE: With the PriorityAttributePrioritizer it will attempt to parse the "priority" attribute as a long. If this doesn't work it will use unicode string ordering. For example: "99" and "100" will be ordered so the flowfile with "99" comes first, but "A-99" and "A-100" will sort so the flowfile with "A-100" comes first.
 
 ==== Changing Configuration and Context Menu Options
 After a connection has been drawn between two components, the connection's configuration may be changed, and the connection may be moved to a new destination; however, the processors on either side of the connection must be stopped before a configuration or destination change may be made.


### PR DESCRIPTION
Clear up the documentation around the PriorityAttributePrioritizer to make it clearer that if the attributes are both number the largest wins but if they are not numbers they sort the other way around.

I had to go and look at the code to work out what was going on after reading the existing documentation.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
