### PR TITLE
Minor Fix for README.md

### DIFF
--- a/nifi-docker/dockerhub/README.md
+++ b/nifi-docker/dockerhub/README.md
@@ -78,7 +78,7 @@ You can also pass in environment variables to change the NiFi communication port
     docker run --name nifi \
       -p 9090:9090 \
       -d \
-      -e NIFI_WEB_HTTP_PORT='9090'
+      -e NIFI_WEB_HTTP_PORT='9090' \
       apache/nifi:latest
 
 For a list of the environment variables recognised in this build, look into the .sh/secure.sh and .sh/start.sh scripts


### PR DESCRIPTION
Super minor fix: Added missing escape slash to docker command.

