### PR TITLE
NIFI-5885 ArrayOutOfBoundsException at EL 'or' and 'and' functions

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/AndEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/AndEvaluator.java
@@ -27,6 +27,7 @@ public class AndEvaluator extends BooleanEvaluator {
 
     private final Evaluator<Boolean> subjectEvaluator;
     private final Evaluator<Boolean> rhsEvaluator;
+    private BooleanQueryResult rhsResult;
 
     public AndEvaluator(final Evaluator<Boolean> subjectEvaluator, final Evaluator<Boolean> rhsEvaluator) {
         this.subjectEvaluator = subjectEvaluator;
@@ -44,9 +45,18 @@ public class AndEvaluator extends BooleanEvaluator {
             return new BooleanQueryResult(false);
         }
 
+        // Returning previously evaluated result.
+        // The same AndEvaluator can be evaluated multiple times if subjectEvaluator is IteratingEvaluator.
+        // In that case, it's enough to evaluate the right hand side.
+        if (rhsResult != null) {
+            return rhsResult;
+        }
+
         final QueryResult<Boolean> rhsValue = rhsEvaluator.evaluate(attributes);
         if (rhsValue == null) {
-            return new BooleanQueryResult(false);
+            rhsResult = new BooleanQueryResult(false);
+        } else {
+            rhsResult = new BooleanQueryResult(rhsValue.getValue());
         }
 
         return new BooleanQueryResult(rhsValue.getValue());

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/OrEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/OrEvaluator.java
@@ -27,6 +27,7 @@ public class OrEvaluator extends BooleanEvaluator {
 
     private final Evaluator<Boolean> subjectEvaluator;
     private final Evaluator<Boolean> rhsEvaluator;
+    private BooleanQueryResult rhsResult;
 
     public OrEvaluator(final Evaluator<Boolean> subjectEvaluator, final Evaluator<Boolean> rhsEvaluator) {
         this.subjectEvaluator = subjectEvaluator;
@@ -44,12 +45,21 @@ public class OrEvaluator extends BooleanEvaluator {
             return new BooleanQueryResult(true);
         }
 
-        final QueryResult<Boolean> rhsValue = rhsEvaluator.evaluate(attributes);
-        if (rhsValue == null) {
-            return new BooleanQueryResult(false);
+        // Returning previously evaluated result.
+        // The same OrEvaluator can be evaluated multiple times if subjectEvaluator is IteratingEvaluator.
+        // In that case, it's enough to evaluate the right hand side.
+        if (rhsResult != null) {
+            return rhsResult;
         }
 
-        return new BooleanQueryResult(rhsValue.getValue());
+        final QueryResult<Boolean> rhsValue = rhsEvaluator.evaluate(attributes);
+        if (rhsValue == null) {
+            rhsResult = new BooleanQueryResult(false);
+        } else {
+            rhsResult = new BooleanQueryResult(rhsValue.getValue());
+        }
+
+        return rhsResult;
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -996,6 +996,42 @@ public class TestQuery {
     }
 
     @Test
+    public void testNestedAnyDelineatedValueOr() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("abc", "a,b,c");
+        attributes.put("xyz", "x");
+
+        // Assert each part separately.
+        assertEquals("true", Query.evaluateExpressions("${anyDelineatedValue('${abc}', ','):equals('c')}",
+                attributes, null));
+        assertEquals("false", Query.evaluateExpressions("${anyDelineatedValue('${xyz}', ','):equals('z')}",
+                attributes, null));
+
+        // Combine them with 'or'.
+        assertEquals("true", Query.evaluateExpressions(
+                "${anyDelineatedValue('${abc}', ','):equals('c'):or(${anyDelineatedValue('${xyz}', ','):equals('z')})}",
+                attributes, null));
+    }
+
+    @Test
+    public void testNestedAnyDelineatedValueAnd() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("abc", "2,0,1,3");
+        attributes.put("xyz", "x,y,z");
+
+        // Assert each part separately.
+        assertEquals("true", Query.evaluateExpressions("${anyDelineatedValue('${abc}', ','):gt('2')}",
+                attributes, null));
+        assertEquals("true", Query.evaluateExpressions("${anyDelineatedValue('${xyz}', ','):equals('z')}",
+                attributes, null));
+
+        // Combine them with 'and'.
+        assertEquals("true", Query.evaluateExpressions(
+                "${anyDelineatedValue('${abc}', ','):gt('2'):and(${anyDelineatedValue('${xyz}', ','):equals('z')})}",
+                attributes, null));
+    }
+
+    @Test
     public void testAllDelineatedValues() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("abc", "a,b,c");


### PR DESCRIPTION
EL 'or' and 'and' functions can be called multiple times within the same context using the same evaluator instance.
That happens if their subject is derived from an IteratingEvaluator such as 'anyDelineatedValues'.

And if the right hand side expression for such 'or' and 'and' contains another IteratingEvaluator,
then it can be evaluated more than the number of its candidates, ultimately an ArrayOutOfBoundsException is thrown.

This commit makes Or/AndEvaluator caching its right hand side result to prevent that happens.
For 'or' and 'and' functions, the right hand side expression is independant from their subject boolean value.
It's enough evaluating right hand side once, because it returns the same result even with different subjects.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
