### PR TITLE
NIFI-5909 PutElasticsearchHttpRecord doesn't allow to customize the timestamp format

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/pom.xml
@@ -122,6 +122,11 @@ language governing permissions and limitations under the License. -->
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+	    <dependency>
+		    <groupId>org.apache.nifi</groupId>
+		    <artifactId>nifi-standard-record-utils</artifactId>
+		    <version>1.9.0-SNAPSHOT</version>
+	    </dependency>
     </dependencies>
 
     <build>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/pom.xml
@@ -122,11 +122,11 @@ language governing permissions and limitations under the License. -->
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-	    <dependency>
-		    <groupId>org.apache.nifi</groupId>
-		    <artifactId>nifi-standard-record-utils</artifactId>
-		    <version>1.9.0-SNAPSHOT</version>
-	    </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-record-utils</artifactId>
+            <version>1.9.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
@@ -45,6 +45,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -68,18 +71,30 @@ public class TestPutElasticsearchHttpRecord {
             assertEquals(1, record.get("id"));
             assertEquals("reç1", record.get("name"));
             assertEquals(101, record.get("code"));
+	        assertEquals("20/12/2018", record.get("date"));
+	        assertEquals("6:55 PM", record.get("time"));
+	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         }, record -> {
             assertEquals(2, record.get("id"));
             assertEquals("ræc2", record.get("name"));
             assertEquals(102, record.get("code"));
+	        assertEquals("20/12/2018", record.get("date"));
+	        assertEquals("6:55 PM", record.get("time"));
+	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         }, record -> {
             assertEquals(3, record.get("id"));
             assertEquals("rèc3", record.get("name"));
             assertEquals(103, record.get("code"));
+	        assertEquals("20/12/2018", record.get("date"));
+	        assertEquals("6:55 PM", record.get("time"));
+	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         }, record -> {
             assertEquals(4, record.get("id"));
             assertEquals("rëc4", record.get("name"));
             assertEquals(104, record.get("code"));
+	        assertEquals("20/12/2018", record.get("date"));
+	        assertEquals("6:55 PM", record.get("time"));
+	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         });
         runner = TestRunners.newTestRunner(processor); // no failures
         generateTestData();
@@ -88,6 +103,9 @@ public class TestPutElasticsearchHttpRecord {
         runner.setProperty(PutElasticsearchHttpRecord.INDEX, "doc");
         runner.setProperty(PutElasticsearchHttpRecord.TYPE, "status");
         runner.setProperty(PutElasticsearchHttpRecord.ID_RECORD_PATH, "/id");
+	    runner.setProperty(PutElasticsearchHttpRecord.DATE_FORMAT, "d/M/yyyy");
+	    runner.setProperty(PutElasticsearchHttpRecord.TIME_FORMAT, "h:m a");
+	    runner.setProperty(PutElasticsearchHttpRecord.TIMESTAMP_FORMAT, "d/M/yyyy h:m a");
 
         runner.enqueue(new byte[0], new HashMap<String, String>() {{
             put("doc_id", "28039652140");
@@ -563,11 +581,14 @@ public class TestPutElasticsearchHttpRecord {
 
         parser.addSchemaField("id", RecordFieldType.INT);
         parser.addSchemaField("name", RecordFieldType.STRING);
-        parser.addSchemaField("code", RecordFieldType.INT);
+	    parser.addSchemaField("code", RecordFieldType.INT);
+	    parser.addSchemaField("date", RecordFieldType.DATE);
+	    parser.addSchemaField("time", RecordFieldType.TIME);
+	    parser.addSchemaField("ts", RecordFieldType.TIMESTAMP);
 
-        parser.addRecord(1, "reç1", 101);
-        parser.addRecord(2, "ræc2", 102);
-        parser.addRecord(3, "rèc3", 103);
-        parser.addRecord(4, "rëc4", 104);
+        parser.addRecord(1, "reç1", 101, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
+        parser.addRecord(2, "ræc2", 102, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
+        parser.addRecord(3, "rèc3", 103, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
+        parser.addRecord(4, "rëc4", 104, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
@@ -41,13 +41,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -586,9 +586,9 @@ public class TestPutElasticsearchHttpRecord {
 	    parser.addSchemaField("time", RecordFieldType.TIME);
 	    parser.addSchemaField("ts", RecordFieldType.TIMESTAMP);
 
-        parser.addRecord(1, "reç1", 101, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
-        parser.addRecord(2, "ræc2", 102, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
-        parser.addRecord(3, "rèc3", 103, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
-        parser.addRecord(4, "rëc4", 104, Date.valueOf("2018-12-20"), Time.valueOf("13:55:50"), Timestamp.valueOf("2018-12-20 13:55:50"));
+        parser.addRecord(1, "reç1", 101, new Date(1545282000000L), new Time(68150000), new Timestamp(1545332150000L));
+        parser.addRecord(2, "ræc2", 102, new Date(1545282000000L), new Time(68150000), new Timestamp(1545332150000L));
+        parser.addRecord(3, "rèc3", 103, new Date(1545282000000L), new Time(68150000), new Timestamp(1545332150000L));
+        parser.addRecord(4, "rëc4", 104, new Date(1545282000000L), new Time(68150000), new Timestamp(1545332150000L));
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/test/java/org/apache/nifi/processors/elasticsearch/TestPutElasticsearchHttpRecord.java
@@ -71,30 +71,30 @@ public class TestPutElasticsearchHttpRecord {
             assertEquals(1, record.get("id"));
             assertEquals("reç1", record.get("name"));
             assertEquals(101, record.get("code"));
-	        assertEquals("20/12/2018", record.get("date"));
-	        assertEquals("6:55 PM", record.get("time"));
-	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
+            assertEquals("20/12/2018", record.get("date"));
+            assertEquals("6:55 PM", record.get("time"));
+            assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         }, record -> {
             assertEquals(2, record.get("id"));
             assertEquals("ræc2", record.get("name"));
             assertEquals(102, record.get("code"));
-	        assertEquals("20/12/2018", record.get("date"));
-	        assertEquals("6:55 PM", record.get("time"));
-	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
+            assertEquals("20/12/2018", record.get("date"));
+            assertEquals("6:55 PM", record.get("time"));
+            assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         }, record -> {
             assertEquals(3, record.get("id"));
             assertEquals("rèc3", record.get("name"));
             assertEquals(103, record.get("code"));
-	        assertEquals("20/12/2018", record.get("date"));
-	        assertEquals("6:55 PM", record.get("time"));
-	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
+            assertEquals("20/12/2018", record.get("date"));
+            assertEquals("6:55 PM", record.get("time"));
+            assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         }, record -> {
             assertEquals(4, record.get("id"));
             assertEquals("rëc4", record.get("name"));
             assertEquals(104, record.get("code"));
-	        assertEquals("20/12/2018", record.get("date"));
-	        assertEquals("6:55 PM", record.get("time"));
-	        assertEquals("20/12/2018 6:55 PM", record.get("ts"));
+            assertEquals("20/12/2018", record.get("date"));
+            assertEquals("6:55 PM", record.get("time"));
+            assertEquals("20/12/2018 6:55 PM", record.get("ts"));
         });
         runner = TestRunners.newTestRunner(processor); // no failures
         generateTestData();
@@ -103,9 +103,9 @@ public class TestPutElasticsearchHttpRecord {
         runner.setProperty(PutElasticsearchHttpRecord.INDEX, "doc");
         runner.setProperty(PutElasticsearchHttpRecord.TYPE, "status");
         runner.setProperty(PutElasticsearchHttpRecord.ID_RECORD_PATH, "/id");
-	    runner.setProperty(PutElasticsearchHttpRecord.DATE_FORMAT, "d/M/yyyy");
-	    runner.setProperty(PutElasticsearchHttpRecord.TIME_FORMAT, "h:m a");
-	    runner.setProperty(PutElasticsearchHttpRecord.TIMESTAMP_FORMAT, "d/M/yyyy h:m a");
+        runner.setProperty(PutElasticsearchHttpRecord.DATE_FORMAT, "d/M/yyyy");
+        runner.setProperty(PutElasticsearchHttpRecord.TIME_FORMAT, "h:m a");
+        runner.setProperty(PutElasticsearchHttpRecord.TIMESTAMP_FORMAT, "d/M/yyyy h:m a");
 
         runner.enqueue(new byte[0], new HashMap<String, String>() {{
             put("doc_id", "28039652140");
@@ -581,10 +581,10 @@ public class TestPutElasticsearchHttpRecord {
 
         parser.addSchemaField("id", RecordFieldType.INT);
         parser.addSchemaField("name", RecordFieldType.STRING);
-	    parser.addSchemaField("code", RecordFieldType.INT);
-	    parser.addSchemaField("date", RecordFieldType.DATE);
-	    parser.addSchemaField("time", RecordFieldType.TIME);
-	    parser.addSchemaField("ts", RecordFieldType.TIMESTAMP);
+        parser.addSchemaField("code", RecordFieldType.INT);
+        parser.addSchemaField("date", RecordFieldType.DATE);
+        parser.addSchemaField("time", RecordFieldType.TIME);
+        parser.addSchemaField("ts", RecordFieldType.TIMESTAMP);
 
         parser.addRecord(1, "reç1", 101, new Date(1545282000000L), new Time(68150000), new Timestamp(1545332150000L));
         parser.addRecord(2, "ræc2", 102, new Date(1545282000000L), new Time(68150000), new Timestamp(1545332150000L));

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3Streaming.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3Streaming.java
@@ -17,11 +17,9 @@
 package org.apache.nifi.processors.hive;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hive.common.util.ShutdownHookManager;
 import org.apache.hive.streaming.ConnectionError;
 import org.apache.hive.streaming.HiveStreamingConnection;
 import org.apache.hive.streaming.InvalidTable;


### PR DESCRIPTION
 added optional settings for date, time, and timestamp formats used to write Records to Elasticsearch

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
