### PR TITLE
NIFI-5935: Handle error in LDAP sync background thread

### DIFF
--- a/nifi-framework-api/src/main/java/org/apache/nifi/authorization/Group.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/authorization/Group.java
@@ -89,7 +89,7 @@ public class Group { // TODO rename to UserGroup
 
     @Override
     public String toString() {
-        return String.format("identifier[%s], name[%s]", getIdentifier(), getName());
+        return String.format("identifier[%s], name[%s], users[%s]", getIdentifier(), getName(), String.join(", ", users));
     }
 
 


### PR DESCRIPTION
NIFI-5935:
- Ensuring exceptions are handled in the ldap user/group sync background thread.
- Adding additional logging around what users/groups were discovered.