### PR TITLE
NIFI-5841 Fix memory leak of PutHive3Streaming

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3Streaming.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3Streaming.java
@@ -412,9 +412,6 @@ public class PutHive3Streaming extends AbstractProcessor {
                 }
 
                 hiveStreamingConnection = makeStreamingConnection(options, reader);
-                // Add shutdown handler with higher priority than FileSystem shutdown hook so that streaming connection gets closed first before
-                // filesystem close (to avoid ClosedChannelException)
-                ShutdownHookManager.addShutdownHook(hiveStreamingConnection::close, FileSystem.SHUTDOWN_HOOK_PRIORITY + 1);
 
                 // Write records to Hive streaming, then commit and close
                 hiveStreamingConnection.beginTransaction();


### PR DESCRIPTION
PutHive3Streaming must not call `ShutdownHookManager.addShutdownHook` because Hive3.1 adds shutdownhook within connect(). See [HiveStreamingConnection.java](https://github.com/apache/hive/blob/bcc7df95824831a8d2f1524e4048dfc23ab98c19/streaming/src/java/org/apache/hive/streaming/HiveStreamingConnection.java#L335).
For each connection redundant shutdownhook occurs memory leak.