### PR TITLE
NIFI-5940 Cluster Node Offload Hangs if any RPG on flow is Disabled

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -710,7 +710,9 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                     .forEach(pn -> pn.getProcessGroup().terminateProcessor(pn));
 
             // request to stop all remote process groups
-            flowManager.getRootGroup().findAllRemoteProcessGroups().forEach(RemoteProcessGroup::stopTransmitting);
+            flowManager.getRootGroup().findAllRemoteProcessGroups()
+                    .stream().filter(rpg -> rpg.isTransmitting())
+                    .forEach(RemoteProcessGroup::stopTransmitting);
 
             // offload all queues on node
             final Set<Connection> connections = flowManager.findAllConnections();


### PR DESCRIPTION
If any Remote Process Group on the flow is disabled when a user starts a node Offload, then offload fails.

This is because the Offload process tries to turn off all Remote Process Group's, even if they are already disabled; and this causes an unexpected exception to be thrown.

There are no test cases for OffLoad (there is the 'Problematic unit test' written in Groovy, but it's very problematic).

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
