### PR TITLE
NIFI-5869 Support Reconnection for JMS

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderDefinition.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderDefinition.java
@@ -35,4 +35,12 @@ public interface JMSConnectionFactoryProviderDefinition extends ControllerServic
      */
     ConnectionFactory getConnectionFactory();
 
+    /**
+     * Resets {@link ConnectionFactory}.
+     * Provider should reset {@link ConnectionFactory} only if a copy provided by a client matches
+     * current {@link ConnectionFactory}.
+     * @param cachedFactory - {@link ConnectionFactory} cached by client.
+     */
+    void resetConnectionFactory(ConnectionFactory cachedFactory);
+
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
@@ -139,6 +139,14 @@ public class JMSConnectionFactoryProvider extends AbstractControllerService impl
                 .build();
     }
 
+    @Override
+    public void resetConnectionFactory(ConnectionFactory cachedFactory) {
+        if (cachedFactory == connectionFactory) {
+            getLogger().debug("Resetting connection factory");
+            connectionFactory = null;
+        }
+    }
+
     /**
      * @return new instance of {@link ConnectionFactory}
      */
@@ -316,5 +324,4 @@ public class JMSConnectionFactoryProvider extends AbstractControllerService impl
             return StandardValidators.NON_EMPTY_VALIDATOR.validate(subject, input, context);
         }
     }
-
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProvider.java
@@ -139,6 +139,14 @@ public class JndiJmsConnectionFactoryProvider extends AbstractControllerService 
     }
 
     @Override
+    public synchronized void resetConnectionFactory(ConnectionFactory cachedFactory) {
+        if (cachedFactory == connectionFactory) {
+            getLogger().debug("Resetting connection factory");
+            connectionFactory = null;
+        }
+    }
+
+    @Override
     public synchronized ConnectionFactory getConnectionFactory() {
         if (connectionFactory == null) {
             connectionFactory = lookupConnectionFactory();

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -157,8 +157,16 @@ abstract class AbstractJMSProcessor<T extends JMSWorker> extends AbstractProcess
 
         try {
             rendezvousWithJms(context, session, worker);
+        } catch(ProcessException e) {
+            //in case of exception, make worker null so it won't be pushed back into a queue of workers.
+            //this will be helpful in a situation, when JNDI has changed, or JMS server is not available
+            //and reconnection is required.
+            worker = null;
+            throw e; //throw the exception as is. it will be printed into logs/bulletin by the framework.
         } finally {
-            workerPool.offer(worker);
+            if (worker != null) {
+                workerPool.offer(worker);
+            }
         }
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSWorker.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSWorker.java
@@ -36,6 +36,7 @@ abstract class JMSWorker {
     protected final JmsTemplate jmsTemplate;
     protected final ComponentLog processLog;
     private final CachingConnectionFactory connectionFactory;
+    private boolean isValid = true;
 
 
     /**
@@ -60,5 +61,13 @@ abstract class JMSWorker {
     public String toString() {
         return this.getClass().getSimpleName() + "[destination:" + this.jmsTemplate.getDefaultDestinationName()
                 + "; pub-sub:" + this.jmsTemplate.isPubSubDomain() + ";]";
+    }
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public void setValid(boolean isValid) {
+        this.isValid = isValid;
     }
 }


### PR DESCRIPTION
Resets worker if it doesn't work anymore for any reason. this will add "reconnect" capabilities. Will solve issues for following use cases:
- authentication changed after successful connection
- JNDI mapping changed and requires recaching.
- JMS server isn't available anymore or restarted.
-------
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
