### PR TITLE
NIFI-5972: LdapUserGroupProvider logging

### DIFF
--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
@@ -506,7 +506,8 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                                 final Attribute attributeGroups = ctx.getAttributes().get(userGroupNameAttribute);
 
                                 if (attributeGroups == null) {
-                                    logger.warn("User group name attribute [" + userGroupNameAttribute + "] does not exist. Ignoring group membership.");
+                                    logger.debug(String.format("User group name attribute [%s] does not exist for %s. This may be due to "
+                                            + "misconfiguration or the user may just not belong to any groups. Ignoring group membership.", userGroupNameAttribute, identity));
                                 } else {
                                     try {
                                         final NamingEnumeration<String> groupValues = (NamingEnumeration<String>) attributeGroups.getAll();
@@ -562,7 +563,8 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                             if (!StringUtils.isBlank(groupMemberAttribute)) {
                                 Attribute attributeUsers = ctx.getAttributes().get(groupMemberAttribute);
                                 if (attributeUsers == null) {
-                                    logger.warn("Group member attribute [" + groupMemberAttribute + "] does not exist. Ignoring group membership.");
+                                    logger.debug(String.format("Group member attribute [%s] does not exist for %s. This may be due to "
+                                            + "misconfiguration or the group may not have any members. Ignoring group membership.", groupMemberAttribute, name));
                                 } else {
                                     try {
                                         final NamingEnumeration<String> userValues = (NamingEnumeration<String>) attributeUsers.getAll();
@@ -577,7 +579,8 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                                                 if (user != null) {
                                                     groupToUserIdentifierMappings.computeIfAbsent(referencedGroupValue, g -> new HashSet<>()).add(user.getIdentifier());
                                                 } else {
-                                                    logger.warn(String.format("%s contains member %s but that user was not found while searching users. Ignoring group membership.", name, userValue));
+                                                    logger.debug(String.format("%s contains member %s but that user was not found while searching users. This may be due "
+                                                                    + "to a misconfiguration or it's possible the user is not a NiFi user. Ignoring group membership.", name, userValue));
                                                 }
                                             } else {
                                                 // since performUserSearch is false, then the referenced group attribute must be blank... the user value must be the dn
@@ -621,8 +624,8 @@ public class LdapUserGroupProvider implements UserGroupProvider {
 
                 // any remaining groupDn's were referenced by a user but not found while searching groups
                 groupToUserIdentifierMappings.forEach((referencedGroupValue, userIdentifiers) -> {
-                    logger.warn(String.format("[%s] are members of %s but that group was not found while searching users. Ignoring group membership.",
-                            StringUtils.join(userIdentifiers, ", "), referencedGroupValue));
+                    logger.debug(String.format("[%s] are members of %s but that group was not found while searching groups. This may be due to a misconfiguration "
+                                    + "or it's possible the group is not a NiFi group. Ignoring group membership.", StringUtils.join(userIdentifiers, ", "), referencedGroupValue));
                 });
             } else {
                 // since performGroupSearch is false, then the referenced user attribute must be blank... the group value must be the dn


### PR DESCRIPTION
NIFI-5972:
- Converting some warning log messages to debug as they could possibly be due to a valid scenario like NiFi users belonging to a group that is not relevant to NiFi.