### PR TITLE
NIFI-5974 fix: Fragment Attributes are populated in case no split has…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitContent.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_COUNT;
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_ID;
+import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_INDEX;
+import static org.apache.nifi.processors.standard.SplitContent.SEGMENT_ORIGINAL_FILENAME;
 
 public class TestSplitContent {
 
@@ -370,5 +372,32 @@ public class TestSplitContent {
 
         final List<MockFlowFile> packed = mergeRunner.getFlowFilesForRelationship(MergeContent.REL_MERGED);
         packed.get(0).assertContentEquals(new byte[]{1, 2, 3, 4, 5, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 5, 4, 3, 2, 1});
+    }
+    
+    @Test
+    public void testNoSplitterInString() {
+        
+        String content = "UVAT";
+        
+        final TestRunner runner = TestRunners.newTestRunner(new SplitContent());
+        runner.setProperty(SplitContent.FORMAT, SplitContent.UTF8_FORMAT.getValue());
+        runner.setProperty(SplitContent.BYTE_SEQUENCE, ",");
+        runner.setProperty(SplitContent.KEEP_SEQUENCE, "false");
+        runner.setProperty(SplitContent.BYTE_SEQUENCE_LOCATION, SplitContent.TRAILING_POSITION.getValue());
+
+        runner.enqueue(content.getBytes());
+        runner.run();
+
+        runner.assertTransferCount(SplitContent.REL_SPLITS, 1);
+        MockFlowFile splitResult = runner.getFlowFilesForRelationship(SplitContent.REL_SPLITS).get(0);
+        splitResult.assertAttributeExists(FRAGMENT_ID);
+        splitResult.assertAttributeExists(SEGMENT_ORIGINAL_FILENAME);
+        splitResult.assertAttributeEquals(FRAGMENT_COUNT, "1");
+        splitResult.assertAttributeEquals(FRAGMENT_INDEX, "1");
+        runner.assertTransferCount(SplitContent.REL_ORIGINAL, 1);
+
+        runner.assertQueueEmpty();
+        final List<MockFlowFile> splits = runner.getFlowFilesForRelationship(SplitContent.REL_SPLITS);
+        splits.get(0).assertContentEquals(content);
     }
 }


### PR DESCRIPTION
… occured.

Unit test is implemented: testNoSplitterInString

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [Y] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message? NIFI-5974

- [Y] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [Y] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [Y] Is your initial contribution a single, squashed commit?

### For code changes:
- [Y] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [Y] Have you written or updated unit tests to verify your changes?
- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [N/A] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [N/A] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [N/A] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [N/A] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
