### PR TITLE
NIFI-6000 Catch also IllegalArgumentException in ConvertAvroToORC hiv…

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/hadoop/hive/ql/io/orc/NiFiOrcUtils.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/hadoop/hive/ql/io/orc/NiFiOrcUtils.java
@@ -244,6 +244,7 @@ public class NiFiOrcUtils {
             case DOUBLE:
             case FLOAT:
             case STRING:
+            case NULL:
                 return getPrimitiveOrcTypeFromPrimitiveAvroType(fieldType);
 
             case UNION:
@@ -335,6 +336,7 @@ public class NiFiOrcUtils {
             case LONG:
                 return TypeInfoFactory.getPrimitiveTypeInfo("bigint");
             case BOOLEAN:
+            case NULL: // ORC has no null type, so just pick the smallest. All values are necessarily null.
                 return TypeInfoFactory.getPrimitiveTypeInfo("boolean");
             case BYTES:
                 return TypeInfoFactory.getPrimitiveTypeInfo("binary");
@@ -362,6 +364,7 @@ public class NiFiOrcUtils {
             case LONG:
                 return "BIGINT";
             case BOOLEAN:
+            case NULL: // Hive has no null type, we picked boolean as the ORC type so use it for Hive DDL too. All values are necessarily null.
                 return "BOOLEAN";
             case BYTES:
                 return "BINARY";

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/ConvertAvroToORC.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/ConvertAvroToORC.java
@@ -283,8 +283,8 @@ public class ConvertAvroToORC extends AbstractProcessor {
             session.transfer(flowFile, REL_SUCCESS);
             session.getProvenanceReporter().modifyContent(flowFile, "Converted "+totalRecordCount.get()+" records", System.currentTimeMillis() - startTime);
 
-        } catch (final ProcessException pe) {
-            getLogger().error("Failed to convert {} from Avro to ORC due to {}; transferring to failure", new Object[]{flowFile, pe});
+        } catch (ProcessException | IllegalArgumentException e) {
+            getLogger().error("Failed to convert {} from Avro to ORC due to {}; transferring to failure", new Object[]{flowFile, e});
             session.transfer(flowFile, REL_FAILURE);
         }
     }

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/test/java/org/apache/nifi/util/orc/TestNiFiOrcUtils.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/test/java/org/apache/nifi/util/orc/TestNiFiOrcUtils.java
@@ -34,7 +34,9 @@ import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -271,7 +273,7 @@ public class TestNiFiOrcUtils {
 
     @Test
     public void test_convertToORCObject() {
-        Schema schema = SchemaBuilder.enumeration("myEnum").symbols("x","y","z");
+        Schema schema = SchemaBuilder.enumeration("myEnum").symbols("x", "y", "z");
         List<Object> objects = Arrays.asList(new Utf8("Hello"), new GenericData.EnumSymbol(schema, "x"));
         objects.forEach((avroObject) -> {
             Object o = NiFiOrcUtils.convertToORCObject(TypeInfoUtils.getTypeInfoFromTypeString("uniontype<bigint,string>"), avroObject);
@@ -301,6 +303,29 @@ public class TestNiFiOrcUtils {
         builder.name("double").type().doubleType().doubleDefault(0.0);
         builder.name("bytes").type().bytesType().noDefault();
         builder.name("string").type().stringType().stringDefault("default");
+        return builder.endRecord();
+    }
+
+    public static Schema buildAvroSchemaWithNull() {
+        // Build a fake Avro record which contains null
+        final SchemaBuilder.FieldAssembler<Schema> builder = SchemaBuilder.record("test.record").namespace("any.data").fields();
+        builder.name("string").type().stringType().stringDefault("default");
+        builder.name("null").type().nullType().noDefault();
+        return builder.endRecord();
+    }
+
+    public static Schema buildAvroSchemaWithEmptyArray() {
+        // Build a fake Avro record which contains empty array
+        final SchemaBuilder.FieldAssembler<Schema> builder = SchemaBuilder.record("test.record").namespace("any.data").fields();
+        builder.name("string").type().stringType().stringDefault("default");
+        builder.name("emptyArray").type().array().items().nullType().noDefault();
+        return builder.endRecord();
+    }
+
+    public static Schema buildAvroSchemaWithFixed() {
+        // Build a fake Avro record which contains null
+        final SchemaBuilder.FieldAssembler<Schema> builder = SchemaBuilder.record("test.record").namespace("any.data").fields();
+        builder.name("fixed").type().fixed("fixedField").size(6).fixedDefault("123456");
         return builder.endRecord();
     }
 
@@ -348,6 +373,29 @@ public class TestNiFiOrcUtils {
         row.put("myEnum", e);
         row.put("myLongOrFloat", unionVal);
         row.put("myIntList", intArray);
+        return row;
+    }
+
+    public static GenericData.Record buildAvroRecordWithNull(String string) {
+        Schema schema = buildAvroSchemaWithNull();
+        GenericData.Record row = new GenericData.Record(schema);
+        row.put("string", string);
+        row.put("null", null);
+        return row;
+    }
+
+    public static GenericData.Record buildAvroRecordWithEmptyArray(String string) {
+        Schema schema = buildAvroSchemaWithEmptyArray();
+        GenericData.Record row = new GenericData.Record(schema);
+        row.put("string", string);
+        row.put("emptyArray", Collections.emptyList());
+        return row;
+    }
+
+    public static GenericData.Record buildAvroRecordWithFixed(String string) {
+        Schema schema = buildAvroSchemaWithFixed();
+        GenericData.Record row = new GenericData.Record(schema);
+        row.put("fixed", new GenericData.Fixed(schema, string.getBytes(StandardCharsets.UTF_8)));
         return row;
     }
 


### PR DESCRIPTION
NIFI-6000 Catch also IllegalArgumentException in ConvertAvroToORC hive processor for routing FlowFiles to failure relationship when the input avro data has null types or empty arrays.


Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
