### PR TITLE
NIFI-6031: allow OS level socket keep alive checking

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/SocketChannelDispatcher.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/listen/dispatcher/SocketChannelDispatcher.java
@@ -146,6 +146,7 @@ public class SocketChannelDispatcher<E extends Event<SocketChannel>> implements 
                             // Handle new connections coming in
                             final ServerSocketChannel channel = (ServerSocketChannel) key.channel();
                             final SocketChannel socketChannel = channel.accept();
+                            socketChannel.setOption(StandardSocketOptions.SO_KEEPALIVE, true);
                             // Check for available connections
                             if (currentConnections.incrementAndGet() > maxConnections){
                                 currentConnections.decrementAndGet();

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/record/listen/SocketChannelRecordReaderDispatcher.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/record/listen/SocketChannelRecordReaderDispatcher.java
@@ -25,6 +25,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.io.Closeable;
 import java.net.SocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
@@ -79,6 +80,7 @@ public class SocketChannelRecordReaderDispatcher implements Runnable, Closeable 
                     continue;
                 }
 
+                socketChannel.setOption(StandardSocketOptions.SO_KEEPALIVE, true);
                 final SocketAddress remoteSocketAddress = socketChannel.getRemoteAddress();
                 socketChannel.socket().setSoTimeout(socketReadTimeout);
                 socketChannel.socket().setReceiveBufferSize(receiveBufferSize);


### PR DESCRIPTION
This pull request aims to bring best effort socket keep alive support to 
ListenTCP and ListenTCPRecord processors.

This code change allows the client-socket to be polled by the underlying OS.

The underlying OS's keep alive configuration can be tweaked as described in http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html



------------------------
Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
