### PR TITLE
NIFI-6076 syslog5424 should support missing MSG

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.github.palindromicity</groupId>
             <artifactId>simple-syslog-5424</artifactId>
-            <version>0.0.10</version>
+            <version>0.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.github.palindromicity</groupId>
             <artifactId>simple-syslog-5424</artifactId>
-            <version>0.0.8</version>
+            <version>0.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/src/test/java/org/apache/nifi/syslog/BaseStrictSyslog5424ParserTest.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/src/test/java/org/apache/nifi/syslog/BaseStrictSyslog5424ParserTest.java
@@ -158,10 +158,6 @@ public abstract class BaseStrictSyslog5424ParserTest {
                 + " d0602076-b14a-4c55-852a-981e7afeed38 DEA MSG-01"
                 + " [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]"
                 + " [exampleSDID@32480 iut=\"4\" eventSource=\"Other Application\" eventID=\"2022\"] Removing instance");
-        messages.add("<14>1 2015-07-20T09:30:07+00:00 fooservice"
-            + " d0602076-b14a-4c55-852a-981e7afood38 DEA MSG-02"
-            + " [exampleSDID@32473 iut=\"5\" eventSource=\"Application\" eventID=\"1013\"]"
-            + " [exampleSDID@32480 iut=\"6\" eventSource=\"Other Application\" eventID=\"2024\"]");
 
         for (final String message : messages) {
             final byte[] bytes = message.getBytes(CHARSET);
@@ -172,6 +168,33 @@ public abstract class BaseStrictSyslog5424ParserTest {
             final Syslog5424Event event = parser.parseEvent(buffer);
             Assert.assertTrue(event.isValid());
         }
+    }
+
+    @Test
+    public void testMessagePartNotRequired() {
+        final List<String> messages = new ArrayList<>();
+
+        messages.add("<14>1 2014-06-20T09:14:07+00:00 loggregator"
+            + " d0602076-b14a-4c55-852a-981e7afeed38 DEA MSG-01"
+            + " [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]");
+
+        messages.add("<14>1 2014-06-20T09:14:07+00:00 loggregator"
+            + " d0602076-b14a-4c55-852a-981e7afeed38 DEA MSG-01"
+            + " [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]"
+            + " [exampleSDID@32480 iut=\"4\" eventSource=\"Other Application\" eventID=\"2022\"]");
+
+        for (final String message : messages) {
+            final byte[] bytes = message.getBytes(CHARSET);
+            final ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
+            buffer.clear();
+            buffer.put(bytes);
+
+            final Syslog5424Event event = parser.parseEvent(buffer);
+            Assert.assertTrue(event.isValid());
+            Assert.assertNull(event.getFieldMap().get(SyslogAttributes.SYSLOG_BODY));
+        }
+
+
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/src/test/java/org/apache/nifi/syslog/BaseStrictSyslog5424ParserTest.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/src/test/java/org/apache/nifi/syslog/BaseStrictSyslog5424ParserTest.java
@@ -149,7 +149,7 @@ public abstract class BaseStrictSyslog5424ParserTest {
     public void testVariety() {
         final List<String> messages = new ArrayList<>();
 
-        // supported examples from RFC 5424
+        // supported examples from RFC 5424 including structured data with no message
         messages.add("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - " +
                 "ID47 - BOM'su root' failed for lonvick on /dev/pts/8");
         messages.add("<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc " +
@@ -158,6 +158,10 @@ public abstract class BaseStrictSyslog5424ParserTest {
                 + " d0602076-b14a-4c55-852a-981e7afeed38 DEA MSG-01"
                 + " [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]"
                 + " [exampleSDID@32480 iut=\"4\" eventSource=\"Other Application\" eventID=\"2022\"] Removing instance");
+        messages.add("<14>1 2015-07-20T09:30:07+00:00 fooservice"
+            + " d0602076-b14a-4c55-852a-981e7afood38 DEA MSG-02"
+            + " [exampleSDID@32473 iut=\"5\" eventSource=\"Application\" eventID=\"1013\"]"
+            + " [exampleSDID@32480 iut=\"6\" eventSource=\"Other Application\" eventID=\"2024\"]");
 
         for (final String message : messages) {
             final byte[] bytes = message.getBytes(CHARSET);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/fingerprint/FingerprintFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/fingerprint/FingerprintFactory.java
@@ -766,7 +766,7 @@ public class FingerprintFactory {
             }
         };
     }
-    
+
     private Comparator<Element> getElementTextComparator() {
         return new Comparator<Element>() {
             @Override


### PR DESCRIPTION
This issue is fixed in new simple-syslog-5424 v. 0.0.10
### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [-] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [-] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
