### PR TITLE
NIFI-6077 Added force Expression Language switch for properties PoC

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DynamicProperty.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DynamicProperty.java
@@ -41,6 +41,7 @@ public @interface DynamicProperty {
 
     @Deprecated
     boolean supportsExpressionLanguage() default false;
+    boolean forcedExpressionLanguage() default false;
 
     String value();
 

--- a/nifi-api/src/main/java/org/apache/nifi/components/ValidationContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/ValidationContext.java
@@ -88,6 +88,14 @@ public interface ValidationContext extends PropertyContext {
     boolean isExpressionLanguageSupported(String propertyName);
 
     /**
+     * @param propertyName to test whether expression language is forced
+     * @return <code>true</code> if the property with the given name forced
+     * the NiFi Expression Language, <code>false</code> if the property does not
+     * forced the Expression Language or is not a valid property name
+     */
+    boolean isExpressionLanguageForced(String propertyName);
+
+    /**
      * Returns the identifier of the ProcessGroup that the component being validated lives in
      *
      * @return the identifier of the ProcessGroup that the component being validated lives in

--- a/nifi-api/src/main/java/org/apache/nifi/documentation/xml/XmlDocumentationWriter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/documentation/xml/XmlDocumentationWriter.java
@@ -148,6 +148,7 @@ public class XmlDocumentationWriter extends AbstractDocumentationWriter {
         writeBooleanElement("required", property.isRequired());
         writeBooleanElement("sensitive", property.isSensitive());
         writeBooleanElement("expressionLanguageSupported", property.isExpressionLanguageSupported());
+        writeBooleanElement("expressionLanguageForced", property.isExpressionLanguageForced());
         writeTextElement("expressionLanguageScope", property.getExpressionLanguageScope() == null ? null : property.getExpressionLanguageScope().name());
         writeBooleanElement("dynamicallyModifiesClasspath", property.isDynamicClasspathModifier());
         writeBooleanElement("dynamic", property.isDynamic());
@@ -167,6 +168,7 @@ public class XmlDocumentationWriter extends AbstractDocumentationWriter {
         writeTextElement("value", property.value());
         writeTextElement("description", property.description());
         writeBooleanElement("expressionLanguageSupported", property.supportsExpressionLanguage());
+        writeBooleanElement("expressionLanguageForced", property.forcedExpressionLanguage());
         writeTextElement("expressionLanguageScope", property.expressionLanguageScope() == null ? null : property.expressionLanguageScope().name());
 
         writeEndElement();

--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NotificationServiceManager.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NotificationServiceManager.java
@@ -256,7 +256,10 @@ public class NotificationServiceManager {
                     configuredValue = fullPropDescriptor.getDefaultValue();
                 }
 
-                return new StandardPropertyValue(configuredValue, null, variableRegistry);
+                if( descriptor.isExpressionLanguageForced() )
+                    return new StandardPropertyValue(configuredValue, null, variableRegistry).evaluateAttributeExpressions();
+                else
+                    return new StandardPropertyValue(configuredValue, null, variableRegistry);
             }
 
             @Override

--- a/nifi-mock/src/main/java/org/apache/nifi/util/ControllerServiceConfiguration.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/ControllerServiceConfiguration.java
@@ -21,11 +21,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.nifi.attribute.expression.language.StandardPropertyValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ControllerService;
 
 public class ControllerServiceConfiguration {
-
     private final ControllerService service;
     private final AtomicBoolean enabled = new AtomicBoolean(false);
     private String annotationData;
@@ -56,7 +56,10 @@ public class ControllerServiceConfiguration {
         if (value == null) {
             return descriptor.getDefaultValue();
         } else {
-            return value;
+            if( descriptor.isExpressionLanguageForced() )
+                return new StandardPropertyValue(value, null, null).evaluateAttributeExpressions().getValue();
+            else
+                return value;
         }
     }
 
@@ -69,6 +72,10 @@ public class ControllerServiceConfiguration {
     }
 
     public Map<PropertyDescriptor, String> getProperties() {
-        return Collections.unmodifiableMap(properties);
+        final Map<PropertyDescriptor, String> props = new HashMap<>();
+        for (final PropertyDescriptor descriptor : properties.keySet()) {
+            props.put(descriptor, getProperty(descriptor));
+        }
+        return Collections.unmodifiableMap(props);
     }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockValidationContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockValidationContext.java
@@ -39,6 +39,7 @@ public class MockValidationContext extends MockControllerServiceLookup implement
 
     private final MockProcessContext context;
     private final Map<String, Boolean> expressionLanguageSupported;
+    private final Map<String, Boolean> expressionLanguageForced;
     private final StateManager stateManager;
     private final VariableRegistry variableRegistry;
 
@@ -55,6 +56,10 @@ public class MockValidationContext extends MockControllerServiceLookup implement
         expressionLanguageSupported = new HashMap<>(properties.size());
         for (final PropertyDescriptor descriptor : properties.keySet()) {
             expressionLanguageSupported.put(descriptor.getName(), descriptor.isExpressionLanguageSupported());
+        }
+        expressionLanguageForced = new HashMap<>(properties.size());
+        for (final PropertyDescriptor descriptor : properties.keySet()) {
+            expressionLanguageForced.put(descriptor.getName(), descriptor.isExpressionLanguageForced());
         }
     }
 
@@ -153,6 +158,12 @@ public class MockValidationContext extends MockControllerServiceLookup implement
     public boolean isExpressionLanguageSupported(final String propertyName) {
         final Boolean supported = expressionLanguageSupported.get(propertyName);
         return Boolean.TRUE.equals(supported);
+    }
+
+    @Override
+    public boolean isExpressionLanguageForced(final String propertyName) {
+        final Boolean forced = expressionLanguageForced.get(propertyName);
+        return Boolean.TRUE.equals(forced);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/PropertyDescriptorDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/PropertyDescriptorDTO.java
@@ -37,6 +37,7 @@ public class PropertyDescriptorDTO {
     private Boolean sensitive;
     private Boolean dynamic;
     private Boolean supportsEl;
+    private Boolean forceEl;
     private String expressionLanguageScope;
     private String identifiesControllerService;
     private BundleDTO identifiesControllerServiceBundle;
@@ -165,6 +166,20 @@ public class PropertyDescriptorDTO {
 
     public void setSupportsEl(Boolean supportsEl) {
         this.supportsEl = supportsEl;
+    }
+
+    /**
+     * @return specifies whether or not this property forcelly support expression language
+     */
+    @ApiModelProperty(
+            value = "Whether the property forcelly supports expression language."
+    )
+    public Boolean getForceEl() {
+        return forceEl;
+    }
+
+    public void setForceEl(Boolean forceEl) {
+        this.forceEl = forceEl;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
@@ -60,6 +60,7 @@ import org.apache.nifi.web.api.dto.PositionDTO;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.api.dto.RelationshipDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupContentsDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
@@ -244,6 +245,9 @@ public class StandardFlowSnippet implements FlowSnippet {
                 final String serviceId = controllerServiceDTO.getId();
                 final ControllerServiceNode serviceNode = flowManager.getControllerServiceNode(serviceId);
                 serviceNode.setProperties(controllerServiceDTO.getProperties());
+                for (final Map.Entry<String, PropertyDescriptorDTO> entry : controllerServiceDTO.getDescriptors().entrySet()) {
+                    serviceNode.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+                }
             }
         } finally {
             serviceNodes.forEach(ControllerServiceNode::resumeValidationTrigger);
@@ -389,6 +393,12 @@ public class StandardFlowSnippet implements FlowSnippet {
 
                 if (config.getProperties() != null) {
                     procNode.setProperties(config.getProperties());
+                }
+
+                if (config.getDescriptors() != null) {
+                    for (final Map.Entry<String, PropertyDescriptorDTO> entry : config.getDescriptors().entrySet()) {
+                        procNode.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+                    }
                 }
 
                 group.addProcessor(procNode);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
@@ -86,6 +86,7 @@ import org.apache.nifi.web.api.dto.PositionDTO;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
 import org.apache.nifi.web.api.dto.TemplateDTO;
@@ -664,6 +665,9 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
 
             reportingTask.setAnnotationData(dto.getAnnotationData());
             reportingTask.setProperties(dto.getProperties());
+            for (final Map.Entry<String, PropertyDescriptorDTO> entry : dto.getDescriptors().entrySet()) {
+                reportingTask.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+            }
             return reportingTask;
         } else {
             // otherwise return the existing reporting task node
@@ -1162,6 +1166,9 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
             }
 
             procNode.setProperties(config.getProperties());
+            for (final Map.Entry<String, PropertyDescriptorDTO> entry : config.getDescriptors().entrySet()) {
+                procNode.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+            }
 
             final ScheduledState scheduledState = ScheduledState.valueOf(processorDTO.getState());
             if (ScheduledState.RUNNING.equals(scheduledState)) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingContext.java
@@ -123,7 +123,10 @@ public class StandardReportingContext implements ReportingContext, ControllerSer
         }
 
         final String configuredValue = properties.get(property);
-        return new StandardPropertyValue(configuredValue == null ? descriptor.getDefaultValue() : configuredValue, this, preparedQueries.get(property), variableRegistry);
+        if( property.isExpressionLanguageForced() )
+            return new StandardPropertyValue(configuredValue == null ? descriptor.getDefaultValue() : configuredValue, this, preparedQueries.get(property), variableRegistry).evaluateAttributeExpressions();
+        else
+            return new StandardPropertyValue(configuredValue == null ? descriptor.getDefaultValue() : configuredValue, this, preparedQueries.get(property), variableRegistry);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/FlowFromDOMFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/FlowFromDOMFactory.java
@@ -37,6 +37,7 @@ import org.apache.nifi.web.api.dto.PortDTO;
 import org.apache.nifi.web.api.dto.PositionDTO;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
@@ -114,6 +115,7 @@ public class FlowFromDOMFactory {
         dto.setState(enabled ? ControllerServiceState.ENABLED.name() : ControllerServiceState.DISABLED.name());
 
         dto.setProperties(getProperties(element, encryptor));
+        dto.setDescriptors(getDescriptors(element, encryptor));
         dto.setAnnotationData(getString(element, "annotationData"));
 
         return dto;
@@ -132,6 +134,7 @@ public class FlowFromDOMFactory {
         dto.setSchedulingStrategy(getString(element, "schedulingStrategy"));
 
         dto.setProperties(getProperties(element, encryptor));
+        dto.setDescriptors(getDescriptors(element, encryptor));
         dto.setAnnotationData(getString(element, "annotationData"));
 
         return dto;
@@ -461,6 +464,7 @@ public class FlowFromDOMFactory {
         }
 
         configDto.setProperties(getProperties(element, encryptor));
+        configDto.setDescriptors(getDescriptors(element, encryptor));
         configDto.setAnnotationData(getString(element, "annotationData"));
 
         final Set<String> autoTerminatedRelationships = new HashSet<>();
@@ -484,6 +488,18 @@ public class FlowFromDOMFactory {
             properties.put(name, value);
         }
         return properties;
+    }
+
+    private static LinkedHashMap<String, PropertyDescriptorDTO> getDescriptors(final Element element, final StringEncryptor encryptor) {
+        final LinkedHashMap<String, PropertyDescriptorDTO> descriptors = new LinkedHashMap<>();
+        final List<Element> propertyNodeList = getChildrenByTagName(element, "property");
+        for (final Element propertyElement : propertyNodeList) {
+            final PropertyDescriptorDTO descriptor = new PropertyDescriptorDTO();
+            descriptor.setName(getString(propertyElement, "name"));
+            descriptor.setForceEl(getBoolean(propertyElement, "forceEl"));
+            descriptors.put(descriptor.getName(), descriptor);
+        }
+        return descriptors;
     }
 
     private static String getString(final Element element, final String childElementName) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardConfigurationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardConfigurationContext.java
@@ -84,12 +84,19 @@ public class StandardConfigurationContext implements ConfigurationContext {
             return new StandardPropertyValue(resolvedDescriptor.getDefaultValue(), serviceLookup, preparedQueries.get(property), variableRegistry);
         }
 
-        return new StandardPropertyValue(resolvedValue, serviceLookup, preparedQueries.get(property), variableRegistry);
+        if( property.isExpressionLanguageForced() )
+            return new StandardPropertyValue(resolvedValue, serviceLookup, preparedQueries.get(property), variableRegistry).evaluateAttributeExpressions();
+        else
+            return new StandardPropertyValue(resolvedValue, serviceLookup, preparedQueries.get(property), variableRegistry);
     }
 
     @Override
     public Map<PropertyDescriptor, String> getProperties() {
-        return component.getProperties();
+        final Map<PropertyDescriptor, String> props = new HashMap<>();
+        for (final PropertyDescriptor descriptor : component.getProperties().keySet()) {
+            props.put(descriptor, getProperty(descriptor).getValue());
+        }
+        return props;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/StandardStateProviderInitializationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/StandardStateProviderInitializationContext.java
@@ -58,7 +58,10 @@ public class StandardStateProviderInitializationContext implements StateProvider
 
     @Override
     public PropertyValue getProperty(final PropertyDescriptor property) {
-        return properties.get(property);
+        if( property.isExpressionLanguageForced() )
+            return properties.get(property).evaluateAttributeExpressions();
+        else
+            return properties.get(property);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
@@ -89,7 +89,10 @@ public class StandardProcessContext implements ProcessContext, ControllerService
 
         final String setPropertyValue = properties.get(descriptor);
         if (setPropertyValue != null) {
-            return new StandardPropertyValue(setPropertyValue, this, preparedQueries.get(descriptor), procNode.getVariableRegistry());
+            if( descriptor.isExpressionLanguageForced() )
+                return new StandardPropertyValue(setPropertyValue, this, preparedQueries.get(descriptor), procNode.getVariableRegistry()).evaluateAttributeExpressions();
+            else
+                return new StandardPropertyValue(setPropertyValue, this, preparedQueries.get(descriptor), procNode.getVariableRegistry());
         }
 
         // Get the "canonical" Property Descriptor from the Processor
@@ -116,7 +119,10 @@ public class StandardProcessContext implements ProcessContext, ControllerService
         final String setPropertyValue = properties.get(descriptor);
         final String propValue = (setPropertyValue == null) ? descriptor.getDefaultValue() : setPropertyValue;
 
-        return new StandardPropertyValue(propValue, this, preparedQueries.get(descriptor), procNode.getVariableRegistry());
+        if( descriptor.isExpressionLanguageForced() )
+            return new StandardPropertyValue(propValue, this, preparedQueries.get(descriptor), procNode.getVariableRegistry()).evaluateAttributeExpressions();
+        else
+            return new StandardPropertyValue(propValue, this, preparedQueries.get(descriptor), procNode.getVariableRegistry());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardProcessorNode.java
@@ -530,6 +530,11 @@ public class TestStandardProcessorNode {
                     }
 
                     @Override
+                    public boolean isExpressionLanguageForced(String propertyName) {
+                        return false;
+                    }
+
+                    @Override
                     public String getProcessGroupIdentifier() {
                         return groupId;
                     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/templates/template-0.7.0.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/templates/template-0.7.0.xml
@@ -661,6 +661,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -676,6 +677,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -689,6 +691,7 @@
                                     <required>false</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -710,6 +713,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -731,6 +735,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -754,6 +759,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -776,6 +782,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -797,6 +804,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -820,6 +828,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -843,6 +852,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -866,6 +876,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -889,6 +900,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -912,6 +924,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -924,6 +937,7 @@
                                     <required>false</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                         </descriptors>
@@ -1056,6 +1070,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>true</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -1073,6 +1088,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>true</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -1086,6 +1102,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -1104,6 +1121,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -1151,6 +1169,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -1173,6 +1192,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                         </descriptors>
@@ -1289,6 +1309,7 @@
                                     <required>true</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>false</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                             <entry>
@@ -1301,6 +1322,7 @@
                                     <required>false</required>
                                     <sensitive>false</sensitive>
                                     <supportsEl>true</supportsEl>
+                                    <forceEl>false</forceEl>
                                 </value>
                             </entry>
                         </descriptors>
@@ -1399,6 +1421,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1414,6 +1437,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1427,6 +1451,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1448,6 +1473,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1469,6 +1495,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1492,6 +1519,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1513,6 +1541,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1534,6 +1563,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1557,6 +1587,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1579,6 +1610,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1602,6 +1634,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1625,6 +1658,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1648,6 +1682,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1660,6 +1695,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -1792,6 +1828,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1809,6 +1846,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1822,6 +1860,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1839,6 +1878,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1886,6 +1926,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -1908,6 +1949,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -2023,6 +2065,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2035,6 +2078,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -2134,6 +2178,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2146,6 +2191,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -2230,6 +2276,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2245,6 +2292,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2258,6 +2306,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2279,6 +2328,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2300,6 +2350,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2323,6 +2374,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2344,6 +2396,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2365,6 +2418,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2388,6 +2442,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2410,6 +2465,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2433,6 +2489,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2456,6 +2513,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2479,6 +2537,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2491,6 +2550,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -2638,6 +2698,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2650,6 +2711,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -2734,6 +2796,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2749,6 +2812,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2762,6 +2826,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2783,6 +2848,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2804,6 +2870,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2827,6 +2894,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2848,6 +2916,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2869,6 +2938,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2892,6 +2962,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2914,6 +2985,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2937,6 +3009,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2960,6 +3033,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2983,6 +3057,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -2995,6 +3070,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -3127,6 +3203,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3144,6 +3221,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3157,6 +3235,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3174,6 +3253,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3221,6 +3301,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3243,6 +3324,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -3343,6 +3425,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3358,6 +3441,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3371,6 +3455,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3392,6 +3477,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3413,6 +3499,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3436,6 +3523,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3457,6 +3545,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3478,6 +3567,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3501,6 +3591,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3523,6 +3614,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3546,6 +3638,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3569,6 +3662,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3592,6 +3686,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3604,6 +3699,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -3736,6 +3832,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3753,6 +3850,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3766,6 +3864,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3783,6 +3882,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3830,6 +3930,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3852,6 +3953,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -3951,6 +4053,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3964,6 +4067,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -3985,6 +4089,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4008,6 +4113,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -4110,6 +4216,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4122,6 +4229,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -4206,6 +4314,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4221,6 +4330,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4234,6 +4344,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4255,6 +4366,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4276,6 +4388,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4299,6 +4412,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4320,6 +4434,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4341,6 +4456,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4364,6 +4480,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4386,6 +4503,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4409,6 +4527,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4432,6 +4551,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4455,6 +4575,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4467,6 +4588,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -4599,6 +4721,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4616,6 +4739,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4629,6 +4753,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4646,6 +4771,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4693,6 +4819,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4715,6 +4842,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -4815,6 +4943,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4830,6 +4959,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4843,6 +4973,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4864,6 +4995,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4885,6 +5017,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4908,6 +5041,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4929,6 +5063,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4950,6 +5085,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4973,6 +5109,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -4995,6 +5132,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5018,6 +5156,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5041,6 +5180,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5064,6 +5204,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5076,6 +5217,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -5223,6 +5365,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5235,6 +5378,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -5334,6 +5478,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5346,6 +5491,7 @@
                             <required>false</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -5430,6 +5576,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5447,6 +5594,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5460,6 +5608,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5477,6 +5626,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5524,6 +5674,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5546,6 +5697,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>
@@ -5646,6 +5798,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5663,6 +5816,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>true</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5676,6 +5830,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5693,6 +5848,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5740,6 +5896,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                     <entry>
@@ -5762,6 +5919,7 @@
                             <required>true</required>
                             <sensitive>false</sensitive>
                             <supportsEl>false</supportsEl>
+                            <forceEl>false</forceEl>
                         </value>
                     </entry>
                 </descriptors>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -3719,6 +3719,7 @@ public final class DtoFactory {
         dto.setDescription(propertyDescriptor.getDescription());
         dto.setDefaultValue(propertyDescriptor.getDefaultValue());
         dto.setSupportsEl(propertyDescriptor.isExpressionLanguageSupported());
+        dto.setForceEl(propertyDescriptor.isExpressionLanguageForced());
 
         // to support legacy/deprecated method .expressionLanguageSupported(true)
         String description = propertyDescriptor.isExpressionLanguageSupported()

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
@@ -36,6 +36,7 @@ import org.apache.nifi.web.NiFiCoreException;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.api.dto.BundleDTO;
 import org.apache.nifi.web.api.dto.ControllerServiceDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.dao.ComponentStateDAO;
 import org.apache.nifi.web.dao.ControllerServiceDAO;
 
@@ -306,6 +307,7 @@ public class StandardControllerServiceDAO extends ComponentDAO implements Contro
                 controllerServiceDTO.getAnnotationData(),
                 controllerServiceDTO.getComments(),
                 controllerServiceDTO.getProperties(),
+                controllerServiceDTO.getDescriptors(),
                 controllerServiceDTO.getBundle())) {
             modificationRequest = true;
 
@@ -336,6 +338,7 @@ public class StandardControllerServiceDAO extends ComponentDAO implements Contro
         final String annotationData = controllerServiceDTO.getAnnotationData();
         final String comments = controllerServiceDTO.getComments();
         final Map<String, String> properties = controllerServiceDTO.getProperties();
+        final Map<String, PropertyDescriptorDTO> descriptors = controllerServiceDTO.getDescriptors();
 
         controllerService.pauseValidationTrigger(); // avoid causing validation to be triggered multiple times
         try {
@@ -350,6 +353,11 @@ public class StandardControllerServiceDAO extends ComponentDAO implements Contro
             }
             if (isNotNull(properties)) {
                 controllerService.setProperties(properties);
+            }
+            if (isNotNull(descriptors)) {
+                for (final Map.Entry<String, PropertyDescriptorDTO> entry : descriptors.entrySet()) {
+                    controllerService.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+                }
             }
         } finally {
             controllerService.resumeValidationTrigger();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -42,6 +42,7 @@ import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.api.dto.BundleDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.dao.ComponentStateDAO;
 import org.apache.nifi.web.dao.ProcessorDAO;
 import org.quartz.CronExpression;
@@ -133,6 +134,7 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
             final String annotationData = config.getAnnotationData();
             final Integer maxTasks = config.getConcurrentlySchedulableTaskCount();
             final Map<String, String> configProperties = config.getProperties();
+            final Map<String, PropertyDescriptorDTO> configDescriptors = config.getDescriptors();
             final String schedulingPeriod = config.getSchedulingPeriod();
             final String penaltyDuration = config.getPenaltyDuration();
             final String yieldDuration = config.getYieldDuration();
@@ -179,6 +181,11 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                 }
                 if (isNotNull(configProperties)) {
                     processor.setProperties(configProperties);
+                }
+                if (isNotNull(configDescriptors)) {
+                    for (final Map.Entry<String, PropertyDescriptorDTO> entry : configDescriptors.entrySet()) {
+                        processor.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+                    }
                 }
 
                 if (isNotNull(undefinedRelationshipsToTerminate)) {
@@ -395,6 +402,7 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                     configDTO.getConcurrentlySchedulableTaskCount(),
                     configDTO.getPenaltyDuration(),
                     configDTO.getProperties(),
+                    configDTO.getDescriptors(),
                     configDTO.getSchedulingPeriod(),
                     configDTO.getSchedulingStrategy(),
                     configDTO.getExecutionNode(),

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
@@ -36,6 +36,7 @@ import org.apache.nifi.web.NiFiCoreException;
 import org.apache.nifi.web.ResourceNotFoundException;
 import org.apache.nifi.web.api.dto.BundleDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.dao.ComponentStateDAO;
 import org.apache.nifi.web.dao.ReportingTaskDAO;
 import org.quartz.CronExpression;
@@ -283,6 +284,7 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
                 reportingTaskDTO.getSchedulingPeriod(),
                 reportingTaskDTO.getAnnotationData(),
                 reportingTaskDTO.getProperties(),
+                reportingTaskDTO.getDescriptors(),
                 reportingTaskDTO.getBundle())) {
             modificationRequest = true;
 
@@ -316,6 +318,7 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
         final String annotationData = reportingTaskDTO.getAnnotationData();
         final String comments = reportingTaskDTO.getComments();
         final Map<String, String> properties = reportingTaskDTO.getProperties();
+        final Map<String, PropertyDescriptorDTO> descriptors = reportingTaskDTO.getDescriptors();
 
         reportingTask.pauseValidationTrigger(); // avoid triggering validation multiple times
         try {
@@ -338,6 +341,11 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
             }
             if (isNotNull(properties)) {
                 reportingTask.setProperties(properties);
+            }
+            if (isNotNull(descriptors)) {
+                for (final Map.Entry<String, PropertyDescriptorDTO> entry : descriptors.entrySet()) {
+                    reportingTask.getPropertyDescriptor(entry.getKey()).setExpressionLanguageForced(entry.getValue().getForceEl());
+                }
             }
         } finally {
             reportingTask.resumeValidationTrigger();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
@@ -130,6 +130,8 @@
     var marshalDetails = function () {
         // properties
         var properties = $('#controller-service-properties').propertytable('marshalProperties');
+        // descriptors
+        var descriptors = $('#controller-service-properties').propertytable('marshalDescriptors');
 
         // create the controller service dto
         var controllerServiceDto = {};
@@ -140,6 +142,11 @@
         // set the properties
         if ($.isEmptyObject(properties) === false) {
             controllerServiceDto['properties'] = properties;
+        }
+
+        // set the descriptors
+        if ($.isEmptyObject(descriptors) === false) {
+            controllerServiceDto['descriptors'] = descriptors;
         }
 
         // create the controller service entity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -348,10 +348,17 @@
 
         // properties
         var properties = $('#processor-properties').propertytable('marshalProperties');
+        // descriptors
+        var descriptors = $('#processor-properties').propertytable('marshalDescriptors');
 
         // set the properties
         if ($.isEmptyObject(properties) === false) {
             processorConfigDto['properties'] = properties;
+        }
+
+        // set the descriptors
+        if ($.isEmptyObject(descriptors) === false) {
+            processorConfigDto['descriptors'] = descriptors;
         }
 
         // create the processor dto

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
@@ -158,6 +158,7 @@
     var marshalDetails = function () {
         // properties
         var properties = $('#reporting-task-properties').propertytable('marshalProperties');
+        var descriptors = $('#reporting-task-properties').propertytable('marshalDescriptors');
 
         // get the scheduling strategy
         var schedulingStrategy = $('#reporting-task-scheduling-strategy-combo').combo('getSelectedOption').value;
@@ -188,6 +189,11 @@
         // set the properties
         if ($.isEmptyObject(properties) === false) {
             reportingTaskDto['properties'] = properties;
+        }
+
+        // set the descriptors
+        if ($.isEmptyObject(descriptors) === false) {
+            reportingTaskDto['descriptors'] = descriptors;
         }
 
         // create the reporting task entity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -1043,7 +1043,7 @@
          */
         supportsEl: function (propertyDescriptor) {
             if (nfCommon.isDefinedAndNotNull(propertyDescriptor)) {
-                return propertyDescriptor.supportsEl === true;
+                return propertyDescriptor.supportsEl === true || propertyDescriptor.forceEl === true;
             } else {
                 return false;
             }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/impl/ValidationContextAdapter.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/impl/ValidationContextAdapter.java
@@ -90,6 +90,11 @@ public abstract class ValidationContextAdapter implements ValidationContext {
     }
 
     @Override
+    public boolean isExpressionLanguageForced(String propertyName) {
+        return innerValidationContext.isExpressionLanguageForced(propertyName);
+    }
+
+    @Override
     public String getProcessGroupIdentifier() {
         return innerValidationContext.getProcessGroupIdentifier();
     }


### PR DESCRIPTION
Hi Guys

This change is a PoC of user-controlled enabling Expression Language for the current NiFi. You can test it, but seems this approach will never be completed because of compatibility issues (it adds additional `PropertyDescriptor` field `forceEl` that saved into the flow/template).

Hopefully this one will help someone else to setup CICD for NiFi flows properly.

Thank you

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?