### PR TITLE
NIFI-6099 Added Expression Language `default` function

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
@@ -158,6 +158,7 @@ FIND	: 'find';	// regex
 MATCHES : 'matches';	// regex
 EQUALS	: 'equals';
 EQUALS_IGNORE_CASE : 'equalsIgnoreCase';
+DEFAULT : 'default';
 GREATER_THAN	: 'gt';
 LESS_THAN		: 'lt';
 GREATER_THAN_OR_EQUAL	: 'ge';

--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
@@ -83,7 +83,7 @@ fiveArgString : GET_DELIMITED_FIELD LPAREN! anyArg (COMMA! anyArg (COMMA! anyArg
 
 // functions that return Booleans
 zeroArgBool : (IS_NULL | NOT_NULL | IS_EMPTY | NOT) LPAREN! RPAREN!;
-oneArgBool	: ((FIND | MATCHES | EQUALS_IGNORE_CASE) LPAREN! anyArg RPAREN!) |
+oneArgBool	: ((FIND | MATCHES | EQUALS_IGNORE_CASE | DEFAULT) LPAREN! anyArg RPAREN!) |
 			  (GREATER_THAN | LESS_THAN | GREATER_THAN_OR_EQUAL | LESS_THAN_OR_EQUAL) LPAREN! anyArg RPAREN! |
 			  (EQUALS) LPAREN! anyArg RPAREN! |
 			  (AND | OR) LPAREN! anyArg RPAREN!;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
@@ -46,6 +46,7 @@ import org.apache.nifi.attribute.expression.language.evaluation.functions.Divide
 import org.apache.nifi.attribute.expression.language.evaluation.functions.EndsWithEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.EqualsEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.EqualsIgnoreCaseEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.functions.DefaultEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.FindEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.FormatEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.FromRadixEvaluator;
@@ -147,6 +148,7 @@ import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpre
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.ENDS_WITH;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.EQUALS;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.EQUALS_IGNORE_CASE;
+import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.DEFAULT;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.ESCAPE_CSV;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.ESCAPE_HTML3;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.ESCAPE_HTML4;
@@ -603,6 +605,11 @@ public class ExpressionCompiler {
             case UNESCAPE_XML: {
                 verifyArgCount(argEvaluators, 0, "unescapeXml");
                 return addToken(CharSequenceTranslatorEvaluator.xmlUnescapeEvaluator(toStringEvaluator(subjectEvaluator)), "escapeJson");
+            }
+            case DEFAULT: {
+                verifyArgCount(argEvaluators, 1, "default");
+                return addToken(new DefaultEvaluator(toStringEvaluator(subjectEvaluator),
+                    toStringEvaluator(argEvaluators.get(0), "first argument to default")), "default");
             }
             case SUBSTRING_BEFORE: {
                 verifyArgCount(argEvaluators, 1, "substringBefore");

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/DefaultEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/DefaultEvaluator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import java.util.Map;
+
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
+
+public class DefaultEvaluator extends StringEvaluator {
+
+    private final Evaluator<String> subject;
+    private final Evaluator<String> defaultEvaluator;
+
+    public DefaultEvaluator(final Evaluator<String> subject, final Evaluator<String> defaultEvaluator) {
+        this.subject = subject;
+        this.defaultEvaluator = defaultEvaluator;
+    }
+
+    @Override
+    public QueryResult<String> evaluate(final Map<String, String> attributes) {
+        final String subjectValue = subject.evaluate(attributes).getValue();
+        final String defaultValue = defaultEvaluator.evaluate(attributes).getValue();
+        if ( subjectValue == null )
+            return new StringQueryResult(defaultValue);
+        return new StringQueryResult(subjectValue);
+    }
+
+    @Override
+    public Evaluator<?> getSubjectEvaluator() {
+        return subject;
+    }
+
+}

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -1347,6 +1347,15 @@ public class TestQuery {
     }
 
     @Test
+    public void testDefault() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("exists_val", "existsValue");
+
+        verifyEquals("${exists_val:default('defaultValue')}", attributes, "existsValue");
+        verifyEquals("${not_exists_val:default('defaultValue')}", attributes, "defaultValue");
+    }
+
+    @Test
     public void testSubstringAfter() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("filename", "file-255");

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -624,6 +624,34 @@ Each of the following functions manipulates a String in some way.
 
 
 [.function]
+=== default
+
+*Description*: [.description]#Returns Subject if it's defined & not null, will return first argument otherwise.#
+
+*Subject Type*: [.subject]#Any#
+
+*Arguments*:
+
+	- [.argName]#_value_# : [.argDesc]#The String with default value#
+
+*Return Type*: [.returnType]#String#
+
+*Examples*: If the "filename" attribute is defined with value "filename.txt" and
+    "not_filename" attribute is not defined or equal null, then the following
+    Expressions will result in the following values:
+
+.SubstringBefore Examples
+|======================================================================
+| Expression | Value
+| `${filename:default('default.txt')}` | `filename.txt`
+| `${not_filename:default('default.txt')}` | `default.txt`
+|======================================================================
+
+
+
+
+
+[.function]
 === substring
 
 *Description*:


### PR DESCRIPTION
This simple change introduces `default` function for the NiFi Expression Language.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
