### PR TITLE
NIFI-6106 Add tests for commons utilities & fix FormatUtils bug

### DIFF
--- a/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/StringUtilsTest.java
+++ b/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/StringUtilsTest.java
@@ -1,0 +1,81 @@
+package org.apache.nifi.util;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+  @Test
+  public void testIsBlank() {
+    assertFalse(StringUtils.isBlank("0"));
+    assertFalse(StringUtils.isBlank("\u0000"));
+    assertFalse(StringUtils.isBlank(" \u0000 "));
+    assertFalse(StringUtils.isBlank(" \u5678 "));
+
+    assertTrue(StringUtils.isBlank(" "));
+    assertTrue(StringUtils.isBlank(""));
+  }
+
+  @Test
+  public void testStartsWith() {
+    assertFalse(StringUtils.startsWith("!", "something"));
+
+    assertTrue(StringUtils.startsWith("!!!!!test", "!!!!"));
+    assertTrue(StringUtils.startsWith("!something", "!"));
+    assertTrue(StringUtils.startsWith(null, null));
+  }
+
+  @Test
+  public void testPadRight() {
+    assertEquals("sample", StringUtils.padRight("sample", 0, '0'));
+    assertEquals("sample0000", StringUtils.padRight("sample", 10, '0'));
+    assertEquals("0000000000", StringUtils.padRight("", 10, '0'));
+
+    assertNull(StringUtils.padRight(null, 0, '0'));
+  }
+
+  @Test
+  public void testPadLeft() {
+    assertEquals("sample", StringUtils.padLeft("sample", 0, '0'));
+    assertEquals("0000sample", StringUtils.padLeft("sample", 10, '0'));
+    assertEquals("0000000000", StringUtils.padLeft("", 10, '0'));
+
+    assertNull(StringUtils.padLeft(null, 0, '0'));
+  }
+
+  @Test
+  public void testIsEmpty() {
+    assertFalse(StringUtils.isEmpty("AAAAAAAA"));
+    assertFalse(StringUtils.isEmpty(" "));
+
+    assertTrue(StringUtils.isEmpty(""));
+    assertTrue(StringUtils.isEmpty(null));
+  }
+
+  @Test
+  public void testSubstringAfter() {
+    assertEquals("", StringUtils.substringAfter("", ""));
+    assertEquals("", StringUtils.substringAfter("", ">>"));
+    assertEquals("after", StringUtils.substringAfter("substring>>after", ">>"));
+    assertEquals("after>>another", StringUtils.substringAfter("substring>>after>>another", ">>"));
+    assertEquals("", StringUtils.substringAfter("substring>>after", null));
+    assertEquals("", StringUtils.substringAfter("substring.after", ">>"));
+  }
+
+  @Test
+  public void testJoin() {
+    final ArrayList<String> collection = new ArrayList<>();
+    assertEquals("", StringUtils.join(collection, ","));
+
+    collection.add("test1");
+    assertEquals("test1", StringUtils.join(collection, ","));
+
+    collection.add("test2");
+    assertEquals("test1,test2", StringUtils.join(collection, ","));
+
+    collection.add(null);
+    assertEquals("test1,test2,null", StringUtils.join(collection, ","));
+  }
+}

--- a/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/StringUtilsTest.java
+++ b/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/StringUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.util;
 
 import static org.junit.Assert.assertFalse;

--- a/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/StringUtilsTest.java
+++ b/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/StringUtilsTest.java
@@ -1,6 +1,9 @@
 package org.apache.nifi.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import org.junit.Test;

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -399,8 +399,8 @@ public class FormatUtils {
     public static String formatNanos(final long nanos, final boolean includeTotalNanos) {
         final StringBuilder sb = new StringBuilder();
 
-        final long seconds = nanos > 1000000000L ? nanos / 1000000000L : 0L;
-        long millis = nanos > 1000000L ? nanos / 1000000L : 0L;
+        final long seconds = nanos >= 1000000000L ? nanos / 1000000000L : 0L;
+        long millis = nanos >= 1000000L ? nanos / 1000000L : 0L;
         final long nanosLeft = nanos % 1000000L;
 
         if (seconds > 0) {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/processor/TestFormatUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/processor/TestFormatUtils.java
@@ -47,9 +47,9 @@ public class TestFormatUtils {
         assertEquals("00:00:07.777", FormatUtils.formatHoursMinutesSeconds(7777, TimeUnit.MILLISECONDS));
 
         assertEquals("20:11:36.897", FormatUtils.formatHoursMinutesSeconds(TimeUnit.MILLISECONDS.convert(20, TimeUnit.HOURS)
-                        + TimeUnit.MILLISECONDS.convert(11, TimeUnit.MINUTES)
-                        + TimeUnit.MILLISECONDS.convert(36, TimeUnit.SECONDS)
-                        + TimeUnit.MILLISECONDS.convert(897, TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS));
+                + TimeUnit.MILLISECONDS.convert(11, TimeUnit.MINUTES)
+                + TimeUnit.MILLISECONDS.convert(36, TimeUnit.SECONDS)
+                + TimeUnit.MILLISECONDS.convert(897, TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS));
 
         assertEquals("1000:01:01.001", FormatUtils.formatHoursMinutesSeconds(TimeUnit.MILLISECONDS.convert(999, TimeUnit.HOURS)
                 + TimeUnit.MILLISECONDS.convert(60, TimeUnit.MINUTES)
@@ -57,4 +57,48 @@ public class TestFormatUtils {
                 + TimeUnit.MILLISECONDS.convert(1001, TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS));
     }
 
+
+    @Test
+    public void testFormatNanos() {
+        assertEquals("0 nanos", FormatUtils.formatNanos(0L, false));
+        assertEquals("0 nanos (0 nanos)", FormatUtils.formatNanos(0L, true));
+
+        assertEquals("1 millis, 0 nanos", FormatUtils.formatNanos(1_000_000L, false));
+        assertEquals("1 millis, 0 nanos (1000000 nanos)", FormatUtils.formatNanos(1_000_000L, true));
+
+        assertEquals("1 millis, 1 nanos", FormatUtils.formatNanos(1_000_001L, false));
+        assertEquals("1 millis, 1 nanos (1000001 nanos)", FormatUtils.formatNanos(1_000_001L, true));
+
+        assertEquals("1 seconds, 0 millis, 0 nanos", FormatUtils.formatNanos(1_000_000_000L, false));
+        assertEquals(
+            "1 seconds, 0 millis, 0 nanos (1000000000 nanos)",
+            FormatUtils.formatNanos(1_000_000_000L, true));
+
+        assertEquals("1 seconds, 1 millis, 0 nanos", FormatUtils.formatNanos(1_001_000_000L, false));
+        assertEquals(
+            "1 seconds, 1 millis, 0 nanos (1001000000 nanos)",
+            FormatUtils.formatNanos(1_001_000_000L, true));
+
+        assertEquals("1 seconds, 1 millis, 1 nanos", FormatUtils.formatNanos(1_001_000_001L, false));
+        assertEquals(
+            "1 seconds, 1 millis, 1 nanos (1001000001 nanos)",
+            FormatUtils.formatNanos(1_001_000_001L, true));
+    }
+
+    @Test
+    public void testFormatDataSize() {
+        assertEquals("0 bytes", FormatUtils.formatDataSize(0d));
+        assertEquals("10.4 bytes", FormatUtils.formatDataSize(10.4d));
+        assertEquals("1,024 bytes", FormatUtils.formatDataSize(1024d));
+
+        assertEquals("1 KB", FormatUtils.formatDataSize(1025d));
+        assertEquals("1.95 KB", FormatUtils.formatDataSize(2000d));
+        assertEquals("195.31 KB", FormatUtils.formatDataSize(200_000d));
+
+        assertEquals("190.73 MB", FormatUtils.formatDataSize(200_000_000d));
+
+        assertEquals("186.26 GB", FormatUtils.formatDataSize(200_000_000_000d));
+
+        assertEquals("181.9 TB", FormatUtils.formatDataSize(200_000_000_000_000d));
+    }
 }


### PR DESCRIPTION
I analyzed this project and noticed some methods lacking tests in these two utilities classes. I've written some tests using [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/datasheet) which should hopefully help you to detect any regressions caused by future code changes. 

I also corrected a small bug in `FormatUtils` which caused the `formatNanos` method to incorrectly format multiples of 1000000 or 1000000000 to `"0 nanos"`.

Please let me know if there are any other areas of your project which you would like tests written for, I would be more than happy to help.