### PR TITLE
NIFI-6180: exposing firehose grace period to DruidTranquilityController

### DIFF
--- a/nifi-nar-bundles/nifi-druid-bundle/nifi-druid-controller-service/src/main/java/org/apache/nifi/controller/druid/DruidTranquilityController.java
+++ b/nifi-nar-bundles/nifi-druid-bundle/nifi-druid-controller-service/src/main/java/org/apache/nifi/controller/druid/DruidTranquilityController.java
@@ -80,6 +80,7 @@ public class DruidTranquilityController extends AbstractControllerService implem
     private final static String FIREHOSE_PATTERN = "druid:firehose:%s";
 
     private final static AllowableValue PT1M = new AllowableValue("PT1M", "1 minute", "1 minute");
+    private final static AllowableValue PT5M = new AllowableValue("PT5M", "5 minute", "5 minute");
     private final static AllowableValue PT10M = new AllowableValue("PT10M", "10 minutes", "10 minutes");
     private final static AllowableValue PT60M = new AllowableValue("PT60M", "60 minutes", "1 hour");
 
@@ -276,6 +277,16 @@ public class DruidTranquilityController extends AbstractControllerService implem
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor FIREHOSE_GRACE_PERIOD = new PropertyDescriptor.Builder()
+            .name("druid-cs-firehose-grace-period")
+            .displayName("Firehose Grace Period")
+            .description("An additional grace period, after the \"Late Event Grace Period\" (window period) has elapsed, but before the indexing task is shut down.")
+            .required(true)
+            .allowableValues(PT1M, PT5M, PT10M, PT60M)
+            .defaultValue(PT5M.getValue())
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
     public static final PropertyDescriptor MAX_BATCH_SIZE = new PropertyDescriptor.Builder()
             .name("druid-cs-batch-size")
             .displayName("Batch Size")
@@ -331,6 +342,7 @@ public class DruidTranquilityController extends AbstractControllerService implem
         props.add(SEGMENT_GRANULARITY);
         props.add(QUERY_GRANULARITY);
         props.add(WINDOW_PERIOD);
+        props.add(FIREHOSE_GRACE_PERIOD);
         props.add(TIMESTAMP_FIELD);
         props.add(MAX_BATCH_SIZE);
         props.add(MAX_PENDING_BATCHES);
@@ -377,6 +389,7 @@ public class DruidTranquilityController extends AbstractControllerService implem
         final String segmentGranularity = context.getProperty(SEGMENT_GRANULARITY).getValue();
         final String queryGranularity = context.getProperty(QUERY_GRANULARITY).getValue();
         final String windowPeriod = context.getProperty(WINDOW_PERIOD).getValue();
+        final String firehoseGracePeriod = context.getProperty(FIREHOSE_GRACE_PERIOD).getValue();
         final String indexRetryPeriod = context.getProperty(INDEX_RETRY_PERIOD).getValue();
         final String aggregatorJSON = context.getProperty(AGGREGATOR_JSON).evaluateAttributeExpressions().getValue();
         final String dimensionsStringList = context.getProperty(DIMENSIONS_LIST).evaluateAttributeExpressions().getValue();
@@ -415,7 +428,7 @@ public class DruidTranquilityController extends AbstractControllerService implem
         final TimestampSpec timestampSpec = new TimestampSpec(timestampField, "auto", null);
 
         final Beam<Map<String, Object>> beam = buildBeam(dataSource, indexService, discoveryPath, clusterPartitions, clusterReplication,
-                segmentGranularity, queryGranularity, windowPeriod, indexRetryPeriod, dimensions, aggregator, timestamper, timestampSpec);
+                segmentGranularity, queryGranularity, windowPeriod, firehoseGracePeriod, indexRetryPeriod, dimensions, aggregator, timestamper, timestampSpec);
 
         tranquilizer = buildTranquilizer(maxBatchSize, maxPendingBatches, lingerMillis, beam);
 
@@ -432,7 +445,7 @@ public class DruidTranquilityController extends AbstractControllerService implem
     }
 
     Beam<Map<String, Object>> buildBeam(String dataSource, String indexService, String discoveryPath, int clusterPartitions, int clusterReplication,
-                                        String segmentGranularity, String queryGranularity, String windowPeriod, String indexRetryPeriod, List<String> dimensions,
+                                        String segmentGranularity, String queryGranularity, String windowPeriod, String firehoseGracePeriod, String indexRetryPeriod, List<String> dimensions,
                                         List<AggregatorFactory> aggregator, Timestamper<Map<String, Object>> timestamper, TimestampSpec timestampSpec) {
         return DruidBeams.builder(timestamper)
                 .curator(curator)
@@ -453,6 +466,7 @@ public class DruidTranquilityController extends AbstractControllerService implem
                         DruidBeamConfig
                                 .builder()
                                 .indexRetryPeriod(new Period(indexRetryPeriod))
+                                .firehoseGracePeriod(new Period(firehoseGracePeriod))
                                 .build())
                 .buildBeam();
     }

--- a/nifi-nar-bundles/nifi-druid-bundle/nifi-druid-processors/src/test/java/org/apache/nifi/controller/druid/MockDruidTranquilityController.java
+++ b/nifi-nar-bundles/nifi-druid-bundle/nifi-druid-processors/src/test/java/org/apache/nifi/controller/druid/MockDruidTranquilityController.java
@@ -137,7 +137,7 @@ public class MockDruidTranquilityController extends DruidTranquilityController {
     @SuppressWarnings("unchecked")
     @Override
     Beam<Map<String, Object>> buildBeam(String dataSource, String indexService, String discoveryPath, int clusterPartitions, int clusterReplication,
-                                        String segmentGranularity, String queryGranularity, String windowPeriod, String indexRetryPeriod, List<String> dimensions,
+                                        String segmentGranularity, String queryGranularity, String windowPeriod, String firehoseGracePeriod, String indexRetryPeriod, List<String> dimensions,
                                         List<AggregatorFactory> aggregator, Timestamper<Map<String, Object>> timestamper, TimestampSpec timestampSpec) {
         return mock(Beam.class);
     }


### PR DESCRIPTION
this allows for configuring `druidBeam.firehoseGracePeriod`
(https://github.com/druid-io/tranquility/blob/master/docs/configuration.md#properties)

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
