### PR TITLE
NIFI-5900 Add a SplitLargeJson processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/src/main/resources/META-INF/NOTICE
@@ -239,6 +239,8 @@ The following binary components are provided under the Common Development and Di
     (CDDL 1.1) (GPL2 w/ CPE) Javax JMS Api (javax.jms:javax.jms-api:jar:2.0.1 - http://java.net/projects/jms-spec/pages/Home)
     (CDDL 1.1) (GPL2 w/ CPE) Expression Language 3.0 API (javax.el:javax.el-api:jar:3.0.0 - http://uel-spec.java.net)
     (CDDL 1.1) (GPL2 w/ CPE) javax.ws.rs-api (javax.ws.rs:javax.ws.rs-api:jar:2.1 - http://jax-rs-spec.java.net)
+    (CDDL 1.1) (GPL2 w/ CPE) JSON-P (org.glassfish:javax.json:jar:1.1 - https://javaee.github.io/jsonp)
+    (CDDL 1.1) (GPL2 w/ CPE) JSON API (javax.json:jsonx.json-api:jar:1.1 - https://javaee.github.io/jsonp)
 
 *****************
 Common Development and Distribution License v1.0:

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -354,6 +354,16 @@
             <version>1.10.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-standard-web-test-utils</artifactId>
             <version>1.10.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java
@@ -39,6 +39,7 @@ import org.apache.nifi.annotation.behavior.SystemResource;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -72,7 +73,9 @@ import static org.apache.nifi.flowfile.attributes.FragmentAttributes.copyAttribu
 @CapabilityDescription("Splits a JSON File into multiple, separate FlowFiles for an array element specified by a JsonPath expression. "
         + "Each generated FlowFile is comprised of an element of the specified array and transferred to relationship 'split,' "
         + "with the original file transferred to the 'original' relationship. If the specified JsonPath is not found or "
-        + "does not evaluate to an array element, the original file is routed to 'failure' and no files are generated.")
+        + "does not evaluate to an array element, the original file is routed to 'failure' and no files are generated. "
+        + "If a designated object in the JSON document is to be split into its key-value pairs, the SplitLargeJson "
+        + "processor can be used. This processor can split arrays and supports the full JSON Path specification.")
 @WritesAttributes({
         @WritesAttribute(attribute = "fragment.identifier",
                 description = "All split FlowFiles produced from the same parent FlowFile will have the same randomly generated UUID added for this attribute"),
@@ -82,9 +85,12 @@ import static org.apache.nifi.flowfile.attributes.FragmentAttributes.copyAttribu
                 description = "The number of split FlowFiles generated from the parent FlowFile"),
         @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile")
 })
+@SeeAlso(SplitLargeJson.class)
 @SystemResourceConsideration(resource = SystemResource.MEMORY, description = "The entirety of the FlowFile's content (as a JsonNode object) is read into memory, " +
-        "in addition to all of the generated FlowFiles representing the split JSON. If many splits are generated due to the size of the JSON, or how the JSON is " +
-        "configured to be split, a two-phase approach may be necessary to avoid excessive use of memory.")
+        "in addition to all of the generated FlowFiles representing the split JSON.  If the JSON documents to be " +
+        "split are large, then the SplitLargeJson processor should be considered in order to avoid excessive " +
+        "memory usage.  If a complex JSON Path is required and the JSON documents are large, then a two-phase " +
+        "approach may be necessary.")
 public class SplitJson extends AbstractJsonPathProcessor {
 
     public static final PropertyDescriptor ARRAY_JSON_PATH_EXPRESSION = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitLargeJson.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitLargeJson.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.standard.util.JsonFragmentWriter;
+import org.apache.nifi.processors.standard.util.JsonStack;
+import org.apache.nifi.processors.standard.util.SimpleJsonPath;
+
+import javax.json.Json;
+import javax.json.stream.JsonParser;
+import javax.json.stream.JsonParsingException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.copyAttributesToOriginal;
+
+@EventDriven
+@SideEffectFree
+@SupportsBatching
+@Tags({"json", "split", "jsonpath"})
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@CapabilityDescription("Splits a JSON File into multiple, separate FlowFiles.  Each element of the object or array " +
+        "specified by the JSON Path will be sent in a dedicated flowfile to the 'split' relationship.  The " +
+        "original file will be transferred to the 'original' relationship.  If the specified JSON Path is not found, " +
+        "the original file is routed to 'failure' and no files are generated. "+
+        "The purpose of this processor is to minimize the amount of memory needed to split a JSON document.  It is " +
+        "intended for use with large JSON files when the JSON Path is rudimentary. This processor conserves memory " +
+        "by reading documents in a streaming fashion (without loading the whole document into memory at once) and " +
+        "therefore cannot support all JSON Path expressions.  Note, however, that a fragment.index attribute is set " +
+        "on every outgoing FlowFile. This, in combination with a RouteOnAttribute processor, can be used in place " +
+        "of certain JSON Path constructs. The specified JSON Path will be checked and the processor will reflect " +
+        "an invalid state if the expression is not supported.  Lastly, in contrast with the SplitJson processor, " +
+        "every generated flowfile will always be a self-contained valid JSON document.  For example, when " +
+        "splitting an array of scalar values, each resulting document will be framed in array context.")
+@WritesAttributes({
+        @WritesAttribute(attribute = "fragment.identifier",
+                description = "All split FlowFiles produced from the same parent FlowFile will have the same " +
+                        "randomly generated UUID added for this attribute"),
+        @WritesAttribute(attribute = "fragment.index",
+                description = "A one-up number that indicates the ordering of the split FlowFiles that were " +
+                        "created from a single parent FlowFile"),
+        @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile")
+})
+@SeeAlso(SplitJson.class)
+public class SplitLargeJson extends AbstractProcessor {
+
+    public static final PropertyDescriptor JSON_PATH_EXPRESSION = new PropertyDescriptor.Builder()
+            .name("JsonPath Expression")
+            .description("A JsonPath expression that indicates the array element to split into JSON/scalar fragments.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR) // Full validation occurs in #customValidate
+            .required(true)
+            .build();
+
+    public static final Relationship REL_ORIGINAL = new Relationship.Builder()
+            .name("original")
+            .description("The original FlowFile that was split into segments. If the FlowFile fails processing, " +
+                    "nothing will be sent to this relationship")
+            .build();
+    public static final Relationship REL_SPLIT = new Relationship.Builder()
+            .name("split")
+            .description("All segments of the original FlowFile will be routed to this relationship")
+            .build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid " +
+                    "JSON or the specified path does not exist), it will be routed to this relationship")
+            .build();
+
+    private List<PropertyDescriptor> properties;
+    private Set<Relationship> relationships;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(JSON_PATH_EXPRESSION);
+        this.properties = Collections.unmodifiableList(properties);
+
+        final Set<Relationship> relationships = new HashSet<>();
+        relationships.add(REL_ORIGINAL);
+        relationships.add(REL_SPLIT);
+        relationships.add(REL_FAILURE);
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        String value = validationContext.getProperty(JSON_PATH_EXPRESSION).getValue();
+        ValidationResult.Builder vrb = new ValidationResult.Builder();
+        try {
+            SimpleJsonPath.of(value);
+            vrb.valid(true);
+        } catch (Exception e) {
+            vrb.subject(value);
+            vrb.input(getClass().getName());
+            vrb.explanation("the specified JSON path is either invalid or not supported by this processor.");
+        }
+        return Collections.singleton(vrb.build());
+    }
+
+    /** Provide read-only access to a JsonParser, exposing only the getter methods for the current value. */
+    public static class JsonParserView {
+        private final JsonParser parser;
+
+        JsonParserView(JsonParser parser) {
+            this.parser = parser;
+        }
+
+        public String getString() {
+            return parser.getString();
+        }
+
+        public BigDecimal getBigDecimal() {
+            return parser.getBigDecimal();
+        }
+
+        public int getInt() {
+            return parser.getInt();
+        }
+
+        public boolean isIntegralNumber() {
+            return parser.isIntegralNumber();
+        }
+    }
+
+    @Override
+    /** The specified JSON Path property will be used to split an incoming FlowFile into multiple FlowFiles.  The
+     * method uses the JSON Path property to build a <code>SimpleJsonPath</code> instance.  It then uses the JSR-374
+     * API (AKA JSON-P) read the incoming JSON in a streaming fashion, building a <code>JsonStack</code> instance as
+     * it goes.  Every time the stack changes it is compared with the <code>SimpleJsonPath</code> to determine if the
+     * current point in the file should be copied to an outgoing FlowFile. */
+    public void onTrigger(final ProcessContext processContext, final ProcessSession processSession) {
+        FlowFile original = processSession.get();
+        if (original == null) {
+            return;
+        }
+
+        final ComponentLog logger = getLogger();
+
+        String groupId = UUID.randomUUID().toString();
+        SimpleJsonPath path = SimpleJsonPath.of(processContext.getProperty(JSON_PATH_EXPRESSION).getValue());
+        JsonFragmentWriter fragmentWriter = new JsonFragmentWriter(processSession, original, REL_SPLIT, groupId,
+                path.hasWildcard() ? JsonFragmentWriter.Mode.DISJOINT : JsonFragmentWriter.Mode.CONTIGUOUS);
+        JsonStack stack = new JsonStack();
+        JsonFragmentWriter.BoolPair section = new JsonFragmentWriter.BoolPair();
+        if (path.isEmpty()) {
+            section.push(true);
+        }
+
+        try (InputStream is = processSession.read(original);
+             JsonParser parser = Json.createParser(is)) {
+            JsonParserView view = new JsonParserView(parser);
+            while (parser.hasNext()) {
+                JsonParser.Event e = parser.next();
+                stack.receive(e, view);
+                section.push(stack.startsWith(path));
+                fragmentWriter.filterEvent(section, e, view, stack.size());
+            }
+        } catch (JsonParsingException e) {
+            logger.error("FlowFile {} did not have valid JSON content.", new Object[]{original});
+            processSession.transfer(original, REL_FAILURE);
+            return;
+        } catch (Exception e) {
+            logger.error("Problems with FlowFile {}: {}", new Object[]{original, e.getMessage()});
+            processSession.transfer(original, REL_FAILURE);
+            return;
+        }
+
+        if (fragmentWriter.getCount() == 0) {
+            logger.error("No object or array was found at the specified json path");
+            processSession.transfer(original, REL_FAILURE);
+            return;
+        }
+
+        logger.info("Split {} into {} FlowFile(s)", new Object[]{original, fragmentWriter.getCount()});
+        original = copyAttributesToOriginal(processSession, original, groupId, fragmentWriter.getCount());
+        processSession.transfer(original, REL_ORIGINAL);
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JsonFragmentWriter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JsonFragmentWriter.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processors.standard.SplitLargeJson;
+
+import javax.json.Json;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonGeneratorFactory;
+import javax.json.stream.JsonParser.Event;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.FRAGMENT_ID;
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.FRAGMENT_INDEX;
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.SEGMENT_ORIGINAL_FILENAME;
+
+/** An instance of <code>JsonFragmentWriter</code> serves as a filter for
+ * <code>javax.json.stream.JsonParser.Event</code> instances, creating new FlowFiles when necessary. The Event that
+ * is passed to the <code>filterEvent</code> method can be thought of as a "cursor" passing through the original
+ * JSON document.  When a fragment of interest comes into view (see comments for the <code>BoolPair</code> class),
+ * a new FlowFile is created. Subsequent calls to <code>filterEvent</code> will copy the desired JSON fragment into
+ * the FlowFile. When the fragment passes out of view, the FlowFile is closed and transferred, freeing up associated
+ * resources from memory. */
+public class JsonFragmentWriter {
+
+    private static JsonGeneratorFactory factory = Json.createGeneratorFactory(null);
+    private final ProcessSession processSession;
+    private final FlowFile original;
+    private final Relationship relSplit;
+    private final Mode mode;
+    private FlowFile fragment;
+    private OutputStream outputStream;
+    private JsonGenerator generator;
+    private Integer targetDepth;
+    private Integer prevDepth;
+    private Event context;
+    private String contextName;
+    private Boolean addContext;
+    private int fragmentIndex;
+    private Map<String, String> attributes = new HashMap<>();
+
+    private final String groupId;
+
+    public int getCount() {
+        return fragmentIndex;
+    }
+
+    public enum Mode {
+        /** When a single contiguous section of a large JSON file is split into multiple FlowFiles */
+        CONTIGUOUS,
+
+        /** When multiple disjoint excerpts from a large JSON are to become separate FlowFiles */
+        DISJOINT
+    }
+
+    /** This is a helper class to keep track of when a targeted section of JSON is coming into view ("waxing"),
+     * in view ("full"), or going out of view ("waning"). */
+    public static class BoolPair {
+        private boolean previous;
+        private boolean current;
+
+        boolean waxing() {
+            return !previous && current;
+        }
+
+        boolean waning() {
+            return previous && !current;
+        }
+
+        boolean full() {
+            return current && previous;
+        }
+
+        public void push(boolean current) {
+            previous = this.current;
+            this.current = current;
+        }
+    }
+
+    public JsonFragmentWriter(ProcessSession processSession, FlowFile original, Relationship relSplit, String groupId, Mode mode){
+        this.processSession = processSession;
+        this.original = original;
+        this.relSplit = relSplit;
+        this.mode = mode;
+        this.groupId = groupId;
+        attributes.put(FRAGMENT_ID.key(), groupId);
+        attributes.put(SEGMENT_ORIGINAL_FILENAME.key(), original.getAttribute(CoreAttributes.FILENAME.key()));
+    }
+
+    private void newFragment(SplitLargeJson.JsonParserView view) {
+        fragment = processSession.create(original);
+        outputStream = processSession.write(fragment);
+        generator = factory.createGenerator(outputStream);
+        if ((addContext != null) && addContext) {
+            write(context, view);
+        }
+    }
+
+    private void endFragment() throws IOException {
+        if ((addContext != null) && addContext) {
+            generator.writeEnd();
+        }
+        generator.flush();
+        generator.close();
+        generator = null;
+        outputStream.close();
+        addContext = null;
+        attributes.put(FRAGMENT_INDEX.key(), String.valueOf(fragmentIndex++));
+        processSession.transfer(processSession.putAllAttributes(fragment, attributes), relSplit);
+    }
+
+    private void write(Event e, SplitLargeJson.JsonParserView view) {
+        switch (e) {
+            case START_ARRAY:
+                generator.writeStartArray();
+                break;
+            case START_OBJECT:
+                generator.writeStartObject();
+                break;
+            case KEY_NAME:
+                generator.writeKey(view.getString());
+                break;
+            case VALUE_STRING:
+                generator.write(view.getString());
+                break;
+            case VALUE_NUMBER:
+                if (view.isIntegralNumber()) {
+                    generator.write(view.getInt());
+                } else {
+                    generator.write(view.getBigDecimal().doubleValue());
+                }
+                break;
+            case VALUE_TRUE:
+                generator.write(true);
+                break;
+            case VALUE_FALSE:
+                generator.write(false);
+                break;
+            case VALUE_NULL:
+                generator.writeNull();
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                generator.writeEnd();
+                break;
+        }
+    }
+
+    public void filterEvent(BoolPair section, Event e, SplitLargeJson.JsonParserView view, int stackDepth) throws IOException {
+        switch (mode) {
+            case CONTIGUOUS:
+                filterContiguous(section, e, view, stackDepth);
+                break;
+            case DISJOINT:
+                filterDisjoint(section, e, view);
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private void filterDisjoint(BoolPair section, Event e, SplitLargeJson.JsonParserView view) throws IOException {
+        if (section.waxing()) {
+            if (e == Event.KEY_NAME) {
+                context = Event.START_OBJECT;
+                contextName = view.getString();
+            } else {
+                context = Event.START_ARRAY;
+                contextName = null;
+            }
+        } else if (section.full()) {
+            if (generator == null) {
+                newFragment(view);
+            }
+            write(e, view);
+        } else if (section.waning()) {
+            if (generator == null) {
+                writeDisjointSingle(e, view);
+            } else {
+                write(e, view);
+                endFragment();
+            }
+        }
+    }
+
+    private void writeDisjointSingle(Event e, SplitLargeJson.JsonParserView view) throws IOException {
+        addContext = true;
+        newFragment(view);
+        if (contextName != null) {
+            generator.writeKey(contextName);
+        }
+        write(e, view);
+        endFragment();
+        addContext = false;
+    }
+
+    private void filterContiguous(BoolPair section, Event e, SplitLargeJson.JsonParserView view, int stackDepth)
+            throws IOException {
+        if (section.full()) {
+            if (context == null) {
+                targetDepth = stackDepth;
+                if ((e != Event.START_ARRAY) && (e != Event.START_OBJECT)) {
+                    throw new IllegalArgumentException("First event must be the beginning of an array or object");
+                }
+                context = e;
+            } else {
+                if (addContext == null) {
+                    addContext = (e != Event.START_ARRAY && e != Event.START_OBJECT);
+                }
+                if (generator == null) {
+                    newFragment(view);
+                }
+                write(e, view);
+                if ((addContext && context != Event.START_OBJECT) ||
+                    ((stackDepth == targetDepth) && (stackDepth < prevDepth))) {
+                    endFragment();
+                }
+            }
+        }
+        prevDepth = stackDepth;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JsonStack.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/JsonStack.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.nifi.processors.standard.SplitLargeJson;
+
+import javax.json.stream.JsonParser.Event;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+
+/** A <code>JsonStack</code> instance represents a location in a JSON document in a manner that is comparable
+ * with a <code>SimpleJsonPath</code>.  As an extension of <code>ArrayDeque</code>, it grows and shrinks as a
+ * JSON file is parsed, keeping track of only the <code>SimpleJsonPath.Element</code> instances needed to
+ * "arrive at" the current location.  The <code>receive</code> method is used to convert from an instance of
+ * <code>javax.json.stream.JsonParser.Event</code> to an instance of a concrete subclass of
+ * <code>SimpleJsonPath.Element</code>. */
+public class JsonStack extends ArrayDeque<SimpleJsonPath.Element> {
+
+    public void receive(Event e, SplitLargeJson.JsonParserView parserView) {
+        switch (e) {
+            case KEY_NAME:
+                add(new SimpleJsonPath.NamedElement(parserView.getString()));
+                break;
+            case START_ARRAY:
+                add(new SimpleJsonPath.NumberedElement(0));
+                break;
+            case START_OBJECT:
+                add(new SimpleJsonPath.ObjectElement());
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                removeLast();
+            case VALUE_STRING:
+            case VALUE_NUMBER:
+            case VALUE_TRUE:
+            case VALUE_FALSE:
+            case VALUE_NULL:
+                if (!isEmpty()) {
+                    SimpleJsonPath.Element last = peekLast();
+                    if (last instanceof SimpleJsonPath.NumberedElement) {
+                        ((SimpleJsonPath.NumberedElement) last).increment();
+                    } else {
+                        removeLast();
+                    }
+                }
+                break;
+        }
+    }
+
+    public boolean startsWith(SimpleJsonPath path) {
+        return path.isBeginningOf(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("$");
+        Iterator<SimpleJsonPath.Element> i = iterator();
+        for (SimpleJsonPath.Element e : this) {
+            if (e instanceof SimpleJsonPath.NumberedElement) {
+                sb.append(String.format("[%d]", ((SimpleJsonPath.NumberedElement)e).getIndex()));
+            } else if (e instanceof SimpleJsonPath.NamedElement){
+                sb.append(((SimpleJsonPath.NamedElement)e).getName());
+            } else {
+                sb.append(".");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SimpleJsonPath.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SimpleJsonPath.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/** A <code>SimpleJsonPath</code> instance serves as a functional representation of a JSON Path string. An instance
+ * of this class can be used to determine whether a particular location in a JSON document is targeted by a particular
+ * JSON Path expression. It is  a list of the fundamental elements of a JSON Path, as designated by its inner classes
+ * (<code>Element</code> and its subclasses). */
+public class SimpleJsonPath {
+    private final List<Element> path;
+    private final List<Element> altPath;
+    private Boolean hasWildcard;
+
+    private SimpleJsonPath(List<Element> path) {
+        this.path = Collections.unmodifiableList(path);
+        this.altPath = null;
+    }
+
+    private SimpleJsonPath(List<Element> path, List<Element> altPath) {
+        this.path = Collections.unmodifiableList(path);
+        this.altPath = Collections.unmodifiableList(altPath);
+    }
+
+    /* Unfortunately, the "[*]" construct is ambiguous in the JSON Path specification.   It could either
+     * match a range of array elements OR a range of object fields.  For example, see the disjointEmbeddedStar
+     * unit tests.  This ambiguity ends up muddying the code.  Accounting for a possible "alternative path" (altPath)
+     * is probably the cleanest (though maybe not the most efficient) way to handle the oddity. */
+    public static SimpleJsonPath of(String str) {
+        str = str.replaceAll("\\[\\*\\]$", "").replaceAll("\\.\\*$", "");
+        if (str.equals("$")) {
+            return new SimpleJsonPath(new ArrayList<>());
+        }
+        if (!str.startsWith("$") || str.endsWith(".") || !isSupported(str)) {
+            throw new IllegalArgumentException("Invalid or unsupported path");
+        }
+        if (str.contains("[*]")) {
+            return new SimpleJsonPath(build(str), build(str.replaceAll("\\[\\*\\]", ".*")));
+        } else {
+            return new SimpleJsonPath(build(str));
+        }
+    }
+
+    /* Returns false if unsupported characters are found in the supplied JsonPath string; true otherwise.
+     * Calling this method on a valid-but-unsupported JsonPath expression will be faster than attempting construction
+     * of an unsupported JsonPath and catching the subsequent exception.  The throw-catch mechanics are expensive,
+     * from a timing perspective. */
+    public static boolean isSupported(String path) {
+        return !path.contains("..") && path.matches("[-\\w.\\[\\]$'*]+");
+    }
+
+    private static List<Element> build(String str) {
+        List<Element> path = new ArrayList<>();
+        str = str.substring(1).replaceAll("\\['", ".").replaceAll("'\\]", "");
+        String[] parts = str.split("[\\.\\[]");
+        for (String part : parts) {
+            if (part.matches("^\\d.*") || part.equals("*]")) {
+                String[] subParts = part.split("]");
+                for (String subPart : subParts) {
+                    if ("*".equals(subPart)) {
+                        path.add(new NumberedElement());
+                    } else {
+                        path.add(new FixedNumberedElement(Integer.parseInt(subPart)));
+                    }
+                }
+            } else if (!part.isEmpty()) {
+                path.add(new ObjectElement());
+                if ("*".equals(part)) {
+                    path.add(new NamedElement());
+                } else {
+                    path.add(new NamedElement(part));
+                }
+            }
+        }
+        return path;
+    }
+
+    public boolean isEmpty() {
+        return path.isEmpty();
+    }
+
+    public boolean isBeginningOf(JsonStack stack) {
+        boolean startsWith = stackStartsWith(stack, path);
+        if (!startsWith && altPath != null) {
+            return stackStartsWith(stack, altPath);
+        } else {
+            return startsWith;
+        }
+    }
+
+    private boolean stackStartsWith(JsonStack stack, List<Element> path) {
+        if (path.isEmpty()) {
+            return !stack.isEmpty();
+        }
+        Iterator<Element> i = stack.iterator();
+        int p = 0;
+        while (i.hasNext() && (p < path.size())) {
+            if (!i.next().equals(path.get(p))) {
+                break;
+            }
+            p++;
+        }
+        return (p == path.size());
+    }
+
+    public boolean hasWildcard() {
+        // this could be determined and set at construction time, but there's a lot going on in the build() method,
+        // so the second traversal seems worth the reduced clutter...
+        if (hasWildcard != null) {
+            return hasWildcard;
+        } else {
+            hasWildcard = false;
+            for (Element e : path) {
+                if (e.wildcard) {
+                    hasWildcard = true;
+                    break;
+                }
+            }
+        }
+        return hasWildcard;
+    }
+
+    static abstract class Element {
+        final boolean wildcard;
+
+        Element(boolean wildcard) {
+            this.wildcard = wildcard;
+        }
+    }
+
+    public static class ObjectElement extends  Element {
+        ObjectElement() {
+            super(false);
+        }
+        @Override
+        public boolean equals(Object o) {
+            return ((this == o) || ((o != null) && (getClass() == o.getClass())));
+        }
+    }
+
+    public static class NamedElement extends Element {
+        private final String name;
+
+        NamedElement() {
+            super(true);
+            name = null;
+        }
+
+        NamedElement(String name) {
+            super(false);
+            this.name = name;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            NamedElement that = (NamedElement) o;
+
+            return (wildcard || that.wildcard || (name != null ? name.equals(that.name) : that.name == null));
+        }
+
+        @Override
+        public int hashCode() {
+            return name != null ? name.hashCode() : 0;
+        }
+    }
+
+    public static class NumberedElement extends Element {
+        private int index;
+
+        NumberedElement() {
+            super(true);
+        }
+
+        NumberedElement(int index) {
+            super(false);
+            this.index = index;
+        }
+
+        int getIndex() {
+            return index;
+        }
+
+        public void increment() {
+            index++;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof NumberedElement)) return false;
+
+            NumberedElement that = (NumberedElement) o;
+
+            return (wildcard || that.wildcard || (index == that.index));
+        }
+
+        @Override
+        public int hashCode() {
+            return index;
+        }
+    }
+
+    public static final class FixedNumberedElement extends NumberedElement {
+
+        FixedNumberedElement(int index) {
+            super(index);
+        }
+
+        @Override
+        public void increment() {
+            throw new RuntimeException("Not allowed");
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitLargeJson.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitLargeJson.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processors.standard.util.SimpleJsonPath;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.FRAGMENT_COUNT;
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.FRAGMENT_ID;
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.FRAGMENT_INDEX;
+import static org.apache.nifi.flowfile.attributes.FragmentAttributes.SEGMENT_ORIGINAL_FILENAME;
+
+public class TestSplitLargeJson {
+
+    private static final Path WEATHER_JSON = Paths.get("src/test/resources/TestSplitLargeJson/weather.json");
+    private static final Path MISC_JSON    = Paths.get("src/test/resources/TestSplitLargeJson/misc.json");
+    private static final Path SAMPLE_XML   = Paths.get("src/test/resources/TestSplitLargeJson/sample.xml");
+
+    @Test
+    public void testInvalidJsonPaths() {
+        String[] badValues = { //some of these are normally OK json-paths, but not for streaming mode
+            "$..", "$.asdf[:2]", "$.store..price", "$.book[?(@.isbn)]", "$.book[0].", "$.store/price"
+        };
+        for (String bad : badValues) {
+            boolean failed = false;
+            try {
+                SimpleJsonPath.of(bad);
+            } catch (Exception e) {
+                failed = true;
+            }
+            Assert.assertTrue(String.format("Path should be invalid but was valid: %s", bad), failed);
+        }
+    }
+
+    @Test
+    public void testValidJsonPaths() {
+        String[] okValues = {
+            "$", "$.asdf", "$.asdf[1]", "$.asdf.qwer", "$['address']['city']", "$['phoneNumbers'][0]",
+            "$.store.book[*].author", "$[0].blah.*[4].asdf"
+        };
+        for (String ok : okValues) {
+            try {
+                SimpleJsonPath.of(ok);
+            } catch (Exception e) {
+                Assert.fail(String.format("Path should be valid but was not: %s (%s)", ok, e.getMessage()));
+            }
+        }
+    }
+
+    @Test
+    public void testProcessorValidation() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new SplitLargeJson());
+        testRunner.setProperty(SplitLargeJson.JSON_PATH_EXPRESSION, "badpath!");
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void invalidJson() throws Exception {
+        final TestRunner testRunner = newTestRunner(SAMPLE_XML, "$");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(SplitLargeJson.REL_FAILURE, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(SplitLargeJson.REL_FAILURE).get(0);
+        out.assertContentEquals(SAMPLE_XML);
+    }
+
+    @Test
+    public void contiguousScalar() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[0].name");
+        testRunner.run();
+
+        Relationship expectedRel = SplitLargeJson.REL_FAILURE;
+
+        testRunner.assertAllFlowFilesTransferred(expectedRel, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(expectedRel).get(0);
+        out.assertContentEquals(WEATHER_JSON);
+    }
+
+    @Test
+    public void contiguousScalar2() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[0]['name']");
+        testRunner.run();
+
+        Relationship expectedRel = SplitLargeJson.REL_FAILURE;
+
+        testRunner.assertAllFlowFilesTransferred(expectedRel, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(expectedRel).get(0);
+        out.assertContentEquals(WEATHER_JSON);
+    }
+
+    @Test
+    public void contiguousArrayOfObject() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[1].weather");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 2, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 2);
+        checkSplit(0, WEATHER_JSON, "{\"main\":\"Mist\",\"description\":\"mist\"}", testRunner);
+        checkSplit(1, WEATHER_JSON, "{\"main\":\"Fog\",\"description\":\"fog\"}",   testRunner);
+    }
+
+    @Test
+    public void contiguousObject() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[1].main");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 5, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 5);
+        checkSplit(1, WEATHER_JSON, "{\"humidity\":93}", testRunner);
+    }
+
+    @Test
+    public void rootSplitArray() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$");
+        testRunner.run();
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+    }
+
+    @Test
+    public void rootSplitObject() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$");
+        testRunner.run();
+        checkOriginal(MISC_JSON, 5, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 5);
+        checkSplit(0, MISC_JSON, "{\"autumn\":\"leaves\"}", testRunner);
+    }
+
+    @Test
+    public void impliedRootSplitArray() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*]");
+        testRunner.run();
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+    }
+
+    @Test
+    public void impliedRootSplitObject() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.*");
+        testRunner.run();
+        checkOriginal(MISC_JSON, 5, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 5);
+        checkSplit(0, MISC_JSON, "{\"autumn\":\"leaves\"}", testRunner);
+    }
+
+    @Test
+    public void disjointSetOfObjects() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*].main");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(1, WEATHER_JSON,
+                "{\"temp\":56.14,\"humidity\":93,\"temp_min\":50,\"temp_max\":62.6,\"something\":[4,5,6]}",
+                testRunner);
+    }
+
+    @Test
+    public void disjointSetOfArrays() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*].weather");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(0, WEATHER_JSON, "[{\"main\":\"Snow\",\"description\":\"light snow\"}]", testRunner);
+    }
+
+    @Test
+    public void contiguousArrayOfArray() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.two-d");
+        testRunner.run();
+
+        checkOriginal(MISC_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(2, MISC_JSON, "[2,0,1,8]", testRunner);
+    }
+
+    @Test
+    public void contiguousMixedArray() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.mixed-arr");
+        testRunner.run();
+
+        checkOriginal(MISC_JSON, 7, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 7);
+        checkSplit(0, MISC_JSON, "[true]", testRunner);
+        checkSplit(1, MISC_JSON, "[false]", testRunner);
+        checkSplit(2, MISC_JSON, "[null]", testRunner);
+        checkSplit(3, MISC_JSON, "[23]", testRunner);
+        checkSplit(4, MISC_JSON, "[3.14]", testRunner);
+        checkSplit(5, MISC_JSON, "[\"pi\"]", testRunner);
+        checkSplit(6, MISC_JSON, "{\"g\":3927}", testRunner);
+    }
+
+    @Test
+    public void arrayOffsetFromWildcard() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.fence.*[1]");
+        testRunner.run();
+        
+        checkOriginal(MISC_JSON, 2, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 2);
+        checkSplit(0, MISC_JSON, "[\"brown\"]", testRunner);
+        checkSplit(1, MISC_JSON, "[\"hinges\"]", testRunner);
+    }
+
+    @Test
+    public void disjointEmbeddedStar() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.nest.*.red");
+        testRunner.run();
+
+        checkOriginal(MISC_JSON, 2, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 2);
+        checkSplit(0, MISC_JSON, "{\"red\":3}", testRunner);
+        checkSplit(1, MISC_JSON, "{\"red\":7}", testRunner);
+    }
+
+    @Test
+    public void disjointEmbeddedStar2() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.nest[*]['red']");
+        testRunner.run();
+
+        checkOriginal(MISC_JSON, 2, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 2);
+        checkSplit(0, MISC_JSON, "{\"red\":3}", testRunner);
+        checkSplit(1, MISC_JSON, "{\"red\":7}", testRunner);
+    }
+
+    @Test
+    public void disjointEmbeddedStar3() throws Exception {
+        final TestRunner testRunner = newTestRunner(MISC_JSON, "$.nest.arr[*]['orange']");
+        testRunner.run();
+
+        checkOriginal(MISC_JSON, 2, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 2);
+        checkSplit(0, MISC_JSON, "{\"orange\":9}", testRunner);
+        checkSplit(1, MISC_JSON, "{\"orange\":2}", testRunner);
+    }
+
+    @Test
+    public void disjointSetOfScalarsArrContext() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*].main.something[1]");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(0, WEATHER_JSON, "[2]", testRunner);
+        checkSplit(1, WEATHER_JSON, "[5]", testRunner);
+        checkSplit(2, WEATHER_JSON, "[8]", testRunner);
+    }
+
+    @Test
+    public void disjointSetOfScalarsArrContext2() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*]['main']['something'][1]");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(0, WEATHER_JSON, "[2]", testRunner);
+        checkSplit(1, WEATHER_JSON, "[5]", testRunner);
+        checkSplit(2, WEATHER_JSON, "[8]", testRunner);
+    }
+
+    @Test
+    public void disjointSetOfScalarsObjContext() throws Exception {
+        final TestRunner testRunner = TestRunners.newTestRunner(new SplitLargeJson());
+        testRunner.setProperty(SplitLargeJson.JSON_PATH_EXPRESSION, "$[*].name");
+        final String filename = "test.json";
+
+        testRunner.enqueue(WEATHER_JSON, new HashMap<String, String>() {
+            {
+                put(CoreAttributes.FILENAME.key(), filename);
+            }
+        });
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(0, filename, "{\"name\":\"Seattle\"}", testRunner);
+        checkSplit(1, filename, "{\"name\":\"Washington, DC\"}", testRunner);
+        checkSplit(2, filename, "{\"name\":\"Miami\"}", testRunner);
+    }
+
+    @Test
+    public void pathNotFound() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$.nonexistent");
+        testRunner.run();
+
+        testRunner.assertTransferCount(SplitLargeJson.REL_FAILURE, 1);
+        testRunner.getFlowFilesForRelationship(SplitLargeJson.REL_FAILURE).get(0).assertContentEquals(WEATHER_JSON);
+    }
+
+    @Test
+    public void contiguousDotStarEnd() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[0].coord.*");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 2, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 2);
+        checkSplit(0, WEATHER_JSON, "{\"lon\":-122.33}", testRunner);
+    }
+
+    @Test
+    public void contiguousBracketStarEnd() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[0].weather[*]");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 1, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 1);
+        checkSplit(0, WEATHER_JSON, "{\"main\":\"Snow\",\"description\":\"light snow\"}", testRunner);
+    }
+
+    @Test
+    public void disjointDotStarEnd() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*].coord.*");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(0, WEATHER_JSON, "{\"lon\":-122.33,\"lat\":47.61}", testRunner);
+    }
+
+    @Test
+    public void disjointBracketStarEnd() throws Exception {
+        final TestRunner testRunner = newTestRunner(WEATHER_JSON, "$[*].weather[*]");
+        testRunner.run();
+
+        checkOriginal(WEATHER_JSON, 3, testRunner);
+        testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
+        checkSplit(0, WEATHER_JSON, "[{\"main\":\"Snow\",\"description\":\"light snow\"}]", testRunner);
+    }
+
+    private TestRunner newTestRunner(Path testFile, String path) throws IOException {
+        final TestRunner testRunner = TestRunners.newTestRunner(new SplitLargeJson());
+        testRunner.setProperty(SplitLargeJson.JSON_PATH_EXPRESSION, path);
+        testRunner.enqueue(testFile);
+        return testRunner;
+    }
+
+    private void printSplit(TestRunner testRunner, int i) {
+        MockFlowFile split = testRunner.getFlowFilesForRelationship(SplitLargeJson.REL_SPLIT).get(i);
+        System.out.printf("\nSplit %d:\n", i);
+        System.out.println(new String(testRunner.getContentAsByteArray(split)));
+    }
+
+    private void checkOriginal(Path path, int numSplitsExpected, TestRunner testRunner) throws IOException {
+        testRunner.assertTransferCount(SplitLargeJson.REL_ORIGINAL, 1);
+        final MockFlowFile orig = testRunner.getFlowFilesForRelationship(SplitLargeJson.REL_ORIGINAL).get(0);
+        orig.assertAttributeExists(FRAGMENT_ID.key());
+        orig.assertAttributeEquals(FRAGMENT_COUNT.key(), String.valueOf(numSplitsExpected));
+        orig.assertContentEquals(path);
+    }
+
+    private void checkSplit(int i, Path path, String content, TestRunner testRunner) {
+        checkSplit(i, path.getFileName().toString(), content, testRunner);
+    }
+
+    private void checkSplit(int i, String fileName, String content, TestRunner testRunner) {
+        MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(SplitLargeJson.REL_SPLIT).get(i);
+        flowFile.assertContentEquals(content);
+        flowFile.assertAttributeEquals(FRAGMENT_INDEX.key(), String.valueOf(i));
+        flowFile.assertAttributeEquals(SEGMENT_ORIGINAL_FILENAME.key(), fileName);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJsonStack.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestJsonStack.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.util;
+
+import org.apache.nifi.processors.standard.SplitLargeJson;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.stream.JsonParser;
+
+public class TestJsonStack {
+
+    @Test
+    public void stackPrint() {
+        JsonStack stack = new JsonStack();
+
+        SplitLargeJson.JsonParserView view = Mockito.mock(SplitLargeJson.JsonParserView.class);
+        stack.receive(JsonParser.Event.START_ARRAY, view);
+        stack.receive(JsonParser.Event.START_OBJECT, view);
+
+        Mockito.when(view.getString()).thenReturn("key1");
+        stack.receive(JsonParser.Event.KEY_NAME, view);
+
+        Assert.assertEquals("$[0].key1", stack.toString());
+    }
+
+    @Test
+    public void startsWith() {
+        JsonStack stack = new JsonStack();
+
+        SplitLargeJson.JsonParserView view = Mockito.mock(SplitLargeJson.JsonParserView.class);
+        stack.receive(JsonParser.Event.START_ARRAY, view);
+        stack.receive(JsonParser.Event.START_OBJECT, view);
+
+        Mockito.when(view.getString()).thenReturn("key1");
+        stack.receive(JsonParser.Event.KEY_NAME, view);
+        stack.receive(JsonParser.Event.VALUE_TRUE, view);
+        stack.receive(JsonParser.Event.END_OBJECT, view);
+        stack.receive(JsonParser.Event.START_OBJECT, view);
+
+        Assert.assertTrue(stack.startsWith(SimpleJsonPath.of("$[1]")));
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestSplitLargeJson/misc.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestSplitLargeJson/misc.json
@@ -1,0 +1,39 @@
+{
+  "autumn": "leaves",
+  "fence": {
+    "colors": ["black", "brown"],
+    "materials": ["wood", "hinges", "screws"]
+  },
+  "mixed-arr": [
+    true,
+    false,
+    null,
+    23,
+    3.14,
+    "pi",
+    {"g": 3927}
+  ],
+  "two-d": [
+    [3,7],
+    [3,4,1],
+    [2,0,1,8]
+  ],
+  "nest": {
+    "obj1": {
+      "red": 3,
+      "green": 6
+    },
+    "obj2": {
+      "red": 7,
+      "green": 7
+    },
+    "arr": [
+      { "orange": 9,
+        "white": 10
+      },
+      { "orange": 2,
+        "white": 3
+      }
+    ]
+  }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestSplitLargeJson/sample.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestSplitLargeJson/sample.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<note>
+  <to>Internet</to>
+  <from>W3Schools</from>
+  <heading>Sample</heading>
+  <body>This here is XML</body>
+</note>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestSplitLargeJson/weather.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestSplitLargeJson/weather.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": 5809844,
+    "name": "Seattle",
+    "coord": {
+      "lon": -122.33,
+      "lat": 47.61
+    },
+    "weather": [
+      {
+        "main": "Snow",
+        "description": "light snow"
+      }
+    ],
+    "main": {
+      "temp": 35.78,
+      "humidity": 100,
+      "temp_min": 33.8,
+      "temp_max": 39.2,
+      "something": [1, 2, 3]
+    }
+  },
+  {
+    "id": 4140963,
+    "name": "Washington, DC",
+    "coord": {
+      "lon": -77.04,
+      "lat": 38.9
+    },
+    "weather": [
+      {
+        "main": "Mist",
+        "description": "mist"
+      },
+      {
+        "main": "Fog",
+        "description": "fog"
+      }
+    ],
+    "main": {
+      "temp": 56.14,
+      "humidity": 93,
+      "temp_min": 50,
+      "temp_max": 62.6,
+      "something": [4, 5, 6]
+    }
+  },
+  {
+    "id": 4164138,
+    "name": "Miami",
+    "coord": {
+      "lon": -80.19,
+      "lat": 25.77
+    },
+    "weather": [
+      {
+        "main": "Clouds",
+        "description": "few clouds"
+      }
+    ],
+    "main": {
+      "temp": 71.98,
+      "humidity": 73,
+      "temp_min": 69.8,
+      "temp_max": 75.2,
+      "something": [7, 8, 9]
+    }
+  }
+]


### PR DESCRIPTION

### Overview

The current `SplitJson` processor works great when the targeted documents are small.  However, if a given flow needs to handle large JSON documents, the SplitJson processor can consume a lot of memory.  This is already noted as a "System Resource Consideration" in the [documentation](https://github.com/apache/nifi/blob/rel/nifi-1.9.1/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java#L85) for the `SplitJson` processor.

I created a `SplitLargeJson` processor to address this concern. It uses an [event-based streaming API](https://javaee.github.io/jsonp/) to process the JSON without loading the whole document into memory, similar to SAX implementations for XML processing. This allows for near-constant memory usage, independent of file size, as shown in the following test results:

![MemoryUsage](https://user-images.githubusercontent.com/1693576/55675222-4606e200-588d-11e9-84af-5c1abf326070.png)

The trade-off is between heap space usage and JSON Path functionality.  The `SplitLargeJson` processor supports a basic subset of JSON Path, excluding constructs that would require "backtracking" in the file.  See below for examples.  For full JSON Path support, the `SplitJson` processor should be used.  When memory conservation is important, the `SplitLargeJson` processor should be used. `SplitLargeJson` runs about 20 to 70 percent faster than `SplitJson` because it doesn't have to build a DOM before processing the JSON Path.  See the "Test Methodology" section, below.

### Licensing

The `SplitLargeJson` processor depends on `javax.json`, which is licensed under either GNU v2 or CDDL.  According to Apache legal docs, there is a ["weak copyleft" provision](https://www.apache.org/legal/resolved.html#weak-copyleft-licenses) allowing for compatibility between CDDL and ASF licensing.  Furthermore, Apache NiFi already includes `javax.json` in other modules:

```
$ find . -type f | fgrep pom.xml | xargs fgrep -l javax.json
./nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/pom.xml
./nifi-nar-bundles/nifi-extension-utils/nifi-reporting-utils/pom.xml
./nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
./nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/pom.xml
./nifi-nar-bundles/nifi-ambari-bundle/nifi-ambari-reporting-task/pom.xml
```

The LICENSE and NOTICE files were not changed with this PR since `javax.json` is already included.

### Testing

This PR includes 30 new unit tests to verify the changes, primarily exercising different permutations of JSON Path expressions.  In addition, memory and timing metrics were gathered in order to confirm the trade-offs between `SplitJson` and `SplitLargeJson`.  See the memory usage chart above and the "Test Methodology" section, below.

### How to use SplitLargeJson Processor

Given an incoming FlowFile and a valid JSON Path setting, `SplitLargeJson` will send one or more FlowFiles to the `split` relation, and the original FlowFile will be sent to the `original` relation.  If JSON Path did not match any object or array in the document, then the document will be passed to the `failure` relation.

#### JSON Path Examples

Here is a sample JSON file, followed by JSON Path expressions and the content of the FlowFiles that would be output from the `SplitLargeJson` processor.

Sample JSON:
```
[
  {
    "name": "Seattle",
    "weather": [
      {
        "main": "Snow",
        "description": "light snow"
      }
    ]
  },
  {
    "name": "Washington, DC",
    "weather": [
      {
        "main": "Mist",
        "description": "mist"
      },
      {
        "main": "Fog",
        "description": "fog"
      }
    ]
  }
]
```

* JSON Path Expression: `$[1].weather`
    - FlowFile 0: `{"main":"Mist","description":"mist"}`
    - FlowFile 1: `{"main":"Fog","description":"fog"}`
* JSON Path Expression: `$[1].weather[0]`
    - FlowFile 0: `{"main":"Mist"}`
    - FlowFile 1: `{"description":"mist"}`
* JSON Path Expression: `$[*].name`
    - FlowFile 0: `["Seattle"]`
    - FlowFile 1: `["Washington, DC"]`
* JSON Path Expression: `$[*]['weather'][*]['main']`
    - FlowFile 0: `{"main":"Snow"}`
    - FlowFile 1: `{"main":"Mist"}`
    - FlowFile 2: `{"main":"Fog"}`

Array slices (`:`), recursive descent (`..`), and script expressions (`()`) are not supported.  However, a `fragment.index` attribute is set on every outgoing FlowFile to the `split` relation.  This, in combination with a `RouteOnAttribute` processor, can be used in place of JSON Path array slices.

### Test Methodology

Measuring the memory usage of a NiFi processor can be tricky because these processors aren't meant to run in isolation.  They're designed to run in the NiFi JVM, of course, but in that context a processor will share heap space with all the other processors, controller services, and "housekeeping" infrastructure required to support the data flow.  This section describes how memory and timing metrics were obtained for evaluation of the `SplitLargeJson` processor.

An extensive testing framework exists for Apache NiFi that allows for processors to be exercised outside of a NiFi data flow.  The framework provides the ability to send FlowFiles to a processor and then assert the presence and content of FlowFiles generated by the processor.  This framework is built using JUnit and Maven, and can be invoked within an IDE or via command line interface (CLI).  Most Java IDEs are written in Java, and tests run from within the IDE share heap space with the IDE itself. Therefore, memory measurements were taken outside NiFi and outside an IDE, via CLI invocation of the NiFi testing framework.

The goal was to compare `SplitLargeJson` processor with the existing `SplitJson` processor.  To do this, NiFi was cloned, built locally, and instrumented to log its memory usage.  The following four lines were added at the end of the `onTrigger` method of `org.apache.nifi.processors.standard.SplitJson`:

```
        Runtime rt = Runtime.getRuntime();
        rt.gc();
        logger.info(String.format("Memory used: %.3f",
              (double)(rt.totalMemory() - rt.freeMemory())/(1024 * 1024)));
```

At this point in the code, resources used to split the original FlowFile are still in scope.  A similar change was made to `SplitLargeJson`, to log memory before its `JsonParser` falls out of scope (after the the `while` loop yet inside the `try` block of the `onTrigger` method).  A simple test was then created that runs an arbitrary JSON file through the processor:

```
    @Test
    public void test() throws Exception {
        { // invoke static loading and "prime the pumps" by running a small file
            TestRunner testRunner = TestRunners.newTestRunner(new SplitLargeJson());
            testRunner.setProperty(SplitLargeJson.JSON_PATH_EXPRESSION, "$.*[0][0][0]");

            testRunner.enqueue(Paths.get("/tmp/little.json"));
            testRunner.run();

            testRunner.assertTransferCount(SplitLargeJson.REL_SPLIT, 3);
        }

        TestRunner testRunner = TestRunners.newTestRunner(new SplitLargeJson());
        testRunner.setProperty(SplitLargeJson.JSON_PATH_EXPRESSION, "$.*[2][2][2]");
        testRunner.enqueue(Paths.get(System.getProperty("testFile")));

        long start = System.currentTimeMillis();
        testRunner.run();
        long stop  = System.currentTimeMillis();

        testRunner.getLogger().info(String.format("Process time: %.3f sec", (double)(stop - start)/1000));
    }
```

Five JSON files were generated using a python script, starting with 8 MiB and doubling until 128 MiB.  Each file was tested with each processor via CLI invocation of the NiFi testing framework, as mentioned above.  The resulting log output would then contain memory and timing information.  For example, this command runs a 32 MiB file through `SplitLargeJson` and shows the memory and timing results:

```
mvn test -Dtest=gov.ic.cte.nifi.processors.PerformanceTest -DtestFile=/tmp/s32.json && \
tail -3 target/surefire-reports/gov.ic.cte.nifi.processors.PerformanceTest-output.txt | cut -c70-
...
argeJson - SplitLargeJson[id=5a60a1ab-912c-4d2a-aa4d-ce63badc8af0] Memory used: 34.382
argeJson - SplitLargeJson[id=5a60a1ab-912c-4d2a-aa4d-ce63badc8af0] Split FlowFile[0,s32.json,33741503B] into 3 FlowFile(s)
SplitLargeJson[id=5a60a1ab-912c-4d2a-aa4d-ce63badc8af0] Process time: 0.261 sec
```

Here is the corresponding test and output for `SplitJson`:

```
mvn test -Dtest=org.apache.nifi.processors.standard.PerformanceTest -DtestFile=/tmp/s32.json && \
tail -3 target/surefire-reports/org.apache.nifi.processors.standard.PerformanceTest-output.txt | cut -c70-
...
tJson - SplitJson[id=33b08e70-c38e-4674-9b2d-0ffc087503f2] Split FlowFile[0,s32.json,33741503B] into 3 FlowFiles
tJson - SplitJson[id=33b08e70-c38e-4674-9b2d-0ffc087503f2] Memory used: 164.947
itJson[id=33b08e70-c38e-4674-9b2d-0ffc087503f2] Process time: 0.549 sec
```

The attentive reader may notice that the above memory usage statistics don't match those presented in the graph from the "Overview" section.  This is because the raw output needs to be adjusted to account for the fact that FlowFiles are kept in memory while Apache's NiFi testing framework is running.  When these processors are running in an actual NiFi instance (under default configuration), the FlowFile content would be stored on disk.

It's worth noting that FlowFiles _provided to_ and _generated by_ processors in the testing framework are kept in memory (see the [importFrom method](https://github.com/apache/nifi/blob/rel/nifi-1.4.0/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java#L431) and usage of the [transferMap](https://github.com/apache/nifi/blob/rel/nifi-1.4.0/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java#L64) in MockProcessSession).  This is why a deep and specific JSON Path was selected for the tests: to reduce the size and count of the resulting FlowFile splits.  Otherwise, if a more inclusive JSON Path were to be used, the memory reading would need further correction to account for data generated by the processor in question.  The content of the three FlowFiles generated in these tests were only 41 bytes each.

As for the timing results, `SplitLargeJson` completed between 20 and 70 percent faster than `SplitJson`, for the same five generated JSON files:

![Timing](https://user-images.githubusercontent.com/1693576/55675224-4c955980-588d-11e9-8956-4b3a4940a79e.png)

The timing metrics will vary based on the structure of the JSON document being split.  As an additional time test, a JSON file representing the City and County of [San Francisco's Subdivision parcels](https://github.com/zemirco/sf-city-lots-json) was split into fifteen thousand FlowFiles using both processors.  A perl script was used to create 5 different subsets from this file, at the same size increments as above (8, 16, 32, 64, and 128).  These tests had run times between 2 seconds and 5 minutes, and `SplitLargeJson` ranged between 20 and 50 percent faster.

### Checklist

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Is your initial contribution a single, squashed commit?

- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
      (Note: `mvn clean install` completes without error after disabling `FileBasedClusterNodeFirewallTest` and `DBCPServiceTest`.
       Adding `-Pcontrib-check` fails , but it appears to fail on `master` branch too)
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

