### PR TITLE
NIFI-6197 HBase: Fix deprecations, default for client retries & validations

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/scan/ResultCell.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/scan/ResultCell.java
@@ -31,16 +31,10 @@ public class ResultCell {
     int qualifierLength;
 
     long timestamp;
-    byte typeByte;
-    long sequenceId;
 
     byte[] valueArray;
     int valueOffset;
     int valueLength;
-
-    byte[] tagsArray;
-    int tagsOffset;
-    int tagsLength;
 
     public byte[] getRowArray() {
         return rowArray;
@@ -122,22 +116,6 @@ public class ResultCell {
         this.timestamp = timestamp;
     }
 
-    public byte getTypeByte() {
-        return typeByte;
-    }
-
-    public void setTypeByte(byte typeByte) {
-        this.typeByte = typeByte;
-    }
-
-    public long getSequenceId() {
-        return sequenceId;
-    }
-
-    public void setSequenceId(long sequenceId) {
-        this.sequenceId = sequenceId;
-    }
-
     public byte[] getValueArray() {
         return valueArray;
     }
@@ -162,27 +140,4 @@ public class ResultCell {
         this.valueLength = valueLength;
     }
 
-    public byte[] getTagsArray() {
-        return tagsArray;
-    }
-
-    public void setTagsArray(byte[] tagsArray) {
-        this.tagsArray = tagsArray;
-    }
-
-    public int getTagsOffset() {
-        return tagsOffset;
-    }
-
-    public void setTagsOffset(int tagsOffset) {
-        this.tagsOffset = tagsOffset;
-    }
-
-    public int getTagsLength() {
-        return tagsLength;
-    }
-
-    public void setTagsLength(int tagsLength) {
-        this.tagsLength = tagsLength;
-    }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
@@ -113,30 +113,29 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
 
     static final PropertyDescriptor ZOOKEEPER_QUORUM = new PropertyDescriptor.Builder()
         .name("ZooKeeper Quorum")
-        .description("Comma-separated list of ZooKeeper hosts for HBase. Required if Hadoop Configuration Files are not provided.")
+        .description("Comma-separated list of ZooKeeper hosts for HBase. Required if HBase Configuration Files are not provided.")
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     static final PropertyDescriptor ZOOKEEPER_CLIENT_PORT = new PropertyDescriptor.Builder()
         .name("ZooKeeper Client Port")
-        .description("The port on which ZooKeeper is accepting client connections. Required if Hadoop Configuration Files are not provided.")
+        .description("The port on which ZooKeeper is accepting client connections.")
         .addValidator(StandardValidators.PORT_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     static final PropertyDescriptor ZOOKEEPER_ZNODE_PARENT = new PropertyDescriptor.Builder()
         .name("ZooKeeper ZNode Parent")
-        .description("The ZooKeeper ZNode Parent value for HBase (example: /hbase). Required if Hadoop Configuration Files are not provided.")
+        .description("The ZooKeeper ZNode Parent value for HBase (example: /hbase).")
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     static final PropertyDescriptor HBASE_CLIENT_RETRIES = new PropertyDescriptor.Builder()
         .name("HBase Client Retries")
-        .description("The number of times the HBase client will retry connecting. Required if Hadoop Configuration Files are not provided.")
+        .description("The number of times the HBase client will retry all retryable operations.")
         .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-        .defaultValue("1")
         .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
@@ -218,9 +217,6 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
     protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
         boolean confFileProvided = validationContext.getProperty(HADOOP_CONF_FILES).isSet();
         boolean zkQuorumProvided = validationContext.getProperty(ZOOKEEPER_QUORUM).isSet();
-        boolean zkPortProvided = validationContext.getProperty(ZOOKEEPER_CLIENT_PORT).isSet();
-        boolean znodeParentProvided = validationContext.getProperty(ZOOKEEPER_ZNODE_PARENT).isSet();
-        boolean retriesProvided = validationContext.getProperty(HBASE_CLIENT_RETRIES).isSet();
 
         final String explicitPrincipal = validationContext.getProperty(kerberosProperties.getKerberosPrincipal()).evaluateAttributeExpressions().getValue();
         final String explicitKeytab = validationContext.getProperty(kerberosProperties.getKerberosKeytab()).evaluateAttributeExpressions().getValue();
@@ -238,12 +234,11 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
 
         final List<ValidationResult> problems = new ArrayList<>();
 
-        if (!confFileProvided && (!zkQuorumProvided || !zkPortProvided || !znodeParentProvided || !retriesProvided)) {
+        if (!confFileProvided && !zkQuorumProvided) {
             problems.add(new ValidationResult.Builder()
                     .valid(false)
                     .subject(this.getClass().getSimpleName())
-                    .explanation("ZooKeeper Quorum, ZooKeeper Client Port, ZooKeeper ZNode Parent, and HBase Client Retries are required " +
-                            "when Hadoop Configuration Files are not provided.")
+                    .explanation("Either HBase Configuration files (e.g. hbase-site.xml) or an explicit ZooKeeper Quorum are required.")
                     .build());
         }
 
@@ -446,7 +441,6 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
         try (final Table table = connection.getTable(TableName.valueOf(tableName))) {
             // Create one Put per row....
             final Map<String, List<PutColumn>> sorted = new HashMap<>();
-            final List<Put> newPuts = new ArrayList<>();
 
             for (final PutFlowFile putFlowFile : puts) {
                 final String rowKeyString = new String(putFlowFile.getRow(), StandardCharsets.UTF_8);
@@ -459,6 +453,7 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
                 columns.addAll(putFlowFile.getColumns());
             }
 
+            final List<Put> newPuts = new ArrayList<>();
             for (final Map.Entry<String, List<PutColumn>> entry : sorted.entrySet()) {
                 newPuts.addAll(buildPuts(entry.getKey().getBytes(StandardCharsets.UTF_8), entry.getValue()));
             }
@@ -470,7 +465,7 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
     @Override
     public void put(final String tableName, final byte[] rowId, final Collection<PutColumn> columns) throws IOException {
         try (final Table table = connection.getTable(TableName.valueOf(tableName))) {
-            table.put(buildPuts(rowId, new ArrayList(columns)));
+            table.put(buildPuts(rowId, new ArrayList<>(columns)));
         }
     }
 
@@ -510,10 +505,9 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
     @Override
     public void deleteCells(String tableName, List<DeleteRequest> deletes) throws IOException {
         List<Delete> deleteRequests = new ArrayList<>();
-        for (int index = 0; index < deletes.size(); index++) {
-            DeleteRequest req = deletes.get(index);
+        for (DeleteRequest req : deletes) {
             Delete delete = new Delete(req.getRowId())
-                .addColumn(req.getColumnFamily(), req.getColumnQualifier());
+                    .addColumn(req.getColumnFamily(), req.getColumnQualifier());
             if (!StringUtils.isEmpty(req.getVisibilityLabel())) {
                 delete.setCellVisibility(new CellVisibility(req.getVisibilityLabel()));
             }
@@ -525,8 +519,8 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
     @Override
     public void delete(String tableName, List<byte[]> rowIds, String visibilityLabel) throws IOException {
         List<Delete> deletes = new ArrayList<>();
-        for (int index = 0; index < rowIds.size(); index++) {
-            Delete delete = new Delete(rowIds.get(index));
+        for (byte[] rowId : rowIds) {
+            Delete delete = new Delete(rowId);
             if (!StringUtils.isBlank(visibilityLabel)) {
                 delete.setCellVisibility(new CellVisibility(visibilityLabel));
             }
@@ -662,7 +656,6 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
             scan.setAuthorizations(new Authorizations(authorizations));
         }
 
-        Filter filter = null;
         if (columns != null) {
             for (Column col : columns) {
                 if (col.getQualifier() == null) {
@@ -672,6 +665,7 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
                 }
             }
         }
+        Filter filter = null;
         if (!StringUtils.isBlank(filterExpression)) {
             ParseFilter parseFilter = new ParseFilter();
             filter = parseFilter.parseFilterString(filterExpression);
@@ -766,16 +760,11 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
         resultCell.setQualifierLength(cell.getQualifierLength());
 
         resultCell.setTimestamp(cell.getTimestamp());
-        resultCell.setTypeByte(cell.getTypeByte());
-        resultCell.setSequenceId(cell.getSequenceId());
 
         resultCell.setValueArray(cell.getValueArray());
         resultCell.setValueOffset(cell.getValueOffset());
         resultCell.setValueLength(cell.getValueLength());
 
-        resultCell.setTagsArray(cell.getTagsArray());
-        resultCell.setTagsOffset(cell.getTagsOffset());
-        resultCell.setTagsLength(cell.getTagsLength());
         return resultCell;
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/test/java/org/apache/nifi/hbase/TestHBase_1_1_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/test/java/org/apache/nifi/hbase/TestHBase_1_1_2_ClientService.java
@@ -101,21 +101,21 @@ public class TestHBase_1_1_2_ClientService {
         runner.assertValid(service);
         runner.removeControllerService(service);
 
-        // only quorum and no conf file should be invalid
+        // only quorum and no conf file should be valid
         service = new MockHBaseClientService(table, COL_FAM, kerberosPropsWithFile);
         runner.addControllerService("hbaseClientService", service);
         runner.setProperty(service, HBase_1_1_2_ClientService.ZOOKEEPER_QUORUM, "${zk-quorum}");
 
-        runner.assertNotValid(service);
+        runner.assertValid(service);
         runner.removeControllerService(service);
 
-        // quorum and port, no znode, no conf file, should be invalid
+        // quorum and port, no znode, no conf file, should be valid
         service = new MockHBaseClientService(table, COL_FAM, kerberosPropsWithFile);
         runner.addControllerService("hbaseClientService", service);
         runner.setProperty(service, HBase_1_1_2_ClientService.ZOOKEEPER_QUORUM, "${zk-quorum}");
         runner.setProperty(service, HBase_1_1_2_ClientService.ZOOKEEPER_CLIENT_PORT, "${zk-client-port}");
 
-        runner.assertNotValid(service);
+        runner.assertValid(service);
         runner.removeControllerService(service);
 
         // quorum, port, and znode, no conf file, should be valid

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/src/test/java/org/apache/nifi/hbase/TestHBase_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/src/test/java/org/apache/nifi/hbase/TestHBase_2_ClientService.java
@@ -101,21 +101,21 @@ public class TestHBase_2_ClientService {
         runner.assertValid(service);
         runner.removeControllerService(service);
 
-        // only quorum and no conf file should be invalid
+        // only quorum and no conf file should be valid
         service = new MockHBaseClientService(table, COL_FAM, kerberosPropsWithFile);
         runner.addControllerService("hbaseClientService", service);
         runner.setProperty(service, HBase_2_ClientService.ZOOKEEPER_QUORUM, "${zk-quorum}");
 
-        runner.assertNotValid(service);
+        runner.assertValid(service);
         runner.removeControllerService(service);
 
-        // quorum and port, no znode, no conf file, should be invalid
+        // quorum and port, no znode, no conf file, should be valid
         service = new MockHBaseClientService(table, COL_FAM, kerberosPropsWithFile);
         runner.addControllerService("hbaseClientService", service);
         runner.setProperty(service, HBase_2_ClientService.ZOOKEEPER_QUORUM, "${zk-quorum}");
         runner.setProperty(service, HBase_2_ClientService.ZOOKEEPER_CLIENT_PORT, "${zk-client-port}");
 
-        runner.assertNotValid(service);
+        runner.assertValid(service);
         runner.removeControllerService(service);
 
         // quorum, port, and znode, no conf file, should be valid


### PR DESCRIPTION
This is a continuation of #3418 which I managed to somehow break.

- This fixes deprecations in HBase 2.0 which will be removed in 3.0. Amongst other things the typeByte, sequenceId and tags are now considered internal and are not exposed anymore.

- I also made it so that only either an hbase-site.xml or a ZooKeeper quorum need to be provided, previously ZooKeeper Client Port, Client retry and ZK Parent Node were mandatory as well but they are not really needed to connect to HBase

- Removed the default for HBase client retries. This means it can still be overridden if needed but if not the defaults from either hbase-site.xml or HBase itself will be used

- Some minor warnings (e.g. too broad scope, unchecked cast etc.)

@bbende  Thank you for your time in discussing & reviewing the last one. I hope you have the time to look at this one as well (I'll update the Jira ticket as well)