### PR TITLE
NIFI-6221 Adding 'Download' and 'View' content buttons to List Queue

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-queue-listing.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-queue-listing.js
@@ -208,11 +208,13 @@
         var actionsFormatter = function (row,cell,value,columnDef,dataContext) {
             var formatted = '';
 
-            var disabled = (dataContext.size > 0)?'':'disabled';
-            formatted += '<div class="pointer icon download-flowfile-content fa fa-download '+disabled+'" title="Download Content" aria-hidden="true"></div>';
+            var disabled = (dataContext.size > 0)?false:true;
+            formatted += '<div class="icon download-flowfile-content fa fa-download '+((disabled)?'disabled':'pointer')+'"'+
+                ' title="'+((disabled)?'No content available to download':'Download content')+'" aria-hidden="true"></div>';
 
             if(nfCommon.isContentViewConfigured()){
-                formatted += '<div class="pointer icon view-flowfile-content fa fa-eye '+disabled+'" title="View Content" aria-hidden="true"></div>';
+                formatted += '<div class="icon view-flowfile-content fa fa-eye '+((disabled)?'disabled':'pointer')+'"'+
+                    ' title="'+((disabled)?'No content available to view':'View content')+'" aria-hidden="true"></div>';
             }
 
             if(nfCommon.canAccessProvenance()){
@@ -692,14 +694,9 @@
                         nfShell.showPage('provenance?' + $.param({
                                 flowFileUuid: item.uuid
                             }));
-                    } else if (target.hasClass('disabled')) {
-                        nfDialog.showOkDialog({
-                            headerText: 'Empty FlowFile',
-                            dialogContent: 'This FlowFile contains no content to complete this action.'
-                        });
-                    } else if (target.hasClass('download-flowfile-content')) {
+                    } else if (target.hasClass('download-flowfile-content') && !target.hasClass('disabled')) {
                         downloadContent(item);
-                    } else if (target.hasClass('view-flowfile-content')) {
+                    } else if (target.hasClass('view-flowfile-content') && !target.hasClass('disabled')) {
                         viewContent(item);
                     }
                 }


### PR DESCRIPTION
NIFI-6221 Adding 'Download' and 'View' content icon buttons to slick grid actions column to improve end user navigation.

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
