### PR TITLE
NIFI-5556 Adds `NIFI_DEBUG` env var to admin scripts.

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -51,6 +51,9 @@ Apache NiFi can run on something as simple as a laptop, but it can also be clust
 **** `service nifi start`
 **** `service nifi stop`
 **** `service nifi status`
+** When necessary, enable remote debugging via:
+*** shell parameter:  `NIFI_DEBUG=y nifi.sh start`
+*** `java.arg.debug` (see <<bootstrap_properties>> below)
 
 * Windows
 ** Decompress into the desired installation directory

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/cli.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/cli.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} org.apache.nifi.toolkit.cli.CLIMain "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.cli.CLIMain "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/encrypt-config.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} org.apache.nifi.toolkit.encryptconfig.EncryptConfigMain "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.encryptconfig.EncryptConfigMain "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/file-manager.sh
@@ -60,6 +60,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -91,6 +111,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -110,7 +133,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.filemanager.FileManagerTool "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.admin.filemanager.FileManagerTool "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/flow-analyzer.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.flowanalyzer.FlowAnalyzerDriver "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/node-manager.sh
@@ -60,6 +60,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -91,6 +111,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -110,7 +133,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.admin.nodemanager.NodeManagerTool "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/notify.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.admin.notify.NotificationTool "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.admin.notify.NotificationTool "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/s2s.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} org.apache.nifi.toolkit.s2s.SiteToSiteCliMain "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms128m -Xmx256m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.s2s.SiteToSiteCliMain "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/tls-toolkit.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.tls.TlsToolkitMain "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.tls.TlsToolkitMain "$@"
 }
 
 

--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/zk-migrator.sh
@@ -61,6 +61,26 @@ detectOS() {
     fi
 }
 
+debugJava() {
+    # Configure for remote debugging; adapted from kafka/bin/kafka-run-class.sh
+
+    if [ "x$NIFI_DEBUG" != "x" ]; then
+
+        DEFAULT_JAVA_DEBUG_PORT="8000"
+        if [ -z "$JAVA_DEBUG_PORT" ]; then
+            JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+        fi
+
+        # Mirrors  bootstrap.conf values
+        DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=$JAVA_DEBUG_PORT"
+        if [ -z "$JAVA_DEBUG_OPTS" ]; then
+            JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        warn "JAVA_DEBUG_OPTS=${JAVA_DEBUG_OPTS}"
+    fi
+}
+
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
@@ -92,6 +112,9 @@ init() {
     # Determine if there is special OS handling we must perform
     detectOS
 
+    # Allow for various debugging variables
+    debugJava
+
     # Locate the Java VM to execute
     locateJava "$1"
 }
@@ -111,7 +134,7 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain "$@"
+   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS:--Xms12m -Xmx24m} ${JAVA_DEBUG_OPTS} org.apache.nifi.toolkit.zkmigrator.ZooKeeperMigratorMain "$@"
 }
 
 


### PR DESCRIPTION
The code in this change-set adds support for `NIFI_DEBUG` environment variable to the scripts in the PR.  No

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
