### PR TITLE
NIFI-6223 Expose Cluster Node Type to Controller Services

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/AbstractControllerService.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/AbstractControllerService.java
@@ -33,6 +33,7 @@ public abstract class AbstractControllerService extends AbstractConfigurableComp
     private StateManager stateManager;
     private volatile ConfigurationContext configurationContext;
     private volatile boolean enabled = false;
+    private NodeTypeProvider nodeTypeProvider;
 
     @Override
     public final void initialize(final ControllerServiceInitializationContext context) throws InitializationException {
@@ -40,6 +41,7 @@ public abstract class AbstractControllerService extends AbstractConfigurableComp
         serviceLookup = context.getControllerServiceLookup();
         logger = context.getLogger();
         stateManager = context.getStateManager();
+        nodeTypeProvider = context.getNodeTypeProvider();
         init(context);
     }
 
@@ -54,6 +56,14 @@ public abstract class AbstractControllerService extends AbstractConfigurableComp
      */
     protected final ControllerServiceLookup getControllerServiceLookup() {
         return serviceLookup;
+    }
+
+    /**
+     * @return the {@link NodeTypeProvider} that was passed to the
+     * {@link #init(ControllerServiceInitializationContext)} method
+     */
+    protected final NodeTypeProvider getNodeTypeProvider() {
+        return nodeTypeProvider;
     }
 
     /**

--- a/nifi-api/src/main/java/org/apache/nifi/controller/ControllerServiceInitializationContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/ControllerServiceInitializationContext.java
@@ -44,4 +44,10 @@ public interface ControllerServiceInitializationContext extends KerberosContext 
      * @return the StateManager that can be used to store and retrieve state for this component
      */
     StateManager getStateManager();
+
+    /**
+     * @return the {@link NodeTypeProvider} which can be used to detect the node
+     * type of this NiFi instance.
+     */
+    NodeTypeProvider getNodeTypeProvider();
 }

--- a/nifi-api/src/main/java/org/apache/nifi/documentation/init/DocumentationControllerServiceInitializationContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/documentation/init/DocumentationControllerServiceInitializationContext.java
@@ -19,6 +19,7 @@ package org.apache.nifi.documentation.init;
 import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 
 import java.io.File;
@@ -47,6 +48,11 @@ public class DocumentationControllerServiceInitializationContext implements Cont
     @Override
     public StateManager getStateManager() {
         return new NopStateManager();
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return null;
     }
 
     @Override

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockControllerServiceInitializationContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockControllerServiceInitializationContext.java
@@ -21,6 +21,7 @@ import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.state.MockStateManager;
 
@@ -68,6 +69,11 @@ public class MockControllerServiceInitializationContext extends MockControllerSe
     @Override
     public StateManager getStateManager() {
         return stateManager;
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return null;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -381,7 +381,7 @@ public class ExtensionBuilder {
 
             final StateManager stateManager = stateManagerProvider.getStateManager(identifier);
             final ControllerServiceInitializationContext initContext = new StandardControllerServiceInitializationContext(identifier, terminationAwareLogger,
-                    serviceProvider, stateManager, kerberosConfig);
+                    serviceProvider, stateManager, kerberosConfig, nodeTypeProvider);
             serviceImpl.initialize(initContext);
 
             final LoggableComponent<ControllerService> originalLoggableComponent = new LoggableComponent<>(serviceImpl, bundleCoordinate, terminationAwareLogger);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceInitializationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceInitializationContext.java
@@ -20,6 +20,7 @@ import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.controller.kerberos.KerberosConfig;
 import org.apache.nifi.logging.ComponentLog;
 
@@ -33,16 +34,18 @@ public class StandardControllerServiceInitializationContext implements Controlle
     private final ComponentLog logger;
     private final StateManager stateManager;
     private final KerberosConfig kerberosConfig;
+    private NodeTypeProvider nodeTypeProvider;
 
     public StandardControllerServiceInitializationContext(
             final String identifier, final ComponentLog logger,
             final ControllerServiceProvider serviceProvider, final StateManager stateManager,
-            final KerberosConfig kerberosConfig) {
+            final KerberosConfig kerberosConfig, final NodeTypeProvider nodeTypeProvider) {
         this.id = identifier;
         this.logger = logger;
         this.serviceProvider = serviceProvider;
         this.stateManager = stateManager;
         this.kerberosConfig = kerberosConfig;
+        this.nodeTypeProvider = nodeTypeProvider;
     }
 
     @Override
@@ -93,6 +96,11 @@ public class StandardControllerServiceInitializationContext implements Controlle
     @Override
     public StateManager getStateManager() {
         return stateManager;
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
+        return nodeTypeProvider;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/mock/MockControllerServiceInitializationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/mock/MockControllerServiceInitializationContext.java
@@ -19,6 +19,7 @@ package org.apache.nifi.mock;
 import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 
 import java.io.File;
@@ -48,6 +49,11 @@ public class MockControllerServiceInitializationContext implements ControllerSer
 
     @Override
     public StateManager getStateManager() {
+        return null;
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
         return null;
     }
 

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/lookup/script/BaseScriptedLookupService.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/lookup/script/BaseScriptedLookupService.java
@@ -26,6 +26,7 @@ import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.lookup.LookupService;
@@ -312,6 +313,11 @@ public class BaseScriptedLookupService extends AbstractScriptedControllerService
                                 @Override
                                 public StateManager getStateManager() {
                                     return BaseScriptedLookupService.this.getStateManager();
+                                }
+
+                                @Override
+                                public NodeTypeProvider getNodeTypeProvider() {
+                                    return BaseScriptedLookupService.this.getNodeTypeProvider();
                                 }
 
                                 @Override


### PR DESCRIPTION
ControllerServices already support the `OnPrimaryNodeStateChange` annotation, so really this is just completing the circle.

The motivation behind this change is so that a Controller Service that works with external resources can have that coordination handled by a single node in the cluster.  Specifically this is an issue with the Livy controller service I'm trying to tackle, but there are probably other areas where it would be helpful.


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
