### PR TITLE
NIFI-6280 - Broke out the matching for /access/knox/** and /access/oi…

### DIFF
--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -17,16 +17,9 @@
 
 package org.apache.nifi.record.path;
 
-import org.apache.nifi.record.path.exception.RecordPathException;
-import org.apache.nifi.serialization.SimpleRecordSchema;
-import org.apache.nifi.serialization.record.DataType;
-import org.apache.nifi.serialization.record.MapRecord;
-import org.apache.nifi.serialization.record.Record;
-import org.apache.nifi.serialization.record.RecordField;
-import org.apache.nifi.serialization.record.RecordFieldType;
-import org.apache.nifi.serialization.record.RecordSchema;
-import org.apache.nifi.serialization.record.util.DataTypeUtils;
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
@@ -42,10 +35,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.nifi.record.path.exception.RecordPathException;
+import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.record.DataType;
+import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.util.DataTypeUtils;
+import org.junit.Test;
 
 public class TestRecordPath {
 
@@ -1298,6 +1297,13 @@ public class TestRecordPath {
 
         final FieldValue fieldValue = RecordPath.compile("format( toDate(/date, \"yyyy-MM-dd'T'HH:mm:ss'Z'\"), 'yyyy-MM-dd' )").evaluate(record).getSelectedFields().findFirst().get();
         assertEquals("2017-10-20", fieldValue.getValue());
+        final FieldValue fieldValue2 = RecordPath.compile("format( toDate(/date, \"yyyy-MM-dd'T'HH:mm:ss'Z'\"), 'yyyy-MM-dd' , 'GMT+8:00')")
+            .evaluate(record).getSelectedFields().findFirst().get();
+        assertEquals("2017-10-20", fieldValue2.getValue());
+
+        final FieldValue fieldValue3 = RecordPath.compile("format( toDate(/date, \"yyyy-MM-dd'T'HH:mm:ss'Z'\"), 'yyyy-MM-dd HH:mm', 'GMT+8:00')")
+                .evaluate(record).getSelectedFields().findFirst().get();
+        assertEquals("2017-10-20 19:00", fieldValue3.getValue());
 
         final FieldValue fieldValueUnchanged = RecordPath.compile("format( toDate(/date, \"yyyy-MM-dd'T'HH:mm:ss'Z'\"), 'INVALID' )").evaluate(record).getSelectedFields().findFirst().get();
         assertEquals(DataTypeUtils.getDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse("2017-10-20T11:00:00Z"), fieldValueUnchanged.getValue());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -140,6 +140,9 @@
     <logger name="org.apache.nifi.web.filter.RequestLogger" level="INFO" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
+    <logger name="org.apache.nifi.web.api.AccessResource" level="INFO" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
 
 
     <!--

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
@@ -88,7 +88,9 @@ public class NiFiWebApiSecurityConfiguration extends WebSecurityConfigurerAdapte
         // the /access/download-token and /access/ui-extension-token endpoints
         webSecurity
                 .ignoring()
-                    .antMatchers("/access", "/access/config", "/access/token", "/access/kerberos", "/access/oidc/**", "/access/knox/**");
+                    .antMatchers("/access", "/access/config", "/access/token", "/access/kerberos",
+                            "/access/oidc/exchange", "/access/oidc/callback", "/access/oidc/request",
+                            "/access/knox/callback", "/access/knox/request");
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
@@ -50,7 +50,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
 
 /**
- * NiFi Web Api Spring security
+ * NiFi Web Api Spring security. Applies the various NiFiAuthenticationFilter servlet filters which will extract authentication
+ * credentials from API requests.
  */
 @Configuration
 @EnableWebSecurity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
@@ -770,9 +770,11 @@ public class AccessResource extends ApplicationResource {
 
         if(userIdentity != null && !userIdentity.isEmpty()) {
             try {
+                logger.debug("Logging out user " + userIdentity);
                 jwtService.logOut(userIdentity);
                 return generateOkResponse().build();
             } catch (final JwtException e) {
+                logger.error("Logout of user " + userIdentity + " failed due to: " + e.getMessage());
                 return Response.serverError().build();
             }
         } else {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
@@ -29,6 +29,25 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.net.URI;
+import java.security.cert.X509Certificate;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.ServletContext;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.admin.service.AdministrationException;
 import org.apache.nifi.authentication.AuthenticationResponse;
@@ -68,26 +87,6 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
-
-import javax.servlet.ServletContext;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.net.URI;
-import java.security.cert.X509Certificate;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 /**
  * RESTful endpoint for managing access.
@@ -374,7 +373,7 @@ public class AccessResource extends ApplicationResource {
 
         // build the authorization uri
         final URI authorizationUri = UriBuilder.fromUri(knoxService.getKnoxUrl())
-                .queryParam("originalUrl", originalUri.toString())
+                .queryParam("originalUrl", originalUri)
                 .build();
 
         // generate the response
@@ -415,7 +414,7 @@ public class AccessResource extends ApplicationResource {
     )
     public void knoxLogout(@Context HttpServletRequest httpServletRequest, @Context HttpServletResponse httpServletResponse) throws Exception {
         String redirectPath = generateResourceUri("..", "nifi", "login");
-        httpServletResponse.sendRedirect(redirectPath.toString());
+        httpServletResponse.sendRedirect(redirectPath);
     }
 
     /**
@@ -770,7 +769,7 @@ public class AccessResource extends ApplicationResource {
 
         if(userIdentity != null && !userIdentity.isEmpty()) {
             try {
-                logger.debug("Logging out user " + userIdentity);
+                logger.info("Logging out user " + userIdentity);
                 jwtService.logOut(userIdentity);
                 return generateOkResponse().build();
             } catch (final JwtException e) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/integration/accesscontrol/ITAccessTokenEndpoint.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/integration/accesscontrol/ITAccessTokenEndpoint.java
@@ -410,7 +410,6 @@ public class ITAccessTokenEndpoint {
         String logoutUrl = BASE_URL + "/access/logout";
 
         Response response = TOKEN_USER.testCreateToken(accessTokenUrl, user, password);
-        Response responseA = TOKEN_USER.testCreateToken(accessTokenUrl, "jack", password);
 
         // ensure the request is successful
         Assert.assertEquals(201, response.getStatus());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
@@ -38,7 +38,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 /**
- *
+ * The NiFiAuthenticationFilter abstract class defines the base methods for NiFi's various existing and future
+ * authentication mechanisms. The subclassed filters are applied in NiFiWebApiSecurityConfiguration.
  */
 public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
 
@@ -107,6 +108,14 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
      */
     public abstract Authentication attemptAuthentication(HttpServletRequest request);
 
+    /**
+     * If authentication was successful, apply the successful authentication result to the security context and add
+     * proxy headers to the response if the request was made via a proxy.
+     *
+     * @param request The original client request that was successfully authenticated.
+     * @param response Servlet response to the client containing the successful authentication details.
+     * @param authResult The Authentication 'token'/object created by one of the various NiFiAuthenticationFilter subclasses.
+     */
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authResult) {
         log.info("Authentication success for " + authResult);
 
@@ -114,6 +123,14 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
         ProxiedEntitiesUtils.successfulAuthentication(request, response);
     }
 
+    /**
+     * If authentication was unsuccessful, update the response with the appropriate status and give the reason for why
+     * the user was not able to be authenticated. Update the response with proxy headers if the request was made via a proxy.
+     *
+     * @param request The original client request that failed to be authenticated.
+     * @param response Servlet response to the client containing the unsuccessful authentication attempt details.
+     * @param ae The related exception thrown and explanation for the unsuccessful authentication attempt.
+     */
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException ae) throws IOException {
         // populate the response
         ProxiedEntitiesUtils.unsuccessfulAuthentication(request, response, ae);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/ProxiedEntitiesUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/ProxiedEntitiesUtils.java
@@ -147,12 +147,25 @@ public class ProxiedEntitiesUtils {
         return StringUtils.join(proxyChain, "");
     }
 
+    /**
+     * If a successfully authenticated request was made via a proxy, relevant proxy headers will be added to the response.
+     *
+     * @param request The proxied client request that was successfully authenticated.
+     * @param response A servlet response to the client containing the successful authentication details.
+     */
     public static void successfulAuthentication(HttpServletRequest request, HttpServletResponse response) {
         if (StringUtils.isNotBlank(request.getHeader(PROXY_ENTITIES_CHAIN))) {
             response.setHeader(PROXY_ENTITIES_ACCEPTED, Boolean.TRUE.toString());
         }
     }
 
+    /**
+     * If an unauthenticated request was made via a proxy, add proxy headers to explain why authentication failed.
+     *
+     * @param request The original client request that failed to be authenticated.
+     * @param response Servlet response to the client containing the unsuccessful authentication attempt details.
+     * @param failed The related exception thrown and explanation for the unsuccessful authentication attempt.
+     */
     public static void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
         if (StringUtils.isNotBlank(request.getHeader(PROXY_ENTITIES_CHAIN))) {
             response.setHeader(PROXY_ENTITIES_DETAILS, failed.getMessage());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/ProxiedEntitiesUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/ProxiedEntitiesUtils.java
@@ -27,7 +27,6 @@ import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 /**
@@ -148,13 +147,13 @@ public class ProxiedEntitiesUtils {
         return StringUtils.join(proxyChain, "");
     }
 
-    public static void successfulAuthorization(HttpServletRequest request, HttpServletResponse response, Authentication authResult) {
+    public static void successfulAuthentication(HttpServletRequest request, HttpServletResponse response) {
         if (StringUtils.isNotBlank(request.getHeader(PROXY_ENTITIES_CHAIN))) {
             response.setHeader(PROXY_ENTITIES_ACCEPTED, Boolean.TRUE.toString());
         }
     }
 
-    public static void unsuccessfulAuthorization(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+    public static void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
         if (StringUtils.isNotBlank(request.getHeader(PROXY_ENTITIES_CHAIN))) {
             response.setHeader(PROXY_ENTITIES_DETAILS, failed.getMessage());
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/JwtAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/JwtAuthenticationFilter.java
@@ -16,13 +16,14 @@
  */
 package org.apache.nifi.web.security.jwt;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.web.security.NiFiAuthenticationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  */
@@ -30,8 +31,10 @@ public class JwtAuthenticationFilter extends NiFiAuthenticationFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
+    // The Authorization header contains authentication credentials
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
+    private static final Pattern tokenPattern = Pattern.compile("^Bearer (\\S*\\.\\S*\\.\\S*)$");
 
     @Override
     public Authentication attemptAuthentication(final HttpServletRequest request) {
@@ -43,15 +46,27 @@ public class JwtAuthenticationFilter extends NiFiAuthenticationFilter {
         // TODO: Refactor request header extraction logic to shared utility as it is duplicated in AccessResource
 
         // get the principal out of the user token
-        final String authorization = request.getHeader(AUTHORIZATION);
+        final String authentication = request.getHeader(AUTHORIZATION);
 
-        // if there is no authorization header, we don't know the user
-        if (authorization == null || !StringUtils.startsWith(authorization, BEARER)) {
+        // if there is no authorization (authentication) header, we don't know the user
+        if (authentication == null || !validJwtFormat(authentication)) {
             return null;
         } else {
             // Extract the Base64 encoded token from the Authorization header
-            final String token = StringUtils.substringAfterLast(authorization, " ");
+            final String token = getTokenFromHeader(authentication);
             return new JwtAuthenticationRequestToken(token, request.getRemoteAddr());
         }
     }
+
+    private boolean validJwtFormat(String authenticationHeader) {
+        Matcher matcher = tokenPattern.matcher(authenticationHeader);
+        return matcher.matches();
+    }
+
+    private String getTokenFromHeader(String authenticationHeader) {
+        Matcher matcher = tokenPattern.matcher(authenticationHeader);
+        matcher.matches();
+        return matcher.group(1);
+    }
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/JwtService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/JwtService.java
@@ -32,7 +32,6 @@ import java.util.Calendar;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.admin.service.AdministrationException;
 import org.apache.nifi.admin.service.KeyService;
-import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.apache.nifi.key.Key;
 import org.apache.nifi.web.security.token.LoginAuthenticationToken;
 import org.slf4j.LoggerFactory;
@@ -170,17 +169,15 @@ public class JwtService {
         }
     }
 
-    public void logOut(String authorizationHeader) {
-        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
-            throw new JwtException("Log out failed: The required Authorization header was not present in the request to log out user.");
+    public void logOut(String userIdentity) {
+        if (userIdentity == null || userIdentity.isEmpty()) {
+            throw new JwtException("Log out failed: The user identity was not present in the request token to log out user.");
         }
 
-        String identity = NiFiUserUtils.getNiFiUserIdentity();
-
         try {
-            keyService.deleteKey(identity);
+            keyService.deleteKey(userIdentity);
         } catch (Exception e) {
-            logger.error("Unable to log out user: " + identity + ". Failed to remove their token from database.");
+            logger.error("Unable to log out user: " + userIdentity + ". Failed to remove their token from database.");
             throw e;
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/groovy/org/apache/nifi/web/security/jwt/JwtAuthenticationFilterTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/groovy/org/apache/nifi/web/security/jwt/JwtAuthenticationFilterTest.groovy
@@ -14,26 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.web.security.jwt;
+package org.apache.nifi.web.security.jwt
 
-import net.minidev.json.JSONObject;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
+import groovy.json.JsonOutput
+import net.minidev.json.JSONObject
+import org.apache.nifi.web.security.InvalidAuthenticationException
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Before
 import org.junit.BeforeClass
-import org.junit.Rule;
+import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
 @RunWith(JUnit4.class)
 class JwtAuthenticationFilterTest extends GroovyTestCase {
 
-    public static String jwtString;
+    public static String jwtString
 
     @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    public ExpectedException expectedException = ExpectedException.none()
 
     @BeforeClass
     public static void setUpOnce() throws Exception {
@@ -46,15 +48,17 @@ class JwtAuthenticationFilterTest extends GroovyTestCase {
 
         // Generate a token that we will add a valid signature from a different token
         // Always use LinkedHashMap to enforce order of the keys because the signature depends on order
-        Map<String, Object> claims = new LinkedHashMap<>()
-        claims.put("sub", "unknownuser")
-        claims.put("iss", "MockIdentityProvider")
-        claims.put("aud", "MockIdentityProvider")
-        claims.put("preferred_username", "unknownuser")
-        claims.put("kid", 1)
-        claims.put("exp", TOKEN_EXPIRATION_SECONDS)
-        claims.put("iat", TOKEN_ISSUED_AT)
-        final String EXPECTED_PAYLOAD = new JSONObject(claims).toString()
+        final String EXPECTED_PAYLOAD =
+                JsonOutput.toJson(
+                    sub:'unknownuser',
+                    iss:'MockIdentityProvider',
+                    aud:'MockIdentityProvider',
+                    preferred_username:'unknownuser',
+                    kid:1,
+                    exp:TOKEN_EXPIRATION_SECONDS,
+                    iat:TOKEN_ISSUED_AT)
+
+        // Set up our JWT string with a test token
         jwtString = JwtServiceTest.generateHS256Token(ALG_HEADER, EXPECTED_PAYLOAD, true, true)
 
     }
@@ -77,13 +81,13 @@ class JwtAuthenticationFilterTest extends GroovyTestCase {
     @Test
     void testValidAuthenticationHeaderString() {
         // Arrange
-        String authenticationHeader = ("Bearer " + jwtString)
+        String authenticationHeader = "Bearer " + jwtString
 
         // Act
-        boolean validHeader = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+        boolean isValidHeader = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
 
         // Assert
-        assertTrue(validHeader)
+        assertTrue(isValidHeader)
     }
 
     @Test
@@ -91,10 +95,22 @@ class JwtAuthenticationFilterTest extends GroovyTestCase {
         // Arrange
 
         // Act
-        boolean invalidHeader = new JwtAuthenticationFilter().validJwtFormat(jwtString)
+        boolean isValidHeader = new JwtAuthenticationFilter().validJwtFormat(jwtString)
 
         // Assert
-        assertFalse(invalidHeader)
+        assertFalse(isValidHeader)
+    }
+
+    @Test
+    void testExtraCharactersAtBeginningOfToken() {
+        // Arrange
+        String authenticationHeader = "xBearer " + jwtString
+
+        // Act
+        boolean isValidToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+
+        // Assert
+        assertFalse(isValidToken)
     }
 
     @Test
@@ -104,63 +120,62 @@ class JwtAuthenticationFilterTest extends GroovyTestCase {
         String badToken = "Bearer " + tokenStrings[1] + tokenStrings[2]
 
         // Act
-        boolean invalidToken = new JwtAuthenticationFilter().validJwtFormat(badToken)
+        boolean isValidToken = new JwtAuthenticationFilter().validJwtFormat(badToken)
 
         // Assert
-        assertFalse(invalidToken)
+        assertFalse(isValidToken)
+    }
+
+    @Test
+    void testMultipleTokenInvalid() {
+        // Arrange
+        String authenticationHeader = "Bearer " + jwtString
+        authenticationHeader = authenticationHeader + " " + authenticationHeader
+
+        // Act
+        boolean isValidToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+
+        // Assert
+        assertFalse(isValidToken)
     }
 
     @Test
     void testExtractToken() {
         // Arrange
-        String authenticationHeader = ("Bearer " + jwtString)
+        String authenticationHeader = "Bearer " + jwtString
 
         // Act
-        String validToken = new JwtAuthenticationFilter().getTokenFromHeader(authenticationHeader)
+        String extractedToken = new JwtAuthenticationFilter().getTokenFromHeader(authenticationHeader)
 
         // Assert
-        assertEquals(jwtString, validToken)
-    }
-
-
-    @Test
-    void testMultipleTokenInvalid() {
-        // Arrange
-        String authenticationHeader = ("Bearer " + jwtString)
-        authenticationHeader = authenticationHeader + " " + authenticationHeader
-
-        // Act
-        boolean validToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
-
-        // Assert
-        assertFalse(validToken)
+        assertEquals(jwtString, extractedToken)
     }
 
     @Test
     void testMultipleTokenDottedInvalid() {
         // Arrange
-        String authenticationHeader = ("Bearer " + jwtString)
+        String authenticationHeader = "Bearer " + jwtString
         authenticationHeader = authenticationHeader + "." + authenticationHeader
 
         // Act
-        boolean validToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+        boolean isValidToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
 
         // Assert
-        assertFalse(validToken)
+        assertFalse(isValidToken)
     }
 
     @Test
     void testMultipleTokenNotExtracted() {
         // Arrange
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("No match found");
-        String authenticationHeader = ("Bearer " + jwtString)
+        expectedException.expect(InvalidAuthenticationException.class)
+        expectedException.expectMessage("JWT did not match expected pattern.")
+        String authenticationHeader = "Bearer " + jwtString
         authenticationHeader = authenticationHeader + " " + authenticationHeader
 
         // Act
         String token = new JwtAuthenticationFilter().getTokenFromHeader(authenticationHeader)
 
         // Assert
-        // Expect exception
+        // Expect InvalidAuthenticationException
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/groovy/org/apache/nifi/web/security/jwt/JwtAuthenticationFilterTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/groovy/org/apache/nifi/web/security/jwt/JwtAuthenticationFilterTest.groovy
@@ -17,7 +17,6 @@
 package org.apache.nifi.web.security.jwt
 
 import groovy.json.JsonOutput
-import net.minidev.json.JSONObject
 import org.apache.nifi.web.security.InvalidAuthenticationException
 import org.junit.After
 import org.junit.AfterClass
@@ -38,7 +37,7 @@ class JwtAuthenticationFilterTest extends GroovyTestCase {
     public ExpectedException expectedException = ExpectedException.none()
 
     @BeforeClass
-    public static void setUpOnce() throws Exception {
+    static void setUpOnce() throws Exception {
         final String ALG_HEADER = "{\"alg\":\"HS256\"}"
         final int EXPIRATION_SECONDS = 500
         Calendar now = Calendar.getInstance()
@@ -64,17 +63,17 @@ class JwtAuthenticationFilterTest extends GroovyTestCase {
     }
 
     @AfterClass
-    public static void tearDownOnce() throws Exception {
+    static void tearDownOnce() throws Exception {
 
     }
 
     @Before
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
 
     }
 
     @After
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
 
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/groovy/org/apache/nifi/web/security/jwt/JwtAuthenticationFilterTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/groovy/org/apache/nifi/web/security/jwt/JwtAuthenticationFilterTest.groovy
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.jwt;
+
+import net.minidev.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass
+import org.junit.Rule;
+import org.junit.Test
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+class JwtAuthenticationFilterTest extends GroovyTestCase {
+
+    public static String jwtString;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @BeforeClass
+    public static void setUpOnce() throws Exception {
+        final String ALG_HEADER = "{\"alg\":\"HS256\"}"
+        final int EXPIRATION_SECONDS = 500
+        Calendar now = Calendar.getInstance()
+        final long currentTime = (long) (now.getTimeInMillis() / 1000.0)
+        final long TOKEN_ISSUED_AT = currentTime
+        final long TOKEN_EXPIRATION_SECONDS = currentTime + EXPIRATION_SECONDS
+
+        // Generate a token that we will add a valid signature from a different token
+        // Always use LinkedHashMap to enforce order of the keys because the signature depends on order
+        Map<String, Object> claims = new LinkedHashMap<>()
+        claims.put("sub", "unknownuser")
+        claims.put("iss", "MockIdentityProvider")
+        claims.put("aud", "MockIdentityProvider")
+        claims.put("preferred_username", "unknownuser")
+        claims.put("kid", 1)
+        claims.put("exp", TOKEN_EXPIRATION_SECONDS)
+        claims.put("iat", TOKEN_ISSUED_AT)
+        final String EXPECTED_PAYLOAD = new JSONObject(claims).toString()
+        jwtString = JwtServiceTest.generateHS256Token(ALG_HEADER, EXPECTED_PAYLOAD, true, true)
+
+    }
+
+    @AfterClass
+    public static void tearDownOnce() throws Exception {
+
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    void testValidAuthenticationHeaderString() {
+        // Arrange
+        String authenticationHeader = ("Bearer " + jwtString)
+
+        // Act
+        boolean validHeader = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+
+        // Assert
+        assertTrue(validHeader)
+    }
+
+    @Test
+    void testMissingBearer() {
+        // Arrange
+
+        // Act
+        boolean invalidHeader = new JwtAuthenticationFilter().validJwtFormat(jwtString)
+
+        // Assert
+        assertFalse(invalidHeader)
+    }
+
+    @Test
+    void testBadTokenFormat() {
+        // Arrange
+        String[] tokenStrings = jwtString.split("\\.")
+        String badToken = "Bearer " + tokenStrings[1] + tokenStrings[2]
+
+        // Act
+        boolean invalidToken = new JwtAuthenticationFilter().validJwtFormat(badToken)
+
+        // Assert
+        assertFalse(invalidToken)
+    }
+
+    @Test
+    void testExtractToken() {
+        // Arrange
+        String authenticationHeader = ("Bearer " + jwtString)
+
+        // Act
+        String validToken = new JwtAuthenticationFilter().getTokenFromHeader(authenticationHeader)
+
+        // Assert
+        assertEquals(jwtString, validToken)
+    }
+
+
+    @Test
+    void testMultipleTokenInvalid() {
+        // Arrange
+        String authenticationHeader = ("Bearer " + jwtString)
+        authenticationHeader = authenticationHeader + " " + authenticationHeader
+
+        // Act
+        boolean validToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+
+        // Assert
+        assertFalse(validToken)
+    }
+
+    @Test
+    void testMultipleTokenDottedInvalid() {
+        // Arrange
+        String authenticationHeader = ("Bearer " + jwtString)
+        authenticationHeader = authenticationHeader + "." + authenticationHeader
+
+        // Act
+        boolean validToken = new JwtAuthenticationFilter().validJwtFormat(authenticationHeader)
+
+        // Assert
+        assertFalse(validToken)
+    }
+
+    @Test
+    void testMultipleTokenNotExtracted() {
+        // Arrange
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("No match found");
+        String authenticationHeader = ("Bearer " + jwtString)
+        authenticationHeader = authenticationHeader + " " + authenticationHeader
+
+        // Act
+        String token = new JwtAuthenticationFilter().getTokenFromHeader(authenticationHeader)
+
+        // Assert
+        // Expect exception
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/JwtServiceTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/JwtServiceTest.java
@@ -511,7 +511,7 @@ public class JwtServiceTest {
     public void testLogoutWhenAuthTokenIsEmptyShouldThrowError() throws Exception {
         // Arrange
         expectedException.expect(JwtException.class);
-        expectedException.expectMessage("Log out failed: The required Authorization header was not present in the request to log out user.");
+        expectedException.expectMessage("Log out failed: The user identity was not present in the request token to log out user.");
 
         // Act
         jwtService.logOut(null);
@@ -519,6 +519,5 @@ public class JwtServiceTest {
         // Assert
         // Should throw exception when authorization header is null
     }
-
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-header-controller.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-header-controller.js
@@ -118,12 +118,12 @@
             this.logoutCtrl = {
                 logout: function () {
                     $.ajax({
-                        type: 'GET',
+                        type: 'DELETE',
                         url: '../nifi-api/access/logout',
-                        dataType: 'json'
-                    })
-                    nfStorage.removeItem("jwt");
-                    window.location = '../nifi/logout';
+                    }).done(function () {
+                        nfStorage.removeItem("jwt");
+                        window.location = '../nifi/logout';
+                    }).fail(nfErrorHandler.handleAjaxError);
                 }
             };
         }


### PR DESCRIPTION
…dc/** to allow the Jetty security filters to be applied in the /access/oidc/logout and /access/knox/logout cases.

NIFI-6280 - Updated terminology in JwtAuthenticationFilter to authentication instead of authorization. Added stricter token parsing using an explicit regex pattern. Added tests.

NIFI-6280 - Updated terminology from Authorization to Authentication.

NIFI-6280 - Updated the access logout method to use getNiFiUserIdentity(). Updated javascript logout method to handle errors.

NIFI-6280 - Fixing checkstyle issues

Thank you for submitting a contribution to Apache NiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with NIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
