### PR TITLE
NIFI-6315 Ensuring remote ports get tracked correctly when saving/ret…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/FlowManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/FlowManager.java
@@ -33,6 +33,7 @@ import org.apache.nifi.web.api.dto.FlowSnippetDTO;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 
 public interface FlowManager {
@@ -74,6 +75,22 @@ public interface FlowManager {
      * @return output ports
      */
     Set<Port> getPublicOutputPorts();
+
+    /**
+     * Gets the public input port with the given name.
+     *
+     * @param name the port name
+     * @return an optional containing the public input port with the given name, or empty if one does not exist
+     */
+    Optional<Port> getPublicInputPort(String name);
+
+    /**
+     * Gets the public output port with the given name.
+     *
+     * @param name the port name
+     * @return an optional containing the public output port with the given name, or empty if one does not exist
+     */
+    Optional<Port> getPublicOutputPort(String name);
 
     /**
      * Creates a new Remote Process Group with the given ID that points to the given URI

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
@@ -72,6 +72,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -284,7 +285,8 @@ public class StandardFlowSnippet implements FlowSnippet {
         for (final PortDTO portDTO : dto.getInputPorts()) {
             final Port inputPort;
             if (group.isRootGroup() || Boolean.TRUE.equals(portDTO.getAllowRemoteAccess())) {
-                inputPort = flowManager.createPublicInputPort(portDTO.getId(), portDTO.getName());
+                final String portName = generatePublicInputPortName(flowManager, portDTO.getName());
+                inputPort = flowManager.createPublicInputPort(portDTO.getId(), portName);
                 if (portDTO.getGroupAccessControl() != null) {
                     ((PublicPort) inputPort).setGroupAccessControl(portDTO.getGroupAccessControl());
                 }
@@ -308,7 +310,8 @@ public class StandardFlowSnippet implements FlowSnippet {
         for (final PortDTO portDTO : dto.getOutputPorts()) {
             final Port outputPort;
             if (group.isRootGroup() || Boolean.TRUE.equals(portDTO.getAllowRemoteAccess())) {
-                outputPort = flowManager.createPublicOutputPort(portDTO.getId(), portDTO.getName());
+                final String portName = generatePublicOutputPortName(flowManager, portDTO.getName());
+                outputPort = flowManager.createPublicOutputPort(portDTO.getId(), portName);
                 if (portDTO.getGroupAccessControl() != null) {
                     ((PublicPort) outputPort).setGroupAccessControl(portDTO.getGroupAccessControl());
                 }
@@ -567,6 +570,24 @@ public class StandardFlowSnippet implements FlowSnippet {
 
             connection.setProcessGroup(group);
             group.addConnection(connection);
+        }
+    }
+
+    private String generatePublicInputPortName(final FlowManager flowManager, final String proposedName) {
+        final Optional<Port> existingPort = flowManager.getPublicInputPort(proposedName);
+        if (existingPort.isPresent()) {
+            return generatePublicInputPortName(flowManager, "Copy of " + proposedName);
+        } else {
+            return proposedName;
+        }
+    }
+
+    private String generatePublicOutputPortName(final FlowManager flowManager, final String proposedName) {
+        final Optional<Port> existingPort = flowManager.getPublicOutputPort(proposedName);
+        if (existingPort.isPresent()) {
+            return generatePublicOutputPortName(flowManager, "Copy of " + proposedName);
+        } else {
+            return proposedName;
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
@@ -82,6 +82,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -179,6 +180,26 @@ public class StandardFlowManager implements FlowManager {
         group.getProcessGroups().forEach(childGroup -> getPublicPorts(publicPorts, childGroup, getPorts));
     }
 
+    @Override
+    public Optional<Port> getPublicInputPort(String name) {
+        return findPort(name, getPublicInputPorts());
+    }
+
+    @Override
+    public Optional<Port> getPublicOutputPort(String name) {
+        return findPort(name, getPublicOutputPorts());
+    }
+
+    private Optional<Port> findPort(final String portName, final Set<Port> ports) {
+        if (ports != null) {
+            for (final Port port : ports) {
+                if (portName.equals(port.getName())) {
+                    return Optional.of(port);
+                }
+            }
+        }
+        return Optional.empty();
+    }
 
     public RemoteProcessGroup createRemoteProcessGroup(final String id, final String uris) {
         return new StandardRemoteProcessGroup(requireNonNull(id), uris, null, processScheduler, bulletinRepository, sslContext, nifiProperties);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -4230,6 +4230,7 @@ public final class StandardProcessGroup implements ProcessGroup {
         port.setComments(proposed.getComments());
         port.setName(name);
         port.setPosition(new Position(proposed.getPosition().getX(), proposed.getPosition().getY()));
+        port.setMaxConcurrentTasks(proposed.getConcurrentlySchedulableTaskCount());
     }
 
     private Port addInputPort(final ProcessGroup destination, final VersionedPort proposed, final String componentIdSeed, final String temporaryName) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -3876,9 +3876,9 @@ public final class StandardProcessGroup implements ProcessGroup {
     private String getPublicPortFinalName(final PublicPort publicPort, final String proposedFinalName) {
         final Optional<Port> existingPublicPort;
         if (TransferDirection.RECEIVE == publicPort.getDirection()) {
-            existingPublicPort = findPublicInputPort(proposedFinalName);
+            existingPublicPort = flowManager.getPublicInputPort(proposedFinalName);
         } else {
-            existingPublicPort = findPublicOutputPort(proposedFinalName);
+            existingPublicPort = flowManager.getPublicOutputPort(proposedFinalName);
         }
 
         if (existingPublicPort.isPresent() && !existingPublicPort.get().getIdentifier().equals(publicPort.getIdentifier())) {
@@ -3886,25 +3886,6 @@ public final class StandardProcessGroup implements ProcessGroup {
         } else {
             return proposedFinalName;
         }
-    }
-
-    private Optional<Port> findPublicInputPort(final String portName) {
-        return findPort(portName, flowManager.getPublicInputPorts());
-    }
-
-    private Optional<Port> findPublicOutputPort(final String portName) {
-        return findPort(portName, flowManager.getPublicOutputPorts());
-    }
-
-    private Optional<Port> findPort(final String portName, final Set<Port> ports) {
-        if (ports != null) {
-            for (final Port port : ports) {
-                if (portName.equals(port.getName())) {
-                    return Optional.of(port);
-                }
-            }
-        }
-        return Optional.empty();
     }
 
     private boolean isUpdateable(final Connection connection) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
@@ -58,6 +58,7 @@ import org.apache.nifi.registry.flow.VersionedProcessor;
 import org.apache.nifi.registry.flow.VersionedPropertyDescriptor;
 import org.apache.nifi.registry.flow.VersionedRemoteGroupPort;
 import org.apache.nifi.registry.flow.VersionedRemoteProcessGroup;
+import org.apache.nifi.remote.PublicPort;
 import org.apache.nifi.remote.RemoteGroupPort;
 
 import java.nio.charset.StandardCharsets;
@@ -434,6 +435,13 @@ public class NiFiRegistryFlowMapper {
         versionedPort.setName(port.getName());
         versionedPort.setPosition(mapPosition(port.getPosition()));
         versionedPort.setType(PortType.valueOf(port.getConnectableType().name()));
+
+        if (port instanceof PublicPort) {
+            versionedPort.setAllowRemoteAccess(true);
+        } else {
+            versionedPort.setAllowRemoteAccess(false);
+        }
+
         return versionedPort;
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -19,6 +19,7 @@ package org.apache.nifi.util;
 import org.apache.nifi.registry.flow.ComponentType;
 import org.apache.nifi.registry.flow.VersionedComponent;
 import org.apache.nifi.registry.flow.VersionedFlowCoordinates;
+import org.apache.nifi.registry.flow.VersionedPort;
 import org.apache.nifi.registry.flow.VersionedProcessGroup;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
 import org.apache.nifi.registry.flow.diff.FlowDifference;
@@ -27,6 +28,25 @@ import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedComponent;
 import java.util.function.Predicate;
 
 public class FlowDifferenceFilters {
+
+    /**
+     * Predicate that returns true if the difference is NOT a name change on a public port (i.e. VersionedPort that allows remote access).
+     */
+    public static Predicate<FlowDifference> FILTER_PUBLIC_PORT_NAME_CHANGES = (fd) -> {
+        return !isPublicPortNameChange(fd);
+    };
+
+    public static boolean isPublicPortNameChange(final FlowDifference fd) {
+        final VersionedComponent versionedComponent = fd.getComponentA();
+        if (fd.getDifferenceType() == DifferenceType.NAME_CHANGED && versionedComponent instanceof VersionedPort) {
+            final VersionedPort versionedPort = (VersionedPort) versionedComponent;
+            if (versionedPort.isAllowRemoteAccess()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Predicate that returns true if the difference is NOT a remote port being added, and false if it is.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -18,6 +18,7 @@ package org.apache.nifi.util;
 
 import org.apache.nifi.registry.flow.ComponentType;
 import org.apache.nifi.registry.flow.VersionedFlowCoordinates;
+import org.apache.nifi.registry.flow.VersionedPort;
 import org.apache.nifi.registry.flow.VersionedProcessGroup;
 import org.apache.nifi.registry.flow.VersionedProcessor;
 import org.apache.nifi.registry.flow.VersionedRemoteGroupPort;
@@ -122,5 +123,49 @@ public class TestFlowDifferenceFilters {
         Assert.assertTrue(FlowDifferenceFilters.FILTER_IGNORABLE_VERSIONED_FLOW_COORDINATE_CHANGES.test(flowDifference));
     }
 
+    @Test
+    public void testFilterPublicPortNameChangeWhenNotNameChange() {
+        final VersionedPort portA = new VersionedPort();
+        final VersionedPort portB = new VersionedPort();
+
+        final StandardFlowDifference flowDifference = new StandardFlowDifference(
+                DifferenceType.VERSIONED_FLOW_COORDINATES_CHANGED,
+                portA, portB,
+                "http://localhost:18080", "http://localhost:17080",
+                "");
+
+        Assert.assertTrue(FlowDifferenceFilters.FILTER_PUBLIC_PORT_NAME_CHANGES.test(flowDifference));
+    }
+
+    @Test
+    public void testFilterPublicPortNameChangeWhenNotAllowRemoteAccess() {
+        final VersionedPort portA = new VersionedPort();
+        final VersionedPort portB = new VersionedPort();
+
+        final StandardFlowDifference flowDifference = new StandardFlowDifference(
+                DifferenceType.NAME_CHANGED,
+                portA, portB,
+                "Port A", "Port B",
+                "");
+
+        Assert.assertTrue(FlowDifferenceFilters.FILTER_PUBLIC_PORT_NAME_CHANGES.test(flowDifference));
+    }
+
+    @Test
+    public void testFilterPublicPortNameChangeWhenAllowRemoteAccess() {
+        final VersionedPort portA = new VersionedPort();
+        portA.setAllowRemoteAccess(true);
+
+        final VersionedPort portB = new VersionedPort();
+        portB.setAllowRemoteAccess(false);
+
+        final StandardFlowDifference flowDifference = new StandardFlowDifference(
+                DifferenceType.NAME_CHANGED,
+                portA, portB,
+                "Port A", "Port B",
+                "");
+
+        Assert.assertFalse(FlowDifferenceFilters.FILTER_PUBLIC_PORT_NAME_CHANGES.test(flowDifference));
+    }
 }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -4096,6 +4096,11 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                 continue;
             }
 
+            // Ignore name changes to public ports
+            if (FlowDifferenceFilters.isPublicPortNameChange(difference)) {
+                continue;
+            }
+
             if (FlowDifferenceFilters.isIgnorableVersionedFlowCoordinateChange(difference)) {
                 continue;
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -2324,6 +2324,11 @@ public final class DtoFactory {
                 continue;
             }
 
+            // Ignore name changes to public ports
+            if (FlowDifferenceFilters.isPublicPortNameChange(difference)) {
+                continue;
+            }
+
             if (FlowDifferenceFilters.isIgnorableVersionedFlowCoordinateChange(difference)) {
                 continue;
             }


### PR DESCRIPTION
…rieving versioned flows

@markap14 @ijokarumawak Everything in this PR appears to work in terms of saving to registry and importing, but I did want to ask what should happen when there are public ports with the same name in multiple process groups?

For example, I setup PG1 with public Input Port "IN" -> Update Attribute, and save it to registry. Then I created a GenerateFlowFile -> RPG connected to the "IN". Then I import a new PG and choose the same one I just saved to registry, so now I have two of the same PGs, both with an input port named "IN".

It seemed as though the RPG never recognized the second and continued sending to the original one. Then I renamed the second input port to "IN2" which showed as a local change on the PG, and I stopped the original input port. The RPG somehow refreshed and renamed the connection from "IN" to "IN2".
