### PR TITLE
Added a check whereby, if the user is using the "Use Segment Names" o…

### DIFF
--- a/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
+++ b/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
@@ -284,8 +284,12 @@ public class ExtractHL7Attributes extends AbstractProcessor {
             final Type field = segment.getField(i, 0);
             if (!isEmpty(field)) {
                 final String fieldName;
-                if (useNames) {
-                    fieldName = WordUtils.capitalize(segmentNames[i-1]).replaceAll("\\W+", "");
+                //Some user defined segments (e.g. Z segments) will not have corresponding names returned
+                //from segment.getNames() above. If we encounter one of these, do the next best thing
+                //and return what we otherwise would if we were not in useNames mode.
+                String segmentName = segmentNames[i-1];                
+                if (useNames && StringUtils.isNotBlank(segmentName)) {
+                    fieldName = WordUtils.capitalize(segmentName).replaceAll("\\W+", "");
                 } else {
                     fieldName = String.valueOf(i);
                 }


### PR DESCRIPTION
…ption in the ExtractHL7Attributes processor and the HL7 message being processed contains custom user segments (e.g., Z Segments), the code will downgrade to returning the Segment Label as it does when this option is not used. Without this a null pointer is thrown at line 288.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
