### PR TITLE
NIFI-6320 ExtractHL7Attributes should better tolerate custom segments (e.g. Z segments)

### DIFF
--- a/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
+++ b/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
@@ -284,8 +284,12 @@ public class ExtractHL7Attributes extends AbstractProcessor {
             final Type field = segment.getField(i, 0);
             if (!isEmpty(field)) {
                 final String fieldName;
-                if (useNames) {
-                    fieldName = WordUtils.capitalize(segmentNames[i-1]).replaceAll("\\W+", "");
+                //Some user defined segments (e.g. Z segments) will not have corresponding names returned
+                //from segment.getNames() above. If we encounter one of these, do the next best thing
+                //and return what we otherwise would if we were not in useNames mode.
+                String segmentName = segmentNames[i-1];                
+                if (useNames && StringUtils.isNotBlank(segmentName)) {
+                    fieldName = WordUtils.capitalize(segmentName).replaceAll("\\W+", "");
                 } else {
                     fieldName = String.valueOf(i);
                 }


### PR DESCRIPTION
Added a check whereby, if the user is using the "Use Segment Names” option in the ExtractHL7Attributes processor and the HL7 message being processed contains custom user segments (e.g., Z Segments), the code will downgrade to returning the Segment Label as it does when this option is not used. Without this a null pointer is thrown at line 288.