### PR TITLE
NIFI-6349 Fix to MergeRecords for fragments over multiple iterations

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
@@ -203,6 +203,10 @@ public class RecordBin {
                 return false;
             }
 
+            if(thresholds.getFragmentCountAttribute().isPresent() && this.fragmentCount == getMinimumRecordCount()) {
+                return true;
+            }
+
             int maxRecords = thresholds.getMaxRecords();
 
             if (recordCount >= maxRecords) {
@@ -213,22 +217,6 @@ public class RecordBin {
                 return true;
             }
 
-            Optional<String> fragmentCountAttribute = thresholds.getFragmentCountAttribute();
-            if(fragmentCountAttribute != null && fragmentCountAttribute.isPresent()) {
-                final Optional<String> fragmentCountValue = flowFiles.stream()
-                        .filter(ff -> ff.getAttribute(fragmentCountAttribute.get()) != null)
-                        .map(ff -> ff.getAttribute(fragmentCountAttribute.get()))
-                        .findFirst();
-                if (fragmentCountValue.isPresent()) {
-                    try {
-                        int expectedFragments = Integer.parseInt(fragmentCountValue.get());
-                        if (this.fragmentCount == expectedFragments)
-                            return true;
-                    } catch (NumberFormatException nfe) {
-                        this.logger.error(nfe.getMessage(), nfe);
-                    }
-                }
-            }
             return false;
         } finally {
             readLock.unlock();
@@ -349,14 +337,14 @@ public class RecordBin {
                         count = Integer.parseInt(countVal);
                     } catch (final NumberFormatException nfe) {
                         logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but expected a number",
-                            new Object[] {flowFiles.size(), countAttr.get(), countVal, flowFile});
+                                new Object[] {flowFiles.size(), countAttr.get(), countVal, flowFile});
                         fail();
                         return;
                     }
 
                     if (expectedBinCount != null && count != expectedBinCount) {
                         logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but another FlowFile in the bin had a value of {}",
-                            new Object[] {flowFiles.size(), countAttr.get(), countVal, flowFile, expectedBinCount});
+                                new Object[] {flowFiles.size(), countAttr.get(), countVal, flowFile, expectedBinCount});
                         fail();
                         return;
                     }
@@ -366,15 +354,15 @@ public class RecordBin {
 
                 if (expectedBinCount == null) {
                     logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute was not present on any of the FlowFiles",
-                        new Object[] {flowFiles.size(), countAttr.get()});
+                            new Object[] {flowFiles.size(), countAttr.get()});
                     fail();
                     return;
                 }
 
                 if (expectedBinCount != flowFiles.size()) {
                     logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' but only {} of {} FlowFiles were encountered before this bin was evicted "
-                        + "(due to to Max Bin Age being reached or due to the Maximum Number of Bins being exceeded).",
-                        new Object[] {flowFiles.size(), countAttr.get(), expectedBinCount, flowFiles.size(), expectedBinCount});
+                                    + "(due to to Max Bin Age being reached or due to the Maximum Number of Bins being exceeded).",
+                            new Object[] {flowFiles.size(), countAttr.get(), expectedBinCount, flowFiles.size(), expectedBinCount});
                     fail();
                     return;
                 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
@@ -27,6 +27,7 @@ import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processors.standard.MergeContent;
 import org.apache.nifi.processors.standard.MergeRecord;
 import org.apache.nifi.serialization.RecordReader;
+import org.apache.nifi.util.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -146,7 +147,8 @@ public class RecordBinManager {
         }
 
         // if we've reached this point then we couldn't fit it into any existing bins - gotta make a new one
-        final RecordBin bin = new RecordBin(context, sessionFactory.createSession(), logger, createThresholds());
+
+        final RecordBin bin = new RecordBin(context, sessionFactory.createSession(), logger, createThresholds(flowFile));
         final boolean binAccepted = bin.offer(flowFile, reader, session, true);
         if (!binAccepted) {
             session.rollback();
@@ -179,8 +181,8 @@ public class RecordBinManager {
     }
 
 
-    private RecordBinThresholds createThresholds() {
-        final int minRecords = context.getProperty(MergeRecord.MIN_RECORDS).asInteger();
+    private RecordBinThresholds createThresholds(FlowFile flowfile) {
+        int minRecords = context.getProperty(MergeRecord.MIN_RECORDS).asInteger();
         final int maxRecords = context.getProperty(MergeRecord.MAX_RECORDS).asInteger();
         final long minBytes = context.getProperty(MergeRecord.MIN_SIZE).asDataSize(DataUnit.B).longValue();
 
@@ -195,6 +197,9 @@ public class RecordBinManager {
         final String mergeStrategy = context.getProperty(MergeRecord.MERGE_STRATEGY).getValue();
         if (MergeRecord.MERGE_STRATEGY_DEFRAGMENT.getValue().equals(mergeStrategy)) {
             fragmentCountAttribute = MergeContent.FRAGMENT_COUNT_ATTRIBUTE;
+            if (!StringUtils.isEmpty(fragmentCountAttribute)) {
+                minRecords = Integer.parseInt(flowfile.getAttribute(fragmentCountAttribute));
+            }
         } else {
             fragmentCountAttribute = null;
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
@@ -197,7 +197,7 @@ public class RecordBinManager {
         final String mergeStrategy = context.getProperty(MergeRecord.MERGE_STRATEGY).getValue();
         if (MergeRecord.MERGE_STRATEGY_DEFRAGMENT.getValue().equals(mergeStrategy)) {
             fragmentCountAttribute = MergeContent.FRAGMENT_COUNT_ATTRIBUTE;
-            if (!StringUtils.isEmpty(fragmentCountAttribute)) {
+            if (!StringUtils.isEmpty(flowfile.getAttribute(fragmentCountAttribute))) {
                 minRecords = Integer.parseInt(flowfile.getAttribute(fragmentCountAttribute));
             }
         } else {


### PR DESCRIPTION
When MergeRecords tries to merge fragments it will close the bin after a single run. This means that fragments that come in seconds apart will not be merged but will fail.

The ticket (https://issues.apache.org/jira/browse/NIFI-6349) contains reproduction steps.


