### PR TITLE
NIFI-6322: Introduced EvaluationContext to store state while making evaluator tree reusable

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/CompiledExpression.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/CompiledExpression.java
@@ -55,6 +55,6 @@ public class CompiledExpression implements Expression {
 
     @Override
     public String evaluate(final Map<String, String> variables, final AttributeValueDecorator decorator, final Map<String, String> stateVariables) {
-        return Query.evaluateExpression(getTree(), expression, variables, decorator, stateVariables);
+        return Query.evaluateExpression(tree, rootEvaluator, expression, variables, decorator, stateVariables);
     }
 }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPreparedQuery.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.attribute.expression.language;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.literals.StringLiteralEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.selection.AllAttributesEvaluator;
@@ -99,7 +100,7 @@ public class StandardPreparedQuery implements PreparedQuery {
                     final Evaluator<String> nameEval = attributeEval.getNameEvaluator();
 
                     if (nameEval instanceof StringLiteralEvaluator) {
-                        final String referencedVar = nameEval.evaluate(Collections.emptyMap()).getValue();
+                        final String referencedVar = nameEval.evaluate(Collections.emptyMap(), new EvaluationContext()).getValue();
                         variables.add(referencedVar);
                     }
                 } else if (evaluator instanceof AllAttributesEvaluator) {

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
@@ -28,6 +28,7 @@ import org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionLe
 import org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DateEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.cast.BooleanCastEvaluator;
@@ -947,7 +948,7 @@ public class ExpressionCompiler {
 
                 final List<String> attributeNames = new ArrayList<>();
                 for (int i = 1; i < tree.getChildCount(); i++) {  // skip the first child because that's the name of the multi-attribute function
-                    attributeNames.add(newStringLiteralEvaluator(tree.getChild(i).getText()).evaluate(null).getValue());
+                    attributeNames.add(newStringLiteralEvaluator(tree.getChild(i).getText()).evaluate(null, new EvaluationContext()).getValue());
                 }
 
                 switch (multiAttrType) {

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/BooleanEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/BooleanEvaluator.java
@@ -27,7 +27,7 @@ public abstract class BooleanEvaluator implements Evaluator<Boolean> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/DateEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/DateEvaluator.java
@@ -29,7 +29,7 @@ public abstract class DateEvaluator implements Evaluator<Date> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/DecimalEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/DecimalEvaluator.java
@@ -27,7 +27,7 @@ public abstract class DecimalEvaluator implements Evaluator<Double> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/EvaluationContext.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/EvaluationContext.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.attribute.expression.language.evaluation;
 
 import java.util.HashMap;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/EvaluationContext.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/EvaluationContext.java
@@ -1,0 +1,18 @@
+package org.apache.nifi.attribute.expression.language.evaluation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EvaluationContext {
+
+    private final Map<Evaluator<?>, Object> statePerEvaluator = new HashMap<>();
+
+    public <T> T getState(Evaluator<?> evaluator, Class<T> clazz) {
+        return clazz.cast(statePerEvaluator.get(evaluator));
+    }
+
+    public void putState(Evaluator<?> evaluator, Object state) {
+        statePerEvaluator.put(evaluator, state);
+    }
+
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/Evaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/Evaluator.java
@@ -22,11 +22,11 @@ import org.apache.nifi.expression.AttributeExpression.ResultType;
 
 public interface Evaluator<T> {
 
-    QueryResult<T> evaluate(Map<String, String> attributes);
+    QueryResult<T> evaluate(Map<String, String> attributes, EvaluationContext context);
 
     ResultType getResultType();
 
-    int getEvaluationsRemaining();
+    int getEvaluationsRemaining(EvaluationContext context);
 
     Evaluator<?> getSubjectEvaluator();
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/NumberEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/NumberEvaluator.java
@@ -27,7 +27,7 @@ public abstract class NumberEvaluator implements Evaluator<Number> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/StringEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/StringEvaluator.java
@@ -27,7 +27,7 @@ public abstract class StringEvaluator implements Evaluator<String> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/WholeNumberEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/WholeNumberEvaluator.java
@@ -27,7 +27,7 @@ public abstract class WholeNumberEvaluator implements Evaluator<Long> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/BooleanCastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/BooleanCastEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -33,8 +34,8 @@ public class BooleanCastEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final QueryResult<String> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<String> result = subjectEvaluator.evaluate(attributes, context);
         if (result.getValue() == null) {
             return new BooleanQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/DateCastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/DateCastEvaluator.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
@@ -56,8 +57,8 @@ public class DateCastEvaluator extends DateEvaluator {
     }
 
     @Override
-    public QueryResult<Date> evaluate(final Map<String, String> attributes) {
-        final QueryResult<?> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Date> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<?> result = subjectEvaluator.evaluate(attributes, context);
         if (result.getValue() == null) {
             return new DateQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/DecimalCastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/DecimalCastEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.cast;
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.DecimalEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DecimalQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
@@ -42,8 +43,8 @@ public class DecimalCastEvaluator extends DecimalEvaluator {
     }
 
     @Override
-    public QueryResult<Double> evaluate(final Map<String, String> attributes) {
-        final QueryResult<?> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Double> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<?> result = subjectEvaluator.evaluate(attributes, context);
         if (result.getValue() == null) {
             return new DecimalQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/NumberCastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/NumberCastEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.cast;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.DecimalQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
@@ -42,8 +43,8 @@ public class NumberCastEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final QueryResult<?> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<?> result = subjectEvaluator.evaluate(attributes, context);
         if (result.getValue() == null) {
             return new NumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/StringCastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/StringCastEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.cast;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -32,8 +33,8 @@ public class StringCastEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final QueryResult<?> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<?> result = subjectEvaluator.evaluate(attributes, context);
         if (result.getValue() == null) {
             return new StringQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/WholeNumberCastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/cast/WholeNumberCastEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.DecimalQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
@@ -42,8 +43,8 @@ public class WholeNumberCastEvaluator extends WholeNumberEvaluator {
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
-        final QueryResult<?> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<?> result = subjectEvaluator.evaluate(attributes, context);
         if (result.getValue() == null) {
             return new WholeNumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/AppendEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/AppendEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,9 +35,9 @@ public class AppendEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
-        final String appendValue = appendEvaluator.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
+        final String appendValue = appendEvaluator.evaluate(attributes, context).getValue();
 
         final String result = (subjectValue == null ? "" : subjectValue)
                 + (appendValue == null ? "" : appendValue);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/Base64DecodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/Base64DecodeEvaluator.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Base64;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,8 +35,8 @@ public class Base64DecodeEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/Base64EncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/Base64EncodeEvaluator.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Base64;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,8 +35,8 @@ public class Base64EncodeEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/CharSequenceTranslatorEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/CharSequenceTranslatorEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.text.translate.CharSequenceTranslator;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -75,8 +76,8 @@ public class CharSequenceTranslatorEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         return new StringQueryResult(subjectValue == null ? "" : method.translate(subjectValue));
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ContainsEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ContainsEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class ContainsEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final String searchString = search.evaluate(attributes).getValue();
+        final String searchString = search.evaluate(attributes, context).getValue();
         return new BooleanQueryResult(searchString == null ? false : subjectValue.contains(searchString));
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/DivideEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/DivideEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
@@ -34,13 +35,13 @@ public class DivideEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new NumberQueryResult(null);
         }
 
-        final Number divide = divideValue.evaluate(attributes).getValue();
+        final Number divide = divideValue.evaluate(attributes, context).getValue();
         if (divide == null) {
             return new NumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/EndsWithEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/EndsWithEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class EndsWithEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final String searchString = search.evaluate(attributes).getValue();
+        final String searchString = search.evaluate(attributes, context).getValue();
         return new BooleanQueryResult(searchString == null ? false : subjectValue.endsWith(searchString));
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/EqualsEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/EqualsEvaluator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.expression.AttributeExpression.ResultType;
@@ -36,13 +37,13 @@ public class EqualsEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Object a = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object a = subject.evaluate(attributes, context).getValue();
         if (a == null) {
             return new BooleanQueryResult(false);
         }
 
-        final Object b = compareTo.evaluate(attributes).getValue();
+        final Object b = compareTo.evaluate(attributes, context).getValue();
         if (b == null) {
             return new BooleanQueryResult(false);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/EqualsIgnoreCaseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/EqualsIgnoreCaseEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class EqualsIgnoreCaseEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Object a = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object a = subject.evaluate(attributes, context).getValue();
         if (a == null) {
             return new BooleanQueryResult(false);
         }
 
-        final Object b = compareTo.evaluate(attributes).getValue();
+        final Object b = compareTo.evaluate(attributes, context).getValue();
         if (b == null) {
             return new BooleanQueryResult(false);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/FindEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/FindEvaluator.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.literals.StringLiteralEvaluator;
@@ -39,21 +40,21 @@ public class FindEvaluator extends BooleanEvaluator {
         // if the search string is a literal, we don't need to evaluate it each time; we can just
         // pre-compile it. Otherwise, it must be compiled every time.
         if (search instanceof StringLiteralEvaluator) {
-            this.compiledPattern = Pattern.compile(search.evaluate(null).getValue());
+            this.compiledPattern = Pattern.compile(search.evaluate(null, new EvaluationContext()).getValue());
         } else {
             this.compiledPattern = null;
         }
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
         final Pattern pattern;
         if (compiledPattern == null) {
-            String expression = search.evaluate(attributes).getValue();
+            String expression = search.evaluate(attributes, context).getValue();
             if (expression == null) {
                 return new BooleanQueryResult(false);
             }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/FormatEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/FormatEvaluator.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -41,13 +42,13 @@ public class FormatEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final Date subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Date subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }
 
-        final QueryResult<String> formatResult = format.evaluate(attributes);
+        final QueryResult<String> formatResult = format.evaluate(attributes, context);
         final String format = formatResult.getValue();
         if (format == null) {
             return null;
@@ -56,7 +57,7 @@ public class FormatEvaluator extends StringEvaluator {
         final SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.US);
 
         if(timeZone != null) {
-            final QueryResult<String> tzResult = timeZone.evaluate(attributes);
+            final QueryResult<String> tzResult = timeZone.evaluate(attributes, context);
             final String tz = tzResult.getValue();
             if(tz != null && TimeZone.getTimeZone(tz) != null) {
                 sdf.setTimeZone(TimeZone.getTimeZone(tz));

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/FromRadixEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/FromRadixEvaluator.java
@@ -16,12 +16,13 @@
  */
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
+import java.util.Map;
+
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberQueryResult;
-
-import java.util.Map;
 
 public class FromRadixEvaluator extends WholeNumberEvaluator {
 
@@ -34,13 +35,13 @@ public class FromRadixEvaluator extends WholeNumberEvaluator {
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
-        final String result = numberEvaluator.evaluate(attributes).getValue();
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String result = numberEvaluator.evaluate(attributes, context).getValue();
         if (result == null) {
             return new WholeNumberQueryResult(null);
         }
 
-        final Long radix = radixEvaluator.evaluate(attributes).getValue();
+        final Long radix = radixEvaluator.evaluate(attributes, context).getValue();
         if (radix == null) {
             return new WholeNumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetDelimitedFieldEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetDelimitedFieldEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -64,13 +65,13 @@ public class GetDelimitedFieldEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subject = subjectEval.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subject = subjectEval.evaluate(attributes, context).getValue();
         if (subject == null || subject.isEmpty()) {
             return new StringQueryResult("");
         }
 
-        final Long index = indexEval.evaluate(attributes).getValue();
+        final Long index = indexEval.evaluate(attributes, context).getValue();
         if (index == null) {
             throw new AttributeExpressionLanguageException("Cannot evaluate getDelimitedField function because the index (which field to obtain) was not specified");
         }
@@ -78,7 +79,7 @@ public class GetDelimitedFieldEvaluator extends StringEvaluator {
             return new StringQueryResult("");
         }
 
-        final String delimiter = delimiterEval.evaluate(attributes).getValue();
+        final String delimiter = delimiterEval.evaluate(attributes, context).getValue();
         if (delimiter == null || delimiter.isEmpty()) {
             throw new AttributeExpressionLanguageException("Cannot evaluate getDelimitedField function because the delimiter was not specified");
         } else if (delimiter.length() > 1) {
@@ -86,7 +87,7 @@ public class GetDelimitedFieldEvaluator extends StringEvaluator {
                 + "\", but only a single character is allowed.");
         }
 
-        final String quoteString = quoteCharEval.evaluate(attributes).getValue();
+        final String quoteString = quoteCharEval.evaluate(attributes, context).getValue();
         if (quoteString == null || quoteString.isEmpty()) {
             throw new AttributeExpressionLanguageException("Cannot evaluate getDelimitedField function because the quote character "
                 + "(which character is used to enclose values that contain the delimiter) was not specified");
@@ -95,7 +96,7 @@ public class GetDelimitedFieldEvaluator extends StringEvaluator {
                 + "(which character is used to enclose values that contain the delimiter) evaluated to \"" + quoteString + "\", but only a single character is allowed.");
         }
 
-        final String escapeString = escapeCharEval.evaluate(attributes).getValue();
+        final String escapeString = escapeCharEval.evaluate(attributes, context).getValue();
         if (escapeString == null || escapeString.isEmpty()) {
             throw new AttributeExpressionLanguageException("Cannot evaluate getDelimitedField function because the escape character "
                 + "(which character is used to escape the quote character or delimiter) was not specified");
@@ -104,7 +105,7 @@ public class GetDelimitedFieldEvaluator extends StringEvaluator {
                 + "(which character is used to escape the quote character or delimiter) evaluated to \"" + escapeString + "\", but only a single character is allowed.");
         }
 
-        Boolean stripChars = stripCharsEval.evaluate(attributes).getValue();
+        Boolean stripChars = stripCharsEval.evaluate(attributes, context).getValue();
         if (stripChars == null) {
             stripChars = Boolean.FALSE;
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetStateVariableEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetStateVariableEvaluator.java
@@ -17,13 +17,14 @@
 
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
+import java.util.Map;
+
 import org.apache.nifi.attribute.expression.language.AttributesAndState;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
-
-import java.util.Map;
 
 public class GetStateVariableEvaluator extends StringEvaluator {
 
@@ -34,12 +35,12 @@ public class GetStateVariableEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(Map<String, String> attributes) {
+    public QueryResult<String> evaluate(Map<String, String> attributes, final EvaluationContext context) {
         if (!(attributes instanceof AttributesAndState)){
             return new StringQueryResult(null);
         }
 
-        final String subjectValue = subject.evaluate(attributes).getValue();
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GreaterThanEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GreaterThanEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class GreaterThanEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final Number comparisonValue = comparison.evaluate(attributes).getValue();
+        final Number comparisonValue = comparison.evaluate(attributes, context).getValue();
         if (comparisonValue == null) {
             return new BooleanQueryResult(false);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GreaterThanOrEqualEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GreaterThanOrEqualEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class GreaterThanOrEqualEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final Number comparisonValue = comparison.evaluate(attributes).getValue();
+        final Number comparisonValue = comparison.evaluate(attributes, context).getValue();
         if (comparisonValue == null) {
             return new BooleanQueryResult(false);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/HostnameEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/HostnameEvaluator.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -46,7 +47,7 @@ public class HostnameEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return hostname;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IPEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IPEvaluator.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,7 +35,7 @@ public class IPEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return ipAddress;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IfElseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IfElseEvaluator.java
@@ -16,12 +16,13 @@
  */
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
+import java.util.Map;
+
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
-
-import java.util.Map;
 
 public class IfElseEvaluator extends StringEvaluator {
 
@@ -36,12 +37,12 @@ public class IfElseEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final QueryResult<Boolean> subjectValue = subject.evaluate(attributes);
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<Boolean> subjectValue = subject.evaluate(attributes, context);
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }
-        final String ifElseValue = (Boolean.TRUE.equals(subjectValue.getValue())) ? trueEvaluator.evaluate(attributes).getValue() : falseEvaluator.evaluate(attributes).getValue();
+        final String ifElseValue = (Boolean.TRUE.equals(subjectValue.getValue())) ? trueEvaluator.evaluate(attributes, context).getValue() : falseEvaluator.evaluate(attributes, context).getValue();
         return new StringQueryResult(ifElseValue);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/InEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/InEvaluator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -35,15 +36,15 @@ public class InEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
         boolean isInList = false;
         for (Evaluator<String> evaluator : search) {
-            final String searchString = evaluator.evaluate(attributes).getValue();
+            final String searchString = evaluator.evaluate(attributes, context).getValue();
             isInList = searchString == null ? false : subjectValue.equals(searchString);
             if(isInList) {
                 break;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IndexOfEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IndexOfEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -34,12 +35,12 @@ public class IndexOfEvaluator extends WholeNumberEvaluator {
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new WholeNumberQueryResult(-1L);
         }
-        final String indexEvalValue = indexEvaluator.evaluate(attributes).getValue();
+        final String indexEvalValue = indexEvaluator.evaluate(attributes, context).getValue();
 
         return new WholeNumberQueryResult((long) subjectValue.indexOf(indexEvalValue));
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsEmptyEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsEmptyEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -32,8 +33,8 @@ public class IsEmptyEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Object subjectValue = subjectEvaluator.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object subjectValue = subjectEvaluator.evaluate(attributes, context).getValue();
         return new BooleanQueryResult(subjectValue == null || subjectValue.toString().trim().isEmpty());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsNullEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsNullEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -32,8 +33,8 @@ public class IsNullEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Object subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object subjectValue = subject.evaluate(attributes, context).getValue();
         return new BooleanQueryResult(subjectValue == null);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathEvaluator.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -52,7 +53,7 @@ public class JsonPathEvaluator extends StringEvaluator {
         // time; we can just
         // pre-compile it. Otherwise, it must be compiled every time.
         if (jsonPathExp instanceof StringLiteralEvaluator) {
-            precompiledJsonPathExp = compileJsonPathExpression(jsonPathExp.evaluate(null).getValue());
+            precompiledJsonPathExp = compileJsonPathExpression(jsonPathExp.evaluate(null, new EvaluationContext()).getValue());
         } else {
             precompiledJsonPathExp = null;
         }
@@ -60,8 +61,8 @@ public class JsonPathEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null || subjectValue.length() == 0) {
             throw new  AttributeExpressionLanguageException("Subject is empty");
         }
@@ -76,7 +77,7 @@ public class JsonPathEvaluator extends StringEvaluator {
         if (precompiledJsonPathExp != null) {
             compiledJsonPath = precompiledJsonPathExp;
         } else {
-            compiledJsonPath = compileJsonPathExpression(jsonPathExp.evaluate(attributes).getValue());
+            compiledJsonPath = compileJsonPathExpression(jsonPathExp.evaluate(attributes, context).getValue());
         }
 
         Object result = null;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LastIndexOfEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LastIndexOfEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -34,12 +35,12 @@ public class LastIndexOfEvaluator extends WholeNumberEvaluator {
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new WholeNumberQueryResult(-1L);
         }
-        final String indexEvalValue = indexEvaluator.evaluate(attributes).getValue();
+        final String indexEvalValue = indexEvaluator.evaluate(attributes, context).getValue();
 
         return new WholeNumberQueryResult((long) subjectValue.lastIndexOf(indexEvalValue));
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LengthEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LengthEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -32,8 +33,8 @@ public class LengthEvaluator extends WholeNumberEvaluator {
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         return new WholeNumberQueryResult((long) (subjectValue == null ? 0 : subjectValue.length()));
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LessThanEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LessThanEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class LessThanEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final Number comparisonValue = comparison.evaluate(attributes).getValue();
+        final Number comparisonValue = comparison.evaluate(attributes, context).getValue();
         if (comparisonValue == null) {
             return new BooleanQueryResult(false);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LessThanOrEqualEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/LessThanOrEqualEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class LessThanOrEqualEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final Number comparisonValue = comparison.evaluate(attributes).getValue();
+        final Number comparisonValue = comparison.evaluate(attributes, context).getValue();
         if (comparisonValue == null) {
             return new BooleanQueryResult(false);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MatchesEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MatchesEvaluator.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.literals.StringLiteralEvaluator;
@@ -39,21 +40,21 @@ public class MatchesEvaluator extends BooleanEvaluator {
         // if the search string is a literal, we don't need to evaluate it each time; we can just
         // pre-compile it. Otherwise, it must be compiled every time.
         if (search instanceof StringLiteralEvaluator) {
-            this.compiledPattern = Pattern.compile(search.evaluate(null).getValue());
+            this.compiledPattern = Pattern.compile(search.evaluate(null, new EvaluationContext()).getValue());
         } else {
             this.compiledPattern = null;
         }
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
         final Pattern pattern;
         if (compiledPattern == null) {
-            String expression = search.evaluate(attributes).getValue();
+            String expression = search.evaluate(attributes, context).getValue();
             if (expression == null) {
                 return new BooleanQueryResult(false);
             }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MathEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MathEvaluator.java
@@ -16,15 +16,16 @@
  */
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
 
 public class MathEvaluator extends NumberEvaluator {
 
@@ -39,15 +40,15 @@ public class MathEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final String methodNamedValue = methodName.evaluate(attributes).getValue();
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String methodNamedValue = methodName.evaluate(attributes, context).getValue();
         if (methodNamedValue == null) {
             return new NumberQueryResult(null);
         }
 
         final Number subjectValue;
         if(subject != null) {
-            subjectValue = subject.evaluate(attributes).getValue();
+            subjectValue = subject.evaluate(attributes, context).getValue();
             if(subjectValue == null){
                 return new NumberQueryResult(null);
             }
@@ -57,7 +58,7 @@ public class MathEvaluator extends NumberEvaluator {
 
         final Number optionalArgValue;
         if(optionalArg != null) {
-            optionalArgValue = optionalArg.evaluate(attributes).getValue();
+            optionalArgValue = optionalArg.evaluate(attributes, context).getValue();
 
             if(optionalArgValue == null) {
                 return new NumberQueryResult(null);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MinusEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MinusEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
@@ -34,13 +35,13 @@ public class MinusEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new NumberQueryResult(null);
         }
 
-        final Number minus = minusValue.evaluate(attributes).getValue();
+        final Number minus = minusValue.evaluate(attributes, context).getValue();
         if (minus == null) {
             return new NumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ModEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ModEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
@@ -34,13 +35,13 @@ public class ModEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new NumberQueryResult(null);
         }
 
-        final Number mod = modValue.evaluate(attributes).getValue();
+        final Number mod = modValue.evaluate(attributes, context).getValue();
         if (mod == null) {
             return new NumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MultiplyEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/MultiplyEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
@@ -34,13 +35,13 @@ public class MultiplyEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new NumberQueryResult(null);
         }
 
-        final Number multiply = multiplyValue.evaluate(attributes).getValue();
+        final Number multiply = multiplyValue.evaluate(attributes, context).getValue();
         if (multiply == null) {
             return new NumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NotEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NotEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -32,8 +33,8 @@ public class NotEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final QueryResult<Boolean> subjectValue = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<Boolean> subjectValue = subjectEvaluator.evaluate(attributes, context);
         if (subjectValue == null) {
             return new BooleanQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NotNullEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NotNullEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -32,8 +33,8 @@ public class NotNullEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final Object subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object subjectValue = subject.evaluate(attributes, context).getValue();
         return new BooleanQueryResult(subjectValue != null);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NowEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NowEvaluator.java
@@ -21,13 +21,14 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
 public class NowEvaluator extends DateEvaluator {
 
     @Override
-    public QueryResult<Date> evaluate(final Map<String, String> attributes) {
+    public QueryResult<Date> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new DateQueryResult(new Date());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NumberToDateEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/NumberToDateEvaluator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -33,8 +34,8 @@ public class NumberToDateEvaluator extends DateEvaluator {
     }
 
     @Override
-    public QueryResult<Date> evaluate(final Map<String, String> attributes) {
-        final QueryResult<Long> result = subject.evaluate(attributes);
+    public QueryResult<Date> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<Long> result = subject.evaluate(attributes, context);
         final Long value = result.getValue();
         if (value == null) {
             return new DateQueryResult(null);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/OneUpSequenceEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/OneUpSequenceEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -29,7 +30,7 @@ public class OneUpSequenceEvaluator extends WholeNumberEvaluator {
     private static final AtomicLong value = new AtomicLong(0L);
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new WholeNumberQueryResult(value.getAndIncrement());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/OrEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/OrEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -27,7 +28,6 @@ public class OrEvaluator extends BooleanEvaluator {
 
     private final Evaluator<Boolean> subjectEvaluator;
     private final Evaluator<Boolean> rhsEvaluator;
-    private BooleanQueryResult rhsResult;
 
     public OrEvaluator(final Evaluator<Boolean> subjectEvaluator, final Evaluator<Boolean> rhsEvaluator) {
         this.subjectEvaluator = subjectEvaluator;
@@ -35,8 +35,8 @@ public class OrEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final QueryResult<Boolean> subjectValue = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<Boolean> subjectValue = subjectEvaluator.evaluate(attributes, context);
         if (subjectValue == null) {
             return new BooleanQueryResult(null);
         }
@@ -48,18 +48,20 @@ public class OrEvaluator extends BooleanEvaluator {
         // Returning previously evaluated result.
         // The same OrEvaluator can be evaluated multiple times if subjectEvaluator is IteratingEvaluator.
         // In that case, it's enough to evaluate the right hand side.
+        final BooleanQueryResult rhsResult = context.getState(this, BooleanQueryResult.class);
         if (rhsResult != null) {
             return rhsResult;
         }
 
-        final QueryResult<Boolean> rhsValue = rhsEvaluator.evaluate(attributes);
+        final QueryResult<Boolean> rhsValue = rhsEvaluator.evaluate(attributes, context);
+        BooleanQueryResult result;
         if (rhsValue == null) {
-            rhsResult = new BooleanQueryResult(false);
+            result = new BooleanQueryResult(false);
         } else {
-            rhsResult = new BooleanQueryResult(rhsValue.getValue());
+            result = new BooleanQueryResult(rhsValue.getValue());
         }
-
-        return rhsResult;
+        context.putState(this, result);
+        return result;
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PlusEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PlusEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
@@ -34,13 +35,13 @@ public class PlusEvaluator extends NumberEvaluator {
     }
 
     @Override
-    public QueryResult<Number> evaluate(final Map<String, String> attributes) {
-        final Number subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Number> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Number subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new NumberQueryResult(null);
         }
 
-        final Number plus = plusValue.evaluate(attributes).getValue();
+        final Number plus = plusValue.evaluate(attributes, context).getValue();
         if (plus == null) {
             return new NumberQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PrependEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PrependEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,9 +35,9 @@ public class PrependEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
-        final String prependValue = prependEvaluator.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
+        final String prependValue = prependEvaluator.evaluate(attributes, context).getValue();
 
         final String result = (prependValue == null ? "" : prependValue) + (subjectValue == null ? "" : subjectValue);
         return new StringQueryResult(result);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/RandomNumberGeneratorEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/RandomNumberGeneratorEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -30,7 +31,7 @@ public class RandomNumberGeneratorEvaluator extends WholeNumberEvaluator {
 
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new WholeNumberQueryResult(Math.abs(RNG.nextLong()));
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceAllEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceAllEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -36,13 +37,13 @@ public class ReplaceAllEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }
-        final String searchValue = search.evaluate(attributes).getValue();
-        final String replacementValue = replacement.evaluate(attributes).getValue();
+        final String searchValue = search.evaluate(attributes, context).getValue();
+        final String replacementValue = replacement.evaluate(attributes, context).getValue();
 
         return new StringQueryResult(subjectValue.replaceAll(searchValue, replacementValue));
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceEmptyEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceEmptyEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -33,12 +34,12 @@ public class ReplaceEmptyEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final QueryResult<String> subjectResult = subjectEvaluator.evaluate(attributes);
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<String> subjectResult = subjectEvaluator.evaluate(attributes, context);
         final String subjectValue = subjectResult.getValue();
         final boolean isEmpty = subjectValue == null || subjectValue.toString().trim().isEmpty();
         if (isEmpty) {
-            return replacementEvaluator.evaluate(attributes);
+            return replacementEvaluator.evaluate(attributes, context);
         } else {
             return subjectResult;
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -36,13 +37,13 @@ public class ReplaceEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }
-        final String searchValue = search.evaluate(attributes).getValue();
-        final String replacementValue = replacement.evaluate(attributes).getValue();
+        final String searchValue = search.evaluate(attributes, context).getValue();
+        final String replacementValue = replacement.evaluate(attributes, context).getValue();
 
         return new StringQueryResult(subjectValue.replace(searchValue, replacementValue));
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceFirstEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceFirstEvaluator.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
+
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -35,13 +37,13 @@ public class ReplaceFirstEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }
-        final String searchValue = search.evaluate(attributes).getValue();
-        final String replacementValue = replacement.evaluate(attributes).getValue();
+        final String searchValue = search.evaluate(attributes, context).getValue();
+        final String replacementValue = replacement.evaluate(attributes, context).getValue();
 
         return new StringQueryResult(subjectValue.replaceFirst(searchValue, replacementValue));
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceNullEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ReplaceNullEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,9 +35,9 @@ public class ReplaceNullEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
-        return new StringQueryResult(subjectValue == null ? resultEvaluator.evaluate(attributes).getValue() : subjectValue);
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
+        return new StringQueryResult(subjectValue == null ? resultEvaluator.evaluate(attributes, context).getValue() : subjectValue);
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/StartsWithEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/StartsWithEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,13 +35,13 @@ public class StartsWithEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new BooleanQueryResult(false);
         }
 
-        final String searchString = search.evaluate(attributes).getValue();
+        final String searchString = search.evaluate(attributes, context).getValue();
         return new BooleanQueryResult(searchString == null ? false : subjectValue.startsWith(searchString));
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/StringToDateEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/StringToDateEvaluator.java
@@ -25,6 +25,7 @@ import java.util.TimeZone;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DateEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DateQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.exception.IllegalAttributeException;
@@ -42,9 +43,9 @@ public class StringToDateEvaluator extends DateEvaluator {
     }
 
     @Override
-    public QueryResult<Date> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
-        final String formatValue = format.evaluate(attributes).getValue();
+    public QueryResult<Date> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
+        final String formatValue = format.evaluate(attributes, context).getValue();
         if (subjectValue == null || formatValue == null) {
             return new DateQueryResult(null);
         }
@@ -52,7 +53,7 @@ public class StringToDateEvaluator extends DateEvaluator {
         final SimpleDateFormat sdf = new SimpleDateFormat(formatValue, Locale.US);
 
         if(timeZone != null) {
-            final QueryResult<String> tzResult = timeZone.evaluate(attributes);
+            final QueryResult<String> tzResult = timeZone.evaluate(attributes, context);
             final String tz = tzResult.getValue();
             if(tz != null && TimeZone.getTimeZone(tz) != null) {
                 sdf.setTimeZone(TimeZone.getTimeZone(tz));

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringAfterEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringAfterEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,12 +35,12 @@ public class SubstringAfterEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult("");
         }
-        final String afterValue = afterEvaluator.evaluate(attributes).getValue();
+        final String afterValue = afterEvaluator.evaluate(attributes, context).getValue();
         if (afterValue == null || afterValue.length() == 0) {
             return new StringQueryResult(subjectValue);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringAfterLastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringAfterLastEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,12 +35,12 @@ public class SubstringAfterLastEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult("");
         }
-        final String afterValue = afterEvaluator.evaluate(attributes).getValue();
+        final String afterValue = afterEvaluator.evaluate(attributes, context).getValue();
         final int index = subjectValue.lastIndexOf(afterValue);
         if (index < 0 || index >= subjectValue.length()) {
             return new StringQueryResult(subjectValue);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringBeforeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringBeforeEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,12 +35,12 @@ public class SubstringBeforeEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult("");
         }
-        final String beforeValue = beforeEvaluator.evaluate(attributes).getValue();
+        final String beforeValue = beforeEvaluator.evaluate(attributes, context).getValue();
         if (beforeValue == null || beforeValue.length() == 0) {
             return new StringQueryResult(subjectValue);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringBeforeLastEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringBeforeLastEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,12 +35,12 @@ public class SubstringBeforeLastEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult("");
         }
-        final String beforeValue = beforeEvaluator.evaluate(attributes).getValue();
+        final String beforeValue = beforeEvaluator.evaluate(attributes, context).getValue();
         final int index = subjectValue.lastIndexOf(beforeValue);
         if (index < 0) {
             return new StringQueryResult(subjectValue);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -42,16 +43,16 @@ public class SubstringEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult("");
         }
-        final int startIndexValue = startIndex.evaluate(attributes).getValue().intValue();
+        final int startIndexValue = startIndex.evaluate(attributes, context).getValue().intValue();
         if (endIndex == null) {
             return new StringQueryResult(subjectValue.substring(startIndexValue));
         } else {
-            final int endIndexValue = endIndex.evaluate(attributes).getValue().intValue();
+            final int endIndexValue = endIndex.evaluate(attributes, context).getValue().intValue();
             return new StringQueryResult(subjectValue.substring(startIndexValue, endIndexValue));
         }
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ThreadEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ThreadEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -26,7 +27,7 @@ import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResul
 public class ThreadEvaluator extends StringEvaluator {
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         // See org.apache.nifi.engine.FlowEngine
         return new StringQueryResult(Thread.currentThread().getName());
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToLowerEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToLowerEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -32,8 +33,8 @@ public class ToLowerEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         return new StringQueryResult(subjectValue == null ? null : subjectValue.toLowerCase());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToRadixEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToRadixEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -41,20 +42,20 @@ public class ToRadixEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final Long result = numberEvaluator.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Long result = numberEvaluator.evaluate(attributes, context).getValue();
         if (result == null) {
             return new StringQueryResult(null);
         }
 
-        final Long radix = radixEvaluator.evaluate(attributes).getValue();
+        final Long radix = radixEvaluator.evaluate(attributes, context).getValue();
         if (radix == null) {
             return new StringQueryResult(null);
         }
 
         String stringValue = Long.toString(result.longValue(), radix.intValue());
         if (minimumWidthEvaluator != null) {
-            final Long minimumWidth = minimumWidthEvaluator.evaluate(attributes).getValue();
+            final Long minimumWidth = minimumWidthEvaluator.evaluate(attributes, context).getValue();
             if (minimumWidth != null) {
                 final int paddingWidth = minimumWidth.intValue() - stringValue.length();
                 if (paddingWidth > 0) {

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToStringEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToStringEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -32,8 +33,8 @@ public class ToStringEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final Object result = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object result = subject.evaluate(attributes, context).getValue();
         return new StringQueryResult(result == null ? null : result.toString());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToUpperEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/ToUpperEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -32,8 +33,8 @@ public class ToUpperEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         return new StringQueryResult(subjectValue == null ? null : subjectValue.toUpperCase());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/TrimEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/TrimEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -32,8 +33,8 @@ public class TrimEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         return new StringQueryResult(subjectValue == null ? null : subjectValue.trim());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlDecodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlDecodeEvaluator.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,8 +35,8 @@ public class UrlDecodeEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlEncodeEvaluator.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -34,8 +35,8 @@ public class UrlEncodeEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String subjectValue = subject.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String subjectValue = subject.evaluate(attributes, context).getValue();
         if (subjectValue == null) {
             return new StringQueryResult(null);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UuidEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UuidEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -27,7 +28,7 @@ import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResul
 public class UuidEvaluator extends StringEvaluator {
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new StringQueryResult(UUID.randomUUID().toString());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/BooleanLiteralEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/BooleanLiteralEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -32,7 +33,7 @@ public class BooleanLiteralEvaluator extends BooleanEvaluator {
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new BooleanQueryResult(value);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/DecimalLiteralEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/DecimalLiteralEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.literals;
 
 import org.apache.nifi.attribute.expression.language.evaluation.DecimalEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.DecimalQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -33,7 +34,7 @@ public class DecimalLiteralEvaluator extends DecimalEvaluator {
     }
 
     @Override
-    public QueryResult<Double> evaluate(final Map<String, String> attributes) {
+    public QueryResult<Double> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new DecimalQueryResult(literal);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/StringLiteralEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/StringLiteralEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.literals;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -65,7 +66,7 @@ public class StringLiteralEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new StringQueryResult(value);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/ToLiteralEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/ToLiteralEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.literals;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -31,8 +32,8 @@ public class ToLiteralEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final Object result = argEvaluator.evaluate(attributes);
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final Object result = argEvaluator.evaluate(attributes, context);
         return new StringQueryResult(result == null ? null : result.toString());
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/WholeNumberLiteralEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/WholeNumberLiteralEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.literals;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -32,7 +33,7 @@ public class WholeNumberLiteralEvaluator extends WholeNumberEvaluator {
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
         return new WholeNumberQueryResult(literal);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/reduce/CountEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/reduce/CountEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.reduce;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
@@ -27,15 +28,18 @@ import org.apache.nifi.expression.AttributeExpression.ResultType;
 public class CountEvaluator extends WholeNumberEvaluator implements ReduceEvaluator<Long> {
 
     private final Evaluator<?> subjectEvaluator;
-    private long count = 0L;
 
     public CountEvaluator(final Evaluator<?> subjectEvaluator) {
         this.subjectEvaluator = subjectEvaluator;
     }
 
     @Override
-    public QueryResult<Long> evaluate(final Map<String, String> attributes) {
-        final QueryResult<?> result = subjectEvaluator.evaluate(attributes);
+    public QueryResult<Long> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final QueryResult<?> result = subjectEvaluator.evaluate(attributes, context);
+        Long count = context.getState(this, Long.class);
+        if (count == null) {
+            count = 0L;
+        }
         if (result.getValue() == null) {
             return new WholeNumberQueryResult(count);
         }
@@ -45,6 +49,7 @@ public class CountEvaluator extends WholeNumberEvaluator implements ReduceEvalua
         }
 
         count++;
+        context.putState(this, count);
         return new WholeNumberQueryResult(count);
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/AllAttributesEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/AllAttributesEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,8 +35,8 @@ public class AllAttributesEvaluator extends BooleanEvaluator implements Iteratin
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        QueryResult<Boolean> attributeValueQuery = booleanEvaluator.evaluate(attributes);
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        QueryResult<Boolean> attributeValueQuery = booleanEvaluator.evaluate(attributes, context);
         Boolean result = attributeValueQuery.getValue();
         if (result == null) {
             return new BooleanQueryResult(false);
@@ -45,8 +46,8 @@ public class AllAttributesEvaluator extends BooleanEvaluator implements Iteratin
             return new BooleanQueryResult(false);
         }
 
-        while (multiAttributeEvaluator.getEvaluationsRemaining() > 0) {
-            attributeValueQuery = booleanEvaluator.evaluate(attributes);
+        while (multiAttributeEvaluator.getEvaluationsRemaining(context) > 0) {
+            attributeValueQuery = booleanEvaluator.evaluate(attributes, context);
             result = attributeValueQuery.getValue();
             if (result != null && !result) {
                 return attributeValueQuery;
@@ -57,7 +58,7 @@ public class AllAttributesEvaluator extends BooleanEvaluator implements Iteratin
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/AnyAttributeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/AnyAttributeEvaluator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 
@@ -34,8 +35,8 @@ public class AnyAttributeEvaluator extends BooleanEvaluator implements Iterating
     }
 
     @Override
-    public QueryResult<Boolean> evaluate(final Map<String, String> attributes) {
-        QueryResult<Boolean> attributeValueQuery = booleanEvaluator.evaluate(attributes);
+    public QueryResult<Boolean> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        QueryResult<Boolean> attributeValueQuery = booleanEvaluator.evaluate(attributes, context);
         Boolean result = attributeValueQuery.getValue();
         if (result == null) {
             return new BooleanQueryResult(false);
@@ -45,8 +46,8 @@ public class AnyAttributeEvaluator extends BooleanEvaluator implements Iterating
             return new BooleanQueryResult(true);
         }
 
-        while (multiAttributeEvaluator.getEvaluationsRemaining() > 0) {
-            attributeValueQuery = booleanEvaluator.evaluate(attributes);
+        while (multiAttributeEvaluator.getEvaluationsRemaining(context) > 0) {
+            attributeValueQuery = booleanEvaluator.evaluate(attributes, context);
             result = attributeValueQuery.getValue();
             if (result != null && result) {
                 return attributeValueQuery;
@@ -57,7 +58,7 @@ public class AnyAttributeEvaluator extends BooleanEvaluator implements Iterating
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/AttributeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/AttributeEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.selection;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
@@ -32,8 +33,8 @@ public class AttributeEvaluator extends StringEvaluator {
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        final String nameValue = nameEvaluator.evaluate(attributes).getValue();
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        final String nameValue = nameEvaluator.evaluate(attributes, context).getValue();
         final String attributeValue = attributes.get(nameValue);
         return new StringQueryResult(attributeValue);
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/MappingEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/MappingEvaluator.java
@@ -18,6 +18,7 @@ package org.apache.nifi.attribute.expression.language.evaluation.selection;
 
 import java.util.Map;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.reduce.ReduceEvaluator;
@@ -34,11 +35,11 @@ public class MappingEvaluator<T> implements Evaluator<T> {
     }
 
     @Override
-    public QueryResult<T> evaluate(final Map<String, String> attributes) {
-        QueryResult<T> result = mappingEvaluator.evaluate(attributes);
+    public QueryResult<T> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        QueryResult<T> result = mappingEvaluator.evaluate(attributes, context);
 
-        while (multiAttributeEvaluator.getEvaluationsRemaining() > 0) {
-            result = mappingEvaluator.evaluate(attributes);
+        while (multiAttributeEvaluator.getEvaluationsRemaining(context) > 0) {
+            result = mappingEvaluator.evaluate(attributes, context);
         }
 
         return result;
@@ -50,7 +51,7 @@ public class MappingEvaluator<T> implements Evaluator<T> {
     }
 
     @Override
-    public int getEvaluationsRemaining() {
+    public int getEvaluationsRemaining(final EvaluationContext context) {
         return 0;
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/MultiMatchAttributeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/selection/MultiMatchAttributeEvaluator.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.nifi.attribute.expression.language.evaluation.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
@@ -29,8 +30,6 @@ public class MultiMatchAttributeEvaluator extends MultiAttributeEvaluator {
 
     private final List<Pattern> attributePatterns;
     private final int evaluationType;
-    private final List<String> attributeNames = new ArrayList<>();
-    private int evaluationCount = 0;
 
     public MultiMatchAttributeEvaluator(final List<String> attributeRegexes, final int evaluationType) {
         this.attributePatterns = new ArrayList<>();
@@ -47,27 +46,37 @@ public class MultiMatchAttributeEvaluator extends MultiAttributeEvaluator {
      * @return number of remaining evaluations
      */
     @Override
-    public int getEvaluationsRemaining() {
-        return attributeNames.size() - evaluationCount;
+    public int getEvaluationsRemaining(final EvaluationContext context) {
+        State state = context.getState(this, State.class);
+        if (state == null) {
+            state = new State();
+            context.putState(this, state);
+        }
+        return state.attributeNames.size() - state.evaluationCount;
     }
 
     @Override
-    public QueryResult<String> evaluate(final Map<String, String> attributes) {
-        if (evaluationCount == 0) {
+    public QueryResult<String> evaluate(final Map<String, String> attributes, final EvaluationContext context) {
+        State state = context.getState(this, State.class);
+        if (state == null) {
+            state = new State();
+            context.putState(this, state);
+        }
+        if (state.evaluationCount == 0) {
             for (final Pattern pattern : attributePatterns) {
                 for (final String attrName : attributes.keySet()) {
                     if (pattern.matcher(attrName).matches()) {
-                        attributeNames.add(attrName);
+                        state.attributeNames.add(attrName);
                     }
                 }
             }
         }
 
-        if (evaluationCount >= attributeNames.size()) {
+        if (state.evaluationCount >= state.attributeNames.size()) {
             return new StringQueryResult(null);
         }
 
-        return new StringQueryResult(attributes.get(attributeNames.get(evaluationCount++)));
+        return new StringQueryResult(attributes.get(state.attributeNames.get(state.evaluationCount++)));
     }
 
     @Override
@@ -83,5 +92,10 @@ public class MultiMatchAttributeEvaluator extends MultiAttributeEvaluator {
     @Override
     public Evaluator<?> getLogicEvaluator() {
         return this;
+    }
+
+    private class State {
+        private final List<String> attributeNames = new ArrayList<>();
+        private int evaluationCount = 0;
     }
 }

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
@@ -90,6 +90,152 @@ public class TestStandardPreparedQuery {
     }
 
     @Test
+    public void testPreparedQueryWithReducingFunctionAny() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("comma", ",");
+        attributes.put("question", " how are you?");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${anyAttribute('comma', 'question'):matches('hello')}");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("audience", "bla");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("comma", "hello");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionAll() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("comma", ",");
+        attributes.put("question", " how are you?");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allAttributes('comma', 'question'):matches('hello')}");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("comma", "hello");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("question", "hello");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionAnyMatching() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("comma", ",");
+        attributes.put("question", " how are you?");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${anyMatchingAttribute('audi.*'):matches('hello')}");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("audience", "bla");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("auditorium", "hello");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionAllMatching() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("comma", "hello");
+        attributes.put("question", "hello");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allMatchingAttributes('.*'):matches('hello')}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("audience", "bla");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.remove("audience");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionAnyDelineated() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("number_list", "1,2,3,4,5,6,7");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${anyDelineatedValue(${number_list}, ','):contains('5')}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("number_list", "1,2,3");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("number_list", "5");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionAllDelineated() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("word_list", "beach,bananas,web");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allDelineatedValues(${word_list}, ','):contains('b')}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("word_list", "beach,party,web");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+        attributes.put("word_list", "bee");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionJoin() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "Hello");
+        attributes.put("boat", "World!");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allAttributes('hello', 'boat'):join(' ')}");
+        assertEquals("Hello World!", prepared.evaluateExpressions(attributes, null));
+        attributes.put("boat", "Friend.");
+        assertEquals("Hello Friend.", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithReducingFunctionCount() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "Hello");
+        attributes.put("boat", "World!");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allAttributes('hello', 'boat'):contains('e'):count()}");
+        assertEquals("1", prepared.evaluateExpressions(attributes, null));
+        attributes.put("boat", "end");
+        assertEquals("2", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithSelectingAnd() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "Hello");
+        attributes.put("boat", "World!");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allAttributes('hello', 'boat'):isEmpty():not():and(${hello:contains('o')})}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("hello", "hi");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithAnd() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "Hello");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${hello:contains('H'):and(${hello:contains('o')})}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("hello", "Hell");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithSelectingOr() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "Hello");
+        attributes.put("boat", "World!");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allAttributes('hello', 'boat'):matches('strict'):or(${hello:contains('o')})}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("hello", "hi");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
+    public void testPreparedQueryWithOr() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "Hello");
+        final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${hello:contains('X'):or(${hello:contains('o')})}");
+        assertEquals("true", prepared.evaluateExpressions(attributes, null));
+        attributes.put("hello", "Hell");
+        assertEquals("false", prepared.evaluateExpressions(attributes, null));
+    }
+
+    @Test
     public void testVariableImpacted() {
         final Set<String> attr = new HashSet<>();
         attr.add("attr");


### PR DESCRIPTION
#### Description of PR

This is a followup PR to #3500 . It enables true re-usage of the evaluator tree once created for a prepared query in nifi's expression language. This, at least in our case, saves a ton of CPU.

This PR also includes a lot of tests for functions with stateful evaluators. This wasn't covered before.

#3500 was closed by me because the approach I took there was not thread safe. Instead of cleaning up the state in evaluators I now introduced a context that gets passed through a tree for each evaluation to get rid of state in the evaluators itself. All evaluators that need state (mostly for performance reasons) can store that state in the context. A new context is created for each evaluation. That should also result in lower garbage collection impact, because we are only throwing away the state that needs to be thrown away not the whole evaluator tree again and again.

Another related pull request is #3277 but that takes a different approach and only helps if no stateful evaluators are used in an expression. It also doesn't cover `and` + `or` even though they have state. Even if those will be excluded from optimization, I don't think it's the best approach because there are a ton of expressions (at least in our production scenario) that use functions that have stateful evaluators.

Some profiling tests we did show a performance improvement when compared with the current master (60b5c13ce95fd4d4a5edf0f08b81af19e71b67ee).

This is the test code:

```
@Test
public void testPerformance() {
    final Map<String, String> attributes = new HashMap<String, String>() {{
        put("hello", "Hello");
        put("boat", "World!");
    }};
    final StandardPreparedQuery prepared = (StandardPreparedQuery) Query.prepare("${allAttributes('hello', 'boat'):isEmpty():not():and(${hello:contains('o')})}");
    for (int i = 0; i < 1000000; i++) {
        assertEquals("true", prepared.evaluateExpressions(attributes, null));
    }
}
```

CPU Time for the evaluation loop (instrumented code):
current master - 97.48s
this PR - 23.78s

->75% performance improvement

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
