### PR TITLE
NIFI-6361: Add fix to PutFile processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.standard;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPutFile {
+
+    public static final String TARGET_DIRECTORY = "target/put-file";
+    private File targetDir;
+
+    @Before
+    public void prepDestDirectory() throws IOException {
+        targetDir = new File(TARGET_DIRECTORY);
+        if (!targetDir.exists()) {
+            Files.createDirectories(targetDir.toPath());
+            return;
+        }
+
+        targetDir.setReadable(true);
+
+        deleteDirectoryContent(targetDir);
+    }
+
+    private void deleteDirectoryContent(File directory) throws IOException {
+        for (final File file : directory.listFiles()) {
+            if (file.isDirectory()) {
+                deleteDirectoryContent(file);
+            }
+            Files.delete(file.toPath());
+        }
+    }
+
+    @Test
+    public void testCreateDirectory() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        String newDir = targetDir.getAbsolutePath()+"/new-folder";
+        runner.setProperty(PutFile.DIRECTORY, newDir);
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
+        Path targetPath = Paths.get(TARGET_DIRECTORY + "/new-folder/targetFile.txt");
+        byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+    }
+
+    @Test
+    public void testReplaceConflictResolution() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
+        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+
+        //Second file
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Another file".getBytes(), attributes);
+        runner.run();
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+        File dir = new File(TARGET_DIRECTORY);
+        assertEquals(1, dir.list().length);
+        targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        content = Files.readAllBytes(targetPath);
+        assertEquals("Another file", new String(content));
+    }
+
+    @Test
+    public void testIgnoreConflictResolution() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.IGNORE_RESOLUTION);
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
+        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+
+        //Second file
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Another file".getBytes(), attributes);
+        runner.run();
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+        File dir = new File(TARGET_DIRECTORY);
+        assertEquals(1, dir.list().length);
+        targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+    }
+
+    @Test
+    public void testFailConflictResolution() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.FAIL_RESOLUTION);
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
+        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+
+        //Second file
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Another file".getBytes(), attributes);
+        runner.run();
+        runner.assertTransferCount(PutFile.REL_SUCCESS, 1);
+        runner.assertTransferCount(PutFile.REL_FAILURE, 1);
+        runner.assertPenalizeCount(1);
+    }
+
+    @Test
+    public void testMaxFileLimitReach() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+        runner.setProperty(PutFile.MAX_DESTINATION_FILES, "1");
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
+        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+
+        //Second file
+        attributes.put(CoreAttributes.FILENAME.key(), "secondFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertTransferCount(PutFile.REL_FAILURE, 1);
+        runner.assertPenalizeCount(1);
+    }
+
+    @Test
+    public void testReplaceAndMaxFileLimitReach() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+        runner.setProperty(PutFile.MAX_DESTINATION_FILES, "1");
+
+        Map<String,String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
+        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("Hello world!!", new String(content));
+
+        //Second file
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        runner.enqueue("Another file".getBytes(), attributes);
+        runner.run();
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+        File dir = new File(TARGET_DIRECTORY);
+        assertEquals(1, dir.list().length);
+        targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
+        content = Files.readAllBytes(targetPath);
+        assertEquals("Another file", new String(content));
+    }
+
+}


### PR DESCRIPTION
When PutFile uses 'replace' conflict resolution and max files, there is an issue when the folder has X files, and the limit is also X. The processor fails instead of replacing it, leaving X files. This commit fixes that issue.

    This closes #6361.

    Signed-off-by: Andres Garagiola  <andresgaragiola@gmail.com>

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
