### PR TITLE
NIFI-5839 Applied identity mapping to user lookups and group members

### DIFF
--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
@@ -500,7 +500,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                             final User user = new User.Builder().identifierGenerateFromSeed(identity).identity(identity).build();
 
                             // store the user for group member later
-                            userLookup.put(getReferencedUserValue(ctx), user);
+                            userLookup.put(IdentityMappingUtil.mapIdentity(getReferencedUserValue(ctx), identityMappings), user);
 
                             if (StringUtils.isNotBlank(userGroupNameAttribute)) {
                                 final Attribute attributeGroups = ctx.getAttributes().get(userGroupNameAttribute);
@@ -569,7 +569,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                                     try {
                                         final NamingEnumeration<String> userValues = (NamingEnumeration<String>) attributeUsers.getAll();
                                         while (userValues.hasMoreElements()) {
-                                            final String userValue = userValues.next();
+                                            final String userValue = IdentityMappingUtil.mapIdentity(userValues.next(), identityMappings);
 
                                             if (performUserSearch) {
                                                 // find the user by it's referenced attribute and add the identifier to this group

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/resources/nifi-example.ldif
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/resources/nifi-example.ldif
@@ -157,6 +157,13 @@ objectClass: top
 cn: team2
 member: cn=User 1,ou=users,o=nifi
 
+dn: cn=teamCaseInsensitive,ou=groups,o=nifi
+objectClass: groupOfNames
+objectClass: top
+cn: teamCaseInsensitive
+member: cn=user 1,ou=Users,o=NiFi
+member: cn=USER 2,ou=USERS,o=NIFI
+
 ## since the embedded ldap requires member to be fqdn, we are simulating using room and description
 
 dn: cn=team3,ou=groups-2,o=nifi


### PR DESCRIPTION
 * The members of a group in LDAP do not have to be case identical to the
   actual user's DNs and so need to be transformed first.
 * Added a group with member DNs that do not match the capitalisation of
   the user DNs.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Applies configured transformations to LDAP group members and the user DN look up keys to cater for group members with different capitalisation than the user DN._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [NA] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [NA] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [NA] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [NA] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
