### PR TITLE
NIFI-6513 PutHive3Streaming.AUTO_CREATE_PARTITIONS is not used	

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/HiveOptions.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/HiveOptions.java
@@ -32,7 +32,6 @@ public class HiveOptions implements Serializable {
     protected Integer idleTimeout = 60000;
     protected Integer callTimeout = 0;
     protected List<String> staticPartitionValues = null;
-    protected Boolean autoCreatePartitions = true;
     protected String kerberosPrincipal;
     protected String kerberosKeytab;
     protected HiveConf hiveConf;
@@ -51,11 +50,6 @@ public class HiveOptions implements Serializable {
 
     public HiveOptions withStaticPartitionValues(List<String> staticPartitionValues) {
         this.staticPartitionValues = staticPartitionValues;
-        return this;
-    }
-
-    public HiveOptions withAutoCreatePartitions(Boolean autoCreatePartitions) {
-        this.autoCreatePartitions = autoCreatePartitions;
         return this;
     }
 


### PR DESCRIPTION
#### Description of PR

- Removed unused `AUTOCREATE_PARTITIONS` from `PutHive3Streaming`
 - Renamed `PARTITION_VALUES` to `STATIC_PARTITION_VALUES` for correctness and better understanding
- `STATIC_PARTITION_VALUES` descriptions clearly states that having that property filler implies Hive Static Partitioning

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
