### PR TITLE
NIFI-6534 Improve logging in PutHive3Streaming processor

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
@@ -135,5 +135,10 @@
             <version>1.10.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3Streaming.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3Streaming.java
@@ -431,6 +431,11 @@ public class PutHive3Streaming extends AbstractProcessor {
                 if (rollbackOnFailure) {
                     throw new ProcessException(rrfe);
                 } else {
+                    log.error(
+                            "Failed to create {} for {} - routing to failure",
+                            new Object[]{RecordReader.class.getSimpleName(), flowFile},
+                            rrfe
+                    );
                     session.transfer(flowFile, REL_FAILURE);
                 }
             }
@@ -445,6 +450,11 @@ public class PutHive3Streaming extends AbstractProcessor {
                 updateAttributes.put(HIVE_STREAMING_RECORD_COUNT_ATTR, Long.toString(hiveStreamingConnection.getConnectionStats().getRecordsWritten()));
                 updateAttributes.put(ATTR_OUTPUT_TABLES, options.getQualifiedTableName());
                 flowFile = session.putAllAttributes(flowFile, updateAttributes);
+                log.error(
+                        "Exception while processing {} - routing to failure",
+                        new Object[]{flowFile},
+                        e
+                );
                 session.transfer(flowFile, REL_FAILURE);
             }
         } catch (DiscontinuedException e) {
@@ -479,6 +489,11 @@ public class PutHive3Streaming extends AbstractProcessor {
                 updateAttributes.put(HIVE_STREAMING_RECORD_COUNT_ATTR, Long.toString(hiveStreamingConnection.getConnectionStats().getRecordsWritten()));
                 updateAttributes.put(ATTR_OUTPUT_TABLES, options.getQualifiedTableName());
                 flowFile = session.putAllAttributes(flowFile, updateAttributes);
+                log.error(
+                        "Exception while trying to stream {} to hive - routing to failure",
+                        new Object[]{flowFile},
+                        se
+                );
                 session.transfer(flowFile, REL_FAILURE);
             }
 

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/test/java/org/apache/nifi/processors/hive/TestPutHive3Streaming.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/test/java/org/apache/nifi/processors/hive/TestPutHive3Streaming.java
@@ -97,10 +97,14 @@ import java.util.function.BiFunction;
 import static org.apache.nifi.processors.hive.AbstractHive3QLProcessor.ATTR_OUTPUT_TABLES;
 import static org.apache.nifi.processors.hive.PutHive3Streaming.HIVE_STREAMING_RECORD_COUNT_ATTR;
 import static org.apache.nifi.processors.hive.PutHive3Streaming.KERBEROS_CREDENTIALS_SERVICE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -362,6 +366,10 @@ public class TestPutHive3Streaming {
         runner.run();
 
         runner.assertTransferCount(PutHive3Streaming.REL_FAILURE, 1);
+        assertThat(
+                runner.getLogger().getErrorMessages(),
+                hasItem(hasProperty("msg", containsString("Exception while trying to stream {} to hive - routing to failure")))
+        );
     }
 
     @Test
@@ -395,6 +403,10 @@ public class TestPutHive3Streaming {
         runner.run();
 
         runner.assertTransferCount(PutHive3Streaming.REL_FAILURE, 1);
+        assertThat(
+                runner.getLogger().getErrorMessages(),
+                hasItem(hasProperty("msg", containsString("Failed to create {} for {} - routing to failure")))
+        );
     }
 
     @Test
@@ -465,6 +477,10 @@ public class TestPutHive3Streaming {
         runner.assertTransferCount(PutHive3Streaming.REL_SUCCESS, 0);
         runner.assertTransferCount(PutHive3Streaming.REL_FAILURE, 1);
         runner.assertTransferCount(PutHive3Streaming.REL_RETRY, 0);
+        assertThat(
+                runner.getLogger().getErrorMessages(),
+                hasItem(hasProperty("msg", containsString("Exception while processing {} - routing to failure")))
+        );
     }
 
     @Test
@@ -577,6 +593,10 @@ public class TestPutHive3Streaming {
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutHive3Streaming.REL_FAILURE).get(0);
         assertEquals("0", flowFile.getAttribute(HIVE_STREAMING_RECORD_COUNT_ATTR));
         assertEquals("default.users", flowFile.getAttribute(ATTR_OUTPUT_TABLES));
+        assertThat(
+                runner.getLogger().getErrorMessages(),
+                hasItem(hasProperty("msg", containsString("Exception while processing {} - routing to failure")))
+        );
     }
 
     @Test
@@ -630,6 +650,10 @@ public class TestPutHive3Streaming {
 
         runner.assertTransferCount(PutHive3Streaming.REL_SUCCESS, 0);
         runner.assertTransferCount(PutHive3Streaming.REL_FAILURE, 1);
+        assertThat(
+                runner.getLogger().getErrorMessages(),
+                hasItem(hasProperty("msg", containsString("Exception while processing {} - routing to failure")))
+        );
     }
 
     @Test


### PR DESCRIPTION
Added logging for PutHive3Streaming when routing to failure

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
