### PR TITLE
[WIP] NIFI-5505 Added Java 11 build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,88 @@
 
 language: java
 
-env:
-  - USER_LANGUAGE=en USER_REGION=US'
-  - USER_LANGUAGE=fr USER_REGION=FR'
-  - USER_LANGUAGE=ja USER_REGION=JP'
+matrix:
+  include:
+    - stage: "Cache"
+      name: "Cache Dependencies - no explicit jdk specified"
+      script: >-
+        if [ ! -d "$HOME"/.m2/repository ] || [ ! "$(ls -A "$HOME"/.m2/repository)" ] ; then
+          echo "Cached Maven repository does not exist, downloading dependencies..."
+          mvn -V -T 1C dependency:go-offline -Dsilent -ntp --fail-never \
+          | grep -v -F -f .travis-output-filters -e "Failed to execute goal on project"
+        else
+          echo "Cached Maven repository exists, skipping dependency cache"
+        fi
+    - stage: "Cache"
+      name: "Cache Dependencies - openjdk8"
+      jdk: openjdk8
+      script: >-
+        if [ ! -d "$HOME"/.m2/repository ] || [ ! "$(ls -A "$HOME"/.m2/repository)" ] ; then
+          echo "Cached Maven repository does not exist, downloading dependencies..."
+          mvn -V -T 1C dependency:go-offline -Dsilent -ntp --fail-never \
+          | grep -v -F -f .travis-output-filters -e "Failed to execute goal on project"
+        else
+          echo "Cached Maven repository exists, skipping dependency cache"
+        fi
+    # For the build stages, use -pl to exclude the following from the build to reduce build time:
+    #   non-api nar modules
+    #   assembly modules
+    #   nifi-maven-archetype directories that have "__" in the name
+    - stage: "Build"
+      name: "Build Java 8 EN"
+      jdk: openjdk8
+      script: >-
+        mvn clean install -V -T 1C
+        -pl `find . -type d \( -name "*-nar" -or -name "*-assembly" \) -and -not -name "*api-nar" -and -not -path "*/target/*" -and -not -name "*__*" -printf "!./%P,"`
+        -Pcontrib-check,include-grpc -Ddir-only
+        -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
+        | grep -v -F -f .travis-output-filters
+        && test ${PIPESTATUS[0]} -eq 0
+    - stage: "Build"
+      name: "Build Java 8 FR"
+      jdk: openjdk8
+      script: >-
+        mvn clean install -V -T 1C
+        -pl `find . -type d \( -name "*-nar" -or -name "*-assembly" \) -and -not -name "*api-nar" -and -not -path "*/target/*" -and -not -name "*__*" -printf "!./%P,"`
+        -Pcontrib-check,include-grpc -Ddir-only
+        -Dmaven.surefire.arguments="-Duser.language=fr -Duser.region=FR"
+        | grep -v -F -f .travis-output-filters
+        && test ${PIPESTATUS[0]} -eq 0
+    - stage: "Build"
+      name: "Build Java 8 JA"
+      jdk: openjdk8
+      script: >-
+        mvn clean install -V -T 1C
+        -pl `find . -type d \( -name "*-nar" -or -name "*-assembly" \) -and -not -name "*api-nar" -and -not -path "*/target/*" -and -not -name "*__*" -printf "!./%P,"`
+        -Pcontrib-check,include-grpc -Ddir-only
+        -Dmaven.surefire.arguments="-Duser.language=ja -Duser.region=JP"
+        | grep -v -F -f .travis-output-filters
+        && test ${PIPESTATUS[0]} -eq 0
+    - stage: "Build"
+      name: "Build Java 11 EN"
+      # Do not specify "jdk:" here, install-jdk.sh will download the JDK set JAVA_HOME appropriately
+      before_script:
+        # Download the newest version of sormuras' install-jdk.sh to /tmp
+        # install-jdk.sh is used by Travis internally, sormoras is the maintainer of that script
+        - wget -O /tmp/install-jdk.sh https://github.com/sormuras/bach/raw/master/install-jdk.sh
+        # Need to specifically install AdoptOpenJDK 11.0.4 (Linux, HotSpot) since Travis does not offer it by default
+        # The link to the AdoptOpenJDK 11.0.4 .tar.gz is taken directly from AdoptOpenJDK's website
+        - >-
+          source /tmp/install-jdk.sh
+          --url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz'
+      script:
+        - >-
+          mvn clean install -V -T 1C
+          -pl `find . -type d \( -name "*-nar" -or -name "*-assembly" \) -and -not -name "*api-nar" -and -not -path "*/target/*" -and -not -name "*__*" -printf "!./%P,"`
+          -Pcontrib-check,include-grpc -Ddir-only
+          -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
+          | grep -v -F -f .travis-output-filters
+          && test ${PIPESTATUS[0]} -eq 0
 
 os:
   - linux
 
-jdk:
-  - openjdk8
-
-# Caches mvn repository in order to speed upbuilds
+# Caches mvn repository in order to speed up builds
 cache:
   directories:
     - $HOME/.m2
@@ -47,12 +117,10 @@ before_install:
   - cat ~/.mavenrc
   # Remove nifi repo again to save travis from caching it
   - rm -rf $HOME/.m2/repository/org/apache/nifi/
+  # Install Maven 3.6.1
+  - wget -O /tmp/apache-maven-3.6.1-bin.tar.gz https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
+  - tar xzf /tmp/apache-maven-3.6.1-bin.tar.gz -C /tmp
+  - export M2_HOME=/tmp/apache-maven-3.6.1
+  - export PATH=$M2_HOME/bin:$PATH
 
 install: true
-    
-script:
-  # Replace variables seems to be the only option to pass proper values to surefire
-  # Note: The reason the sed is done as part of script is to ensure the pom hack 
-  # won't affect the 'clean install' above
-  - bash .travis.sh
-  - mvn -T 1C clean install -Pcontrib-check,include-grpc,include-atlas,include-hive3 -Ddir-only | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
```
Introduced stages to cache dependencies before build and test
Added --fail-never to dependency cache stage to allow dependency:go-offline to finish and update the cache with any dependencies that were able to be downloaded
Added download of AdoptOpenJDK 11.0.4 for the Java 11 build
Removed setting environment variables to enable easier sharing of cache between build, region/language settings are passed in via the command line when invoking maven
Formatted scripts to allow multiline commands for more readability
Replaced "exit ${PIPESTATUS[0]}" with "test ${PIPESTATUS[0]} -eq 0" to avoid using "exit" in script, which prevents Travis from completing the cache upload after the build completes
Install Maven 3.6.1 for the -ntp (no-transfer-progress) feature
Updated all build stages to exclude non-api nar and assembly modules to decrease build time
Dependency cache stages check if the cached maven repository doesn't exist or is empty before attempting to download dependencies
```
----
To verify this PR, Travis should have a completed build, with two stages executed to download and cache dependencies for openjdk8 and non-explicit-jdk Cache stages, and four stages for the various locale and JDK version builds.

Please be aware that the four stages which build and test the code exclude assembly and -nar modules to decrease build time, so that all stages can finish in less than 50 minutes.

----
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Added Java 11 build to Travis CI._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [n/a] Have you written or updated unit tests to verify your changes?
- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [n/a] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [n/a] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [n/a] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [n/a] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
