### PR TITLE
NIFI-6571 - TLS toolkit server mode - check token length at startup

### DIFF
--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/commandLine/ExitCode.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/commandLine/ExitCode.java
@@ -67,6 +67,11 @@ public enum ExitCode {
     ERROR_TOKEN_ARG_EMPTY,
 
     /**
+     * Token does not meet minimum size of 16 bytes
+     */
+    ERROR_TOKEN_ARG_TOO_SHORT,
+
+    /**
      * Unable to read nifi.properties
      */
     ERROR_READING_NIFI_PROPERTIES,

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/service/BaseCertificateAuthorityCommandLine.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/service/BaseCertificateAuthorityCommandLine.java
@@ -25,6 +25,7 @@ import org.apache.nifi.toolkit.tls.configuration.TlsConfig;
 import org.apache.nifi.util.StringUtils;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Common base argument logic for the CA server and client
@@ -81,6 +82,14 @@ public abstract class BaseCertificateAuthorityCommandLine extends BaseTlsToolkit
         if (StringUtils.isEmpty(token) && StringUtils.isEmpty(configJsonIn)) {
             printUsageAndThrow(TOKEN_ARG + " argument must not be empty unless " + USE_CONFIG_JSON_ARG + " or " + READ_CONFIG_JSON_ARG+ " set", ExitCode.ERROR_TOKEN_ARG_EMPTY);
         }
+
+        if (!StringUtils.isEmpty(token)) {
+            byte[] tokenBytes = token.getBytes(StandardCharsets.UTF_8);
+            if (tokenBytes.length < 16) {
+                printUsageAndThrow(TOKEN_ARG + " does not meet minimum size of 16 bytes", ExitCode.ERROR_TOKEN_ARG_TOO_SHORT);
+            }
+        }
+
         port = getIntValue(commandLine, PORT_ARG, TlsConfig.DEFAULT_PORT);
         dn = commandLine.getOptionValue(DN_ARG, new TlsConfig().calcDefaultDn(getDnHostname()));
         return commandLine;

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/client/TlsCertificateAuthorityClientCommandLineTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/client/TlsCertificateAuthorityClientCommandLineTest.java
@@ -42,7 +42,7 @@ public class TlsCertificateAuthorityClientCommandLineTest {
     @Before
     public void setup() {
         tlsCertificateAuthorityClientCommandLine = new TlsCertificateAuthorityClientCommandLine();
-        testToken = "testToken";
+        testToken = "testToken16bytes";
     }
 
     @Test

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/server/TlsCertificateAuthorityServiceCommandLineTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/server/TlsCertificateAuthorityServiceCommandLineTest.java
@@ -44,7 +44,7 @@ public class TlsCertificateAuthorityServiceCommandLineTest {
     @Before
     public void setup() {
         tlsCertificateAuthorityServiceCommandLine = new TlsCertificateAuthorityServiceCommandLine(inputStreamFactory);
-        testToken = "testToken";
+        testToken = "testToken16bytes";
     }
 
     @Test


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

It is possible to start the TLS toolkit in server mode with a token length below the required 16 bits. But when the client is performing the request, it'll be denied with the message "Token does not meet minimum size of 16 bytes". This PR is about preventing the TLS toolkit to start in server mode when the token is below 16 bytes.

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
