### PR TITLE
NIFI-6158 Fix conversion of Avro fixed type with logicalType decimal

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -1012,6 +1012,11 @@ public class AvroTypeUtil {
                 return AvroTypeUtil.convertByteArray(bb.array());
             case FIXED:
                 final GenericFixed fixed = (GenericFixed) value;
+                final LogicalType fixedLogicalType = avroSchema.getLogicalType();
+                if (fixedLogicalType != null && LOGICAL_TYPE_DECIMAL.equals(fixedLogicalType.getName())) {
+                    final ByteBuffer fixedByteBuffer = ByteBuffer.wrap(fixed.bytes());
+                    return new Conversions.DecimalConversion().fromBytes(fixedByteBuffer, avroSchema, fixedLogicalType);
+                }
                 return AvroTypeUtil.convertByteArray(fixed.bytes());
             case ENUM:
                 return value.toString();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -41,6 +41,12 @@
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
@@ -92,6 +98,7 @@
                         <exclude>src/test/resources/avro/user.avsc</exclude>
                         <exclude>src/test/resources/avro/user-with-array.avsc</exclude>
                         <exclude>src/test/resources/avro/user-with-nullable-array.avsc</exclude>
+                        <exclude>src/test/resources/avro/user-with-fixed-decimal.avsc</exclude>
                         <exclude>src/test/resources/avro/all-minus-enum.avsc</exclude>
                     </excludes>
                 </configuration>

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/resources/avro/user-with-fixed-decimal.avsc
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/resources/avro/user-with-fixed-decimal.avsc
@@ -1,0 +1,8 @@
+{"namespace": "example.avro",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "name", "type": "string"},
+     {"name": "amount",  "type": ["null", {"type":"fixed","name":"amount","size":16,"logicalType":"decimal","precision":38,"scale":10} ]}
+ ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.2.3</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This fixes an issue reported through the Parquet processors, but was really a general problem when reading records with a field that used the "fixed" type and a logicalType of decimal. Our type util code was missing the check for the logicalType and just converting to byte array.

I added a unit test to FetchParquet to prove that it is resolved, although there are no code changes to the Parquert bundle itself. 

Also noticed that unit tests were failing to initialize logging correctly due to finding multiple SLF4J bindings, so this PR includes a small change to enforce that logback-core is marked as provided which allows tests to use the slf4j-simple module which is already on the test classpath of all NARs.