### PR TITLE
NIFI-6599 Fix MergeRecord failure in defragment mode

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
@@ -353,9 +353,10 @@ public class MergeRecord extends AbstractSessionFactoryProcessor {
             session.commit();
         }
 
-        // If there is no more data queued up, complete any bin that meets our minimum threshold
+        // If there is no more data queued up, or strategy is defragment, complete any bin that meets our minimum threshold
+        // Otherwise, run one more cycle to process queued FlowFiles to add more fragment into available bins.
         int completedBins = 0;
-        if (flowFiles.isEmpty()) {
+        if (flowFiles.isEmpty() || MERGE_STRATEGY_DEFRAGMENT.getValue().equals(mergeStrategy)) {
             try {
                 completedBins += manager.completeFullEnoughBins();
             } catch (final Exception e) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
@@ -148,6 +148,8 @@ public class RecordBin {
             flowFileMigrated = true;
             this.flowFiles.add(flowFile);
 
+            thresholds.getFragmentCountAttribute().ifPresent(this::validateFragmentCount);
+
             if (recordCount >= getMinimumRecordCount()) {
                 // If we have met our minimum record count, we need to flush so that when we reach the desired number of bytes
                 // the bin is considered 'full enough'.
@@ -203,10 +205,6 @@ public class RecordBin {
                 return false;
             }
 
-            if(thresholds.getFragmentCountAttribute().isPresent() && this.fragmentCount == getMinimumRecordCount()) {
-                return true;
-            }
-
             int maxRecords = thresholds.getMaxRecords();
 
             if (recordCount >= maxRecords) {
@@ -240,6 +238,11 @@ public class RecordBin {
         try {
             if (flowFiles.isEmpty()) {
                 return false;
+            }
+
+            if (thresholds.getFragmentCountAttribute().isPresent()) {
+                // Compare with the target fragment count.
+                return this.fragmentCount == thresholds.getFragmentCount();
             }
 
             final int requiredRecordCount = getMinimumRecordCount();
@@ -301,6 +304,48 @@ public class RecordBin {
         }
     }
 
+    /**
+     * Ensure that at least one FlowFile has a fragment.count attribute and that they all have the same value, if they have a value.
+     */
+    private void validateFragmentCount(String countAttributeName) {
+        Integer expectedFragmentCount = thresholds.getFragmentCount();
+        for (final FlowFile flowFile : flowFiles) {
+            final String countVal = flowFile.getAttribute(countAttributeName);
+            if (countVal == null) {
+                continue;
+            }
+
+            final int count;
+            try {
+                count = Integer.parseInt(countVal);
+            } catch (final NumberFormatException nfe) {
+                logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but expected a number",
+                    new Object[] {flowFiles.size(), countAttributeName, countVal, flowFile});
+                fail();
+                return;
+            }
+
+            if (expectedFragmentCount != null && count != expectedFragmentCount) {
+                logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but another FlowFile in the bin had a value of {}",
+                    new Object[] {flowFiles.size(), countAttributeName, countVal, flowFile, expectedFragmentCount});
+                fail();
+                return;
+            }
+
+            if (expectedFragmentCount == null) {
+                expectedFragmentCount = count;
+                thresholds.setFragmentCount(count);
+            }
+        }
+
+        if (expectedFragmentCount == null) {
+            logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute was not present on any of the FlowFiles",
+                new Object[] {flowFiles.size(), countAttributeName});
+            fail();
+            return;
+        }
+    }
+
     public void complete(final String completionReason) throws IOException {
         writeLock.lock();
         try {
@@ -321,48 +366,16 @@ public class RecordBin {
                 return;
             }
 
-            // If using defragment mode, and we don't have enough FlowFiles, then we need to fail this bin.
             final Optional<String> countAttr = thresholds.getFragmentCountAttribute();
             if (countAttr.isPresent()) {
-                // Ensure that at least one FlowFile has a fragment.count attribute and that they all have the same value, if they have a value.
-                Integer expectedBinCount = null;
-                for (final FlowFile flowFile : flowFiles) {
-                    final String countVal = flowFile.getAttribute(countAttr.get());
-                    if (countVal == null) {
-                        continue;
-                    }
+                validateFragmentCount(countAttr.get());
 
-                    final int count;
-                    try {
-                        count = Integer.parseInt(countVal);
-                    } catch (final NumberFormatException nfe) {
-                        logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but expected a number",
-                                new Object[] {flowFiles.size(), countAttr.get(), countVal, flowFile});
-                        fail();
-                        return;
-                    }
-
-                    if (expectedBinCount != null && count != expectedBinCount) {
-                        logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but another FlowFile in the bin had a value of {}",
-                                new Object[] {flowFiles.size(), countAttr.get(), countVal, flowFile, expectedBinCount});
-                        fail();
-                        return;
-                    }
-
-                    expectedBinCount = count;
-                }
-
-                if (expectedBinCount == null) {
-                    logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute was not present on any of the FlowFiles",
-                            new Object[] {flowFiles.size(), countAttr.get()});
-                    fail();
-                    return;
-                }
-
-                if (expectedBinCount != flowFiles.size()) {
+                // If using defragment mode, and we don't have enough FlowFiles, then we need to fail this bin.
+                Integer expectedFragmentCount = thresholds.getFragmentCount();
+                if (expectedFragmentCount != flowFiles.size()) {
                     logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' but only {} of {} FlowFiles were encountered before this bin was evicted "
                                     + "(due to to Max Bin Age being reached or due to the Maximum Number of Bins being exceeded).",
-                            new Object[] {flowFiles.size(), countAttr.get(), expectedBinCount, flowFiles.size(), expectedBinCount});
+                            new Object[] {flowFiles.size(), countAttr.get(), expectedFragmentCount, flowFiles.size(), expectedFragmentCount});
                     fail();
                     return;
                 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
@@ -197,9 +197,8 @@ public class RecordBinManager {
         final String mergeStrategy = context.getProperty(MergeRecord.MERGE_STRATEGY).getValue();
         if (MergeRecord.MERGE_STRATEGY_DEFRAGMENT.getValue().equals(mergeStrategy)) {
             fragmentCountAttribute = MergeContent.FRAGMENT_COUNT_ATTRIBUTE;
-            if (!StringUtils.isEmpty(flowfile.getAttribute(fragmentCountAttribute))) {
-                minRecords = Integer.parseInt(flowfile.getAttribute(fragmentCountAttribute));
-            }
+            // We don't know minRecords in defragment mode.
+            minRecords = Integer.MAX_VALUE;
         } else {
             fragmentCountAttribute = null;
         }
@@ -240,15 +239,15 @@ public class RecordBinManager {
 
     public int completeExpiredBins() throws IOException {
         final long maxNanos = maxBinAgeNanos.get();
-        return handleCompletedBins(bin -> bin.isOlderThan(maxNanos, TimeUnit.NANOSECONDS));
+        return handleCompletedBins(bin -> bin.isOlderThan(maxNanos, TimeUnit.NANOSECONDS), "Bin has reached Max Bin Age");
     }
 
     public int completeFullEnoughBins() throws IOException {
-        return handleCompletedBins(RecordBin::isFullEnough);
+        return handleCompletedBins(RecordBin::isFullEnough, "Bin is full enough");
     }
 
-    private int handleCompletedBins(final Predicate<RecordBin> completionTest) throws IOException {
-        final Map<String, List<RecordBin>> expiredBinMap = new HashMap<>();
+    private int handleCompletedBins(final Predicate<RecordBin> completionTest, final String completionReason) throws IOException {
+        final Map<String, List<RecordBin>> completedBinMap = new HashMap<>();
 
         lock.lock();
         try {
@@ -258,7 +257,7 @@ public class RecordBinManager {
 
                 for (final RecordBin bin : bins) {
                     if (completionTest.test(bin)) {
-                        final List<RecordBin> expiredBinsForKey = expiredBinMap.computeIfAbsent(key, ignore -> new ArrayList<>());
+                        final List<RecordBin> expiredBinsForKey = completedBinMap.computeIfAbsent(key, ignore -> new ArrayList<>());
                         expiredBinsForKey.add(bin);
                     }
                 }
@@ -268,17 +267,17 @@ public class RecordBinManager {
         }
 
         int completed = 0;
-        for (final Map.Entry<String, List<RecordBin>> entry : expiredBinMap.entrySet()) {
+        for (final Map.Entry<String, List<RecordBin>> entry : completedBinMap.entrySet()) {
             final String key = entry.getKey();
-            final List<RecordBin> expiredBins = entry.getValue();
+            final List<RecordBin> completeBins = entry.getValue();
 
-            for (final RecordBin bin : expiredBins) {
-                logger.debug("Completing Bin {} because it has expired");
-                bin.complete("Bin has reached Max Bin Age");
+            for (final RecordBin bin : completeBins) {
+                logger.debug("Completing Bin {} because {}", new Object[]{bin, completionReason});
+                bin.complete(completionReason);
                 completed++;
             }
 
-            removeBins(key, expiredBins);
+            removeBins(key, completeBins);
         }
 
         return completed;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinThresholds.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinThresholds.java
@@ -27,6 +27,7 @@ public class RecordBinThresholds {
     private final long maxBinMillis;
     private final String maxBinAge;
     private final Optional<String> fragmentCountAttribute;
+    private Integer fragmentCount;
 
     public RecordBinThresholds(final int minRecords, final int maxRecords, final long minBytes, final long maxBytes, final long maxBinMillis,
         final String maxBinAge, final String fragmentCountAttribute) {
@@ -65,5 +66,13 @@ public class RecordBinThresholds {
 
     public Optional<String> getFragmentCountAttribute() {
         return fragmentCountAttribute;
+    }
+
+    public Integer getFragmentCount() {
+        return fragmentCount;
+    }
+
+    public void setFragmentCount(Integer fragmentCount) {
+        this.fragmentCount = fragmentCount;
     }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

MergeRecord processor misuses 'fragment.count' as minimum required record count. This commit fixes the issue. Please refer the JIRA description for more detail.
https://issues.apache.org/jira/browse/NIFI-6599

This PR has two commits intentionally. The first one only contains the unit test that fails without the 2nd commit.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
