### PR TITLE
NIFI-6666 Add Useragent Header to InvokeHTTP requests

### DIFF
--- a/nifi-api/pom.xml
+++ b/nifi-api/pom.xml
@@ -23,4 +23,99 @@
     <artifactId>nifi-api</artifactId>
     <packaging>jar</packaging>
     <!-- This module should kept to having no dependencies -->
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- https://github.com/git-commit-id/maven-git-commit-id-plugin -->
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- This is the same as the default date time format of this plugin.      -->
+                    <!-- Because we want to parse the result we are fixing it to avoid problems. -->
+                    <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>Generate NifiBuildProperties Java class</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.basedir}/src/main/code-gen/NifiBuildProperties.java.template</file>
+                            <outputFile>${project.build.directory}/generated-sources/java/org/apache/nifi/build/NifiBuildProperties.java</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <replacements>
+                        <replacement>
+                            <token>#maven.build.timestamp#</token>
+                            <value>${maven.build.timestamp}</value>
+                        </replacement>
+
+                        <replacement>
+                            <token>#project.version#</token>
+                            <value>${project.version}</value>
+                        </replacement>
+
+                        <replacement><token>#git.branch#</token><value>${git.branch}</value></replacement>
+                        <replacement><token>#git.build.number#</token><value>${git.build.number}</value></replacement>
+                        <replacement><token>#git.build.number.unique#</token><value>${git.build.number.unique}</value></replacement>
+                        <replacement><token>#git.build.time#</token><value>${git.build.time}</value></replacement>
+                        <replacement><token>#git.build.version#</token><value>${git.build.version}</value></replacement>
+                        <replacement><token>#git.closest.tag.commit.count#</token><value>${git.closest.tag.commit.count}</value></replacement>
+                        <replacement><token>#git.closest.tag.name#</token><value>${git.closest.tag.name}</value></replacement>
+                        <replacement><token>#git.commit.id#</token><value>${git.commit.id}</value></replacement>
+                        <replacement><token>#git.commit.id.abbrev#</token><value>${git.commit.id.abbrev}</value></replacement>
+                        <replacement><token>#git.commit.id.describe#</token><value>${git.commit.id.describe}</value></replacement>
+                        <replacement><token>#git.commit.id.describe-short#</token><value>${git.commit.id.describe-short}</value></replacement>
+                        <replacement><token>#git.commit.time#</token><value>${git.commit.time}</value></replacement>
+                        <replacement><token>#git.dirty#</token><value>${git.dirty}</value></replacement>
+                        <replacement><token>#git.total.commit.count#</token><value>${git.total.commit.count}</value></replacement>
+
+                    </replacements>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/java/</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+
  </project>

--- a/nifi-api/src/main/code-gen/NifiBuildProperties.java.template
+++ b/nifi-api/src/main/code-gen/NifiBuildProperties.java.template
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.build;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Properties;
+
+public final class NifiBuildProperties {
+
+    private static final String MAVEN_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
+    private static final String GIT_TIMESTAMP_FORMAT   = "yyyy-MM-dd'T'HH:mm:ssZ";
+
+    public static final String  NIFI_VERSION                               = "#project.version#";
+    public static final Instant BUILD_TIMESTAMP                            = parseDateTime("#maven.build.timestamp#", MAVEN_TIMESTAMP_FORMAT);
+    public static final String  BUILD_TIMESTAMP_STR                        = instantToString(BUILD_TIMESTAMP);
+
+    public static final String  BUILD_GIT_BRANCH                           = "#git.branch#";
+    public static final String  BUILD_GIT_BUILD_NUMBER                     = "#git.build.number#";
+    public static final String  BUILD_GIT_BUILD_NUMBER_UNIQUE              = "#git.build.number.unique#";
+    public static final Instant BUILD_GIT_BUILD_TIME                       = parseDateTime("#git.build.time#", GIT_TIMESTAMP_FORMAT);
+    public static final String  BUILD_GIT_BUILD_TIME_STR                   = instantToString(BUILD_GIT_BUILD_TIME);
+    public static final String  BUILD_GIT_BUILD_VERSION                    = "#git.build.version#";
+    public static final String  BUILD_GIT_CLOSEST_TAG_COMMIT_COUNT         = "#git.closest.tag.commit.count#";
+    public static final String  BUILD_GIT_CLOSEST_TAG_NAME                 = "#git.closest.tag.name#";
+    public static final String  BUILD_GIT_COMMIT_ID                        = "#git.commit.id#";
+    public static final String  BUILD_GIT_COMMIT_ID_ABBREV                 = "#git.commit.id.abbrev#";
+    public static final String  BUILD_GIT_COMMIT_ID_DESCRIBE               = "#git.commit.id.describe#";
+    public static final String  BUILD_GIT_COMMIT_ID_DESCRIBE_SHORT         = "#git.commit.id.describe-short#";
+    public static final Instant BUILD_GIT_COMMIT_TIME                      = parseDateTime("#git.commit.time#", GIT_TIMESTAMP_FORMAT);
+    public static final String  BUILD_GIT_COMMIT_TIME_STR                  = instantToString(BUILD_GIT_COMMIT_TIME);
+    public static final String  BUILD_GIT_DIRTY                            = "#git.dirty#";
+    public static final String  BUILD_GIT_TOTAL_COMMIT_COUNT               = "#git.total.commit.count#";
+
+    private static Instant parseDateTime(String dateTime, String pattern) {
+        // This is to reliably parse the datetime format configured in the git-commit-id-plugin
+        try {
+            return DateTimeFormatter.ofPattern(pattern).parse(dateTime, Instant::from);
+        } catch (DateTimeParseException dtpe) {
+            return Instant.EPOCH;
+        }
+    }
+
+    private static String instantToString(Instant dateTime) {
+        // Default zone to format the build time in.
+        try {
+            return DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.of("Europe/Amsterdam")).format(dateTime);
+        } catch (DateTimeParseException dtpe) {
+            return "1970-01-01T00:00:00+0000";
+        }
+    }
+
+    public static final Properties getBuildProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("nifi.version",                            NIFI_VERSION                       );
+        properties.setProperty("nifi.build.timestamp",                    BUILD_TIMESTAMP_STR                );
+
+        properties.setProperty("nifi.build.git.branch",                   BUILD_GIT_BRANCH                   );
+        properties.setProperty("nifi.build.git.build.number",             BUILD_GIT_BUILD_NUMBER             );
+        properties.setProperty("nifi.build.git.build.number.unique",      BUILD_GIT_BUILD_NUMBER_UNIQUE      );
+        properties.setProperty("nifi.build.git.build.time",               BUILD_GIT_BUILD_TIME_STR           );
+        properties.setProperty("nifi.build.git.build.version",            BUILD_GIT_BUILD_VERSION            );
+        properties.setProperty("nifi.build.git.closest.tag.commit.count", BUILD_GIT_CLOSEST_TAG_COMMIT_COUNT );
+        properties.setProperty("nifi.build.git.closest.tag.name",         BUILD_GIT_CLOSEST_TAG_NAME         );
+        properties.setProperty("nifi.build.git.commit.id",                BUILD_GIT_COMMIT_ID                );
+        properties.setProperty("nifi.build.git.commit.id.abbrev",         BUILD_GIT_COMMIT_ID_ABBREV         );
+        properties.setProperty("nifi.build.git.commit.id.describe",       BUILD_GIT_COMMIT_ID_DESCRIBE       );
+        properties.setProperty("nifi.build.git.commit.id.describe-short", BUILD_GIT_COMMIT_ID_DESCRIBE_SHORT );
+        properties.setProperty("nifi.build.git.commit.time",              BUILD_GIT_COMMIT_TIME_STR          );
+        properties.setProperty("nifi.build.git.dirty",                    BUILD_GIT_DIRTY                    );
+        properties.setProperty("nifi.build.git.total.commit.count",       BUILD_GIT_TOTAL_COMMIT_COUNT       );
+
+        return properties;
+    }
+
+}

--- a/nifi-api/src/main/java/org/apache/nifi/registry/VariableRegistry.java
+++ b/nifi-api/src/main/java/org/apache/nifi/registry/VariableRegistry.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.registry;
 
+import org.apache.nifi.build.NifiBuildProperties;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,6 +54,13 @@ public interface VariableRegistry {
             System.getProperties().entrySet().stream().forEach((entry) -> {
                 final VariableDescriptor desc = new VariableDescriptor.Builder(entry.getKey().toString())
                         .description("System Property")
+                        .sensitive(false)
+                        .build();
+                map.put(desc, entry.getValue().toString());
+            });
+            NifiBuildProperties.getBuildProperties().entrySet().stream().forEach((entry) -> {
+                final VariableDescriptor desc = new VariableDescriptor.Builder(entry.getKey().toString())
+                        .description("Build Property")
                         .sensitive(false)
                         .build();
                 map.put(desc, entry.getValue().toString());

--- a/nifi-api/src/test/java/org/apache/nifi/build/TestBuildProperties.java
+++ b/nifi-api/src/test/java/org/apache/nifi/build/TestBuildProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.build;
+
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class TestBuildProperties {
+
+    @Test
+    public void testCheckGeneratedBuildProperties() {
+        assertNotEquals("An error occurred in the parsed Maven build time",
+                Instant.EPOCH, NifiBuildProperties.BUILD_TIMESTAMP);
+
+        assertNotEquals("An error occurred in the parsed Git build time",
+                Instant.EPOCH, NifiBuildProperties.BUILD_GIT_BUILD_TIME);
+
+        assertNotEquals("An error occurred in the parsed Git commit time",
+                Instant.EPOCH, NifiBuildProperties.BUILD_GIT_COMMIT_TIME);
+    }
+
+}

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -16,6 +16,35 @@
  */
 package org.apache.nifi.util;
 
+import static java.util.Objects.requireNonNull;
+import static org.apache.nifi.registry.VariableRegistry.ENVIRONMENT_SYSTEM_REGISTRY;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
 import org.apache.nifi.annotation.behavior.TriggerSerially;
 import org.apache.nifi.annotation.lifecycle.OnAdded;
 import org.apache.nifi.annotation.lifecycle.OnConfigurationRestored;
@@ -120,6 +149,10 @@ public class StandardProcessorTestRunner implements TestRunner {
         this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed);
         this.processorStateManager = new MockStateManager(processor);
         this.variableRegistry = new MockVariableRegistry();
+
+        // Ensure the test runner has the environment and build variables
+        ENVIRONMENT_SYSTEM_REGISTRY.getVariableMap().forEach(this.variableRegistry::setVariable);
+
         this.context = new MockProcessContext(processor, processorName, processorStateManager, variableRegistry);
         this.kerberosContext = kerberosContext;
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -230,6 +230,16 @@ public class InvokeHTTP extends AbstractProcessor {
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor PROP_USERAGENT = new PropertyDescriptor.Builder()
+            .name("Useragent")
+            .displayName("Useragent")
+            .description("The Useragent identifier sent along with each request")
+            .required(false)
+            .defaultValue("Apache Nifi/${nifi.version} (git:${nifi.build.git.commit.id.describe}; Java/${java.version}; ${os.name} ${os.version}; ${os.arch}; https://nifi.apache.org/)")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
     public static final PropertyDescriptor PROP_SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
             .name("SSL Context Service")
             .description("The SSL Context Service used to provide client certificate information for TLS/SSL (https) connections."
@@ -459,6 +469,7 @@ public class InvokeHTTP extends AbstractProcessor {
             PROP_DATE_HEADER,
             PROP_FOLLOW_REDIRECTS,
             PROP_ATTRIBUTES_TO_SEND,
+            PROP_USERAGENT,
             PROP_BASIC_AUTH_USERNAME,
             PROP_BASIC_AUTH_PASSWORD,
             PROXY_CONFIGURATION_SERVICE,
@@ -1003,6 +1014,11 @@ public class InvokeHTTP extends AbstractProcessor {
                 break;
             default:
                 requestBuilder = requestBuilder.method(method, null);
+        }
+
+        String userAgent = trimToEmpty(context.getProperty(PROP_USERAGENT).evaluateAttributeExpressions(requestFlowFile).getValue());
+        if (!userAgent.isEmpty()) {
+            requestBuilder.addHeader("User-Agent", userAgent);
         }
 
         requestBuilder = setHeaderProperties(context, requestBuilder, requestFlowFile);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/text/TestFreeFormTextRecordSetWriter.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/text/TestFreeFormTextRecordSetWriter.java
@@ -42,7 +42,7 @@ public class TestFreeFormTextRecordSetWriter {
 
         runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(writer, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
-        runner.setProperty(writer, FreeFormTextRecordSetWriter.TEXT, "ID: ${ID}, Name: ${NAME}, Age: ${AGE}, Country: ${COUNTRY}, Username: ${user.name}");
+        runner.setProperty(writer, FreeFormTextRecordSetWriter.TEXT, "ID: ${ID}, Name: ${NAME}, Age: ${AGE}, Country: ${COUNTRY}, Username: ${login.name}");
 
         return runner;
     }
@@ -54,7 +54,7 @@ public class TestFreeFormTextRecordSetWriter {
 
         runner.enableControllerService(writer);
         Map<String, String> attributes = new HashMap<>();
-        attributes.put("user.name", "jdoe64");
+        attributes.put("login.name", "jdoe64");
         runner.enqueue("", attributes);
         runner.run();
         // In addition to making sure a flow file was output successfully, also check nothing got rolled back into the incoming queue. May be a moot point as there is a


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

This enables the option of sending out a Useragent header to all InvokeHTTP requests and also adds a sensible default value.

Something like this was present before in the (now deprecated) GetHTTP (but without the default value).

The default useragent value is based on a combination of the version of Nifi at hand, the java version and the operating system version.

In my local environment the end result was this default useragent:

`Apache Nifi/1.10.0-SNAPSHOT (git:rel/nifi-1.9.0-347-gec3ea46; Java/1.8.0_222; Linux 4.4.0-159-generic; amd64; https://nifi.apache.org/)`

To make this possible I changed:
1. The nifi-api now has a generated class that contains several build time variables (like project version, build time and git information).
1. The VariableRegistry ENVIRONMENT_SYSTEM_REGISTRY includes these variables.
1. The StandardProcessorTestRunner now loads the ENVIRONMENT_SYSTEM_REGISTRY variables by default to allow any testing on these variables.
1. The InvokeHTTP now has a property with that holds the useragent value that uses the Expression language to make it dynamic. It is dynamic per flow file so people have the option of writing a flow that changes the useragent per flowfile going through.

This improvement fixes NIFI-6666.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
**Checked using the Travis build**

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
