### PR TITLE
NIFI-6672 Expression language plus operation doesn't check for overflow 

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PlusEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PlusEvaluator.java
@@ -48,7 +48,7 @@ public class PlusEvaluator extends NumberEvaluator {
         if (subjectValue instanceof Double || plus instanceof Double){
             result = subjectValue.doubleValue() + plus.doubleValue();
         } else {
-            result = subjectValue.longValue() + plus.longValue();
+            result = Math.addExact(subjectValue.longValue(), plus.longValue());
         }
         return new NumberQueryResult(result);
     }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PlusEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/PlusEvaluator.java
@@ -48,7 +48,7 @@ public class PlusEvaluator extends NumberEvaluator {
         if (subjectValue instanceof Double || plus instanceof Double){
             result = subjectValue.doubleValue() + plus.doubleValue();
         } else {
-            result = Math.addExact(subjectValue.longValue(), plus.longValue());
+            result = subjectValue.longValue() + plus.longValue();
         }
         return new NumberQueryResult(result);
     }

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -993,8 +993,21 @@ public class TestQuery {
         attributes.put("four", "4");
         attributes.put("five", "5");
         attributes.put("hundred", "100");
+        attributes.put("max_long", String.valueOf(Long.MAX_VALUE));
 
         verifyEquals("${hundred:toNumber():multiply(${two}):divide(${three}):plus(${one}):mod(${five})}", attributes, 2L);
+
+
+        try {
+            // The expected result is purposely an overflow
+            verifyEquals("${max_long:plus(100)}", attributes, Long.MAX_VALUE + 100);
+            fail("Long.MAX_VALUE summed with integer number produced undetected overflow");
+        } catch (ArithmeticException e){
+            // This means the overflow has been detected
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
     }
 
     @Test
@@ -1006,9 +1019,12 @@ public class TestQuery {
         attributes.put("fourth", "4.201");
         attributes.put("fifth", "5.1");
         attributes.put("hundred", "100");
+        attributes.put("max_double", String.valueOf(Double.MAX_VALUE));
 
         // The expected resulted is calculated instead of a set number due to the inaccuracy of double arithmetic
         verifyEquals("${hundred:toNumber():multiply(${second}):divide(${third}):plus(${first}):mod(${fifth})}", attributes, (((100 * 12.3) / 3) + 1.5) %5.1);
+
+        verifyEquals("${max_double:plus(${max_double})}", attributes, Double.POSITIVE_INFINITY);
     }
 
     @Test

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -997,17 +997,8 @@ public class TestQuery {
 
         verifyEquals("${hundred:toNumber():multiply(${two}):divide(${three}):plus(${one}):mod(${five})}", attributes, 2L);
 
-
-        try {
-            // The expected result is purposely an overflow
-            verifyEquals("${max_long:plus(100)}", attributes, Long.MAX_VALUE + 100);
-            fail("Long.MAX_VALUE summed with integer number produced undetected overflow");
-        } catch (ArithmeticException e){
-            // This means the overflow has been detected
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
-
+        // The expected result is purposely an overflow
+        verifyEquals("${max_long:plus(100)}", attributes, Long.MAX_VALUE + 100);
     }
 
     @Test

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -1818,7 +1818,7 @@ Divide. This is to preserve backwards compatibility and to not force rounding er
 === plus
 
 *Description*: [.description]#Adds a numeric value to the Subject. If either the argument or the Subject cannot be
-	coerced into a Number, returns `null`.#
+	coerced into a Number, returns `null`. Does not provide handling for overflow.
 
 *Subject Type*: [.subject]#Number or Decimal#
 


### PR DESCRIPTION
#### Description of PR

*  `TestQuery` adds a unit test to cover the current behavior of `plus` overflow with `Long` values and checks `Double` overflow is correctly promoted to `POSITIVE_INFINITY`
*  Overflow issue is documented

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
