### PR TITLE
NIFI-6682 SplitJson does not work if the input is null

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractJsonPathProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractJsonPathProcessor.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.standard;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
@@ -79,6 +80,16 @@ public abstract class AbstractJsonPathProcessor extends AbstractProcessor {
                 try (BufferedInputStream bufferedInputStream = new BufferedInputStream(in)) {
                     DocumentContext ctx = JsonPath.using(STRICT_PROVIDER_CONFIGURATION).parse(bufferedInputStream);
                     contextHolder.set(ctx);
+                } catch (IllegalArgumentException iae) {
+                    // The JsonPath.parse() above first parses the json, then creates a context object from the parsed
+                    // json.  It is possible for the json parsing to complete without error, but produce a null object.
+                    // In this case the context creation will fail and throw an IllegalArgumentException.  This is in
+                    // my opinion a bug in the JsonPath library, as it doesn't really throw the correct exception
+                    // contextually.
+                    // The general handling in derived classes handles InvalidJsonException.
+                    // The best thing to do here, is to re-throw with the proper exception, such that the calling logic
+                    // can route.
+                    throw new InvalidJsonException(iae);
                 }
             }
         });

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitJson.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitJson.java
@@ -235,4 +235,23 @@ public class TestSplitJson {
             testRunner.getFlowFilesForRelationship(SplitJson.REL_SPLIT).get(i).assertContentEquals("null");
         }
     }
+
+    @Test
+    public void testSplit_pathToInputStringNullValue() throws Exception {
+        final TestRunner testRunner = TestRunners.newTestRunner(new SplitJson());
+        testRunner.setProperty(SplitJson.ARRAY_JSON_PATH_EXPRESSION, "$.*");
+        ProcessSession session = testRunner.getProcessSessionFactory().createSession();
+        FlowFile ff = session.create();
+        ff = session.write(ff, new OutputStreamCallback() {
+            @Override
+            public void process(OutputStream out) throws IOException {
+                try (OutputStream outputStream = new BufferedOutputStream(out)) {
+                    outputStream.write("null".getBytes(StandardCharsets.UTF_8));
+                }
+            }
+        });
+        testRunner.enqueue(ff);
+        testRunner.run();
+        testRunner.assertTransferCount(SplitJson.REL_FAILURE, 1);
+    }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

fixes bug NIFI-6682

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
https://travis-ci.org/ottobackwards/nifi/builds/590176405
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [-] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [-] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/nifi/3772)
<!-- Reviewable:end -->
