### PR TITLE
NIFI-6587 - Fix: Unable save sensitive property value that equals masked value

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-parameter-contexts.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-parameter-contexts.js
@@ -958,6 +958,11 @@
             } else {
                 // value is not sensitive or it is sensitive and the user has changed it then always take the current value
                 serializedValue = value;
+
+                // if the param is sensitive and the param value has not "changed", that means it matches the mask and it should still be considered changed
+                if (!hasChanged && !_.isEmpty(parameter) && parameter.sensitive === true && parameter.isNew === false) {
+                    hasChanged = true;
+                }
             }
         } else {
             if (isChecked) {
@@ -1610,15 +1615,7 @@
                     e.stopImmediatePropagation();
                 } else if (target.hasClass('edit-parameter')) {
                     var closeHandler = function () {
-                        $('#parameter-name').val('');
-                        $('#parameter-value-field').val('');
-                        $('#parameter-description-field').val('');
-                        $('#parameter-sensitive-radio-button').prop('checked', false);
-                        $('#parameter-not-sensitive-radio-button').prop('checked', false);
-                        $('#parameter-name').prop('disabled', false);
-                        $('#parameter-sensitive-radio-button').prop('disabled', false);
-                        $('#parameter-not-sensitive-radio-button').prop('disabled', false);
-                        $('#parameter-set-empty-string-field').removeClass('checkbox-checked').addClass('checkbox-unchecked');
+                        resetParameterDialog();
                     };
 
                     var openHandler = function () {


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

There was an issue where the `Apply` button on the Edit Parameter dialog wouldn't be enabled if the parameter value entered matches the masked value that the server sends to the UI (`********`  - 8 asterisks). This PR fixes that as well as ensures that `Set Empty String` checkbox is reset on dialog close like the other input fields.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
