### PR TITLE
NIFI-6751: Fixing user table identifier

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/users/nf-users-table.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/users/nf-users-table.js
@@ -1342,7 +1342,7 @@
                 });
 
                 // set the rows
-                usersData.setItems(users, 'uri');
+                usersData.setItems(users);
 
                 // end the update
                 usersData.endUpdate();


### PR DESCRIPTION
NIFI-6751:
- Fixing the identifier on the user table. In a previous task, this was changed to utilize the URI but that does not work with other code interacting with this table.