### PR TITLE
NIFI-6760: When writing/reading the length of a DataFrame, do so usin…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/LoadBalanceSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/LoadBalanceSession.java
@@ -319,16 +319,15 @@ public class LoadBalanceSession {
                 final byte[] compressed = compressDataFrame(byteBuffer, bytesRead);
                 final int compressedMaxLen = compressed.length;
 
-                buffer = ByteBuffer.allocate(3 + compressedMaxLen);
+                buffer = ByteBuffer.allocate(5 + compressedMaxLen);
                 buffer.put((byte) LoadBalanceProtocolConstants.DATA_FRAME_FOLLOWS);
-                buffer.putShort((short) compressedMaxLen);
+                buffer.putInt(compressedMaxLen);
 
                 buffer.put(compressed, 0, compressedMaxLen);
-
             } else {
-                buffer = ByteBuffer.allocate(3 + bytesRead);
+                buffer = ByteBuffer.allocate(5 + bytesRead);
                 buffer.put((byte) LoadBalanceProtocolConstants.DATA_FRAME_FOLLOWS);
-                buffer.putShort((short) bytesRead);
+                buffer.putInt(bytesRead);
 
                 buffer.put(byteBuffer, 0, bytesRead);
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/server/StandardLoadBalanceProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/server/StandardLoadBalanceProtocol.java
@@ -499,7 +499,7 @@ public class StandardLoadBalanceProtocol implements LoadBalanceProtocol {
             throw new IOException("Expected a Data Frame Indicator from Peer " + peerDescription + " but received a value of " + dataFrameIndicator);
         }
 
-        int dataFrameLength = in.readUnsignedShort();
+        int dataFrameLength = in.readInt();
         logger.trace("Received Data Frame Length of {} for {}", dataFrameLength, peerDescription);
 
         byte[] buffer = getDataBuffer();
@@ -535,7 +535,7 @@ public class StandardLoadBalanceProtocol implements LoadBalanceProtocol {
                 throw new IOException("Expected a Data Frame Indicator from Peer " + peerDescription + " but received a value of " + dataFrameIndicator);
             }
 
-            dataFrameLength = in.readUnsignedShort();
+            dataFrameLength = in.readInt();
             logger.trace("Received Data Frame Length of {} for {}", dataFrameLength, peerDescription);
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/client/async/nio/TestLoadBalanceSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/client/async/nio/TestLoadBalanceSession.java
@@ -157,7 +157,7 @@ public class TestLoadBalanceSession {
         expectedDos.writeLong(flowFile1.getLineageStartDate()); // lineage start date
         expectedDos.writeLong(flowFile1.getEntryDate()); // entry date
         expectedDos.write(LoadBalanceProtocolConstants.DATA_FRAME_FOLLOWS);
-        expectedDos.writeShort(5);
+        expectedDos.writeInt(5);
         expectedDos.write("hello".getBytes());
         expectedDos.write(LoadBalanceProtocolConstants.NO_DATA_FRAME);
 
@@ -171,7 +171,7 @@ public class TestLoadBalanceSession {
         expectedDos.writeLong(flowFile2.getLineageStartDate()); // lineage start date
         expectedDos.writeLong(flowFile2.getEntryDate()); // entry date
         expectedDos.write(LoadBalanceProtocolConstants.DATA_FRAME_FOLLOWS);
-        expectedDos.writeShort(8);
+        expectedDos.writeInt(8);
         expectedDos.write("good-bye".getBytes());
         expectedDos.write(LoadBalanceProtocolConstants.NO_DATA_FRAME);
 
@@ -246,12 +246,12 @@ public class TestLoadBalanceSession {
 
         // first data frame
         expectedDos.write(LoadBalanceProtocolConstants.DATA_FRAME_FOLLOWS);
-        expectedDos.writeShort(LoadBalanceSession.MAX_DATA_FRAME_SIZE);
+        expectedDos.writeInt(LoadBalanceSession.MAX_DATA_FRAME_SIZE);
         expectedDos.write(Arrays.copyOfRange(content, 0, LoadBalanceSession.MAX_DATA_FRAME_SIZE));
 
         // second data frame
         expectedDos.write(LoadBalanceProtocolConstants.DATA_FRAME_FOLLOWS);
-        expectedDos.writeShort(content.length - LoadBalanceSession.MAX_DATA_FRAME_SIZE);
+        expectedDos.writeInt(content.length - LoadBalanceSession.MAX_DATA_FRAME_SIZE);
         expectedDos.write(Arrays.copyOfRange(content, LoadBalanceSession.MAX_DATA_FRAME_SIZE, content.length));
         expectedDos.write(LoadBalanceProtocolConstants.NO_DATA_FRAME);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/server/TestStandardLoadBalanceProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/server/TestStandardLoadBalanceProtocol.java
@@ -655,7 +655,7 @@ public class TestStandardLoadBalanceProtocol {
             final int length = Math.min(content.length - offset, 65535);
 
             out.write(DATA_FRAME_FOLLOWS);
-            out.writeShort(length);
+            out.writeInt(length);
             out.write(content, offset, length);
         }
 


### PR DESCRIPTION
…g a 4-byte integer instead of a 2-byte short. When using uncompressed data, we know that the length of the DataFrame will be no more than 64 KB so a 2-byte short is sufficient. However, if data is compresed, there's a chance that the compressed form of the data will be larger than the uncompressed form (for example, with random binary data or with encrypted data). In this situation, we can end up overflowing the 2-byte short, which causes the length that is written to be wrong. Using a 4-byte integer avoids this situation.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
