### PR TITLE
NIFI-6766: Escape policy label

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/users/nf-users-table.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/users/nf-users-table.js
@@ -556,7 +556,7 @@
         }
 
         var subResource = nfCommon.substringAfterFirst(resource, '/restricted-components/');
-        return "Restricted components requiring '" + subResource + "'";
+        return "Restricted components requiring '" + nfCommon.escapeHtml(subResource) + "'";
     };
 
     /**
@@ -609,9 +609,9 @@
         }
 
         if (dataContext.component.componentReference.permissions.canRead === true) {
-            policyLabel += '<span style="font-weight: 500">' + dataContext.component.componentReference.component.name + '</span>';
+            policyLabel += '<span style="font-weight: 500">' + nfCommon.escapeHtml(dataContext.component.componentReference.component.name) + '</span>';
         } else {
-            policyLabel += '<span class="unset">' + dataContext.component.componentReference.id + '</span>'
+            policyLabel += '<span class="unset">' + nfCommon.escapeHtml(dataContext.component.componentReference.id) + '</span>'
         }
 
         return policyLabel;


### PR DESCRIPTION
NIFI-6766:
- Ensuring policy label is properly escaped when populating the user's access policy listing.