### PR TITLE
NIFI-6795

### DIFF
--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/couchbase/CouchbaseMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/couchbase/CouchbaseMapCacheClient.java
@@ -145,7 +145,7 @@ public class CouchbaseMapCacheClient extends AbstractControllerService implement
 
     @Override
     public <K, V> boolean replace(AtomicCacheEntry<K, V, Long> entry, Serializer<K> keySerializer, Serializer<V> valueSerializer) throws IOException {
-        final Long revision = entry.getRevision().orElse(0L);
+        final Long revision = entry.getRevision().orElse(-1L);
         final String docId = toDocumentId(entry.getKey(), keySerializer);
         final Document doc = toDocument(docId, entry.getValue(), valueSerializer, revision);
         try {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/users/nf-users-table.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/users/nf-users-table.js
@@ -1342,7 +1342,7 @@
                 });
 
                 // set the rows
-                usersData.setItems(users, 'uri');
+                usersData.setItems(users);
 
                 // end the update
                 usersData.endUpdate();


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Fix for NIFI-6795 - change 
  ` 'final Long revision = entry.getRevision().orElse(0L);' `
to 
 `  'final Long revision = entry.getRevision().orElse(-1L);' "`
in CouchbaseMapCacheClient.java




