### PR TITLE
NIFI-6687: Fixing Ranger unit tests

### DIFF
--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/ManagedRangerAuthorizerTest.java
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/ManagedRangerAuthorizerTest.java
@@ -68,7 +68,7 @@ public class ManagedRangerAuthorizerTest {
                 + "</userGroupProvider>"
             + "</managedRangerAuthorizations>";
 
-    private final String serviceType = "nifiService";
+    private final String serviceType = "nifi";
     private final String appId = "nifiAppId";
 
     @Before

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/TestRangerNiFiAuthorizer.java
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/src/test/java/org/apache/nifi/ranger/authorization/TestRangerNiFiAuthorizer.java
@@ -64,7 +64,7 @@ public class TestRangerNiFiAuthorizer {
     private AuthorizerConfigurationContext configurationContext;
     private NiFiProperties nifiProperties;
 
-    private final String serviceType = "nifiService";
+    private final String serviceType = "nifi";
     private final String appId = "nifiAppId";
 
     private RangerAccessResult allowedResult;


### PR DESCRIPTION
NIFI-6687:
- Using correct NiFi Ranger Service name in unit tests.