### PR TITLE
NIFI-6827 Mismatch in "lib" directories of rpm and non-rpm build

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -1020,29 +1020,40 @@ language governing permissions and limitations under the License. -->
                                             <dependency>
                                                 <excludes>
                                                     <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                                    <exclude>org.apache.commons:commons-configuration2</exclude>
                                                     <exclude>org.apache.commons:commons-lang3</exclude>
+                                                    <exclude>org.apache.commons:commons-text</exclude>
                                                     <!-- must be in lib <exclude>org.slf4j:jul-to-slf4j</exclude> -->
                                                     <!-- must be in lib <exclude>ch.qos.logback:logback-classic</exclude> -->
                                                     <!-- must be in lib <exclude>javax.servlet:javax.servlet-api</exclude> -->
-                                                    <!-- must be in lin <exclude>org.eclipse.jetty.toolchain:jetty-schemas<exclude> -->
+                                                    <!-- must be in lib <exclude>org.eclipse.jetty.toolchain:jetty-schemas<exclude> -->
                                                     <exclude>javax.mail:mail</exclude>
                                                     <!-- must be in lib <exclude>org.apache.nifi:nifi-api</exclude> -->
                                                     <exclude>org.apache.nifi:nifi-bootstrap</exclude>
                                                     <exclude>org.apache.nifi:nifi-expression-language</exclude>
+                                                    <exclude>org.apache.nifi:nifi-parameter</exclude>
                                                     <exclude>org.apache.nifi:nifi-processor-utils</exclude>
                                                     <!-- must be in lib <exclude>org.apache.nifi:nifi-properties</exclude> -->
                                                     <exclude>org.apache.nifi:nifi-properties-loader</exclude>
                                                     <!-- must be in lib <exclude>org.slf4j:slf4j-api</exclude> -->
                                                     <exclude>javax.activation:activation</exclude>
+                                                    <exclude>com.sun.activation:javax.activation</exclude>
                                                     <exclude>org.antlr:antlr-runtime</exclude>
                                                     <exclude>asm:asm</exclude>
                                                     <exclude>net.minidev:asm</exclude>
+                                                    <exclude>org.ow2.asm:asm</exclude>
+                                                    <exclude>net.minidev:accessors-smart</exclude>
                                                     <exclude>org.bouncycastle:bcpkix-jdk15on</exclude>
+                                                    <exclude>commons-codec:commons-codec</exclude>
                                                     <exclude>commons-io:commons-io</exclude>
+                                                    <exclude>commons-logging:commons-logging</exclude>
                                                     <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
                                                     <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
                                                     <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
                                                     <exclude>com.jayway.jsonpath:json-path</exclude>
+                                                    <exclude>de.svenkubiak:jBCrypt</exclude>
+                                                    <exclude>net.java.dev.jna:jna</exclude>
+                                                    <exclude>net.java.dev.jna:jna-platform</exclude>
                                                     <exclude>net.minidev:json-smart</exclude>
                                                     <!-- must be in lib <exclude>ch.qos.logback:logback-core</exclude> -->
                                                     <exclude>org.apache.nifi:nifi-security-utils</exclude>
@@ -1051,6 +1062,8 @@ language governing permissions and limitations under the License. -->
                                                     which are also not in bootstrap -->
                                                     <exclude>org.apache.nifi:nifi-resources</exclude>
                                                     <exclude>org.apache.nifi:nifi-docs</exclude>
+                                                    <exclude>com.squareup.okhttp3:okhttp</exclude>
+                                                    <exclude>com.squareup.okio:okio</exclude>
                                                     <!-- exclude jaxb/activation/annotation libs from lib, they'll be included in the java11 subdir -->
                                                     <!-- TODO: remove these once minimum Java version is 11 -->
                                                     <exclude>javax.xml.bind:jaxb-api</exclude>
@@ -1066,27 +1079,38 @@ language governing permissions and limitations under the License. -->
                                             <dependency>
                                                 <includes>
                                                     <include>org.bouncycastle:bcprov-jdk15on</include>
+                                                    <include>org.apache.commons:commons-configuration2</include>
                                                     <include>org.apache.commons:commons-lang3</include>
+                                                    <include>org.apache.commons:commons-text</include>
                                                     <!-- already in lib <include>org.slf4j:jul-to-slf4j</include> -->
                                                     <include>ch.qos.logback:logback-classic</include>
                                                     <include>javax.mail:mail</include>
                                                     <include>org.apache.nifi:nifi-api</include>
                                                     <include>org.apache.nifi:nifi-bootstrap</include>
                                                     <include>org.apache.nifi:nifi-expression-language</include>
+                                                    <include>org.apache.nifi:nifi-parameter</include>
                                                     <include>org.apache.nifi:nifi-processor-utils</include>
                                                     <!-- already in lib <include>org.apache.nifi:nifi-properties</include> -->
                                                     <include>org.apache.nifi:nifi-properties-loader</include>
                                                     <include>org.slf4j:slf4j-api</include>
                                                     <include>javax.activation:activation</include>
+                                                    <include>com.sun.activation:javax.activation</include>
                                                     <include>org.antlr:antlr-runtime</include>
                                                     <include>asm:asm</include>
                                                     <include>net.minidev:asm</include>
+                                                    <include>org.ow2.asm:asm</include>
+                                                    <include>net.minidev:accessors-smart</include>
                                                     <include>org.bouncycastle:bcpkix-jdk15on</include>
+                                                    <include>commons-codec:commons-codec</include>
                                                     <include>commons-io:commons-io</include>
+                                                    <include>commons-logging:commons-logging</include>
                                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                                     <include>com.fasterxml.jackson.core:jackson-core</include>
                                                     <include>com.fasterxml.jackson.core:jackson-databind</include>
                                                     <include>com.jayway.jsonpath:json-path</include>
+                                                    <include>de.svenkubiak:jBCrypt</include>
+                                                    <include>net.java.dev.jna:jna</include>
+                                                    <include>net.java.dev.jna:jna-platform</include>
                                                     <include>net.minidev:json-smart</include>
                                                     <include>ch.qos.logback:logback-core</include>
                                                     <include>org.apache.nifi:nifi-security-utils</include>


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

We have a mismatch in the "lib" directories of rpm and non-rpm build. This causes that NiFi (with Java 11) doesn't start up from the rpm build. Some jar files should be located in the "lib/bootstrap/" but they are currently in "lib/". This PR fixes it to match them.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
