### PR TITLE
NIFI-6836 Increased topic list length in ConsumeKafka and added validator

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_1_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_1_0.java
@@ -89,9 +89,10 @@ public class ConsumeKafka_1_0 extends AbstractProcessor {
     static final PropertyDescriptor TOPICS = new PropertyDescriptor.Builder()
             .name("topic")
             .displayName("Topic Name(s)")
-            .description("The name of the Kafka Topic(s) to pull from. More than one can be supplied if comma separated.")
+            .description("The name of the Kafka Topic(s) to pull from. More than one can be supplied if comma separated. " +
+                    "Maximum length of topic list is " + ConsumeKafkaRecord_1_0.TOPIC_LIST_MAX_LENGTH + ".")
             .required(true)
-            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .addValidator(ConsumeKafkaRecord_1_0.createListLengthValidator(ConsumeKafkaRecord_1_0.TOPIC_LIST_MAX_LENGTH))
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
@@ -304,7 +305,7 @@ public class ConsumeKafka_1_0 extends AbstractProcessor {
         final Pattern headerNamePattern = headerNameRegex == null ? null : Pattern.compile(headerNameRegex);
 
         if (topicType.equals(TOPIC_NAME.getValue())) {
-            for (final String topic : topicListing.split(",", 100)) {
+            for (final String topic : topicListing.split(",", ConsumeKafkaRecord_1_0.TOPIC_LIST_MAX_LENGTH)) {
                 final String trimmedName = topic.trim();
                 if (!trimmedName.isEmpty()) {
                     topics.add(trimmedName);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaTest.java
@@ -52,9 +52,11 @@ public class ConsumeKafkaTest {
         runner.assertNotValid();
         runner.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         runner.assertValid();
+        runner.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        runner.assertNotValid();
         runner.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         runner.assertValid();
-        runner.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        runner.setProperty(ConsumeKafka_1_0.TOPICS, "  ");
         runner.assertNotValid();
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafkaRecord_1_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafkaRecord_1_0.java
@@ -39,6 +39,9 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public class TestConsumeKafkaRecord_1_0 {
 
     private ConsumerLease mockLease = null;
@@ -87,10 +90,22 @@ public class TestConsumeKafkaRecord_1_0 {
         runner.assertNotValid();
         runner.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         runner.assertValid();
-        runner.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        runner.assertValid();
         runner.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         runner.assertNotValid();
+        runner.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        runner.assertValid();
+        runner.setProperty(ConsumeKafkaRecord_1_0.TOPICS, prepareTopics(999));
+        runner.assertValid();
+        runner.setProperty(ConsumeKafkaRecord_1_0.TOPICS, prepareTopics(1000));
+        runner.assertValid();
+        runner.setProperty(ConsumeKafkaRecord_1_0.TOPICS, prepareTopics(1001));
+        runner.assertNotValid();
+        runner.setProperty(ConsumeKafkaRecord_1_0.TOPICS, "   ");
+        runner.assertNotValid();
+    }
+
+    private String prepareTopics(int length){
+        return Stream.<Integer>iterate(0, (a) -> a+1).map(s -> "topic"+s).limit(length).collect(Collectors.joining(","));
     }
 
     @Test


### PR DESCRIPTION
#### Description of PR

NIFI-6836 - this PR increases the topic length limit from 100 to 1000 and also adds validator to warn the user about it. 

I've submitted this issue few days ago and prepared initial version of PR - fixed only for `KafkaConsumer1_0`. This bug is in every Kafka Consumer, from 0_10 to 2_0. I can also make changes in all files, but maybe some refactoring should be done? Some `AbstractKafkaConsumer` with all common properties? Or maybe current approach is intended as you do want to mix code between different versions of Kafka Consumer?

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
