### PR TITLE
NIFI-6931 Add status-history graph to track backpressure estimates

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -248,6 +248,7 @@ public abstract class NiFiProperties {
     public static final String ANALYTICS_CONNECTION_MODEL_IMPLEMENTATION = "nifi.analytics.connection.model.implementation";
     public static final String ANALYTICS_CONNECTION_MODEL_SCORE_NAME= "nifi.analytics.connection.model.score.name";
     public static final String ANALYTICS_CONNECTION_MODEL_SCORE_THRESHOLD = "nifi.analytics.connection.model.score.threshold";
+    public static final String ANALYTICS_STATUS_GRAPH_DISPLAY_THRESHOLD = "nifi.analytics.status.graph.display.threshold";
 
     // defaults
     public static final Boolean DEFAULT_AUTO_RESUME_STATE = true;
@@ -321,10 +322,13 @@ public abstract class NiFiProperties {
     // analytics defaults
     public static final String DEFAULT_ANALYTICS_PREDICTION_ENABLED = "false";
     public static final String DEFAULT_ANALYTICS_PREDICTION_INTERVAL = "3 mins";
-    public static final String DEFAULT_ANALYTICS_QUERY_INTERVAL = "3 mins";
+    public static final String DEFAULT_ANALYTICS_QUERY_INTERVAL = "5 mins";
     public final static String DEFAULT_ANALYTICS_CONNECTION_MODEL_IMPLEMENTATION = "org.apache.nifi.controller.status.analytics.models.OrdinaryLeastSquares";
     public static final String DEFAULT_ANALYTICS_CONNECTION_SCORE_NAME = "rSquared";
     public static final double DEFAULT_ANALYTICS_CONNECTION_SCORE_THRESHOLD = .90;
+    // This is the time, below which the status history graph will actively display
+    // backpressure estimates if prediction analytics are enabled.
+    public static final String DEFAULT_ANALYTICS_STATUS_GRAPH_THRESHOLD = "6 hrs";
 
     /**
      * Retrieves the property value for the given property key.

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/status/history/MetricDescriptor.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/status/history/MetricDescriptor.java
@@ -49,6 +49,14 @@ public interface MetricDescriptor<T> {
     String getLabel();
 
     /**
+     * no-op method that allows the MetricDescriptor labels to be updated.
+     * Used default method to not break existing interfaces using MetricDescriptor.
+     * Created to allow the backpressure graph label to be updated if prediction
+     * analytics are not implemented.
+     */
+    default void updateLabel(String lbl) {}
+
+    /**
      * @return the name of a field
      */
     String getField();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/AbstractMetricDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/AbstractMetricDescriptor.java
@@ -21,7 +21,7 @@ import java.util.List;
 public abstract class AbstractMetricDescriptor<T> implements MetricDescriptor<T> {
     private final IndexableMetric indexableMetric;
     private final String field;
-    private final String label;
+    private String label;
     private final String description;
     private final MetricDescriptor.Formatter formatter;
     private final ValueMapper<T> valueMapper;
@@ -94,5 +94,10 @@ public abstract class AbstractMetricDescriptor<T> implements MetricDescriptor<T>
 
             return sum;
         }
+    }
+
+    @Override
+    public void updateLabel(String label) {
+        this.label = label;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/nifi-context.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/nifi-context.xml
@@ -65,6 +65,17 @@
         <property name="authorizer" ref="authorizer" />
     </bean>
 
+    <!-- enable backpressure status history graph display properties -->
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod"
+                  value="org.apache.nifi.controller.status.history.ConnectionStatusDescriptor.setNifiProperties" />
+        <property name="arguments">
+            <list>
+                <ref bean="nifiProperties" />
+            </list>
+        </property>
+    </bean>
+
     <!-- bulletin repository -->
     <bean id="bulletinRepository" class="org.apache.nifi.events.VolatileBulletinRepository" />
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/TestConnectionStatusDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/TestConnectionStatusDescriptor.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.status.history;
+
+import org.apache.nifi.controller.status.ConnectionStatus;
+import org.apache.nifi.controller.status.analytics.ConnectionStatusPredictions;
+import org.apache.nifi.util.NiFiProperties;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestConnectionStatusDescriptor {
+
+  private NiFiProperties mockNiFiProperties;
+  private final String DEFAULT_LABEL = "Backpressure Estimate";
+  private final String MODIFIED_LABEL = "Backpressure Estimate (Disabled)";
+  private final String FIELD_NAME = "backpressureEstimate";
+
+  private final int  COUNT_THRESHOLD = 100;
+  private final long BYTE_THRESHOLD = 100L;
+
+  /**
+   * Test that Status History Backpressure label is correct when analytics enabled.
+   */
+  @Test
+  public void testActiveLabel() {
+    mockNiFiProperties = mock(NiFiProperties.class);
+    when(mockNiFiProperties.getProperty(NiFiProperties.ANALYTICS_PREDICTION_ENABLED,
+        NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_ENABLED)).thenReturn("true");
+    ConnectionStatusDescriptor.setNifiProperties(mockNiFiProperties);
+
+    Set<MetricDescriptor<?>> CONNECTION_METRICS =
+        Arrays.stream(ConnectionStatusDescriptor.values())
+            .map(ConnectionStatusDescriptor::getDescriptor)
+            .collect(Collectors.toSet());
+
+    CONNECTION_METRICS.forEach(p -> {
+      if (p.getField().equals(FIELD_NAME)) {
+        Assert.assertEquals(DEFAULT_LABEL, p.getLabel());
+      }
+    });
+  }
+
+  /**
+   * Test that Status History Backpressure label is correct when analytics disabled.
+   */
+  @Test
+  public void testInactiveLabel() {
+    mockNiFiProperties = mock(NiFiProperties.class);
+    when(mockNiFiProperties.getProperty(NiFiProperties.ANALYTICS_PREDICTION_ENABLED,
+        NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_ENABLED)).thenReturn("false");
+    ConnectionStatusDescriptor.setNifiProperties(mockNiFiProperties);
+
+    Set<MetricDescriptor<?>> CONNECTION_METRICS =
+        Arrays.stream(ConnectionStatusDescriptor.values())
+            .map(ConnectionStatusDescriptor::getDescriptor)
+            .collect(Collectors.toSet());
+
+    CONNECTION_METRICS.forEach(p -> {
+      if (p.getField().equals(FIELD_NAME)) {
+        Assert.assertEquals(MODIFIED_LABEL, p.getLabel());
+      }
+    });
+  }
+
+  /**
+   * Test correct value returned when predictions are null
+   */
+  @Test
+  public void testGraphPointWithNoPredictions() {
+    ConnectionStatus status = new ConnectionStatus();
+    Assert.assertNull(status.getPredictions());
+    Assert.assertEquals(-1L, ConnectionStatusDescriptor.getGraphPoint(status));
+  }
+
+  //
+  // Verify getGraphPoint returns expected values given various prediction and queue values.
+  //
+  @Test
+  public void testGraphPointValues() {
+    long graphPoint;
+    String GRAPH_THRESHOLD_AS_STRING = "6 hrs";
+    long GRAPH_THRESHOLD = 21_600_000;
+    int MISC_COUNT = 45;
+    long MISC_BYTE = 55;
+    long PREDICTION = 10_000_000L;
+    long LARGE_PREDICTION = 20_000_000L;
+    long SMALL_PREDICTION = 1000L;
+    long EXCESS_PREDICTION = 50_000_000L;
+    long OFFSET = 100;
+
+    mockNiFiProperties = mock(NiFiProperties.class);
+    when(mockNiFiProperties.getProperty(NiFiProperties.ANALYTICS_PREDICTION_ENABLED,
+        NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_ENABLED)).thenReturn("true");
+    when(mockNiFiProperties.getProperty(NiFiProperties.ANALYTICS_STATUS_GRAPH_DISPLAY_THRESHOLD,
+        NiFiProperties.DEFAULT_ANALYTICS_STATUS_GRAPH_THRESHOLD)).thenReturn(
+        GRAPH_THRESHOLD_AS_STRING);
+    ConnectionStatusDescriptor.setNifiProperties(mockNiFiProperties);
+    ConnectionStatusPredictions predictions = new ConnectionStatusPredictions();
+    ConnectionStatus status = new ConnectionStatus();
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-1", 0, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0L, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-2", MISC_COUNT, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0L, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-3", COUNT_THRESHOLD, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0L, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-4", 0, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0L, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-5", 0, COUNT_THRESHOLD);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0L, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-6", MISC_COUNT, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0L, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-7", 0, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(PREDICTION, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(EXCESS_PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(-1L);
+    setStatusValues(predictions, status, "Connection-8", MISC_COUNT, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(GRAPH_THRESHOLD, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(PREDICTION);
+    setStatusValues(predictions, status, "Connection-9", 0, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(PREDICTION, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(PREDICTION);
+    setStatusValues(predictions, status, "Connection-10", COUNT_THRESHOLD, 0L);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(EXCESS_PREDICTION);
+    setStatusValues(predictions, status, "Connection-11", 0, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(GRAPH_THRESHOLD, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(EXCESS_PREDICTION);
+    setStatusValues(predictions, status, "Connection-12", COUNT_THRESHOLD, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(EXCESS_PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(EXCESS_PREDICTION);
+    setStatusValues(predictions, status, "Connection-13", MISC_COUNT, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(GRAPH_THRESHOLD, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(LARGE_PREDICTION);
+    setStatusValues(predictions, status, "Connection-14", MISC_COUNT, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(PREDICTION, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(SMALL_PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(SMALL_PREDICTION + OFFSET);
+    setStatusValues(predictions, status, "Connection-15", COUNT_THRESHOLD, BYTE_THRESHOLD);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(SMALL_PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(SMALL_PREDICTION + OFFSET);
+    setStatusValues(predictions, status, "Connection-16", MISC_COUNT, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(SMALL_PREDICTION, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(PREDICTION);
+    setStatusValues(predictions, status, "Connection-17", COUNT_THRESHOLD, BYTE_THRESHOLD);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(-1L);
+    predictions.setPredictedTimeToBytesBackpressureMillis(PREDICTION);
+    setStatusValues(predictions, status, "Connection-18", MISC_COUNT, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(PREDICTION, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(SMALL_PREDICTION);
+    setStatusValues(predictions, status, "Connection-19", MISC_COUNT, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(SMALL_PREDICTION, graphPoint);
+
+    predictions.setPredictedTimeToCountBackpressureMillis(EXCESS_PREDICTION);
+    predictions.setPredictedTimeToBytesBackpressureMillis(EXCESS_PREDICTION);
+    setStatusValues(predictions, status, "Connection-20", COUNT_THRESHOLD, MISC_BYTE);
+    graphPoint = ConnectionStatusDescriptor.getGraphPoint(status);
+    Assert.assertEquals(0, graphPoint);
+  }
+
+
+  private void setStatusValues(ConnectionStatusPredictions predictions, ConnectionStatus status,
+      String connectionName, int queuedCount, long queuedBytes) {
+    status.setName(connectionName);
+    status.setBackPressureObjectThreshold(COUNT_THRESHOLD);
+    status.setBackPressureBytesThreshold(BYTE_THRESHOLD);
+    status.setPredictions(predictions);
+    status.setQueuedCount(queuedCount);
+    status.setQueuedBytes(queuedBytes);
+  }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -216,6 +216,9 @@
         <nifi.analytics.connection.model.implementation>org.apache.nifi.controller.status.analytics.models.OrdinaryLeastSquares</nifi.analytics.connection.model.implementation>
         <nifi.analytics.connection.model.score.name>rSquared</nifi.analytics.connection.model.score.name>
         <nifi.analytics.connection.model.score.threshold>.90</nifi.analytics.connection.model.score.threshold>
+        <!-- The time in hours, below which the status history graph will actively display
+        backpressure estimates -->
+        <nifi.analytics.status.graph.display.threshold>6 hrs</nifi.analytics.status.graph.display.threshold>
     </properties>
     <build>
         <plugins>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -264,3 +264,4 @@ nifi.analytics.query.interval=${nifi.analytics.query.interval}
 nifi.analytics.connection.model.implementation=${nifi.analytics.connection.model.implementation}
 nifi.analytics.connection.model.score.name=${nifi.analytics.connection.model.score.name}
 nifi.analytics.connection.model.score.threshold=${nifi.analytics.connection.model.score.threshold}
+nifi.analytics.status.graph.display.threshold=${nifi.analytics.status.graph.display.threshold}


### PR DESCRIPTION
NIFI-6931 Add a new status history graph that tracks the time-to-backpressure
estimates that are calculated when utilizing the prediction analytics
engine. When using the analytics engine, the graph will allow users to
view how the backpressure estimates trend over time. A user defined
threshold provides a value to determine the maximum value displayed
onthe graph. The default is 6 hrs.

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ x] Have you written or updated unit tests to verify your changes?
- [ x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
