### PR TITLE
NIFI-6916 - handle null text message in JMSConsumer

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/MessageBodyToBytesConverter.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/MessageBodyToBytesConverter.java
@@ -48,6 +48,9 @@ abstract class MessageBodyToBytesConverter {
      */
     public static byte[] toBytes(TextMessage message, Charset charset) {
         try {
+            if (message.getText() == null) {
+                return new byte[0];
+            }
             if (charset == null) {
                 return message.getText().getBytes();
             } else {
@@ -71,7 +74,6 @@ abstract class MessageBodyToBytesConverter {
             throw new MessageConversionException("Failed to convert BytesMessage to byte[]", e);
         }
     }
-
 
     private static class BytesMessageInputStream extends InputStream {
         private BytesMessage message;
@@ -111,7 +113,6 @@ abstract class MessageBodyToBytesConverter {
             }
         }
     }
-
 
     static class MessageConversionException extends RuntimeException {
         private static final long serialVersionUID = -1464448549601643887L;


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

**Fixes the bug reported in NIFI-6916. If a TextMessage is null, then it will throw a NPE and the message will never be acknowledged.**

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
