### PR TITLE
NIFI-6955 close streams in Reader/writer mock

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/ArrayListRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/ArrayListRecordReader.java
@@ -21,6 +21,7 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -37,7 +38,7 @@ public class ArrayListRecordReader extends AbstractControllerService implements 
 
     @Override
     public ArrayListReader createRecordReader(final Map<String, String> variables, final InputStream in, final long inputLength, final ComponentLog logger) {
-        return new ArrayListReader(records, schema);
+        return new ArrayListReader(records, schema, in);
     }
 
     public void addRecord(final Record record) {
@@ -47,10 +48,12 @@ public class ArrayListRecordReader extends AbstractControllerService implements 
     public static class ArrayListReader implements RecordReader {
         private final RecordSchema schema;
         private final Iterator<Record> itr;
+        private final InputStream in;
 
-        public ArrayListReader(final List<Record> records, final RecordSchema schema) {
+        public ArrayListReader(final List<Record> records, final RecordSchema schema, InputStream in) {
             this.itr = records.iterator();
             this.schema = schema;
+            this.in = in;
         }
 
         @Override
@@ -64,7 +67,8 @@ public class ArrayListRecordReader extends AbstractControllerService implements 
         }
 
         @Override
-        public void close(){
+        public void close() throws IOException {
+            in.close();
         }
     }
 }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/ArrayListRecordWriter.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/ArrayListRecordWriter.java
@@ -49,7 +49,7 @@ public class ArrayListRecordWriter extends AbstractControllerService implements 
 
     @Override
     public RecordSetWriter createWriter(final ComponentLog logger, final RecordSchema schema, final OutputStream out, final Map<String, String> variables) {
-        return new ArrayListRecordSetWriter(records);
+        return new ArrayListRecordSetWriter(records, out);
     }
 
     public List<Record> getRecordsWritten() {
@@ -58,9 +58,11 @@ public class ArrayListRecordWriter extends AbstractControllerService implements 
 
     public static class ArrayListRecordSetWriter implements RecordSetWriter {
         private final List<Record> records;
+        private final OutputStream out;
 
-        public ArrayListRecordSetWriter(final List<Record> records) {
+        public ArrayListRecordSetWriter(final List<Record> records, OutputStream out) {
             this.records = records;
+            this.out = out;
         }
 
         @Override
@@ -97,11 +99,13 @@ public class ArrayListRecordWriter extends AbstractControllerService implements 
         }
 
         @Override
-        public void flush() {
+        public void flush() throws IOException {
+            out.flush();
         }
 
         @Override
-        public void close() {
+        public void close() throws IOException {
+            out.close();
         }
     }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

ArrayListRecordReader (nifi-mock-record-utils) obtain inputStream in own constructor but don't close this. 
ArrayListRecordWriter has the same problem with outputStream.
So if in custom processor i use 
InputStream in = session.read(flowfile)
reader = factory.createRecordReader(flowfile, in, logger)
reader.close() 
Tests fail and complain that file didn't close.

Add streams and close them in close()

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
