### PR TITLE
NIFI-6997: consumeAMQP closing connection when queue not found 

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -205,8 +205,6 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         }
     }
 
-
-
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return propertyDescriptors;

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -194,9 +194,18 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
             return amqpConsumer;
         } catch (final IOException ioe) {
+            try {
+                connection.close();
+                getLogger().warn("Closed connection at port " + connection.getPort());
+            } catch (final IOException ioe_close) {
+                throw new ProcessException("Failed to close connection at port " + connection.getPort());
+            }
+
             throw new ProcessException("Failed to connect to AMQP Broker", ioe);
         }
     }
+
+
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -197,7 +197,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
             try {
                 connection.close();
                 getLogger().warn("Closed connection at port " + connection.getPort());
-            } catch (final IOException ioe_close) {
+            } catch (final IOException ioeClose) {
                 throw new ProcessException("Failed to close connection at port " + connection.getPort());
             }
 


### PR DESCRIPTION
code changes fixes connection bug wherein
- consumeAMQP processor keeps opening tcp-connections while trying to connect to a queue that cannot be found/does not exist. 
- every try results in more connections that are not being closed (immediately)

added code change makes use of the provided connection.close() function inorder to close the connection once connection to queue failed.

see: https://issues.apache.org/jira/projects/NIFI/issues/NIFI-6997