### PR TITLE
NIFI-6964 Use compression level for xz-lzma2 compression format

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
@@ -107,8 +107,8 @@ public class CompressContent extends AbstractProcessor {
     .build();
     public static final PropertyDescriptor COMPRESSION_LEVEL = new PropertyDescriptor.Builder()
     .name("Compression Level")
-    .description("The compression level to use; this is valid only when using GZIP compression. A lower value results in faster processing "
-        + "but less compression; a value of 0 indicates no compression but simply archiving")
+    .description("The compression level to use; this is valid only when using gzip or xz-lzma2 compression. A lower value results in faster processing "
+        + "but less compression; a value of 0 indicates no (that is, simple archiving) for gzip or minimal for xz-lzma2 compression")
         .defaultValue("1")
         .required(true)
         .allowableValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
@@ -264,7 +264,8 @@ public class CompressContent extends AbstractProcessor {
                                     mimeTypeRef.set("application/x-lzma");
                                     break;
                                 case COMPRESSION_FORMAT_XZ_LZMA2:
-                                    compressionOut = new XZOutputStream(bufferedOut, new LZMA2Options());
+                                    final int xzCompressionLevel = context.getProperty(COMPRESSION_LEVEL).asInteger();
+                                    compressionOut = new XZOutputStream(bufferedOut, new LZMA2Options(xzCompressionLevel));
                                     mimeTypeRef.set("application/x-xz");
                                     break;
                                 case COMPRESSION_FORMAT_SNAPPY:


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Enables xz-lzma2 compression format of the CompressContent processor to use the compression level property in addition to the gzip format which already could use compression level; adds functionality requested in NIFI-6964.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ X ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ X ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ X ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ X ] Have you written or updated unit tests to verify your changes? There were no specific tests for the xz-lzma2 format. Apologies I didn't backfill initial tests for this format and then test the compression level. In fact, there were no tests at all for gzip compression level either.
- [ X ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ n/a ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ n/a ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ n/a ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ n/a ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ n/a ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
