### PR TITLE
NIFI-7015 - ConsumeJMS supports additional message types

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -179,6 +179,8 @@ abstract class AbstractJMSProcessor<T extends JMSWorker> extends AbstractProcess
 
         try {
             rendezvousWithJms(context, session, worker);
+        } catch (Exception e) {
+            getLogger().error("Error while trying to process JMS message", e);
         } finally {
             //in case of exception during worker's connection (consumer or publisher),
             //an appropriate service is responsible to invalidate the worker.

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.jms.processors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -23,6 +24,8 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.nifi.jms.cf.JMSConnectionFactoryProviderDefinition;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.util.MockFlowFile;
@@ -31,7 +34,17 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.Test;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
 import org.springframework.jms.support.JmsHeaders;
+
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.jms.StreamMessage;
+import javax.jms.TextMessage;
 
 public class ConsumeJMSIT {
 
@@ -55,6 +68,7 @@ public class ConsumeJMSIT {
             runner.setProperty(PublishJMS.CF_SERVICE, "cfProvider");
             runner.setProperty(ConsumeJMS.DESTINATION, destinationName);
             runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.QUEUE);
+
             runner.run(1, false);
             //
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishJMS.REL_SUCCESS).get(0);
@@ -65,11 +79,183 @@ public class ConsumeJMSIT {
             successFF.assertAttributeEquals("filename", "message.txt");
             successFF.assertAttributeExists("attribute_from_sender");
             successFF.assertAttributeEquals("attribute_from_sender", "some value");
+            successFF.assertAttributeExists("jms.messagetype");
+            successFF.assertAttributeEquals("jms.messagetype", "BytesMessage");
             successFF.assertContentEquals("Hey dude!".getBytes());
             String sourceDestination = successFF.getAttribute(ConsumeJMS.JMS_SOURCE_DESTINATION_NAME);
             assertNotNull(sourceDestination);
         } finally {
             ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
         }
+    }
+
+    @Test
+    public void testValidateErrorQueueWhenDestinationIsTopicAndErrorQueueIsSet() throws Exception {
+        testValidateErrorQueue(ConsumeJMS.TOPIC, "errorQueue", false);
+    }
+
+    @Test
+    public void testValidateErrorQueueWhenDestinationIsTopicAndErrorQueueIsNotSet() throws Exception {
+        testValidateErrorQueue(ConsumeJMS.TOPIC, null, true);
+    }
+
+    @Test
+    public void testValidateErrorQueueWhenDestinationIsQueueAndErrorQueueIsSet() throws Exception {
+        testValidateErrorQueue(ConsumeJMS.QUEUE, "errorQueue", true);
+    }
+
+    @Test
+    public void testValidateErrorQueueWhenDestinationIsQueueAndErrorQueueIsNotSet() throws Exception {
+        testValidateErrorQueue(ConsumeJMS.QUEUE, null, true);
+    }
+
+    private void testValidateErrorQueue(String destinationType, String errorQueue, boolean expectedValid) throws Exception {
+        JmsTemplate jmsTemplate = CommonTest.buildJmsTemplateForDestination(false);
+
+        try {
+            TestRunner runner = TestRunners.newTestRunner(new ConsumeJMS());
+
+            JMSConnectionFactoryProviderDefinition cfService = mock(JMSConnectionFactoryProviderDefinition.class);
+            when(cfService.getIdentifier()).thenReturn("cfService");
+            when(cfService.getConnectionFactory()).thenReturn(jmsTemplate.getConnectionFactory());
+
+            runner.addControllerService("cfService", cfService);
+            runner.enableControllerService(cfService);
+
+            runner.setProperty(PublishJMS.CF_SERVICE, "cfService");
+            runner.setProperty(ConsumeJMS.DESTINATION, "destination");
+            runner.setProperty(ConsumeJMS.DESTINATION_TYPE, destinationType);
+            if (errorQueue != null) {
+                runner.setProperty(ConsumeJMS.ERROR_QUEUE, errorQueue);
+            }
+
+            if (expectedValid) {
+                runner.assertValid();
+            } else {
+                runner.assertNotValid();
+            }
+        } finally {
+            ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
+        }
+    }
+
+    @Test
+    public void testTextMessageTypeAttribute() throws Exception {
+        testMessageTypeAttribute(
+            "testTextMessage",
+            Session::createTextMessage,
+            TextMessage.class.getSimpleName()
+        );
+    }
+
+    @Test
+    public void testByteMessageTypeAttribute() throws Exception {
+        testMessageTypeAttribute(
+            "testByteMessage",
+            Session::createBytesMessage,
+            BytesMessage.class.getSimpleName()
+        );
+    }
+
+    @Test
+    public void testObjectMessageTypeAttribute() throws Exception {
+        String destinationName = "testObjectMessage";
+
+        testMessageTypeAttribute(
+            destinationName,
+            Session::createObjectMessage,
+            ObjectMessage.class.getSimpleName()
+        );
+    }
+
+    @Test
+    public void testStreamMessageTypeAttribute() throws Exception {
+        testMessageTypeAttribute(
+            "testStreamMessage",
+            Session::createStreamMessage,
+            StreamMessage.class.getSimpleName()
+        );
+    }
+
+    @Test
+    public void testMapMessageTypeAttribute() throws Exception {
+        testMessageTypeAttribute(
+            "testMapMessage",
+            Session::createMapMessage,
+            MapMessage.class.getSimpleName()
+        );
+    }
+
+    @Test
+    public void testUnsupportedMessage() throws Exception {
+        JmsTemplate jmsTemplate = CommonTest.buildJmsTemplateForDestination(false);
+        try {
+            ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+
+            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
+
+            sender.jmsTemplate.send("testMapMessage", __ -> createUnsupportedMessage(
+                "unsupportedMessagePropertyKey",
+                "unsupportedMessagePropertyValue"
+            ));
+
+            TestRunner runner = TestRunners.newTestRunner(new ConsumeJMS());
+            JMSConnectionFactoryProviderDefinition cs = mock(JMSConnectionFactoryProviderDefinition.class);
+            when(cs.getIdentifier()).thenReturn("cfProvider");
+            when(cs.getConnectionFactory()).thenReturn(jmsTemplate.getConnectionFactory());
+            runner.addControllerService("cfProvider", cs);
+            runner.enableControllerService(cs);
+
+            runner.setProperty(PublishJMS.CF_SERVICE, "cfProvider");
+            runner.setProperty(ConsumeJMS.DESTINATION, "testMapMessage");
+            runner.setProperty(ConsumeJMS.ERROR_QUEUE, "errorQueue");
+            runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.QUEUE);
+            runner.run(1, false);
+
+            JmsTemplate jmst = new JmsTemplate(cf);
+            Message message = jmst.receive("errorQueue");
+
+            assertNotNull(message);
+            assertEquals(message.getStringProperty("unsupportedMessagePropertyKey"), "unsupportedMessagePropertyValue");
+        } finally {
+            ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
+        }
+    }
+
+    private void testMessageTypeAttribute(String destinationName, final MessageCreator messageCreator, String expectedJmsMessageTypeAttribute) throws Exception {
+        JmsTemplate jmsTemplate = CommonTest.buildJmsTemplateForDestination(false);
+        try {
+            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
+
+            sender.jmsTemplate.send(destinationName, messageCreator);
+
+            TestRunner runner = TestRunners.newTestRunner(new ConsumeJMS());
+            JMSConnectionFactoryProviderDefinition cs = mock(JMSConnectionFactoryProviderDefinition.class);
+            when(cs.getIdentifier()).thenReturn("cfProvider");
+            when(cs.getConnectionFactory()).thenReturn(jmsTemplate.getConnectionFactory());
+            runner.addControllerService("cfProvider", cs);
+            runner.enableControllerService(cs);
+
+            runner.setProperty(PublishJMS.CF_SERVICE, "cfProvider");
+            runner.setProperty(ConsumeJMS.DESTINATION, destinationName);
+            runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.QUEUE);
+            runner.run(1, false);
+            //
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishJMS.REL_SUCCESS).get(0);
+            assertNotNull(successFF);
+
+            successFF.assertAttributeExists(ConsumeJMS.JMS_MESSAGETYPE);
+            successFF.assertAttributeEquals(ConsumeJMS.JMS_MESSAGETYPE, expectedJmsMessageTypeAttribute);
+        } finally {
+            ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
+        }
+    }
+
+    public ActiveMQMessage createUnsupportedMessage(String propertyKey, String propertyValue) throws JMSException {
+        ActiveMQMessage message = new ActiveMQMessage();
+
+        message.setStringProperty(propertyKey, propertyValue);
+
+        return message;
     }
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSManualTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSManualTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jms.processors;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.command.ActiveMQMessage;
+import org.apache.nifi.logging.ComponentLog;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+
+import javax.jms.BytesMessage;
+import javax.jms.ConnectionFactory;
+import javax.jms.MapMessage;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.jms.StreamMessage;
+import javax.jms.TextMessage;
+
+import static org.mockito.Mockito.mock;
+
+@Ignore("Used for manual testing.")
+public class ConsumeJMSManualTest {
+    @Test
+    public void testTextMessage() throws Exception {
+        MessageCreator messageCreator = session -> {
+            TextMessage message = session.createTextMessage("textMessageContent");
+
+            return message;
+        };
+
+        send(messageCreator);
+    }
+
+    @Test
+    public void testBytesMessage() throws Exception {
+        MessageCreator messageCreator = session -> {
+            BytesMessage message = session.createBytesMessage();
+
+            message.writeBytes("bytesMessageContent".getBytes());
+
+            return message;
+        };
+
+        send(messageCreator);
+    }
+
+    @Test
+    public void testObjectMessage() throws Exception {
+        MessageCreator messageCreator = session -> {
+            ObjectMessage message = session.createObjectMessage();
+
+            message.setObject("stringAsObject");
+
+            return message;
+        };
+
+        send(messageCreator);
+    }
+
+    @Test
+    public void testStreamMessage() throws Exception {
+        MessageCreator messageCreator = session -> {
+            StreamMessage message = session.createStreamMessage();
+
+            message.writeBoolean(true);
+            message.writeByte(Integer.valueOf(1).byteValue());
+            message.writeBytes(new byte[] {2, 3, 4});
+            message.writeShort((short)32);
+            message.writeInt(64);
+            message.writeLong(128L);
+            message.writeFloat(1.25F);
+            message.writeDouble(100.867);
+            message.writeChar('c');
+            message.writeString("someString");
+            message.writeObject("stringAsObject");
+
+            return message;
+        };
+
+        send(messageCreator);
+    }
+
+    @Test
+    public void testMapMessage() throws Exception {
+        MessageCreator messageCreator = session -> {
+            MapMessage message = session.createMapMessage();
+
+            message.setBoolean("boolean", true);
+            message.setByte("byte", Integer.valueOf(1).byteValue());
+            message.setBytes("bytes", new byte[] {2, 3, 4});
+            message.setShort("short", (short)32);
+            message.setInt("int", 64);
+            message.setLong("long", 128L);
+            message.setFloat("float", 1.25F);
+            message.setDouble("double", 100.867);
+            message.setChar("char", 'c');
+            message.setString("string", "someString");
+            message.setObject("object", "stringAsObject");
+
+            return message;
+        };
+
+        send(messageCreator);
+    }
+
+    @Test
+    public void testUnsupportedMessage() throws Exception {
+        MessageCreator messageCreator = session -> new ActiveMQMessage();
+
+        send(messageCreator);
+    }
+
+    private void send(MessageCreator messageCreator) throws Exception {
+        final String  destinationName = "TEST";
+
+        ConnectionFactory activeMqConnectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
+        final ConnectionFactory connectionFactory = new CachingConnectionFactory(activeMqConnectionFactory);
+
+        JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+        jmsTemplate.setPubSubDomain(false);
+        jmsTemplate.setSessionAcknowledgeMode(Session.CLIENT_ACKNOWLEDGE);
+        jmsTemplate.setReceiveTimeout(10L);
+
+        try {
+            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
+
+            sender.jmsTemplate.send(destinationName, messageCreator);
+        } finally {
+            ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NIFI-7015

ConsumeJMS now supports ObjectMessage, MapMessage and StreamMessage types as well. Added optional ERROR_QUEUE property. Result flowfiles get a 'jms.messagetype' attribute that contains the incoming message type (TextMessage, BytesMessage, ObjectMessage, MapMessage or StreamMessage).

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
