### PR TITLE
NIFI-7032 Processor Details no longer appears when clicking 'View Processor Details'

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
@@ -179,6 +179,9 @@
                 readOnly: true,
                 getParameterContext: function (groupId) {
                     // processors being configured must be in the current group
+                    if(typeof nfCanvasUtils === "undefined"){
+                        return null;
+                    }
                     return nfCanvasUtils.getParameterContext();
                 }
             });

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
@@ -174,17 +174,18 @@
             }
 
             // initialize the properties
-            $('#read-only-processor-properties').propertytable({
-                supportsGoTo: config.supportsGoTo,
-                readOnly: true,
-                getParameterContext: function (groupId) {
-                    // processors being configured must be in the current group
-                    if(typeof nfCanvasUtils === "undefined"){
-                        return null;
+            
+            $('#read-only-processor-properties').propertytable(Object.assign({
+                    supportsGoTo: config.supportsGoTo,
+                    readOnly: true
+                }, 
+                //incase of summary window, nfCanvasUtils module wont be loaded
+                nfCanvasUtils && { 
+                    getParameterContext: function (groupId) {
+                        // processors being configured must be in the current group
+                        return nfCanvasUtils.getParameterContext();
                     }
-                    return nfCanvasUtils.getParameterContext();
-                }
-            });
+                }));
         },
 
         /**


### PR DESCRIPTION
NIFI-7032 - Processor Details no longer appears when clicking 'View Processor Details'

Please provide a short description of the PR here:

#### Description of PR

fixes bug NIFI-7032 Processor Details no longer appears when clicking 'View Processor Details',

**Root cause:** nf-canvas-utils module will not be loaded in case of NiFi Summary Window (summary window is loaded inside an iframe), so nfCanvasUtil  is undefined and it causes an exception when trying to get the parameter context which is called which creating the processor info dialog, it was induced while fixing, NIFI-6630

**Fix done:** added a check when the nfCanvasUtil is undefined, in such case, the context is not required the porpoerties are non-editable.(the parmeter context is being used in the property table to check whether the user can edit the data etc. as in case of summary dialog, the table is just for display of processor data).

**Tested in:** Chrome 79, Safari 13

**Before Fix:** 

<img width="1436" alt="Before Fix" src="https://user-images.githubusercontent.com/16460179/72541787-2505ff80-38a9-11ea-84c4-49ea298f5849.png">

**After Fix:**

<img width="1440" alt="After Fix" src="https://user-images.githubusercontent.com/16460179/72541817-2df6d100-38a9-11ea-98e8-be25b3bb76c2.png">


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
