### PR TITLE
NIFI-7039 - Fix: PublishJMS can fail with ConcurrentModificationException

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
@@ -133,17 +133,8 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
                 for (final Map.Entry<String, String> entry : flowFile.getAttributes().entrySet()) {
                     final String key = entry.getKey();
                     if (pattern.matcher(key).matches()) {
-                        attributesToSend.put(key, flowFile.getAttribute(key));
-                    }
-                }
-
-                // Optionally remove illegal headers names apart from .type attributes for JMS variable types
-                if (!allowIllegalChars) {
-                    for (final Map.Entry<String,String> entry : attributesToSend.entrySet()) {
-                        if (!entry.getKey().endsWith(".type")){
-                            if (entry.getKey().contains("-") || entry.getKey().contains(".")) {
-                                attributesToSend.remove(entry.getKey());
-                            }
+                        if (allowIllegalChars || key.endsWith(".type") || (!key.contains("-") && !key.contains("."))) {
+                            attributesToSend.put(key, flowFile.getAttribute(key));
                         }
                     }
                 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/PublishJMSIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/PublishJMSIT.java
@@ -63,7 +63,10 @@ public class PublishJMSIT {
         Map<String, String> attributes = new HashMap<>();
         attributes.put("foo", "foo");
         attributes.put(JmsHeaders.REPLY_TO, "cooQueue");
-        attributes.put("test-attribute", "value");
+        attributes.put("test-attribute.type", "allowed1");
+        attributes.put("test.attribute.type", "allowed2");
+        attributes.put("test-attribute", "notAllowed1");
+        attributes.put("jms.source.destination", "notAllowed2");
         runner.enqueue("Hey dude!".getBytes(), attributes);
         runner.run(1, false); // Run once but don't shut down because we want the Connection Factory left in tact so that we can use it.
 
@@ -77,7 +80,10 @@ public class PublishJMSIT {
         assertEquals("Hey dude!", new String(messageBytes));
         assertEquals("cooQueue", ((Queue) message.getJMSReplyTo()).getQueueName());
         assertEquals("foo", message.getStringProperty("foo"));
+        assertEquals("allowed1", message.getStringProperty("test-attribute.type"));
+        assertEquals("allowed2", message.getStringProperty("test.attribute.type"));
         assertNull(message.getStringProperty("test-attribute"));
+        assertNull(message.getStringProperty("jms.source.destination"));
 
         runner.run(1, true, false); // Run once just so that we can trigger the shutdown of the Connection Factory
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NIFI-7039

PublishJMS outgoing flowfile attribute cleanup could lead to ConcurrentModificationException

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
