### PR TITLE
NIFI-7044: Fixed 'InputStream not closed' issue in PutElasticsearchRecord and DeleteHBaseCells

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -224,8 +224,6 @@ public class PutElasticsearchRecord extends AbstractProcessor implements Elastic
                     badRecords.add(bad);
                 }
             }
-
-            session.transfer(input, REL_SUCCESS);
         } catch (ElasticsearchError ese) {
             String msg = String.format("Encountered a server-side problem with Elasticsearch. %s",
                     ese.isElastic() ? "Moving to retry." : "Moving to failure");
@@ -234,11 +232,14 @@ public class PutElasticsearchRecord extends AbstractProcessor implements Elastic
             session.penalize(input);
             session.transfer(input, rel);
             removeBadRecordFlowFiles(badRecords, session);
+            return;
         } catch (Exception ex) {
             getLogger().error("Could not index documents.", ex);
             session.transfer(input, REL_FAILURE);
             removeBadRecordFlowFiles(badRecords, session);
+            return;
         }
+        session.transfer(input, REL_SUCCESS);
     }
 
     private void removeBadRecordFlowFiles(List<FlowFile> bad, ProcessSession session) {

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
@@ -25,6 +25,8 @@ import org.apache.nifi.json.JsonRecordSetWriter
 import org.apache.nifi.json.JsonTreeReader
 import org.apache.nifi.processors.elasticsearch.mock.MockBulkLoadClientService
 import org.apache.nifi.schema.access.SchemaAccessUtils
+import org.apache.nifi.serialization.RecordReaderFactory
+import org.apache.nifi.serialization.record.MockRecordParser
 import org.apache.nifi.serialization.record.MockSchemaRegistry
 import org.apache.nifi.util.TestRunner
 import org.apache.nifi.util.TestRunners
@@ -38,7 +40,7 @@ import static groovy.json.JsonOutput.toJson
 class PutElasticsearchRecordTest {
     MockBulkLoadClientService clientService
     MockSchemaRegistry registry
-    JsonTreeReader reader
+    RecordReaderFactory reader
     TestRunner runner
 
     static final String SCHEMA = prettyPrint(toJson([
@@ -92,6 +94,15 @@ class PutElasticsearchRecordTest {
 
     @Test
     void simpleTest() {
+        basicTest(0, 0, 1)
+    }
+
+    @Test
+    void simpleTestWithMockReader() {
+        reader = new MockRecordParser()
+        runner.addControllerService("mockReader", reader)
+        runner.setProperty(PutElasticsearchRecord.RECORD_READER, "mockReader")
+        runner.enableControllerService(reader)
         basicTest(0, 0, 1)
     }
 

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/DeleteHBaseCells.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/DeleteHBaseCells.java
@@ -109,6 +109,7 @@ public class DeleteHBaseCells extends AbstractDeleteHBase {
                 String[] parts = line.split(separator);
                 if (parts.length < 3 || parts.length > 4) {
                     final String msg = String.format("Invalid line length. It must have 3 or 4 components. It had %d.", parts.length);
+                    is.close();
                     input = writeErrorAttributes(lineNum, msg, input, session);
                     session.transfer(input, REL_FAILURE);
                     getLogger().error(msg);


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Ensure the flowfile InputStream is closed before transferring the flowfile

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
