### PR TITLE
NIFI-7055 createListValidator should treat "," as invalid

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -575,7 +575,12 @@ public class StandardValidators {
                 if (input == null) {
                     return new ValidationResult.Builder().subject(subject).input(null).explanation("List must have at least one non-empty element").valid(false).build();
                 }
+
                 final String[] list = input.split(",");
+                if (list.length == 0) {
+                    return new ValidationResult.Builder().subject(subject).input(null).explanation("List must have at least one non-empty element").valid(false).build();
+                }
+
                 for (String item : list) {
                     String itemToValidate = trimEntries ? item.trim() : item;
                     if (!isEmpty(itemToValidate) || !excludeEmptyEntries) {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
@@ -188,6 +188,9 @@ public class TestStandardValidators {
         vr = val.validate("List", ",", validationContext);
         assertFalse(vr.isValid());
 
+        vr = val.validate("List", " , ", validationContext);
+        assertFalse(vr.isValid());
+
         // will evaluate to no entry
         vr = val.validate("List", ",,,,", validationContext);
         assertFalse(vr.isValid());

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
@@ -184,6 +184,18 @@ public class TestStandardValidators {
         assertFalse(vr.isValid());
         assertEquals(1, mockValidator.getValidateCallCount());
 
+        // An empty list is the same as null, "" or " "
+        vr = val.validate("List", ",", validationContext);
+        assertFalse(vr.isValid());
+
+        // will evaluate to no entry
+        vr = val.validate("List", ",,,,", validationContext);
+        assertFalse(vr.isValid());
+
+        // will evaluate to an empty element
+        vr = val.validate("List", ",foo", validationContext);
+        assertFalse(vr.isValid());
+
         vr = val.validate("List", "1", validationContext);
         assertTrue(vr.isValid());
         assertEquals(1, mockValidator.getValidateCallCount());

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
@@ -187,17 +187,21 @@ public class TestStandardValidators {
         // An empty list is the same as null, "" or " "
         vr = val.validate("List", ",", validationContext);
         assertFalse(vr.isValid());
+        assertEquals(0, mockValidator.getValidateCallCount());
 
         vr = val.validate("List", " , ", validationContext);
         assertFalse(vr.isValid());
+        assertEquals(1, mockValidator.getValidateCallCount());
 
         // will evaluate to no entry
         vr = val.validate("List", ",,,,", validationContext);
         assertFalse(vr.isValid());
+        assertEquals(0, mockValidator.getValidateCallCount());
 
         // will evaluate to an empty element
         vr = val.validate("List", ",foo", validationContext);
         assertFalse(vr.isValid());
+        assertEquals(1, mockValidator.getValidateCallCount());
 
         vr = val.validate("List", "1", validationContext);
         assertTrue(vr.isValid());


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

fixes bug NIFI-7055 -
An empty set returned by split of "," was returning as valid.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [-] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [-] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/nifi/4012)
<!-- Reviewable:end -->
