### PR TITLE
NIFI-4792 Enable Array functions in QueryRecord 

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileEnumerator.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileEnumerator.java
@@ -123,15 +123,13 @@ public class FlowFileEnumerator implements Enumerator<Object> {
     private Object cast(Object o) {
         if (o == null) {
             return null;
-        }
-        else if (o.getClass().isArray()) {
+        } else if (o.getClass().isArray()) {
             List<Object> l = new ArrayList(Array.getLength(o));
             for (int i = 0; i < Array.getLength(o); i++) {
                 l.add(Array.get(o, i));
             }
             return l;
-        }
-        else {
+        } else {
             return o;
         }
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileEnumerator.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileEnumerator.java
@@ -24,9 +24,15 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
 
 import java.io.InputStream;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class FlowFileEnumerator implements Enumerator<Object> {
     private final ProcessSession session;
@@ -111,10 +117,26 @@ public class FlowFileEnumerator implements Enumerator<Object> {
         final Object[] filtered = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             final int indexToKeep = fields[i];
-            filtered[i] = row[indexToKeep];
+            filtered[i] = cast(row[indexToKeep]);
         }
 
         return filtered;
+    }
+
+    private Object cast(Object o) {
+        if (o == null) {
+            return null;
+        }
+        else if (o.getClass().isArray()) {
+            List<Object> l = new ArrayList(Array.getLength(o));
+            for (int i = 0; i < Array.getLength(o); i++) {
+                l.add(Array.get(o, i));
+            }
+            return l;
+        }
+        else {
+            return o;
+        }
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileEnumerator.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileEnumerator.java
@@ -24,14 +24,11 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
-import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
 
 import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class FlowFileEnumerator implements Enumerator<Object> {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileTable.java
@@ -42,6 +42,7 @@ import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.type.ArrayDataType;
 
 import java.lang.reflect.Type;
 import java.math.BigInteger;
@@ -50,7 +51,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 
 public class FlowFileTable extends AbstractTable implements QueryableTable, TranslatableTable {
 
@@ -214,7 +214,8 @@ public class FlowFileTable extends AbstractTable implements QueryableTable, Tran
             case STRING:
                 return typeFactory.createJavaType(String.class);
             case ARRAY:
-                return typeFactory.createJavaType(Object[].class);
+                ArrayDataType array = (ArrayDataType) fieldType;
+                return typeFactory.createArrayType(getRelDataType(array.getElementType(), typeFactory), -1);
             case RECORD:
                 return typeFactory.createJavaType(Record.class);
             case MAP:

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -372,7 +372,7 @@
             <dependency>
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
-                <version>1.17.0</version>
+                <version>1.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Using functions such as CARDINALITY and UNNEST currently fails with a ClassCastException, this patch addresses this issue. In raising the pull request I found NIFI-4792 which seems to be related so I've linked it for now, I can update the test to address specifically the issue referenced in the email thread if necessary.
