### PR TITLE
NIFI-7095: ResetSetRecordSet: handle java.sql.Array Types in normalizeValue method

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -128,13 +128,17 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
     }
 
     @SuppressWarnings("rawtypes")
-    private Object normalizeValue(final Object value) {
+    private Object normalizeValue(final Object value) throws SQLException {
         if (value == null) {
             return null;
         }
 
         if (value instanceof List) {
             return ((List) value).toArray();
+        }
+
+        if (value instanceof Array) {
+            return ((Array) value).getArray();
         }
 
         return value;


### PR DESCRIPTION
Some jdbc drivers e.g. Oracle returns java.sql.Array objects for array types, not just Lists.
This commit also handles these cases, and extracts the primitive java arrays out of this jdbc holder class.