### PR TITLE
NIFI-6958: Fixing issue enabling/disabling processors in sub groups when changing versions

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -4633,9 +4633,9 @@ public final class StandardProcessGroup implements ProcessGroup {
             processor.setPosition(new Position(proposed.getPosition().getX(), proposed.getPosition().getY()));
 
             if (proposed.getScheduledState() == org.apache.nifi.registry.flow.ScheduledState.DISABLED) {
-                disableProcessor(processor);
+                processor.getProcessGroup().disableProcessor(processor);
             } else if (processor.getScheduledState() == ScheduledState.DISABLED) {
-                enableProcessor(processor);
+                processor.getProcessGroup().enableProcessor(processor);
             }
 
             if (!isEqual(processor.getBundleCoordinate(), proposed.getBundle())) {


### PR DESCRIPTION
NIFI-6958:
- Addressing issue causing errors preventing version changes when there is a processor to enable or disable in a sub process group.