### PR TITLE
NIFI-4957: Add ability to get JOLT transform from file

### DIFF
--- a/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/main/java/org/apache/nifi/processors/jolt/record/JoltTransformRecord.java
+++ b/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/main/java/org/apache/nifi/processors/jolt/record/JoltTransformRecord.java
@@ -62,6 +62,7 @@ import org.apache.nifi.util.StopWatch;
 import org.apache.nifi.util.StringUtils;
 import org.apache.nifi.util.file.classloader.ClassLoaderUtils;
 
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -157,7 +158,7 @@ public class JoltTransformRecord extends AbstractProcessor {
             .description("Path to location of a JOLT specification file. Only one of 'Jolt Specification' or 'Path To Jolt Specification' may be used. "
                     + "This value is ignored if the Jolt Sort Transformation is selected.")
             .required(false)
-            .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.FILE)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
@@ -527,6 +528,10 @@ public class JoltTransformRecord extends AbstractProcessor {
     protected static Object transform(JoltTransform joltTransform, Object input) {
         return joltTransform instanceof ContextualTransform
                 ? ((ContextualTransform) joltTransform).transform(input, Collections.emptyMap()) : ((Transform) joltTransform).transform(input);
+    }
+
+    protected FilenameFilter getJarFilenameFilter(){
+        return (dir, name) -> (name != null && name.endsWith(".jar"));
     }
 
     /**

--- a/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/test/java/org/apache/nifi/processors/jolt/record/TestJoltTransformRecord.java
+++ b/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/test/java/org/apache/nifi/processors/jolt/record/TestJoltTransformRecord.java
@@ -304,7 +304,7 @@ public class TestJoltTransformRecord {
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
@@ -326,7 +326,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
@@ -359,7 +359,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
             put("b", 2);
             put("c", 3);
         }});
-        final Object[] recordArray1 = new Object[] {record1, record2, record3};
+        final Object[] recordArray1 = new Object[]{record1, record2, record3};
         parser.addRecord((Object) recordArray1);
 
         final Record record4 = new MapRecord(xSchema, new HashMap<String, Object>() {{
@@ -372,7 +372,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
             put("b", 201);
             put("c", 301);
         }});
-        final Object[] recordArray2 = new Object[] {record4, record5};
+        final Object[] recordArray2 = new Object[]{record4, record5};
         parser.addRecord((Object) recordArray2);
 
         final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutputSchemaMultipleOutputRecords.avsc")));
@@ -392,6 +392,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutputMultipleOutputRecords.json"))),
                 new String(transformed.toByteArray()));
+    }
 
     @Test
     public void testTransformInputWithShiftrFromFile() throws IOException {
@@ -429,7 +430,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/defaultrOutput.json"))),
                 new String(transformed.toByteArray()));
@@ -449,7 +450,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/removrOutput.json"))),
                 new String(transformed.toByteArray()));
@@ -470,7 +471,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/cardrOutput.json"))),
                 new String(transformed.toByteArray()));
@@ -489,7 +490,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
@@ -512,7 +513,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/defaultrELOutput.json"))),
                 new String(transformed.toByteArray()));
@@ -553,7 +554,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/modifierDefineOutput.json"))),
                 new String(transformed.toByteArray()));
@@ -573,7 +574,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/modifierOverwriteOutput.json"))),
                 new String(transformed.toByteArray()));
@@ -592,7 +593,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
@@ -617,7 +618,7 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
@@ -731,5 +732,4 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
             recordGenerator.apply(numRecords, parser);
         }
     }
-
 }

--- a/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/test/java/org/apache/nifi/processors/jolt/record/TestJoltTransformRecord.java
+++ b/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/test/java/org/apache/nifi/processors/jolt/record/TestJoltTransformRecord.java
@@ -110,8 +110,8 @@ public class TestJoltTransformRecord {
         runner.setProperty(writer, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(writer, "Pretty Print JSON", "true");
         runner.enableControllerService(writer);
-        final String spec = "src/test/resources/TestJoltTransformRecord/chainrSpec.json";
-        runner.setProperty(JoltTransformRecord.JOLT_SPEC_FILE, spec);
+        final String spec = "./src/test/resources/TestJoltTransformRecord/chainrSpec.json";
+        runner.setProperty(JoltTransformRecord.JOLT_SPEC, spec);
         runner.enqueue(new byte[0]);
         Set<Relationship> relationships = processor.getRelationships();
         assertTrue(relationships.contains(JoltTransformRecord.REL_FAILURE));
@@ -135,10 +135,6 @@ public class TestJoltTransformRecord {
         final String specLocation = "src/test/resources/TestJoltTransformRecord/chainrSpec.json";
         spec = new String(Files.readAllBytes(Paths.get(specLocation)));
         runner.setProperty(JoltTransformRecord.JOLT_SPEC, spec);
-        runner.assertValid();
-        runner.setProperty(JoltTransformRecord.JOLT_SPEC_FILE, specLocation);
-        runner.assertNotValid();
-        runner.removeProperty(JoltTransformRecord.JOLT_SPEC);
         runner.assertValid();
     }
 
@@ -402,8 +398,8 @@ public class TestJoltTransformRecord {
         runner.setProperty(writer, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(writer, "Pretty Print JSON", "true");
         runner.enableControllerService(writer);
-        final String spec = "src/test/resources/TestJoltTransformRecord/shiftrSpec.json";
-        runner.setProperty(JoltTransformRecord.JOLT_SPEC_FILE, spec);
+        final String spec = "./src/test/resources/TestJoltTransformRecord/shiftrSpec.json";
+        runner.setProperty(JoltTransformRecord.JOLT_SPEC, spec);
         runner.setProperty(JoltTransformRecord.JOLT_TRANSFORM, JoltTransformRecord.SHIFTR);
         runner.enqueue(new byte[0]);
         runner.run();

--- a/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/test/java/org/apache/nifi/processors/jolt/record/TestJoltTransformRecord.java
+++ b/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/test/java/org/apache/nifi/processors/jolt/record/TestJoltTransformRecord.java
@@ -103,6 +103,24 @@ public class TestJoltTransformRecord {
     }
 
     @Test
+    public void testRelationshipsCreatedFromFile() throws IOException {
+        generateTestData(1, null);
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/chainrOutputSchema.avsc")));
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+        final String spec = "src/test/resources/TestJoltTransformRecord/chainrSpec.json";
+        runner.setProperty(JoltTransformRecord.JOLT_SPEC_FILE, spec);
+        runner.enqueue(new byte[0]);
+        Set<Relationship> relationships = processor.getRelationships();
+        assertTrue(relationships.contains(JoltTransformRecord.REL_FAILURE));
+        assertTrue(relationships.contains(JoltTransformRecord.REL_SUCCESS));
+        assertTrue(relationships.contains(JoltTransformRecord.REL_ORIGINAL));
+        assertEquals(3, relationships.size());
+    }
+
+    @Test
     public void testInvalidJOLTSpec() throws IOException {
         generateTestData(1, null);
         final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutputSchema.avsc")));
@@ -110,9 +128,18 @@ public class TestJoltTransformRecord {
         runner.setProperty(writer, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(writer, "Pretty Print JSON", "true");
         runner.enableControllerService(writer);
-        final String spec = "[{}]";
+        String spec = "[{}]";
         runner.setProperty(JoltTransformRecord.JOLT_SPEC, spec);
         runner.assertNotValid();
+
+        final String specLocation = "src/test/resources/TestJoltTransformRecord/chainrSpec.json";
+        spec = new String(Files.readAllBytes(Paths.get(specLocation)));
+        runner.setProperty(JoltTransformRecord.JOLT_SPEC, spec);
+        runner.assertValid();
+        runner.setProperty(JoltTransformRecord.JOLT_SPEC_FILE, specLocation);
+        runner.assertNotValid();
+        runner.removeProperty(JoltTransformRecord.JOLT_SPEC);
+        runner.assertValid();
     }
 
     @Test
@@ -366,6 +393,26 @@ runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
         assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutputMultipleOutputRecords.json"))),
                 new String(transformed.toByteArray()));
 
+    @Test
+    public void testTransformInputWithShiftrFromFile() throws IOException {
+        generateTestData(1, null);
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutputSchema.avsc")));
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+        final String spec = "src/test/resources/TestJoltTransformRecord/shiftrSpec.json";
+        runner.setProperty(JoltTransformRecord.JOLT_SPEC_FILE, spec);
+        runner.setProperty(JoltTransformRecord.JOLT_TRANSFORM, JoltTransformRecord.SHIFTR);
+        runner.enqueue(new byte[0]);
+        runner.run();
+        runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
+        runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
+        transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
+        assertEquals(new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutput.json"))),
+                new String(transformed.toByteArray()));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/JoltTransformJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/JoltTransformJSON.java
@@ -100,10 +100,21 @@ public class JoltTransformJSON extends AbstractProcessor {
     public static final PropertyDescriptor JOLT_SPEC = new PropertyDescriptor.Builder()
             .name("jolt-spec")
             .displayName("Jolt Specification")
-            .description("Jolt Specification for transform of JSON data. This value is ignored if the Jolt Sort Transformation is selected.")
+            .description("Jolt Specification for transform of JSON data. Only one of 'Jolt Specification' or 'Path To Jolt Specification' may be used. "
+                    + "This value is ignored if the Jolt Sort Transformation is selected.")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(false)
+            .build();
+
+    public static final PropertyDescriptor JOLT_SPEC_FILE = new PropertyDescriptor.Builder()
+            .name("jolt-spec-file")
+            .displayName("Path To Jolt Specification")
+            .description("Path to location of a JOLT specification file. Only one of 'Jolt Specification' or 'Path To Jolt Specification' may be used. "
+                    + "This value is ignored if the Jolt Sort Transformation is selected.")
+            .required(false)
+            .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
     public static final PropertyDescriptor CUSTOM_CLASS = new PropertyDescriptor.Builder()
@@ -173,6 +184,7 @@ public class JoltTransformJSON extends AbstractProcessor {
         _properties.add(CUSTOM_CLASS);
         _properties.add(MODULES);
         _properties.add(JOLT_SPEC);
+        _properties.add(JOLT_SPEC_FILE);
         _properties.add(TRANSFORM_CACHE_SIZE);
         _properties.add(PRETTY_PRINT);
         properties = Collections.unmodifiableList(_properties);
@@ -199,13 +211,13 @@ public class JoltTransformJSON extends AbstractProcessor {
         final String transform = validationContext.getProperty(JOLT_TRANSFORM).getValue();
         final String customTransform = validationContext.getProperty(CUSTOM_CLASS).getValue();
         final String modulePath = validationContext.getProperty(MODULES).isSet()? validationContext.getProperty(MODULES).getValue() : null;
+        final String joltSpecBody = validationContext.getProperty(JOLT_SPEC).getValue();
+        final String joltSpecFile = validationContext.getProperty(JOLT_SPEC_FILE).getValue();
 
-        if(!validationContext.getProperty(JOLT_SPEC).isSet() || StringUtils.isEmpty(validationContext.getProperty(JOLT_SPEC).getValue())){
+        if (StringUtils.isEmpty(joltSpecBody) == StringUtils.isEmpty(joltSpecFile)) {
             if(!SORTR.getValue().equals(transform)) {
-                final String message = "A specification is required for this transformation";
-                results.add(new ValidationResult.Builder().valid(false)
-                        .explanation(message)
-                        .build());
+                results.add(new ValidationResult.Builder().subject("Spec Body or Spec File").valid(false).explanation(
+                        "exactly one of 'Jolt Specification' or 'Path To Jolt Specification' must be set, or the Transformation must be 'Sort'").build());
             }
         } else {
             final ClassLoader customClassLoader;
@@ -217,13 +229,19 @@ public class JoltTransformJSON extends AbstractProcessor {
                     customClassLoader =  this.getClass().getClassLoader();
                 }
 
-                final String specValue =  validationContext.getProperty(JOLT_SPEC).getValue();
+                String specValue = validationContext.getProperty(JOLT_SPEC).getValue();
+                final boolean useBody = !StringUtils.isEmpty(specValue);
+                if (!useBody) {
+                    specValue = validationContext.getProperty(JOLT_SPEC_FILE).getValue();
+                }
+                final PropertyDescriptor pd = useBody ? JOLT_SPEC : JOLT_SPEC_FILE;
+                final boolean elPresent = validationContext.isExpressionLanguagePresent(specValue);
 
-                if (validationContext.isExpressionLanguagePresent(specValue)) {
+                if (elPresent) {
                     final String invalidExpressionMsg = validationContext.newExpressionLanguageCompiler().validateExpression(specValue, true);
                     if (!StringUtils.isEmpty(invalidExpressionMsg)) {
                         results.add(new ValidationResult.Builder().valid(false)
-                                .subject(JOLT_SPEC.getDisplayName())
+                                .subject(pd.getDisplayName())
                                 .explanation("Invalid Expression Language: " + invalidExpressionMsg)
                                 .build());
                     }
@@ -236,20 +254,29 @@ public class JoltTransformJSON extends AbstractProcessor {
                                 .build());
                     }
                 } else {
-                    //for validation we want to be able to ensure the spec is syntactically correct and not try to resolve variables since they may not exist yet
-                    Object specJson = SORTR.getValue().equals(transform) ? null : JsonUtils.jsonToObject(specValue.replaceAll("\\$\\{","\\\\\\\\\\$\\{"), DEFAULT_CHARSET);
+                    if (!SORTR.getValue().equals(transform)) {
 
-                    if (CUSTOMR.getValue().equals(transform)) {
-                        if (StringUtils.isEmpty(customTransform)) {
-                            final String customMessage = "A custom transformation class should be provided. ";
-                            results.add(new ValidationResult.Builder().valid(false)
-                                    .explanation(customMessage)
-                                    .build());
+                        //for validation we want to be able to ensure the spec is syntactically correct and not try to resolve variables since they may not exist yet
+                        final String content;
+                        if(useBody) {
+                            content = specValue;
                         } else {
-                            TransformFactory.getCustomTransform(customClassLoader, customTransform, specJson);
+                            content = new String(Files.readAllBytes(Paths.get(specValue)), DEFAULT_CHARSET);
                         }
-                    } else {
-                        TransformFactory.getTransform(customClassLoader, transform, specJson);
+                        final Object specJson = JsonUtils.jsonToObject(content.replaceAll("\\$\\{", "\\\\\\\\\\$\\{"), DEFAULT_CHARSET);
+
+                        if (CUSTOMR.getValue().equals(transform)) {
+                            if (StringUtils.isEmpty(customTransform)) {
+                                final String customMessage = "A custom transformation class should be provided. ";
+                                results.add(new ValidationResult.Builder().valid(false)
+                                        .explanation(customMessage)
+                                        .build());
+                            } else {
+                                TransformFactory.getCustomTransform(customClassLoader, customTransform, specJson);
+                            }
+                        } else {
+                            TransformFactory.getTransform(customClassLoader, transform, specJson);
+                        }
                     }
                 }
             } catch (final Exception e) {
@@ -321,8 +348,13 @@ public class JoltTransformJSON extends AbstractProcessor {
         final Optional<String> specString;
         if (context.getProperty(JOLT_SPEC).isSet()) {
             specString = Optional.of(context.getProperty(JOLT_SPEC).evaluateAttributeExpressions(flowFile).getValue());
-        } else {
+        } else if (context.getProperty(JOLT_SPEC_FILE).isSet()) {
+            final String specLocation = context.getProperty(JOLT_SPEC_FILE).evaluateAttributeExpressions(flowFile).getValue();
+            specString = Optional.of(new String(Files.readAllBytes(Paths.get(specLocation)), DEFAULT_CHARSET));
+        } else if (SORTR.getValue().equals(context.getProperty(JOLT_TRANSFORM).getValue())) {
             specString = Optional.empty();
+        } else {
+            throw new IllegalArgumentException("Exactly one of 'Jolt Specification' or 'Path To Jolt Specification' must be set, or the Transformation must be Sort.");
         }
 
         return transformCache.get(specString, currString -> {
@@ -359,7 +391,8 @@ public class JoltTransformJSON extends AbstractProcessor {
 
     private JoltTransform createTransform(final ProcessContext context, final String specString, final FlowFile flowFile) throws Exception {
         final Object specJson;
-        if (context.getProperty(JOLT_SPEC).isSet() && !SORTR.getValue().equals(context.getProperty(JOLT_TRANSFORM).getValue())) {
+        if ((context.getProperty(JOLT_SPEC).isSet() || context.getProperty(JOLT_SPEC_FILE).isSet())
+                && !SORTR.getValue().equals(context.getProperty(JOLT_TRANSFORM).getValue())) {
             specJson = JsonUtils.jsonToObject(specString, DEFAULT_CHARSET);
         } else {
             specJson = null;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestJoltTransformJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestJoltTransformJSON.java
@@ -72,7 +72,7 @@ public class TestJoltTransformJSON {
     }
 
     @Test
-    public void testInvalidJOLTSpec() {
+    public void testInvalidJOLTSpec() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
         String spec = "[{}]";
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestJoltTransformJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestJoltTransformJSON.java
@@ -62,8 +62,8 @@ public class TestJoltTransformJSON {
     public void testRelationshipsCreatedFromFile() throws IOException{
         Processor processor= new JoltTransformJSON();
         final TestRunner runner = TestRunners.newTestRunner(processor);
-        final String spec = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
-        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, spec);
+        final String spec = "./src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
         runner.enqueue(JSON_INPUT);
         Set<Relationship> relationships = processor.getRelationships();
         assertTrue(relationships.contains(JoltTransformJSON.REL_FAILURE));
@@ -82,10 +82,6 @@ public class TestJoltTransformJSON {
         spec = new String(Files.readAllBytes(Paths.get(specLocation)));
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
         runner.assertValid();
-        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, specLocation);
-        runner.assertNotValid();
-        runner.removeProperty(JoltTransformJSON.JOLT_SPEC);
-        runner.assertValid();
     }
 
     @Test
@@ -100,8 +96,8 @@ public class TestJoltTransformJSON {
     @Test
     public void testIncorrectJOLTSpecFromFile() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
-        final String chainrSpec = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
-        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, chainrSpec);
+        final String chainrSpec = "./src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, chainrSpec);
         runner.setProperty(JoltTransformJSON.JOLT_TRANSFORM, JoltTransformJSON.SHIFTR);
         runner.assertNotValid();
     }
@@ -152,8 +148,8 @@ public class TestJoltTransformJSON {
     @Test
     public void testInvalidFlowFileContentJsonFromFile() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
-        final String spec = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
-        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, spec);
+        final String spec = "./src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
         runner.enqueue("invalid json");
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_FAILURE);
@@ -245,8 +241,8 @@ public class TestJoltTransformJSON {
     @Test
     public void testTransformInputWithShiftrFromFile() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
-        final String spec = "src/test/resources/TestJoltTransformJson/shiftrSpec.json";
-        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, spec);
+        final String spec = "./src/test/resources/TestJoltTransformJson/shiftrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
         runner.setProperty(JoltTransformJSON.JOLT_TRANSFORM, JoltTransformJSON.SHIFTR);
         runner.enqueue(JSON_INPUT);
         runner.run();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestJoltTransformJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestJoltTransformJSON.java
@@ -59,11 +59,33 @@ public class TestJoltTransformJSON {
     }
 
     @Test
+    public void testRelationshipsCreatedFromFile() throws IOException{
+        Processor processor= new JoltTransformJSON();
+        final TestRunner runner = TestRunners.newTestRunner(processor);
+        final String spec = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, spec);
+        runner.enqueue(JSON_INPUT);
+        Set<Relationship> relationships = processor.getRelationships();
+        assertTrue(relationships.contains(JoltTransformJSON.REL_FAILURE));
+        assertTrue(relationships.contains(JoltTransformJSON.REL_SUCCESS));
+        assertEquals(2, relationships.size());
+    }
+
+    @Test
     public void testInvalidJOLTSpec() {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
-        final String spec = "[{}]";
+        String spec = "[{}]";
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
         runner.assertNotValid();
+
+        final String specLocation = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        spec = new String(Files.readAllBytes(Paths.get(specLocation)));
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
+        runner.assertValid();
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, specLocation);
+        runner.assertNotValid();
+        runner.removeProperty(JoltTransformJSON.JOLT_SPEC);
+        runner.assertValid();
     }
 
     @Test
@@ -76,7 +98,16 @@ public class TestJoltTransformJSON {
     }
 
     @Test
-    public void testSpecIsNotSet() {
+    public void testIncorrectJOLTSpecFromFile() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
+        final String chainrSpec = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, chainrSpec);
+        runner.setProperty(JoltTransformJSON.JOLT_TRANSFORM, JoltTransformJSON.SHIFTR);
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testSpecIsNotSet() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
         runner.setProperty(JoltTransformJSON.JOLT_TRANSFORM, JoltTransformJSON.SHIFTR);
         runner.assertNotValid();
@@ -113,6 +144,16 @@ public class TestJoltTransformJSON {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
         final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformJson/chainrSpec.json")));
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
+        runner.enqueue("invalid json");
+        runner.run();
+        runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_FAILURE);
+    }
+
+    @Test
+    public void testInvalidFlowFileContentJsonFromFile() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
+        final String spec = "src/test/resources/TestJoltTransformJson/chainrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, spec);
         runner.enqueue("invalid json");
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_FAILURE);
@@ -189,6 +230,23 @@ public class TestJoltTransformJSON {
         final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
         final String spec = new String(Files.readAllBytes(Paths.get("src/test/resources/TestJoltTransformJson/shiftrSpec.json")));
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
+        runner.setProperty(JoltTransformJSON.JOLT_TRANSFORM, JoltTransformJSON.SHIFTR);
+        runner.enqueue(JSON_INPUT);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
+        transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(),"application/json");
+        Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
+        Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/shiftrOutput.json")));
+        assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
+    }
+
+    @Test
+    public void testTransformInputWithShiftrFromFile() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new JoltTransformJSON());
+        final String spec = "src/test/resources/TestJoltTransformJson/shiftrSpec.json";
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC_FILE, spec);
         runner.setProperty(JoltTransformJSON.JOLT_TRANSFORM, JoltTransformJSON.SHIFTR);
         runner.enqueue(JSON_INPUT);
         runner.run();


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Updated JoltTransformJSON and JoltTransformRecord to be able to take the JOLT spec from a file location rather than having the body in the "Jolt Specification" property. The two properties are mutually exclusive, i.e. only one must be set (unless it's a Sort spec in which case both properties are ignored)

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
