### PR TITLE
NIFI-7117: When SocketLoadBalancedFlowFileQueue creates its array of …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
@@ -151,15 +151,19 @@ public class SocketLoadBalancedFlowFileQueue extends AbstractFlowFileQueue imple
             // that is not the local node identifier. If the Local Node Identifier is not yet known, that's okay. When it becomes known,
             // the queuePartitions array will be recreated with the appropriate partitions.
             final List<QueuePartition> partitionList = new ArrayList<>();
-            partitionList.add(localPartition);
 
             final NodeIdentifier localNodeId = clusterCoordinator.getLocalNodeIdentifier();
             for (final NodeIdentifier nodeId : sortedNodeIdentifiers) {
                 if (nodeId.equals(localNodeId)) {
-                    continue;
+                    partitionList.add(localPartition);
+                } else {
+                    partitionList.add(createRemotePartition(nodeId));
                 }
+            }
 
-                partitionList.add(createRemotePartition(nodeId));
+            // Ensure that our list of queue partitions always contains the local partition.
+            if (!partitionList.contains(localPartition)) {
+                partitionList.add(localPartition);
             }
 
             queuePartitions = partitionList.toArray(new QueuePartition[0]);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/CorrelationAttributePartitioner.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/CorrelationAttributePartitioner.java
@@ -19,8 +19,16 @@ package org.apache.nifi.controller.queue.clustered.partition;
 
 import com.google.common.hash.Hashing;
 import org.apache.nifi.controller.repository.FlowFileRecord;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CorrelationAttributePartitioner implements FlowFilePartitioner {
+    private static final Logger logger = LoggerFactory.getLogger(CorrelationAttributePartitioner.class);
+
     private final String partitioningAttribute;
 
     public CorrelationAttributePartitioner(final String partitioningAttribute) {
@@ -39,6 +47,15 @@ public class CorrelationAttributePartitioner implements FlowFilePartitioner {
             index = Math.floorMod(hash, partitions.length);
         } else {
             index = Hashing.consistentHash(hash, partitions.length);
+        }
+
+        if (logger.isDebugEnabled()) {
+            final List<String> partitionDescriptions = new ArrayList<>(partitions.length);
+            for (final QueuePartition partition : partitions) {
+                partitionDescriptions.add(partition.getSwapPartitionName());
+            }
+
+            logger.debug("Assigning Partition {} to {} based on {}", index, flowFile.getAttribute(CoreAttributes.UUID.key()), partitionDescriptions);
         }
 
         return partitions[index];

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -691,8 +691,11 @@ public class NiFiClientUtil {
 
         final FlowFileSummaryDTO flowFileSummary = flowFileSummaries.get(flowFileIndex);
         final String uuid = flowFileSummary.getUuid();
+        final String nodeId = flowFileSummary.getClusterNodeId();
 
-        return nifiClient.getConnectionClient().getFlowFile(connectionId, uuid);
+        final FlowFileEntity flowFileEntity = nifiClient.getConnectionClient().getFlowFile(connectionId, uuid, nodeId);
+        flowFileEntity.getFlowFile().setClusterNodeId(nodeId);
+        return flowFileEntity;
     }
 
     public VariableRegistryUpdateRequestEntity updateVariableRegistry(final ProcessGroupEntity processGroup, final Map<String, String> variables) throws NiFiClientException, IOException {

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ConnectionClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ConnectionClient.java
@@ -47,4 +47,6 @@ public interface ConnectionClient {
     ListingRequestEntity deleteListingRequest(String connectionId, String listingRequestId) throws NiFiClientException, IOException;
 
     FlowFileEntity getFlowFile(String connectionId, String flowFileUuid) throws NiFiClientException, IOException;
+
+    FlowFileEntity getFlowFile(String connectionId, String flowFileUuid, String nodeId) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyConnectionClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyConnectionClient.java
@@ -242,8 +242,15 @@ public class JerseyConnectionClient extends AbstractJerseyClient implements Conn
         });
     }
 
+
     @Override
     public FlowFileEntity getFlowFile(final String connectionId, final String flowFileUuid) throws NiFiClientException, IOException {
+        return getFlowFile(connectionId, flowFileUuid, null);
+    }
+
+
+    @Override
+    public FlowFileEntity getFlowFile(final String connectionId, final String flowFileUuid, final String nodeId) throws NiFiClientException, IOException {
         if (connectionId == null) {
             throw new IllegalArgumentException("Connection ID cannot be null");
         }
@@ -252,10 +259,14 @@ public class JerseyConnectionClient extends AbstractJerseyClient implements Conn
         }
 
         return executeAction("Error retrieving FlowFile", () -> {
-            final WebTarget target = flowFileQueueTarget
+            WebTarget target = flowFileQueueTarget
                 .path("flowfiles/{uuid}")
                 .resolveTemplate("id", connectionId)
                 .resolveTemplate("uuid", flowFileUuid);
+
+            if (nodeId != null) {
+                target = target.queryParam("clusterNodeId", nodeId);
+            }
 
             return getRequestBuilder(target).get(FlowFileEntity.class);
         });


### PR DESCRIPTION
…Queue Partitions in the constructor, it added the local partition as the first element in that list. This list should be ordered the same across all nodes in the cluster. By making the local partition the first in the array, each node had a different ordering of these partitions. As a result, Partition by Attribute strategy would constantly rebalance flowfiles that it received to other node, and Single Node always transferred data to the first partition, which was the local node, instead of whichever node should have been the first in the list. This commit addresses this issue by instead inserting the local partition intot he 'queuePartitions' array based on the local node identifier.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
