### PR TITLE
NIFI-6551: Improve PutKudu timestamp handling

### DIFF
--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/test/java/org/apache/nifi/processors/kudu/TestPutKudu.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/test/java/org/apache/nifi/processors/kudu/TestPutKudu.java
@@ -60,6 +60,7 @@ import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -424,7 +425,7 @@ public class TestPutKudu {
             new RecordField(recordIdName, RecordFieldType.BIGINT.getDataType()),
             new RecordField("name", RecordFieldType.STRING.getDataType()),
             new RecordField("age", RecordFieldType.SHORT.getDataType()),
-            new RecordField("updated_at", RecordFieldType.BIGINT.getDataType()),
+            new RecordField("updated_at", RecordFieldType.TIMESTAMP.getDataType()),
             new RecordField("score", RecordFieldType.LONG.getDataType())));
 
         Map<String, Object> values = new HashMap<>();
@@ -432,7 +433,7 @@ public class TestPutKudu {
         values.put(recordIdName, id);
         values.put("name", name);
         values.put("age", age);
-        values.put("updated_at", System.currentTimeMillis() * 1000);
+        values.put("updated_at", new Timestamp(System.currentTimeMillis()));
         values.put("score", 10000L);
         processor.buildPartialRow(
             kuduSchema,


### PR DESCRIPTION
Uses `DataTypeUtils.toTimestamp` when writing to Kudu timestamp (`UNIXTIME_MICROS`) columns. This allows us to use the `row.addTimestamp` API and get much more intuitive and predictable timestamp ingest behavior.

While this change fixes flows writing to Kudu timestamp (UNIXTIME_MICROS) columns via timestamp or 
date fields. This change could break PutKudu processors that are writing to Kudu timestamp (UNIXTIME_MICROS) columns via numeric fields. Before this change, flows would often multiply millisecond values by 1000 to write microsecond values to Kudu. On upgrade this multiplication should be removed and milliseconds should be sent.