### PR TITLE
NIFI-7140 Add a property <Support Fragmented Transactions RollBack> for PutSQL

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/DataBaseTransactionException.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/DataBaseTransactionException.java
@@ -1,0 +1,14 @@
+package org.apache.nifi.processor.util.pattern;
+
+import org.apache.nifi.processor.exception.ProcessException;
+
+/**
+ * A simple Exception that indicate the some error about database transaction occurred,
+ * and maybe we need to catch and handle it;
+ * @author zhangcheng
+ */
+public class DataBaseTransactionException extends ProcessException {
+    public DataBaseTransactionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/ErrorTypes.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/ErrorTypes.java
@@ -104,10 +104,24 @@ public enum ErrorTypes {
     public static class Result {
         private final Destination destination;
         private final Penalty penalty;
+        // indicate if we need do database rollback or not
+        private boolean databaseRollBack;
 
         public Result(Destination destination, Penalty penalty) {
+            this(destination,penalty,false);
+        }
+        public Result(Destination destination, Penalty penalty,boolean databaseRollBack) {
             this.destination = destination;
             this.penalty = penalty;
+            this.databaseRollBack = databaseRollBack;
+        }
+
+        public boolean isDatabaseRollBack() {
+            return databaseRollBack;
+        }
+
+        public void databaseCanRollBack() {
+            this.databaseRollBack = true;
         }
 
         public Destination destination() {
@@ -123,6 +137,7 @@ public enum ErrorTypes {
             return "Result{" +
                     "destination=" + destination +
                     ", penalty=" + penalty +
+                    ", databaseRollBack="+ databaseRollBack +
                     '}';
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -615,7 +615,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
         final Boolean rollbackOnFailure = context.getProperty(RollbackOnFailure.ROLLBACK_ON_FAILURE).asBoolean();
         final Boolean dbTransactionRollbackConfig = context.getProperty(SUPPORT_TRANSACTION_ROLLBACK).asBoolean();
         final Boolean supportTransaction = context.getProperty(SUPPORT_TRANSACTIONS).asBoolean();
-        final FunctionContext functionContext = new FunctionContext(rollbackOnFailure,dbTransactionRollbackConfig&supportTransaction);
+        final FunctionContext functionContext = new FunctionContext(rollbackOnFailure,dbTransactionRollbackConfig);
         functionContext.obtainKeys = context.getProperty(OBTAIN_GENERATED_KEYS).asBoolean();
         RollbackOnFailure.onTrigger(context, sessionFactory, functionContext, getLogger(), session -> process.onTrigger(context, session, functionContext));
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -614,7 +614,6 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
     public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
         final Boolean rollbackOnFailure = context.getProperty(RollbackOnFailure.ROLLBACK_ON_FAILURE).asBoolean();
         final Boolean dbTransactionRollbackConfig = context.getProperty(SUPPORT_TRANSACTION_ROLLBACK).asBoolean();
-        final Boolean supportTransaction = context.getProperty(SUPPORT_TRANSACTIONS).asBoolean();
         final FunctionContext functionContext = new FunctionContext(rollbackOnFailure,dbTransactionRollbackConfig);
         functionContext.obtainKeys = context.getProperty(OBTAIN_GENERATED_KEYS).asBoolean();
         RollbackOnFailure.onTrigger(context, sessionFactory, functionContext, getLogger(), session -> process.onTrigger(context, session, functionContext));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -614,7 +614,8 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
     public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
         final Boolean rollbackOnFailure = context.getProperty(RollbackOnFailure.ROLLBACK_ON_FAILURE).asBoolean();
         final Boolean dbTransactionRollbackConfig = context.getProperty(SUPPORT_TRANSACTION_ROLLBACK).asBoolean();
-        final FunctionContext functionContext = new FunctionContext(rollbackOnFailure,dbTransactionRollbackConfig);
+        final Boolean supportTransaction = context.getProperty(SUPPORT_TRANSACTIONS).asBoolean();
+        final FunctionContext functionContext = new FunctionContext(rollbackOnFailure,dbTransactionRollbackConfig&supportTransaction);
         functionContext.obtainKeys = context.getProperty(OBTAIN_GENERATED_KEYS).asBoolean();
         RollbackOnFailure.onTrigger(context, sessionFactory, functionContext, getLogger(), session -> process.onTrigger(context, session, functionContext));
     }


### PR DESCRIPTION
#### Description of PR

https://issues.apache.org/jira/browse/NIFI-7140

Add a property `<Support Fragmented Transactions RollBack`> for PutSQL, so that when some sql of the transaction failed , `<Support Fragmented Transactions`> is true  and `<Rollback On Failure`> is false , the database transaction can still roll back.

### For all changes:
- [√] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [√] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [√] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [√] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
