### PR TITLE
NIFI-7153 Adds ContentLengthFilter and DosFilter to web contexts.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -55,6 +55,7 @@ import org.apache.nifi.web.security.headers.ContentSecurityPolicyFilter;
 import org.apache.nifi.web.security.headers.StrictTransportSecurityFilter;
 import org.apache.nifi.web.security.headers.XFrameOptionsFilter;
 import org.apache.nifi.web.security.headers.XSSProtectionFilter;
+import org.apache.nifi.web.security.request.ContentLengthFilter;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.DeploymentManager;
@@ -590,7 +591,11 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
 
         // add HTTP security headers to all responses
         final String ALL_PATHS = "/*";
-        ArrayList<Class<? extends Filter>> filters = new ArrayList<>(Arrays.asList(XFrameOptionsFilter.class, ContentSecurityPolicyFilter.class, XSSProtectionFilter.class));
+        ArrayList<Class<? extends Filter>> filters = new ArrayList<>(Arrays.asList(
+                ContentLengthFilter.class,
+                XFrameOptionsFilter.class,
+                ContentSecurityPolicyFilter.class,
+                XSSProtectionFilter.class));
         if(props.isHTTPSConfigured()) {
             filters.add(StrictTransportSecurityFilter.class);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/resources/org/apache/nifi/web/webdefault.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/resources/org/apache/nifi/web/webdefault.xml
@@ -551,6 +551,24 @@
             <http-method-omission>TRACE</http-method-omission>
         </web-resource-collection>
     </security-constraint>
-
+    <filter>
+        <filter-name>DoSFilter</filter-name>
+        <filter-class>org.eclipse.jetty.servlets.DoSFilter</filter-class>
+        <init-param>
+            <param-name>maxRequestsPerSec</param-name>
+            <param-value>3000</param-value>
+        </init-param>
+        <init-param>
+            <param-name>delayMs</param-name>
+            <param-value>1000</param-value>
+        </init-param>
+        <init-param>
+            <param-name>trackSessions</param-name>
+            <param-value>false</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>DoSFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 </web-app>
-

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/request/ContentLengthFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/request/ContentLengthFilter.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.request;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This {@link Filter} rejects HTTP requests that exceed a specific, maximum size.
+ */
+public class ContentLengthFilter implements Filter {
+    private static final Logger logger = LoggerFactory.getLogger(ContentLengthFilter.class);
+    public final static String MAX_LENGTH_INIT_PARAM = "maxContentLength";
+    public final static int MAX_LENGTH_DEFAULT = 10_000_000;
+    private int maxContentLength;
+
+    public ContentLengthFilter() {
+        maxContentLength = MAX_LENGTH_DEFAULT;
+    }
+
+    public ContentLengthFilter(int maxLength) {
+        maxContentLength = maxLength;
+    }
+
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+        String maxLength = config.getInitParameter(MAX_LENGTH_INIT_PARAM);
+        int length = maxLength == null ? MAX_LENGTH_DEFAULT : Integer.parseInt(maxLength);
+        if (length < 0) {
+            length = MAX_LENGTH_DEFAULT;
+            // throw new ServletException("Invalid max request length.");
+        }
+        maxContentLength = length;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain next) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String httpMethod = httpRequest.getMethod();
+
+        // Check the HTTP method because the spec says clients don't have to send a content-length header for methods
+        // that don't use it.  So even though an attacker may provide a large body in a GET request, the body should go
+        // unread and a size filter is unneeded at best.  See RFC 2616 section 14.13, and RFC 1945 section 10.4.
+        boolean willReadInputStream = httpMethod.equalsIgnoreCase("POST") || httpMethod.equalsIgnoreCase("PUT");
+        if (!willReadInputStream || maxContentLength <= 0) {
+            logger.info("skipping check of request with method {} and maximum {}", httpMethod, maxContentLength);
+            next.doFilter(request, response);
+            return;
+        }
+
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        int contentLength = request.getContentLength();
+        if (contentLength < 0) {
+            // Request without a content length is rejected:
+            logger.info("request rejected with negative or unknown content-length {}", contentLength);
+            httpResponse.setContentType("text/plain");
+            httpResponse.setStatus(HttpServletResponse.SC_LENGTH_REQUIRED);
+        } else if (contentLength > maxContentLength) {
+            // Request with a client-specified length greater than our max is rejected:
+            logger.info("request rejected with content-length {} greater than maximum {}", contentLength, maxContentLength);
+            httpResponse.setContentType("text/plain");
+            httpResponse.getOutputStream().write("Payload Too large".getBytes());
+            httpResponse.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+        } else {
+            // If or when the request is read, this limits the read to our max:
+            logger.info("request allowed with content-length {} less than maximum {}", contentLength, maxContentLength);
+            next.doFilter(new LimitedContentLengthRequest(httpRequest, maxContentLength), response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    // This wrapper ensures that the input stream of the wrapped request is not read past the given maximum.
+    private static class LimitedContentLengthRequest extends HttpServletRequestWrapper {
+        private int maxRequestLength;
+
+        public LimitedContentLengthRequest(HttpServletRequest request, int maxLength) {
+            super(request);
+            maxRequestLength = maxLength;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            final ServletInputStream originalStream = super.getInputStream();
+            return new ServletInputStream() {
+                private int inputStreamByteCounter = 0;
+
+                @Override
+                public boolean isFinished() {
+                    return originalStream.isFinished();
+                }
+
+                @Override
+                public boolean isReady() {
+                    return originalStream.isReady();
+                }
+
+                @Override
+                public void setReadListener(ReadListener readListener) {
+                    originalStream.setReadListener(readListener);
+                }
+
+                @Override
+                public int read() throws IOException {
+                    int read = originalStream.read();
+                    if (read == -1) {
+                        return read;
+                    }
+
+                    inputStreamByteCounter += 1;
+                    if (inputStreamByteCounter > maxRequestLength) {
+                        throw new IOException(String.format("Request input stream longer than %d bytes.", maxRequestLength));
+                    }
+                    return read;
+                }
+            };
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/request/ContentLengthFilterTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/request/ContentLengthFilterTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.request;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * This test exercises the {@link ContentLengthFilter} class.
+ *
+ * The approach here is to use a {@link LocalConnector} and raw strings for HTTP requests.  The additional complexity
+ * of a complete HTTP client isn't required to determine the behavior, and any client would introduce a new dependency.
+ *
+ */
+public class ContentLengthFilterTest {
+    private static final int MAX_CONTENT_LENGTH = 1000;
+    private static final int SERVER_IDLE_TIMEOUT = 2500; // only one request needed + value large enough for slow systems
+    private static final String POST_REQUEST = "POST / HTTP/1.1\r\nContent-Length: %d\r\nHost: h\r\n\r\n%s";
+    private static final String FORM_REQUEST = "POST / HTTP/1.1\r\nContent-Length: %d\r\nHost: h\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n%s";
+    public static final int FORM_CONTENT_SIZE = 128;
+
+    private Server serverUnderTest;
+    private LocalConnector localConnector;
+    private ServletContextHandler contextUnderTest;
+
+    @After
+    public void stopServer() throws Exception {
+        if (serverUnderTest != null && serverUnderTest.isRunning()) {
+            serverUnderTest.stop();
+        }
+    }
+
+
+    @Test
+    public void testRequestsWithMissingContentLengthHeader() throws Exception {
+        configureAndStartServer(readFullyAndRespondOK, -1);
+
+        // This shows that the ContentLengthFilter rejects a request that does not have a content-length header.
+        String response = localConnector.getResponse("POST / HTTP/1.0\r\n\r\n");
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "411 Length Required"));
+    }
+
+
+    @Test
+    public void testRequestsWithContentLengthHeader() throws Exception {
+        configureAndStartServer(readFullyAndRespondOK, -1);
+
+        int smallClaim = 150;
+        int largeClaim = 2000;
+
+        String incompletePayload = StringUtils.repeat("1", 10);
+        String largePayload = StringUtils.repeat("1", largeClaim + 200);
+
+        // This shows that the ContentLengthFilter rejects a request when the client claims more than the max + sends more than the max:
+        String response = localConnector.getResponse(String.format(POST_REQUEST, largeClaim, largePayload));
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "413 Payload Too Large"));
+
+        // This shows that the ContentLengthFilter rejects a request when the client claims more than the max + sends less the max:
+        response = localConnector.getResponse(String.format(POST_REQUEST, largeClaim, incompletePayload));
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "413 Payload Too Large"));
+
+        // This shows that the ContentLengthFilter allows a request when it claims less than the max + sends more than the max:
+        response = localConnector.getResponse(String.format(POST_REQUEST, smallClaim, largePayload));
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "200 OK"));
+
+        // This shows that the server times out when the client claims less than the max + sends less than the max + sends less than it claims to send:
+        response = localConnector.getResponse(String.format(POST_REQUEST, smallClaim, incompletePayload), 500, TimeUnit.MILLISECONDS);
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "500 Server Error"));
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "Timeout"));
+    }
+
+
+    @Test
+    public void testJettyMaxFormSize() throws Exception {
+        // This shows that the jetty server option for 'maxFormContentSize' is insufficient for our needs because it
+        // catches requests like this:
+        configureAndStartServer(readFormAttempt, FORM_CONTENT_SIZE);
+        String form = "a=" + StringUtils.repeat("1", FORM_CONTENT_SIZE);
+        String response = localConnector.getResponse(String.format(FORM_REQUEST, form.length(), form));
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "413 Payload Too Large"));
+
+
+        // But it does not catch requests like this:
+        response = localConnector.getResponse(String.format(POST_REQUEST, form.length(), form+form));
+        Assert.assertTrue(StringUtils.containsIgnoreCase(response, "417 Read Too Many Bytes"));
+    }
+
+
+
+    private HttpServlet readFullyAndRespondOK = new HttpServlet() {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            ServletInputStream input = req.getInputStream();
+            while (!input.isFinished()) {
+                input.read();
+            }
+            resp.setStatus(HttpServletResponse.SC_OK);
+        }
+    };
+
+
+    private HttpServlet readFormAttempt = new HttpServlet() {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            try {
+                req.getParameterMap();
+                ServletInputStream input = req.getInputStream();
+                int count = 0;
+                while (!input.isFinished()) {
+                    input.read();
+                    count += 1;
+                }
+                if (count > FORM_CONTENT_SIZE + "a=\n".length()) {
+                    resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Should not reach this code.");
+                } else {
+                    resp.sendError(HttpServletResponse.SC_EXPECTATION_FAILED, "Read Too Many Bytes");
+                }
+
+            } catch (final Exception e) {
+                // This is the jetty context returning a 400 from the maxFormContentSize setting:
+                if (StringUtils.containsIgnoreCase(e.getCause().toString(), "Form Too Large")) {
+                    resp.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, "Payload Too Large");
+                } else {
+                    resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Should not reach this code, either.");
+                }
+            }
+        }
+    };
+
+
+    private void configureAndStartServer(HttpServlet servlet, int maxFormContentSize) throws Exception {
+        serverUnderTest = new Server();
+        localConnector = new LocalConnector(serverUnderTest);
+        localConnector.setIdleTimeout(SERVER_IDLE_TIMEOUT);
+        serverUnderTest.addConnector(localConnector);
+
+        contextUnderTest = new ServletContextHandler(serverUnderTest, "/");
+        if (maxFormContentSize > 0) {
+            contextUnderTest.setMaxFormContentSize(maxFormContentSize);
+        }
+        contextUnderTest.addServlet(new ServletHolder(servlet), "/*");
+
+        if (maxFormContentSize < 0) {
+            FilterHolder holder = contextUnderTest.addFilter(ContentLengthFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
+            holder.setInitParameter(ContentLengthFilter.MAX_LENGTH_INIT_PARAM, String.valueOf(MAX_CONTENT_LENGTH));
+        }
+        serverUnderTest.start();
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-error-handler.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-error-handler.js
@@ -73,6 +73,8 @@
                     $('#message-title').text('Insufficient Permissions');
                 } else if (xhr.status === 409) {
                     $('#message-title').text('Invalid State');
+                } else if (xhr.status === 413) {
+                    $('#message-title').text('Payload Too Large');
                 } else {
                     $('#message-title').text('An unexpected error has occurred');
                 }
@@ -89,7 +91,7 @@
             }
 
             // status code 400, 404, and 409 are expected response codes for nfCommon errors.
-            if (xhr.status === 400 || xhr.status === 404 || xhr.status === 409 || xhr.status === 503) {
+            if (xhr.status === 400 || xhr.status === 404 || xhr.status === 409 || xhr.status == 413 || xhr.status === 503) {
                 nfDialog.showOkDialog({
                     headerText: 'Error',
                     dialogContent: nfCommon.escapeHtml(xhr.responseText)


### PR DESCRIPTION
#### NIFI-7153 Limit Length of Component Properties (by limiting HTTP request sizes)

_The code in this change-set adds a new ContentLengthFilter and introduces the DosFilter from the jetty project_

These changes effect every byte that passes thru the HTTP API and HTTP UI so this code needs thorough review and wide testing.

The `ContentLengthFilter` is new and currently activated via code in `JettyServer.java`.  I think the filter should be activated via the various web.xml files but my initial attempts at integrating that way were unsuccessful.  The current activation uses the default of 10MB for the limit on PUT/POST requests to all API and UI contexts.

Before completing the new filter, I attempted to use the `maxFormContentSize` setting to produce the limiting behavior.  Unfortunately, that value is only referenced during `application/x-form-encoded`-type requests, not our typical PUT with `application/json`.  This change-set includes a unit test that demonstrates this distinction.

There is a small change to the UI code to account for the `413` responses returned by the server.

The `DosFilter` is from the jetty project and activated via the `webdefaults.xml` file.  I've set reasonable defaults that allow me to use the application as a user and still trigger the DoS filter behavior with a benchmark (such as `wrk`).

Finally, there is a new behavior introduced by the `ContentLengthFilter` class that will effect older, HTTP 1.0 and non-conforming HTTP user agents.  When a PUT or POST HTTP request is made without sending a `Content-Length` header, the server will now respond with `411 Length Required`.

Remaining steps:
 - finalize activation point for both filters (xml vs code)
 - finalize defaults for both filters
 - apply options to specific contexts/endpoints as necessary




In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
