### PR TITLE
NIFI-7159 - Add support for some data types in various processors

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
@@ -26,6 +26,7 @@ import org.apache.nifi.serialization.record.type.RecordDataType;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
 import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -252,6 +253,11 @@ public class MapRecord implements Record {
     @Override
     public Double getAsDouble(final String fieldName) {
         return DataTypeUtils.toDouble(getValue(fieldName), fieldName);
+    }
+
+    @Override
+    public BigDecimal getAsBigDecimal(final String fieldName) {
+        return DataTypeUtils.toBigDecimal(getValue(fieldName), fieldName);
     }
 
     @Override

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
@@ -19,6 +19,7 @@ package org.apache.nifi.serialization.record;
 
 import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
@@ -101,6 +102,8 @@ public interface Record {
     Integer getAsInt(String fieldName);
 
     Double getAsDouble(String fieldName);
+
+    BigDecimal getAsBigDecimal(String fieldName);
 
     Float getAsFloat(String fieldName);
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
@@ -19,7 +19,6 @@ package org.apache.nifi.serialization.record;
 
 import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 
-import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
@@ -19,6 +19,7 @@ package org.apache.nifi.serialization.record;
 
 import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
@@ -288,23 +288,23 @@ public enum RecordFieldType {
 
     /**
      * Returns a data type that represents a DECIMAL value with given precision and scale
-     * 
-     * @param precision
-     * @param scale
-     * 
+     *
+     * @param precision indicates the expected number of digits before the decimal point
+     * @param scale indicates the expected number of digits after the decimal point
+     *
      * @return a DataType that represents a DECIMAL with specified precision and scale, or <code>null</code> if this RecordFieldType
      *         is not a DECIMAL type
      */
-    
+
     public DataType getDecimalDataType(int precision, int scale) {
-    	if(this != DECIMAL) {
-    		return null;
-    	}
-    	
-    	return new DecimalDataType(precision, scale);
+        if(this != DECIMAL) {
+            return null;
+        }
+
+        return new DecimalDataType(precision, scale);
     }
-    
-    
+
+
     /**
      * Returns a Data Type that represents an "ARRAY" type with the given element type.
      *

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
@@ -289,7 +289,7 @@ public enum RecordFieldType {
     /**
      * Returns a data type that represents a DECIMAL value with given precision and scale
      *
-     * @param precision indicates the expected number of digits before the decimal point
+     * @param precision indicates the total number of digits
      * @param scale indicates the expected number of digits after the decimal point
      *
      * @return a DataType that represents a DECIMAL with specified precision and scale, or <code>null</code> if this RecordFieldType

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
@@ -19,6 +19,7 @@ package org.apache.nifi.serialization.record;
 
 import org.apache.nifi.serialization.record.type.ArrayDataType;
 import org.apache.nifi.serialization.record.type.ChoiceDataType;
+import org.apache.nifi.serialization.record.type.DecimalDataType;
 import org.apache.nifi.serialization.record.type.MapDataType;
 import org.apache.nifi.serialization.record.type.RecordDataType;
 
@@ -71,6 +72,11 @@ public enum RecordFieldType {
      * A double field type. Fields of this type use a {@code double} value.
      */
     DOUBLE("double", FLOAT),
+
+    /**
+     * A decimal field type. Fields of this type use a {@code java.math.BigDecimal} value.
+     */
+    DECIMAL("decimal", null, new DecimalDataType(15, 2)),
 
     /**
      * A timestamp field type. Fields of this type use a {@code java.sql.Timestamp} value.
@@ -280,6 +286,25 @@ public enum RecordFieldType {
         return new RecordDataType(childSchema);
     }
 
+    /**
+     * Returns a data type that represents a DECIMAL value with given precision and scale
+     * 
+     * @param precision
+     * @param scale
+     * 
+     * @return a DataType that represents a DECIMAL with specified precision and scale, or <code>null</code> if this RecordFieldType
+     *         is not a DECIMAL type
+     */
+    
+    public DataType getDecimalDataType(int precision, int scale) {
+    	if(this != DECIMAL) {
+    		return null;
+    	}
+    	
+    	return new DecimalDataType(precision, scale);
+    }
+    
+    
     /**
      * Returns a Data Type that represents an "ARRAY" type with the given element type.
      *

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -213,8 +213,8 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 final Object obj = rs.getObject(columnIndex);
                 if (!(obj instanceof Record)) {
                     final List<DataType> dataTypes = Stream.of(RecordFieldType.BIGINT, RecordFieldType.BOOLEAN, RecordFieldType.BYTE, RecordFieldType.CHAR, RecordFieldType.DATE,
-                        RecordFieldType.DECIMAL, RecordFieldType.DOUBLE, RecordFieldType.FLOAT, RecordFieldType.INT, RecordFieldType.LONG, RecordFieldType.SHORT, RecordFieldType.STRING, RecordFieldType.TIME,
-                        RecordFieldType.TIMESTAMP)
+                        RecordFieldType.DECIMAL, RecordFieldType.DOUBLE, RecordFieldType.FLOAT, RecordFieldType.INT, RecordFieldType.LONG, RecordFieldType.SHORT,
+                        RecordFieldType.STRING, RecordFieldType.TIME, RecordFieldType.TIMESTAMP)
                     .map(RecordFieldType::getDataType)
                     .collect(Collectors.toList());
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Array;
 import java.sql.ResultSet;
@@ -212,7 +213,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 final Object obj = rs.getObject(columnIndex);
                 if (!(obj instanceof Record)) {
                     final List<DataType> dataTypes = Stream.of(RecordFieldType.BIGINT, RecordFieldType.BOOLEAN, RecordFieldType.BYTE, RecordFieldType.CHAR, RecordFieldType.DATE,
-                        RecordFieldType.DOUBLE, RecordFieldType.FLOAT, RecordFieldType.INT, RecordFieldType.LONG, RecordFieldType.SHORT, RecordFieldType.STRING, RecordFieldType.TIME,
+                        RecordFieldType.DECIMAL, RecordFieldType.DOUBLE, RecordFieldType.FLOAT, RecordFieldType.INT, RecordFieldType.LONG, RecordFieldType.SHORT, RecordFieldType.STRING, RecordFieldType.TIME,
                         RecordFieldType.TIMESTAMP)
                     .map(RecordFieldType::getDataType)
                     .collect(Collectors.toList());
@@ -269,6 +270,9 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         if (arrayValue instanceof double[]) {
             return RecordFieldType.DOUBLE.getDataType();
         }
+        if (arrayValue instanceof BigDecimal[]) {
+            return RecordFieldType.DECIMAL.getDataType();
+        }
         if (arrayValue instanceof char[]) {
             return RecordFieldType.CHAR.getDataType();
         }
@@ -309,6 +313,9 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             }
             if (valueToLookAt instanceof Double) {
                 return RecordFieldType.DOUBLE.getDataType();
+            }
+            if (valueToLookAt instanceof BigDecimal) {
+                return RecordFieldType.DECIMAL.getDataType();
             }
             if (valueToLookAt instanceof Boolean) {
                 return RecordFieldType.BOOLEAN.getDataType();
@@ -354,6 +361,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             case Types.DATE:
                 return RecordFieldType.DATE;
             case Types.DECIMAL:
+                return RecordFieldType.DECIMAL;
             case Types.DOUBLE:
             case Types.NUMERIC:
             case Types.REAL:

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
@@ -67,6 +67,6 @@ public class DecimalDataType extends DataType {
 
     @Override
     public String toString() {
-        return "DECIMAL" + Integer.toString(precision) + Integer.toString(scale);
+        return "DECIMAL_" + precision + "_" + scale;
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
@@ -1,0 +1,55 @@
+package org.apache.nifi.serialization.record.type;
+
+import org.apache.nifi.serialization.record.DataType;
+import org.apache.nifi.serialization.record.RecordFieldType;
+
+public class DecimalDataType extends DataType {
+
+    private final int precision;
+    private final int scale;
+	
+	public DecimalDataType(int precision, int scale) {
+	    super(RecordFieldType.DECIMAL, null);
+	    this.precision = precision;
+	    this.scale = scale;
+	}
+    
+    public int getPrecision() {
+    	return precision;
+    }
+    
+    public int getScale() {
+    	return scale;
+    }
+
+    @Override
+    public RecordFieldType getFieldType() {
+        return RecordFieldType.DECIMAL;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 + 41 * getFieldType().hashCode() + 41 * Integer.hashCode(precision) * Integer.hashCode(scale); // Need to confirm this hash * hash is correct
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof DecimalDataType)) {
+            return false;
+        }
+
+        final DecimalDataType other = (DecimalDataType) obj;
+        return precision == other.getPrecision() && scale == other.getScale();
+    }
+
+    @Override
+    public String toString() {
+        return "DECIMAL" + Integer.toString(precision) + Integer.toString(scale);
+    }
+}

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
@@ -7,19 +7,19 @@ public class DecimalDataType extends DataType {
 
     private final int precision;
     private final int scale;
-	
-	public DecimalDataType(int precision, int scale) {
-	    super(RecordFieldType.DECIMAL, null);
-	    this.precision = precision;
-	    this.scale = scale;
-	}
-    
-    public int getPrecision() {
-    	return precision;
+
+    public DecimalDataType(int precision, int scale) {
+        super(RecordFieldType.DECIMAL, null);
+        this.precision = precision;
+        this.scale = scale;
     }
     
+    public int getPrecision() {
+        return precision;
+    }
+
     public int getScale() {
-    	return scale;
+        return scale;
     }
 
     @Override

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.nifi.serialization.record.type;
 
 import org.apache.nifi.serialization.record.DataType;

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/DecimalDataType.java
@@ -13,7 +13,7 @@ public class DecimalDataType extends DataType {
         this.precision = precision;
         this.scale = scale;
     }
-    
+
     public int getPrecision() {
         return precision;
     }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -461,7 +461,7 @@ public class DataTypeUtils {
             }
             if (value instanceof BigDecimal) {
                 return RecordFieldType.DECIMAL.getDecimalDataType(
-                		((BigDecimal) value).precision(), ((BigDecimal) value).scale());
+                        ((BigDecimal) value).precision(), ((BigDecimal) value).scale());
             }
         }
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -26,6 +26,7 @@ import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.type.ArrayDataType;
 import org.apache.nifi.serialization.record.type.ChoiceDataType;
+import org.apache.nifi.serialization.record.type.DecimalDataType;
 import org.apache.nifi.serialization.record.type.MapDataType;
 import org.apache.nifi.serialization.record.type.RecordDataType;
 import org.slf4j.Logger;
@@ -1279,6 +1280,10 @@ public class DataTypeUtils {
             return BigDecimal.valueOf((Double) value);
         }
 
+        if (value instanceof Number) {
+            return new BigDecimal(value.toString());
+        }
+
         if (value instanceof String) {
             return new BigDecimal((String) value);
         }
@@ -1711,7 +1716,6 @@ public class DataTypeUtils {
             if (thisIntTypeValue > otherIntTypeValue) {
                 return Optional.of(thisDataType);
             }
-
             return Optional.of(otherDataType);
         }
 
@@ -1728,6 +1732,16 @@ public class DataTypeUtils {
                 break;
 
             case DECIMAL:
+                if(otherFieldType == RecordFieldType.DECIMAL) {
+
+                    DecimalDataType thisDecimalType = (DecimalDataType) thisDataType;
+                    DecimalDataType otherDecimalType = (DecimalDataType) otherDataType;
+
+                    int widerScale = Math.max(thisDecimalType.getScale(), otherDecimalType.getScale());
+                    int widerPrecision = widerScale + Math.max(thisDecimalType.getPrecision()-thisDecimalType.getScale(), otherDecimalType.getPrecision()-otherDecimalType.getScale());
+
+                    return Optional.of(RecordFieldType.DECIMAL.getDecimalDataType(widerPrecision, widerScale));
+                }
                 if (otherFieldType == RecordFieldType.FLOAT || otherFieldType == RecordFieldType.DOUBLE) {
                     return Optional.of(thisDataType);
                 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -1268,9 +1268,9 @@ public class DataTypeUtils {
         }
 
         if(value instanceof BigDecimal) {
-        	return (BigDecimal) value;
+            return (BigDecimal) value;
         }
-        
+
         if (value instanceof Long) {
             return BigDecimal.valueOf((Long) value);
         }
@@ -1278,7 +1278,7 @@ public class DataTypeUtils {
         if (value instanceof Double) {
             return BigDecimal.valueOf((Double) value);
         }
-        
+
         if (value instanceof String) {
             return new BigDecimal((String) value);
         }
@@ -1387,7 +1387,7 @@ public class DataTypeUtils {
 
         return true;
     }
-    
+
     public static Long toLong(final Object value, final String fieldName) {
         if (value == null) {
             return null;

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
@@ -670,8 +670,6 @@ public class PutElasticsearchHttpRecord extends AbstractElasticsearchHttpProcess
                 break;
             }
             case DECIMAL:
-                generator.writeNumber(DataTypeUtils.toBigDecimal(coercedValue, fieldName));
-                break;
             case DOUBLE:
                 generator.writeNumber(DataTypeUtils.toDouble(coercedValue, fieldName));
                 break;

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchHttpRecord.java
@@ -669,6 +669,9 @@ public class PutElasticsearchHttpRecord extends AbstractElasticsearchHttpProcess
                 }
                 break;
             }
+            case DECIMAL:
+                generator.writeNumber(DataTypeUtils.toBigDecimal(coercedValue, fieldName));
+                break;
             case DOUBLE:
                 generator.writeNumber(DataTypeUtils.toDouble(coercedValue, fieldName));
                 break;

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -44,6 +44,7 @@ import org.apache.nifi.serialization.record.SchemaIdentifier;
 import org.apache.nifi.serialization.record.StandardSchemaIdentifier;
 import org.apache.nifi.serialization.record.type.ArrayDataType;
 import org.apache.nifi.serialization.record.type.ChoiceDataType;
+import org.apache.nifi.serialization.record.type.DecimalDataType;
 import org.apache.nifi.serialization.record.type.MapDataType;
 import org.apache.nifi.serialization.record.type.RecordDataType;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
@@ -256,6 +257,10 @@ public class AvroTypeUtil {
             case LONG:
                 schema = Schema.create(Type.LONG);
                 break;
+            case DECIMAL:
+            	final DecimalDataType decimalDataType = (DecimalDataType) dataType;
+            	schema = LogicalTypes.decimal(decimalDataType.getPrecision(), decimalDataType.getScale()).addToSchema(Schema.create(Type.BYTES));
+                break;
             case MAP:
                 schema = Schema.createMap(buildAvroSchema(((MapDataType) dataType).getValueType(), fieldName, false));
                 break;
@@ -341,7 +346,15 @@ public class AvroTypeUtil {
                 case LOGICAL_TYPE_TIMESTAMP_MICROS:
                     return RecordFieldType.TIMESTAMP.getDataType();
                 case LOGICAL_TYPE_DECIMAL:
-                    // We convert Decimal to Double.
+                	// Convert here into a DECIMAL type with a specified precision and scale
+                	if(logicalType instanceof LogicalTypes.Decimal) {
+                		
+                		return RecordFieldType.DECIMAL.getDecimalDataType(
+                				((LogicalTypes.Decimal) logicalType).getPrecision(),
+                				((LogicalTypes.Decimal) logicalType).getScale());
+                	}
+                	
+                	// We convert Decimal to Double.
                     // Alternatively we could convert it to String, but numeric type is generally more preferable by users.
                     return RecordFieldType.DOUBLE.getDataType();
             }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -258,8 +258,8 @@ public class AvroTypeUtil {
                 schema = Schema.create(Type.LONG);
                 break;
             case DECIMAL:
-            	final DecimalDataType decimalDataType = (DecimalDataType) dataType;
-            	schema = LogicalTypes.decimal(decimalDataType.getPrecision(), decimalDataType.getScale()).addToSchema(Schema.create(Type.BYTES));
+                final DecimalDataType decimalDataType = (DecimalDataType) dataType;
+                schema = LogicalTypes.decimal(decimalDataType.getPrecision(), decimalDataType.getScale()).addToSchema(Schema.create(Type.BYTES));
                 break;
             case MAP:
                 schema = Schema.createMap(buildAvroSchema(((MapDataType) dataType).getValueType(), fieldName, false));
@@ -346,15 +346,15 @@ public class AvroTypeUtil {
                 case LOGICAL_TYPE_TIMESTAMP_MICROS:
                     return RecordFieldType.TIMESTAMP.getDataType();
                 case LOGICAL_TYPE_DECIMAL:
-                	// Convert here into a DECIMAL type with a specified precision and scale
-                	if(logicalType instanceof LogicalTypes.Decimal) {
-                		
-                		return RecordFieldType.DECIMAL.getDecimalDataType(
-                				((LogicalTypes.Decimal) logicalType).getPrecision(),
-                				((LogicalTypes.Decimal) logicalType).getScale());
-                	}
-                	
-                	// We convert Decimal to Double.
+                    // Convert here into a DECIMAL type with a specified precision and scale
+                    if(logicalType instanceof LogicalTypes.Decimal) {
+
+                        return RecordFieldType.DECIMAL.getDecimalDataType(
+                                ((LogicalTypes.Decimal) logicalType).getPrecision(),
+                                ((LogicalTypes.Decimal) logicalType).getScale());
+                    }
+
+                    // We convert Decimal to Double.
                     // Alternatively we could convert it to String, but numeric type is generally more preferable by users.
                     return RecordFieldType.DOUBLE.getDataType();
             }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/schema/access/InferenceSchemaStrategy.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/schema/access/InferenceSchemaStrategy.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
@@ -58,6 +59,11 @@ public class InferenceSchemaStrategy implements JsonSchemaAccessStrategy {
                 field = new RecordField(entry.getKey(), RecordFieldType.BOOLEAN.getDataType());
             } else if (entry.getValue() instanceof Double) {
                 field = new RecordField(entry.getKey(), RecordFieldType.DOUBLE.getDataType());
+            } else if (entry.getValue() instanceof BigDecimal) {
+                field = new RecordField(entry.getKey(), 
+                		RecordFieldType.DECIMAL.getDecimalDataType(
+                				((BigDecimal) entry.getValue()).precision(),
+                				((BigDecimal) entry.getValue()).scale()));
             } else if (entry.getValue() instanceof Date) {
                 field = new RecordField(entry.getKey(), RecordFieldType.DATE.getDataType());
             } else if (entry.getValue() instanceof List) {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/schema/access/InferenceSchemaStrategy.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/schema/access/InferenceSchemaStrategy.java
@@ -60,10 +60,10 @@ public class InferenceSchemaStrategy implements JsonSchemaAccessStrategy {
             } else if (entry.getValue() instanceof Double) {
                 field = new RecordField(entry.getKey(), RecordFieldType.DOUBLE.getDataType());
             } else if (entry.getValue() instanceof BigDecimal) {
-                field = new RecordField(entry.getKey(), 
-                		RecordFieldType.DECIMAL.getDecimalDataType(
-                				((BigDecimal) entry.getValue()).precision(),
-                				((BigDecimal) entry.getValue()).scale()));
+                field = new RecordField(entry.getKey(),
+                        RecordFieldType.DECIMAL.getDecimalDataType(
+                                ((BigDecimal) entry.getValue()).precision(),
+                                ((BigDecimal) entry.getValue()).scale()));
             } else if (entry.getValue() instanceof Date) {
                 field = new RecordField(entry.getKey(), RecordFieldType.DATE.getDataType());
             } else if (entry.getValue() instanceof List) {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
@@ -434,10 +434,10 @@ public class TestAvroTypeUtil {
 
         final Object resultObject = convertedMap.get("amount");
         assertNotNull(resultObject);
-        assertTrue(resultObject instanceof Double);
+        assertTrue(resultObject instanceof BigDecimal);
 
-        final Double resultDouble = (Double) resultObject;
-        assertEquals(Double.valueOf(expectedDecimalValue.doubleValue()), resultDouble);
+        final BigDecimal resultDouble = (BigDecimal) resultObject;
+        assertEquals(expectedDecimalValue, resultDouble);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.schema.validation;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Map;
 
@@ -243,6 +244,8 @@ public class StandardSchemaValidator implements RecordSchemaValidator {
                 return value instanceof Character;
             case DATE:
                 return value instanceof java.sql.Date;
+            case DECIMAL:
+                return value instanceof BigDecimal;
             case DOUBLE:
                 return value instanceof Double;
             case FLOAT:

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-reporting-utils/src/main/java/org/apache/nifi/reporting/util/metrics/MetricsService.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-reporting-utils/src/main/java/org/apache/nifi/reporting/util/metrics/MetricsService.java
@@ -138,10 +138,17 @@ public class MetricsService {
 
     private Map<String,Double> getDoubleMetrics(JvmMetrics virtualMachineMetrics) {
         final Map<String,Double> metrics = new HashMap<>();
-        metrics.put(MetricNames.JVM_HEAP_USED, virtualMachineMetrics.heapUsed(DataUnit.B));
-        metrics.put(MetricNames.JVM_HEAP_USAGE, virtualMachineMetrics.heapUsage());
-        metrics.put(MetricNames.JVM_NON_HEAP_USAGE, virtualMachineMetrics.nonHeapUsage());
-        metrics.put(MetricNames.JVM_FILE_DESCRIPTOR_USAGE, virtualMachineMetrics.fileDescriptorUsage());
+
+        final double jvmHeapUsed = virtualMachineMetrics.heapUsed(DataUnit.B);
+        final double jvmHeapUsage = virtualMachineMetrics.heapUsage();
+        final double jvmNonHeapUsage = virtualMachineMetrics.nonHeapUsage();
+        final double jvmFileDescriptorUsage = virtualMachineMetrics.fileDescriptorUsage();
+       
+        metrics.put(MetricNames.JVM_HEAP_USED, Double.isNaN(jvmHeapUsed) ? null : jvmHeapUsed);
+        metrics.put(MetricNames.JVM_HEAP_USAGE, Double.isNaN(jvmHeapUsage) ? null : jvmHeapUsage);
+        metrics.put(MetricNames.JVM_NON_HEAP_USAGE, Double.isNaN(jvmNonHeapUsage) ? null : jvmNonHeapUsage);
+        metrics.put(MetricNames.JVM_FILE_DESCRIPTOR_USAGE, Double.isNaN(jvmFileDescriptorUsage) ? null : jvmFileDescriptorUsage);
+
         return metrics;
     }
 

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-reporting-utils/src/main/java/org/apache/nifi/reporting/util/metrics/MetricsService.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-reporting-utils/src/main/java/org/apache/nifi/reporting/util/metrics/MetricsService.java
@@ -143,7 +143,7 @@ public class MetricsService {
         final double jvmHeapUsage = virtualMachineMetrics.heapUsage();
         final double jvmNonHeapUsage = virtualMachineMetrics.nonHeapUsage();
         final double jvmFileDescriptorUsage = virtualMachineMetrics.fileDescriptorUsage();
-       
+
         metrics.put(MetricNames.JVM_HEAP_USED, Double.isNaN(jvmHeapUsed) ? null : jvmHeapUsed);
         metrics.put(MetricNames.JVM_HEAP_USAGE, Double.isNaN(jvmHeapUsage) ? null : jvmHeapUsage);
         metrics.put(MetricNames.JVM_NON_HEAP_USAGE, Double.isNaN(jvmNonHeapUsage) ? null : jvmNonHeapUsage);

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
@@ -341,6 +341,8 @@ public class PutHBaseRecord extends AbstractPutHBase {
                 case BOOLEAN:
                     retVal = clientService.toBytes(record.getAsBoolean(field));
                     break;
+                case DECIMAL:
+                	// Decimal to be treated as the same as double
                 case DOUBLE:
                     retVal = clientService.toBytes(record.getAsDouble(field));
                     break;

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
@@ -342,7 +342,7 @@ public class PutHBaseRecord extends AbstractPutHBase {
                     retVal = clientService.toBytes(record.getAsBoolean(field));
                     break;
                 case DECIMAL:
-                	// Decimal to be treated as the same as double
+                    // Decimal to be treated as the same as double
                 case DOUBLE:
                     retVal = clientService.toBytes(record.getAsDouble(field));
                     break;

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
@@ -342,7 +342,8 @@ public class PutHBaseRecord extends AbstractPutHBase {
                     retVal = clientService.toBytes(record.getAsBoolean(field));
                     break;
                 case DECIMAL:
-                    // Decimal to be treated as the same as double
+                    retVal = clientService.toBytes(record.getAsBigDecimal(field));
+                    break;
                 case DOUBLE:
                     retVal = clientService.toBytes(record.getAsDouble(field));
                     break;

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/MockHBaseClientService.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/MockHBaseClientService.java
@@ -24,6 +24,8 @@ import org.apache.nifi.hbase.scan.ResultCell;
 import org.apache.nifi.hbase.scan.ResultHandler;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -272,6 +274,15 @@ public class MockHBaseClientService extends AbstractControllerService implements
     @Override
     public byte[] toBytes(final double d) {
         return toBytes(Double.doubleToRawLongBits(d));
+    }
+
+    @Override
+    public byte[] toBytes(final BigDecimal d) {
+        byte[] valueBytes = d.unscaledValue().toByteArray();
+        ByteBuffer b = ByteBuffer.allocate(valueBytes.length + (int) (Integer.SIZE / Byte.SIZE));
+        b.putInt(valueBytes.length);
+        b.put(valueBytes);
+        return b.array();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-controller-service/src/main/java/org/apache/nifi/controller/kudu/KuduLookupService.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-controller-service/src/main/java/org/apache/nifi/controller/kudu/KuduLookupService.java
@@ -317,7 +317,7 @@ public class KuduLookupService extends AbstractControllerService implements Reco
                 case BINARY:
                 case STRING:
                 case DECIMAL:
-                    fields.add(new RecordField(cs.getName(), RecordFieldType.STRING.getDataType()));
+                    fields.add(new RecordField(cs.getName(), RecordFieldType.DECIMAL.getDataType()));
                     break;
                 case DOUBLE:
                     fields.add(new RecordField(cs.getName(), RecordFieldType.DOUBLE.getDataType()));

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
@@ -28,26 +28,35 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
-import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.type.ArrayDataType;
+import org.apache.nifi.serialization.record.type.ChoiceDataType;
+import org.apache.nifi.serialization.record.type.MapDataType;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
 import org.bson.Document;
+import org.bson.types.Decimal128;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @EventDriven
 @Tags({"mongodb", "insert", "record", "put"})
@@ -78,7 +87,7 @@ public class PutMongoRecord extends AbstractMongoProcessor {
             .required(true)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
-
+    
     private final static Set<Relationship> relationships;
     private final static List<PropertyDescriptor> propertyDescriptors;
 
@@ -107,14 +116,15 @@ public class PutMongoRecord extends AbstractMongoProcessor {
     }
 
     @Override
-    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
-        final FlowFile flowFile = session.get();
-        if (flowFile == null) {
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+
+    	final FlowFile flowFile = session.get();
+
+    	if (flowFile == null) {
             return;
         }
 
-        final RecordReaderFactory recordParserFactory = context.getProperty(RECORD_READER_FACTORY)
-                .asControllerService(RecordReaderFactory.class);
+        final RecordReaderFactory recordParserFactory = context.getProperty(RECORD_READER_FACTORY).asControllerService(RecordReaderFactory.class);
 
         final WriteConcern writeConcern = getWriteConcern(context);
 
@@ -125,35 +135,42 @@ public class PutMongoRecord extends AbstractMongoProcessor {
 
         try (final InputStream inStream = session.read(flowFile);
              final RecordReader reader = recordParserFactory.createRecordReader(flowFile, inStream, getLogger())) {
-            final MongoCollection<Document> collection = getCollection(context, flowFile).withWriteConcern(writeConcern);
-            RecordSchema schema = reader.getSchema();
+
+        	final MongoCollection<Document> collection = getCollection(context, flowFile).withWriteConcern(writeConcern);
+
             Record record;
+
             while ((record = reader.nextRecord()) != null) {
-                // Convert each Record to HashMap and put into the Mongo document
-                Map<String, Object> contentMap = (Map<String, Object>) DataTypeUtils.convertRecordFieldtoObject(record, RecordFieldType.RECORD.getRecordDataType(record.getSchema()));
-                Document document = new Document();
-                for (String name : schema.getFieldNames()) {
-                    document.put(name, contentMap.get(name));
-                }
-                inserts.add(convertArrays(document));
+ 
+            	// Convert each Record to HashMap and put into the Mongo document
+
+            	inserts.add(convertArrays(new Document(buildRecord(record))));
+            	
+                // If inserts pending reach a specific level, trigger a write
                 if (inserts.size() == ceiling) {
                     collection.insertMany(inserts);
                     added += inserts.size();
                     inserts = new ArrayList<>();
                 }
             }
-            if (inserts.size() > 0) {
-                collection.insertMany(inserts);
+            
+            // Flush any pending inserts
+            if (!inserts.isEmpty()) {
+            	collection.insertMany(inserts);
             }
         } catch (SchemaNotFoundException | IOException | MalformedRecordException | MongoException e) {
             getLogger().error("PutMongoRecord failed with error:", e);
             session.transfer(flowFile, REL_FAILURE);
             error = true;
-        } finally {
+        } 
+        catch(Exception ex) {
+            getLogger().error("PutMongoRecord failed with error:", ex);
+            session.transfer(flowFile, REL_FAILURE);
+            error = true;
+        }
+        finally {
             if (!error) {
-                String url = clientService != null
-                        ? clientService.getURI()
-                        : context.getProperty(URI).evaluateAttributeExpressions().getValue();
+                String url = clientService != null ? clientService.getURI() : context.getProperty(URI).evaluateAttributeExpressions().getValue();
                 session.getProvenanceReporter().send(flowFile, url, String.format("Added %d documents to MongoDB.", added));
                 session.transfer(flowFile, REL_SUCCESS);
                 getLogger().info("Inserted {} records into MongoDB", new Object[]{ added });
@@ -162,13 +179,14 @@ public class PutMongoRecord extends AbstractMongoProcessor {
         session.commit();
     }
 
+    @SuppressWarnings("unchecked")
     private Document convertArrays(Document doc) {
         Document retVal = new Document();
         for (Map.Entry<String, Object> entry : doc.entrySet()) {
             if (entry.getValue() != null && entry.getValue().getClass().isArray()) {
                 retVal.put(entry.getKey(), convertArrays((Object[])entry.getValue()));
             } else if (entry.getValue() != null && (entry.getValue() instanceof Map || entry.getValue() instanceof Document)) {
-                retVal.put(entry.getKey(), convertArrays(new Document((Map)entry.getValue())));
+                retVal.put(entry.getKey(), convertArrays(new Document((Map<String,Object>) entry.getValue())));
             } else {
                 retVal.put(entry.getKey(), entry.getValue());
             }
@@ -177,18 +195,95 @@ public class PutMongoRecord extends AbstractMongoProcessor {
         return retVal;
     }
 
-    private List convertArrays(Object[] input) {
-        List retVal = new ArrayList();
+    @SuppressWarnings("unchecked")
+    private List<Object> convertArrays(Object[] input) {
+        List<Object> retVal = new ArrayList<>();
         for (Object o : input) {
             if (o != null && o.getClass().isArray()) {
                 retVal.add(convertArrays((Object[])o));
             } else if (o instanceof Map) {
-                retVal.add(convertArrays(new Document((Map)o)));
+                retVal.add(convertArrays(new Document((Map<String,Object>)o)));
             } else {
                 retVal.add(o);
             }
         }
 
         return retVal;
+    }
+    
+    private Map<String,Object> buildRecord(final Record record) {
+
+    	Map<String,Object> result = new HashMap<>();
+    	
+    	for(RecordField field : record.getSchema().getFields()) {
+
+    		result.put(field.getFieldName(), mapValue(field.getFieldName(), record.getValue(field.getFieldName()), field.getDataType()));
+    	}
+    	
+		return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object mapValue(final String fieldName, final Object value, final DataType dataType) {
+
+    	if(value == null) {
+    		
+    		return null;
+    	}
+    	
+        final DataType chosenDataType = dataType.getFieldType() == RecordFieldType.CHOICE ? DataTypeUtils.chooseDataType(value, (ChoiceDataType) dataType) : dataType;
+        final Object coercedValue = DataTypeUtils.convertType(value, chosenDataType, fieldName);
+
+        if(coercedValue == null) {
+        	
+        	return null;
+        }
+        
+        switch (chosenDataType.getFieldType()) {
+        
+        	case DATE:
+        	case TIME:
+            case DOUBLE:
+            case FLOAT:
+            case LONG:
+            case INT:
+            case BYTE:
+            case SHORT:
+            case CHAR:
+            case STRING:
+            case BIGINT:
+            case BOOLEAN:
+            	return coercedValue;
+            	
+            case TIMESTAMP:
+            	return ((Timestamp) coercedValue).toInstant();
+            	
+            case DECIMAL:
+            	return new Decimal128((BigDecimal) coercedValue);
+            
+            case RECORD:
+                return buildRecord((Record) coercedValue);
+
+            case ARRAY:
+            	// Map the value of each element of the array
+            	return Arrays.stream((Object[]) coercedValue)
+            		.map(v -> mapValue(fieldName, v, ((ArrayDataType) chosenDataType).getElementType())).collect(Collectors.toList()).toArray();
+
+            case MAP: {
+            	// Map the values of each entry in the map
+
+            	Map<String,Object> result = new HashMap<>();
+            	
+            	for(Map.Entry<String,Object> entry : ((Map<String, Object>) coercedValue).entrySet()) {
+            		
+            		result.put(entry.getKey(), mapValue(entry.getKey(), entry.getValue(), ((MapDataType) chosenDataType).getValueType()));
+            	}
+            	
+            	return result;
+            }
+
+            default:
+            	return coercedValue.toString();
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/main/java/org/apache/nifi/reporting/prometheus/PrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/main/java/org/apache/nifi/reporting/prometheus/PrometheusRecordSink.java
@@ -197,6 +197,7 @@ public class PrometheusRecordSink extends AbstractControllerService implements R
                 || RecordFieldType.BIGINT.equals(dataType)
                 || RecordFieldType.FLOAT.equals(dataType)
                 || RecordFieldType.DOUBLE.equals(dataType)
+                || RecordFieldType.DECIMAL.equals(dataType)
                 || RecordFieldType.BOOLEAN.equals(dataType);
 
     }

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/AbstractSiteToSiteReportingTask.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/AbstractSiteToSiteReportingTask.java
@@ -364,6 +364,7 @@ public abstract class AbstractSiteToSiteReportingTask extends AbstractReportingT
                 case BYTE:
                 case CHAR:
                 case DOUBLE:
+                case DECIMAL:
                 case FLOAT:
                 case INT:
                 case BIGINT:

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/SolrUtils.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/SolrUtils.java
@@ -415,6 +415,8 @@ public class SolrUtils {
                 }
                 break;
             }
+            case DECIMAL:
+            	// Decimal will map to Double for Solr as there is no general purpose large decimal type suitable
             case DOUBLE:
                 addFieldToSolrDocument(inputDocument,fieldName,DataTypeUtils.toDouble(coercedValue, fieldName),fieldsToIndex);
                 break;

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/SolrUtils.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/SolrUtils.java
@@ -416,7 +416,7 @@ public class SolrUtils {
                 break;
             }
             case DECIMAL:
-            	// Decimal will map to Double for Solr as there is no general purpose large decimal type suitable
+                // Decimal will map to Double for Solr as there is no general purpose large decimal type suitable
             case DOUBLE:
                 addFieldToSolrDocument(inputDocument,fieldName,DataTypeUtils.toDouble(coercedValue, fieldName),fieldsToIndex);
                 break;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileTable.java
@@ -45,6 +45,7 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.type.ArrayDataType;
 
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -197,6 +198,8 @@ public class FlowFileTable extends AbstractTable implements QueryableTable, Tran
                 return typeFactory.createJavaType(char.class);
             case DATE:
                 return typeFactory.createJavaType(java.sql.Date.class);
+            case DECIMAL:
+                return typeFactory.createJavaType(BigDecimal.class);
             case DOUBLE:
                 return typeFactory.createJavaType(double.class);
             case FLOAT:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/HBaseClientService.java
@@ -25,6 +25,7 @@ import org.apache.nifi.hbase.scan.Column;
 import org.apache.nifi.hbase.scan.ResultHandler;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 
@@ -209,6 +210,14 @@ public interface HBaseClientService extends ControllerService {
      * @return the double represented as bytes
      */
     byte[] toBytes(double d);
+
+    /**
+     * Converts the given double to it's byte representation.
+     *
+     * @param d a double
+     * @return the double represented as bytes
+     */
+    byte[] toBytes(BigDecimal d);
 
     /**
      * Converts the given string to it's byte representation.

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_1_1_2_ClientService.java
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.login.LoginException;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -837,6 +838,11 @@ public class HBase_1_1_2_ClientService extends AbstractControllerService impleme
 
     @Override
     public byte[] toBytes(double d) {
+        return Bytes.toBytes(d);
+    }
+
+    @Override
+    public byte[] toBytes(BigDecimal d) {
         return Bytes.toBytes(d);
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_2_ClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_2_ClientService.java
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.login.LoginException;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -836,6 +837,11 @@ public class HBase_2_ClientService extends AbstractControllerService implements 
 
     @Override
     public byte[] toBytes(double d) {
+        return Bytes.toBytes(d);
+    }
+
+    @Override
+    public byte[] toBytes(BigDecimal d) {
         return Bytes.toBytes(d);
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/csv/AbstractCSVRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/csv/AbstractCSVRecordReader.java
@@ -104,6 +104,8 @@ abstract public class AbstractCSVRecordReader implements RecordReader {
             case LONG:
             case FLOAT:
             case DOUBLE:
+            case BIGINT:
+            case DECIMAL:
             case BYTE:
             case CHAR:
             case SHORT:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/csv/WriteCSVResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/csv/WriteCSVResult.java
@@ -157,6 +157,7 @@ public class WriteCSVResult extends AbstractRecordSetWriter implements RecordSet
             case BIGINT:
             case BYTE:
             case DOUBLE:
+            case DECIMAL:
             case FLOAT:
             case LONG:
             case INT:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonSchemaInference.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonSchemaInference.java
@@ -63,7 +63,10 @@ public class JsonSchemaInference extends HierarchicalSchemaInference<JsonNode> {
         }
 
         if (jsonNode.isFloatingPointNumber()) {
-            return RecordFieldType.DOUBLE.getDataType();
+        	if(jsonNode.isBigDecimal()) {
+            	return RecordFieldType.DECIMAL.getDataType();
+        	}
+        	return RecordFieldType.DOUBLE.getDataType();
         }
         if (jsonNode.isBinary()) {
             return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType());

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonSchemaInference.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonSchemaInference.java
@@ -63,10 +63,10 @@ public class JsonSchemaInference extends HierarchicalSchemaInference<JsonNode> {
         }
 
         if (jsonNode.isFloatingPointNumber()) {
-        	if(jsonNode.isBigDecimal()) {
-            	return RecordFieldType.DECIMAL.getDataType();
-        	}
-        	return RecordFieldType.DOUBLE.getDataType();
+            if(jsonNode.isBigDecimal()) {
+                return RecordFieldType.DECIMAL.getDataType();
+            }
+            return RecordFieldType.DOUBLE.getDataType();
         }
         if (jsonNode.isBinary()) {
             return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType());

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
@@ -161,8 +161,10 @@ public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
             case BYTE:
             case CHAR:
             case DOUBLE:
+            case DECIMAL:
             case FLOAT:
             case INT:
+            case BIGINT:
             case LONG:
             case SHORT:
             case STRING:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -358,6 +358,9 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
                 }
                 break;
             }
+            case DECIMAL:
+                generator.writeNumber(DataTypeUtils.toBigDecimal(coercedValue, fieldName));
+                break;
             case DOUBLE:
                 generator.writeNumber(DataTypeUtils.toDouble(coercedValue, fieldName));
                 break;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/WriteXMLResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/WriteXMLResult.java
@@ -251,7 +251,9 @@ public class WriteXMLResult extends AbstractRecordSetWriter implements RecordSet
             case BYTE:
             case CHAR:
             case DOUBLE:
+            case DECIMAL:
             case FLOAT:
+            case BIGINT:
             case INT:
             case LONG:
             case SHORT:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLRecordReader.java
@@ -146,8 +146,10 @@ public class XMLRecordReader implements RecordReader {
             case BYTE:
             case CHAR:
             case DOUBLE:
+            case DECIMAL:
             case FLOAT:
             case INT:
+            case BIGINT:
             case LONG:
             case SHORT:
             case STRING:
@@ -529,8 +531,10 @@ public class XMLRecordReader implements RecordReader {
             case BYTE:
             case CHAR:
             case DOUBLE:
+            case DECIMAL:
             case FLOAT:
             case INT:
+            case BIGINT:
             case LONG:
             case SHORT:
             case STRING:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestAvroReaderWithEmbeddedSchema.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestAvroReaderWithEmbeddedSchema.java
@@ -113,7 +113,7 @@ public class TestAvroReaderWithEmbeddedSchema {
             assertEquals(RecordFieldType.TIMESTAMP, recordSchema.getDataType("timestampMillis").get().getFieldType());
             assertEquals(RecordFieldType.TIMESTAMP, recordSchema.getDataType("timestampMicros").get().getFieldType());
             assertEquals(RecordFieldType.DATE, recordSchema.getDataType("date").get().getFieldType());
-            assertEquals(RecordFieldType.DOUBLE, recordSchema.getDataType("decimal").get().getFieldType());
+            assertEquals(RecordFieldType.DECIMAL, recordSchema.getDataType("decimal").get().getFieldType());
 
             final Record record = reader.nextRecord();
             assertEquals(new java.sql.Time(millisSinceMidnight), record.getValue("timeMillis"));
@@ -123,7 +123,7 @@ public class TestAvroReaderWithEmbeddedSchema {
             final DateFormat noTimeOfDayDateFormat = new SimpleDateFormat("yyyy-MM-dd");
             noTimeOfDayDateFormat.setTimeZone(TimeZone.getTimeZone("gmt"));
             assertEquals(noTimeOfDayDateFormat.format(new java.sql.Date(timeLong)), noTimeOfDayDateFormat.format(record.getValue("date")));
-            assertEquals(bigDecimal.doubleValue(), record.getValue("decimal"));
+            assertEquals(bigDecimal, record.getValue("decimal"));
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestWriteCSVResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestWriteCSVResult.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
@@ -126,6 +127,7 @@ public class TestWriteCSVResult {
             valueMap.put("long", 8L);
             valueMap.put("float", 8.0F);
             valueMap.put("double", 8.0D);
+            valueMap.put("decimal", new BigDecimal("8.0"));
             valueMap.put("date", new Date(now));
             valueMap.put("time", new Time(now));
             valueMap.put("timestamp", new Timestamp(now));
@@ -154,7 +156,7 @@ public class TestWriteCSVResult {
 
         final String values = splits[1];
         final StringBuilder expectedBuilder = new StringBuilder();
-        expectedBuilder.append("\"true\",\"1\",\"8\",\"9\",\"8\",\"8\",\"8.0\",\"8.0\",\"" + timestampValue + "\",\"" + dateValue + "\",\"" + timeValue + "\",\"c\",\"a孟bc李12儒3\",,\"48\",,");
+        expectedBuilder.append("\"true\",\"1\",\"8\",\"9\",\"8\",\"8\",\"8.0\",\"8.0\",\"8.0\",\"" + timestampValue + "\",\"" + dateValue + "\",\"" + timeValue + "\",\"c\",\"a孟bc李12儒3\",,\"48\",,");
 
         final String expectedValues = expectedBuilder.toString();
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -94,6 +95,7 @@ public class TestWriteJsonResult {
         valueMap.put("long", 8L);
         valueMap.put("float", 8.0F);
         valueMap.put("double", 8.0D);
+        valueMap.put("decimal", new BigDecimal("8.0"));
         valueMap.put("date", new Date(time));
         valueMap.put("time", new Time(time));
         valueMap.put("timestamp", new Timestamp(time));

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestWriteXMLResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestWriteXMLResult.java
@@ -35,6 +35,7 @@ import org.xmlunit.matchers.CompareMatcher;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Time;
@@ -189,6 +190,7 @@ public class TestWriteXMLResult {
         valueMap.put("long", 8L);
         valueMap.put("float", 8.0F);
         valueMap.put("double", 8.0D);
+        valueMap.put("decimal", new BigDecimal("8.0"));
         valueMap.put("date", new Date(time));
         valueMap.put("time", new Time(time));
         valueMap.put("timestamp", new Timestamp(time));
@@ -207,7 +209,7 @@ public class TestWriteXMLResult {
         writer.flush();
 
         String xmlResult = "<ROOT><RECORD><string>string</string><boolean>true</boolean><byte>1</byte><char>c</char><short>8</short>" +
-                "<int>9</int><bigint>8</bigint><long>8</long><float>8.0</float><double>8.0</double><date>2017-01-01</date>" +
+                "<int>9</int><bigint>8</bigint><long>8</long><float>8.0</float><double>8.0</double><decimal>8.0</decimal><date>2017-01-01</date>" +
                 "<time>17:00:00</time><timestamp>2017-01-01 17:00:00</timestamp><record /><choice>48</choice><array />" +
                 "<map><height>48</height><width>96</width></map></RECORD></ROOT>";
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/output/dataTypes.json
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/output/dataTypes.json
@@ -7,6 +7,7 @@
   "bigint" : 8,
   "float" : 8.0,
   "double" : 8.0,
+  "decimal" : 8.0,
   "timestamp" : "2017-01-01 17:00:00",
   "date" : "2017-01-01",
   "time" : "17:00:00",


### PR DESCRIPTION
Aligning the implementation of DECIMAL RecordFieldType with other types

Introduce RecordFieldType of DECIMAL for BigDecimal values

Adding RecordFieldType DECIMAL to ResultSetRecordSet

Introduce RecordFieldType DECIMAL into DataTypeUtils

Added missing BIGINT type to convertSimpleIfPossible method

Added missing type BIGINT to convertField method

Added missing type BIGINT to writeFieldForType

Added missing type BIGINT to parseFieldForType

Added missing type BIGINT to parseStringForType

Potentially breaking change of behaviour for Kudu Service.
Switched decimal from treatment as string to treatment as decimal

Added big decimal support for ElasticSearch

Added big decimal support for hbase processors

Added big decimal support for prometheus reporting

Added big decimal support to solr

Big decimal support in site to site reporting

Core support for big decimal

Fix issue with new toBigDecimal method

Issue where method was not correctly handling the situation where a
BigDecimal values was received as input.

Update test to reflect use of BigDecimal

Changes to unit tests to support DECIMAL type

Fix bug where NaN Double reported from jvm metrics not handled

BigDecimal implementation for mongo processor

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-7159._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [Y] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [Y] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [Y] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [Y] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [Y] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [Y] Have you written or updated unit tests to verify your changes?
- [Y] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [N/A] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [N/A] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [N/A] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [N/A] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
