### PR TITLE
NIFI-7318 Allow 'docker stop' to gracefully shutdown

### DIFF
--- a/nifi-docker/dockerhub/sh/start.sh
+++ b/nifi-docker/dockerhub/sh/start.sh
@@ -83,7 +83,7 @@ esac
 nifi_pid="$!"
 tail -F --pid=${nifi_pid} "${NIFI_HOME}/logs/nifi-app.log" &
 
-trap 'echo Received trapped signal, beginning shutdown...;./bin/nifi.sh stop;exit 0;' KILL TERM HUP INT;
+trap 'echo Received trapped signal, beginning shutdown...;./bin/nifi.sh stop;exit 0;' TERM HUP INT;
 trap ":" EXIT
 
 echo NiFi running with PID ${nifi_pid}.

--- a/nifi-docker/dockerhub/sh/start.sh
+++ b/nifi-docker/dockerhub/sh/start.sh
@@ -79,11 +79,12 @@ case ${AUTH} in
 esac
 
 # Continuously provide logs so that 'docker logs' can    produce them
-tail -F "${NIFI_HOME}/logs/nifi-app.log" &
 "${NIFI_HOME}/bin/nifi.sh" run &
 nifi_pid="$!"
+tail -F --pid=${nifi_pid} "${NIFI_HOME}/logs/nifi-app.log" &
 
-trap "echo Received trapped signal, beginning shutdown...;" KILL TERM HUP INT EXIT;
+trap 'echo Received trapped signal, beginning shutdown...;./bin/nifi.sh stop;exit 0;' KILL TERM HUP INT;
+trap ":" EXIT
 
 echo NiFi running with PID ${nifi_pid}.
 wait ${nifi_pid}


### PR DESCRIPTION
#### Description of PR

_Enables docker graceful shutdown functionality; fixes bug NIFI-7318._

As it is, issuing 'docker stop' will immediatly exit the container.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
