### PR TITLE
NIFI-7300 Allowing narrow numeric types to fit againt schema check with wider type

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
@@ -364,4 +364,8 @@ public enum RecordFieldType {
     public static RecordFieldType of(final String typeString) {
       return SIMPLE_NAME_MAP.get(typeString);
     }
+
+    public Set<RecordFieldType> getNarrowDataTypes() {
+        return Collections.unmodifiableSet(narrowDataTypes);
+    }
 }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
@@ -18,7 +18,9 @@
 package org.apache.nifi.schema.validation;
 
 import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.Record;
@@ -36,6 +38,18 @@ import org.apache.nifi.serialization.record.validation.ValidationError;
 import org.apache.nifi.serialization.record.validation.ValidationErrorType;
 
 public class StandardSchemaValidator implements RecordSchemaValidator {
+    private static final Map<RecordFieldType, Predicate<Object>> NUMERIC_VALIDATORS = new HashMap();
+
+    static {
+        NUMERIC_VALIDATORS.put(RecordFieldType.BIGINT, value -> value instanceof BigInteger);
+        NUMERIC_VALIDATORS.put(RecordFieldType.LONG, value -> value instanceof Long);
+        NUMERIC_VALIDATORS.put(RecordFieldType.INT, value -> value instanceof Integer);
+        NUMERIC_VALIDATORS.put(RecordFieldType.BYTE, value -> value instanceof Byte);
+        NUMERIC_VALIDATORS.put(RecordFieldType.SHORT, value -> value instanceof Short);
+        NUMERIC_VALIDATORS.put(RecordFieldType.DOUBLE, value -> value instanceof Double);
+        NUMERIC_VALIDATORS.put(RecordFieldType.FLOAT, value -> value instanceof Float);
+    }
+
     private final SchemaValidationContext validationContext;
 
     public StandardSchemaValidator(final SchemaValidationContext validationContext) {
@@ -233,39 +247,51 @@ public class StandardSchemaValidator implements RecordSchemaValidator {
                 }
 
                 return false;
-            case BIGINT:
-                return value instanceof BigInteger;
             case BOOLEAN:
                 return value instanceof Boolean;
-            case BYTE:
-                return value instanceof Byte;
             case CHAR:
                 return value instanceof Character;
             case DATE:
                 return value instanceof java.sql.Date;
-            case DOUBLE:
-                return value instanceof Double;
-            case FLOAT:
-                // Some readers do not provide float vs. double.
-                // We should consider if it makes sense to allow either a Float or a Double here or have
-                // a Reader indicate whether or not it supports higher precision, etc.
-                // Same goes for Short/Integer
-                return value instanceof Float;
-            case INT:
-                return value instanceof Integer;
-            case LONG:
-                return value instanceof Long;
-            case SHORT:
-                return value instanceof Short;
             case STRING:
                 return value instanceof String;
             case TIME:
                 return value instanceof java.sql.Time;
             case TIMESTAMP:
                 return value instanceof java.sql.Timestamp;
+
+            // Numeric data types
+            case BIGINT:
+            case LONG:
+            case INT:
+            case SHORT:
+            case BYTE:
+
+            case DOUBLE:
+            case FLOAT:
+                // Some readers do not provide float vs. double.
+                // We should consider if it makes sense to allow either a Float or a Double here or have
+                // a Reader indicate whether or not it supports higher precision, etc.
+                // Same goes for Short/Integer
+                return isFittingNumberType(value, dataType.getFieldType());
         }
 
         return false;
+    }
+
+    /**
+     * Checks if an incoming value satisfies the requirements of a given (numeric) type or any of it's narrow data type.
+     *
+     * @param value Incoming value.
+     * @param fieldType The expected field type.
+     *
+     * @return Returns true if the incoming value satisfies the data type of any of it's narrow data types. Otherwise returns false. Only numeric data types are supported.
+     */
+    private boolean isFittingNumberType(final Object value, final RecordFieldType fieldType) {
+        return NUMERIC_VALIDATORS.containsKey(fieldType)
+            && (NUMERIC_VALIDATORS.get(fieldType).test(value)
+                || fieldType.getNarrowDataTypes().stream().map(type -> NUMERIC_VALIDATORS.get(type)).anyMatch(validator -> validator.test(value))
+        );
     }
 
     private String concat(final String fieldPrefix, final RecordField field) {


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/NIFI-7300](https://issues.apache.org/jira/browse/NIFI-7300)

As the JSON files are read without considering the schema (used for validation), it might happen that a field which we expect to be a long is parsed into an integer based on its current value. During validation the AVRO record incorrectly ends up as invalid (because of an integer is not considered as long in this example). This is a fix for allow narrow numeric data types for fit into wider types during schema based validation.

Example:

Existing behaviour:
- Step 1.: incoming value is "5"
- Step 2.: record is being read, the representing object will be an Integer
- Step 3.: the record is validated against a schema which expect the field to be a Long
- Step 4.: the record is considered as invalid as the Integer field is not considered as valid Long

Proposed behaviour:
- Step 1-3.: the same as the existing behaviour
- Step 4.: as Integer is considered as a narrow data type of Long, the record is considered as valid (if there are no other discrepancies in the record)

Implementation:
Building on top of `RecordFieldType's` existing "narrowDataTypes" collection, in case of numeric types, I extended the validation check with the check of these narrow types: if the incoming value fits to the original, or any of the narrow types, it is considered as valid.

Note:
Even if String also has a numerous amount of narrow types for example, in order to keep compatibility I did not extended other data types with this fix, only numeric ones. Extending them would be a change of behaviour instead of a fix. See `TestValidateRecord#testValidateMissingRequiredArray` which for example breaks if narrow types would be allowed for Strings.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
