### PR TITLE
NIFI-7300 Allowing narrow numeric types to fit againt schema check with wider type;

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
@@ -232,7 +232,7 @@ public enum RecordFieldType {
         this.defaultFormat = null;
         this.defaultDataType = new DataType(this, defaultFormat);
 
-        this.narrowDataTypes = new HashSet<>(Arrays.asList(narrowDataTypes));
+        this.narrowDataTypes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(narrowDataTypes)));
     }
 
     private RecordFieldType(final String simpleName, final String defaultFormat) {
@@ -366,6 +366,6 @@ public enum RecordFieldType {
     }
 
     public Set<RecordFieldType> getNarrowDataTypes() {
-        return Collections.unmodifiableSet(narrowDataTypes);
+        return narrowDataTypes;
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordFieldType.java
@@ -364,4 +364,8 @@ public enum RecordFieldType {
     public static RecordFieldType of(final String typeString) {
       return SIMPLE_NAME_MAP.get(typeString);
     }
+
+    public Set<RecordFieldType> getNarrowDataTypes() {
+        return Collections.unmodifiableSet(narrowDataTypes);
+    }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -579,4 +579,155 @@ public class TestDataTypeUtils {
             assertEquals(Optional.ofNullable(expected), actual);
         });
     }
+
+    @Test
+    public void testIsIntegerFitsToFloat() {
+        final int maxRepresentableInt = Double.valueOf(Math.pow(2, 24)).intValue();
+
+        assertTrue(DataTypeUtils.isIntegerFitsToFloat(0));
+        assertTrue(DataTypeUtils.isIntegerFitsToFloat(9));
+        assertTrue(DataTypeUtils.isIntegerFitsToFloat(maxRepresentableInt));
+        assertTrue(DataTypeUtils.isIntegerFitsToFloat(-1 * maxRepresentableInt));
+
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat("test"));
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat(9L));
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat(9.0));
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat(Integer.MAX_VALUE));
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat(Integer.MIN_VALUE));
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat(maxRepresentableInt + 1));
+        assertFalse(DataTypeUtils.isIntegerFitsToFloat(-1 * maxRepresentableInt - 1));
+    }
+
+    @Test
+    public void testIsLongFitsToFloat() {
+        final long maxRepresentableLong = Double.valueOf(Math.pow(2, 24)).longValue();
+
+        assertTrue(DataTypeUtils.isLongFitsToFloat(0L));
+        assertTrue(DataTypeUtils.isLongFitsToFloat(9L));
+        assertTrue(DataTypeUtils.isLongFitsToFloat(maxRepresentableLong));
+        assertTrue(DataTypeUtils.isLongFitsToFloat(-1L * maxRepresentableLong));
+
+        assertFalse(DataTypeUtils.isLongFitsToFloat("test"));
+        assertFalse(DataTypeUtils.isLongFitsToFloat(9));
+        assertFalse(DataTypeUtils.isLongFitsToFloat(9.0));
+        assertFalse(DataTypeUtils.isLongFitsToFloat(Long.MAX_VALUE));
+        assertFalse(DataTypeUtils.isLongFitsToFloat(Long.MIN_VALUE));
+        assertFalse(DataTypeUtils.isLongFitsToFloat(maxRepresentableLong + 1L));
+        assertFalse(DataTypeUtils.isLongFitsToFloat(-1L * maxRepresentableLong - 1L));
+    }
+
+    @Test
+    public void testIsLongFitsToDouble() {
+        final long maxRepresentableLong = Double.valueOf(Math.pow(2, 53)).longValue();
+
+        assertTrue(DataTypeUtils.isLongFitsToDouble(0L));
+        assertTrue(DataTypeUtils.isLongFitsToDouble(9L));
+        assertTrue(DataTypeUtils.isLongFitsToDouble(maxRepresentableLong));
+        assertTrue(DataTypeUtils.isLongFitsToDouble(-1L * maxRepresentableLong));
+
+        assertFalse(DataTypeUtils.isLongFitsToDouble("test"));
+        assertFalse(DataTypeUtils.isLongFitsToDouble(9));
+        assertFalse(DataTypeUtils.isLongFitsToDouble(9.0));
+        assertFalse(DataTypeUtils.isLongFitsToDouble(Long.MAX_VALUE));
+        assertFalse(DataTypeUtils.isLongFitsToDouble(Long.MIN_VALUE));
+        assertFalse(DataTypeUtils.isLongFitsToDouble(maxRepresentableLong + 1L));
+        assertFalse(DataTypeUtils.isLongFitsToDouble(-1L * maxRepresentableLong - 1L));
+    }
+
+    @Test
+    public void testIsBigIntFitsToFloat() {
+        final BigInteger maxRepresentableBigInt = BigInteger.valueOf(Double.valueOf(Math.pow(2, 24)).longValue());
+
+        assertTrue(DataTypeUtils.isBigIntFitsToFloat(BigInteger.valueOf(0L)));
+        assertTrue(DataTypeUtils.isBigIntFitsToFloat(BigInteger.valueOf(8L)));
+        assertTrue(DataTypeUtils.isBigIntFitsToFloat(maxRepresentableBigInt));
+        assertTrue(DataTypeUtils.isBigIntFitsToFloat(maxRepresentableBigInt.negate()));
+
+        assertFalse(DataTypeUtils.isBigIntFitsToFloat("test"));
+        assertFalse(DataTypeUtils.isBigIntFitsToFloat(9));
+        assertFalse(DataTypeUtils.isBigIntFitsToFloat(9.0));
+        assertFalse(DataTypeUtils.isBigIntFitsToFloat(new BigInteger(String.join("", Collections.nCopies(100, "1")))));
+        assertFalse(DataTypeUtils.isBigIntFitsToFloat(new BigInteger(String.join("", Collections.nCopies(100, "1"))).negate()));
+    }
+
+    @Test
+    public void testIsBigIntFitsToDouble() {
+        final BigInteger maxRepresentableBigInt = BigInteger.valueOf(Double.valueOf(Math.pow(2, 53)).longValue());
+
+        assertTrue(DataTypeUtils.isBigIntFitsToDouble(BigInteger.valueOf(0L)));
+        assertTrue(DataTypeUtils.isBigIntFitsToDouble(BigInteger.valueOf(8L)));
+        assertTrue(DataTypeUtils.isBigIntFitsToDouble(maxRepresentableBigInt));
+        assertTrue(DataTypeUtils.isBigIntFitsToDouble(maxRepresentableBigInt.negate()));
+
+        assertFalse(DataTypeUtils.isBigIntFitsToDouble("test"));
+        assertFalse(DataTypeUtils.isBigIntFitsToDouble(9));
+        assertFalse(DataTypeUtils.isBigIntFitsToDouble(9.0));
+        assertFalse(DataTypeUtils.isBigIntFitsToDouble(new BigInteger(String.join("", Collections.nCopies(100, "1")))));
+        assertFalse(DataTypeUtils.isBigIntFitsToDouble(new BigInteger(String.join("", Collections.nCopies(100, "1"))).negate()));
+    }
+
+    @Test
+    public void testIsDoubleWithinFloatInterval() {
+        assertTrue(DataTypeUtils.isDoubleWithinFloatInterval(0D));
+        assertTrue(DataTypeUtils.isDoubleWithinFloatInterval(0.1D));
+        assertTrue(DataTypeUtils.isDoubleWithinFloatInterval((double) Float.MAX_VALUE));
+        assertTrue(DataTypeUtils.isDoubleWithinFloatInterval((double) Float.MIN_VALUE));
+        assertTrue(DataTypeUtils.isDoubleWithinFloatInterval((double) -1 * Float.MAX_VALUE));
+        assertTrue(DataTypeUtils.isDoubleWithinFloatInterval((double) -1 * Float.MIN_VALUE));
+
+
+        assertFalse(DataTypeUtils.isDoubleWithinFloatInterval("test"));
+        assertFalse(DataTypeUtils.isDoubleWithinFloatInterval(9));
+        assertFalse(DataTypeUtils.isDoubleWithinFloatInterval(9.0F));
+        assertFalse(DataTypeUtils.isDoubleWithinFloatInterval(Double.MAX_VALUE));
+        assertFalse(DataTypeUtils.isDoubleWithinFloatInterval((double) -1 * Double.MAX_VALUE));
+    }
+
+    @Test
+    public void testIsFittingNumberType() {
+        // Byte
+        assertTrue(DataTypeUtils.isFittingNumberType((byte) 9, RecordFieldType.BYTE));
+        assertFalse(DataTypeUtils.isFittingNumberType((short)9, RecordFieldType.BYTE));
+        assertFalse(DataTypeUtils.isFittingNumberType(9, RecordFieldType.BYTE));
+        assertFalse(DataTypeUtils.isFittingNumberType(9L, RecordFieldType.BYTE));
+        assertFalse(DataTypeUtils.isFittingNumberType(BigInteger.valueOf(9L), RecordFieldType.BYTE));
+
+        // Short
+        assertTrue(DataTypeUtils.isFittingNumberType((byte) 9, RecordFieldType.SHORT));
+        assertTrue(DataTypeUtils.isFittingNumberType((short)9, RecordFieldType.SHORT));
+        assertFalse(DataTypeUtils.isFittingNumberType(9, RecordFieldType.SHORT));
+        assertFalse(DataTypeUtils.isFittingNumberType(9L, RecordFieldType.SHORT));
+        assertFalse(DataTypeUtils.isFittingNumberType(BigInteger.valueOf(9L), RecordFieldType.SHORT));
+
+        // Integer
+        assertTrue(DataTypeUtils.isFittingNumberType((byte) 9, RecordFieldType.INT));
+        assertTrue(DataTypeUtils.isFittingNumberType((short)9, RecordFieldType.INT));
+        assertTrue(DataTypeUtils.isFittingNumberType(9, RecordFieldType.INT));
+        assertFalse(DataTypeUtils.isFittingNumberType(9L, RecordFieldType.INT));
+        assertFalse(DataTypeUtils.isFittingNumberType(BigInteger.valueOf(9L), RecordFieldType.INT));
+
+        // Long
+        assertTrue(DataTypeUtils.isFittingNumberType((byte) 9, RecordFieldType.LONG));
+        assertTrue(DataTypeUtils.isFittingNumberType((short)9, RecordFieldType.LONG));
+        assertTrue(DataTypeUtils.isFittingNumberType(9, RecordFieldType.LONG));
+        assertTrue(DataTypeUtils.isFittingNumberType(9L, RecordFieldType.LONG));
+        assertFalse(DataTypeUtils.isFittingNumberType(BigInteger.valueOf(9L), RecordFieldType.LONG));
+
+        // Bigint
+        assertTrue(DataTypeUtils.isFittingNumberType((byte) 9, RecordFieldType.BIGINT));
+        assertTrue(DataTypeUtils.isFittingNumberType((short)9, RecordFieldType.BIGINT));
+        assertTrue(DataTypeUtils.isFittingNumberType(9, RecordFieldType.BIGINT));
+        assertTrue(DataTypeUtils.isFittingNumberType(9L, RecordFieldType.BIGINT));
+        assertTrue(DataTypeUtils.isFittingNumberType(BigInteger.valueOf(9L), RecordFieldType.BIGINT));
+
+        // Float
+        assertTrue(DataTypeUtils.isFittingNumberType(9F, RecordFieldType.FLOAT));
+        assertFalse(DataTypeUtils.isFittingNumberType(9D, RecordFieldType.FLOAT));
+        assertFalse(DataTypeUtils.isFittingNumberType(9, RecordFieldType.FLOAT));
+
+        // Double
+        assertTrue(DataTypeUtils.isFittingNumberType(9F, RecordFieldType.DOUBLE));
+        assertTrue(DataTypeUtils.isFittingNumberType(9D, RecordFieldType.DOUBLE));
+        assertFalse(DataTypeUtils.isFittingNumberType(9, RecordFieldType.DOUBLE));
+    }
 }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
@@ -17,11 +17,6 @@
 
 package org.apache.nifi.schema.validation;
 
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Predicate;
-
 import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
@@ -37,18 +32,10 @@ import org.apache.nifi.serialization.record.validation.SchemaValidationResult;
 import org.apache.nifi.serialization.record.validation.ValidationError;
 import org.apache.nifi.serialization.record.validation.ValidationErrorType;
 
-public class StandardSchemaValidator implements RecordSchemaValidator {
-    private static final Map<RecordFieldType, Predicate<Object>> NUMERIC_VALIDATORS = new HashMap();
+import java.util.Map;
 
-    static {
-        NUMERIC_VALIDATORS.put(RecordFieldType.BIGINT, value -> value instanceof BigInteger);
-        NUMERIC_VALIDATORS.put(RecordFieldType.LONG, value -> value instanceof Long);
-        NUMERIC_VALIDATORS.put(RecordFieldType.INT, value -> value instanceof Integer);
-        NUMERIC_VALIDATORS.put(RecordFieldType.BYTE, value -> value instanceof Byte);
-        NUMERIC_VALIDATORS.put(RecordFieldType.SHORT, value -> value instanceof Short);
-        NUMERIC_VALIDATORS.put(RecordFieldType.DOUBLE, value -> value instanceof Double);
-        NUMERIC_VALIDATORS.put(RecordFieldType.FLOAT, value -> value instanceof Float);
-    }
+public class StandardSchemaValidator implements RecordSchemaValidator {
+
 
     private final SchemaValidationContext validationContext;
 
@@ -266,36 +253,29 @@ public class StandardSchemaValidator implements RecordSchemaValidator {
             case INT:
             case SHORT:
             case BYTE:
+                return DataTypeUtils.isFittingNumberType(value, dataType.getFieldType());
             case DOUBLE:
-                return isFittingNumberType(value, dataType.getFieldType());
+                return DataTypeUtils.isFittingNumberType(value, dataType.getFieldType())
+                        || value instanceof Byte
+                        || value instanceof Short
+                        || value instanceof Integer
+                        || DataTypeUtils.isLongFitsToDouble(value)
+                        || DataTypeUtils.isBigIntFitsToDouble(value);
             case FLOAT:
                 // Some readers do not provide float vs. double.
                 // We should consider if it makes sense to allow either a Float or a Double here or have
                 // a Reader indicate whether or not it supports higher precision, etc.
                 // Same goes for Short/Integer
-                return isFittingNumberType(value, dataType.getFieldType()) || isDoubleWithinFloatInterval(value);
+                return DataTypeUtils.isFittingNumberType(value, dataType.getFieldType())
+                        || value instanceof Byte
+                        || value instanceof Short
+                        || DataTypeUtils.isDoubleWithinFloatInterval(value)
+                        || DataTypeUtils.isIntegerFitsToFloat(value)
+                        || DataTypeUtils.isLongFitsToFloat(value)
+                        || DataTypeUtils.isBigIntFitsToFloat(value);
         }
 
         return false;
-    }
-
-    /**
-     * Checks if an incoming value satisfies the requirements of a given (numeric) type or any of it's narrow data type.
-     *
-     * @param value Incoming value.
-     * @param fieldType The expected field type.
-     *
-     * @return Returns true if the incoming value satisfies the data type of any of it's narrow data types. Otherwise returns false. Only numeric data types are supported.
-     */
-    private boolean isFittingNumberType(final Object value, final RecordFieldType fieldType) {
-        return NUMERIC_VALIDATORS.containsKey(fieldType)
-            && (NUMERIC_VALIDATORS.get(fieldType).test(value)
-                || fieldType.getNarrowDataTypes().stream().map(type -> NUMERIC_VALIDATORS.get(type)).anyMatch(validator -> validator.test(value))
-        );
-    }
-
-    private boolean isDoubleWithinFloatInterval(final Object value) {
-        return value instanceof Double && Float.valueOf(((Double) value).floatValue()).doubleValue() == ((Double) value).doubleValue();
     }
 
     private String concat(final String fieldPrefix, final RecordField field) {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/test/java/org/apache/nifi/schema/validation/TestStandardSchemaValidator.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/test/java/org/apache/nifi/schema/validation/TestStandardSchemaValidator.java
@@ -30,11 +30,14 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import org.apache.nifi.serialization.SimpleRecordSchema;
@@ -46,9 +49,19 @@ import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.validation.SchemaValidationResult;
 import org.apache.nifi.serialization.record.validation.ValidationError;
+import org.apache.nifi.serialization.record.validation.ValidationErrorType;
 import org.junit.Test;
 
 public class TestStandardSchemaValidator {
+    private static final Set<RecordFieldType> NUMERIC_TYPES = new HashSet<>(Arrays.asList(
+            RecordFieldType.BYTE,
+            RecordFieldType.SHORT,
+            RecordFieldType.INT,
+            RecordFieldType.LONG,
+            RecordFieldType.BIGINT,
+            RecordFieldType.FLOAT,
+            RecordFieldType.DOUBLE
+    ));
 
     @Test
     public void testValidateCorrectSimpleTypesStrictValidation() throws ParseException {
@@ -64,6 +77,12 @@ public class TestStandardSchemaValidator {
                 fields.add(new RecordField(fieldType.name().toLowerCase(), fieldType.getMapDataType(RecordFieldType.INT.getDataType())));
             } else {
                 fields.add(new RecordField(fieldType.name().toLowerCase(), fieldType.getDataType()));
+            }
+
+            if (NUMERIC_TYPES.contains(fieldType)) {
+                for (final RecordFieldType narrowType : fieldType.getNarrowDataTypes()) {
+                    fields.add(new RecordField(narrowType.name().toLowerCase() + "_as_" + fieldType.name().toLowerCase(), fieldType.getDataType()));
+                }
             }
         }
 
@@ -103,6 +122,22 @@ public class TestStandardSchemaValidator {
         valueMap.put("map", intMap);
         valueMap.put("mapRecord", mapRecord);
 
+        valueMap.put("byte_as_short", (byte) 8);
+
+        valueMap.put("short_as_int", (short) 8);
+        valueMap.put("byte_as_int", (byte) 8);
+
+        valueMap.put("int_as_long", 9);
+        valueMap.put("short_as_long", (short) 8);
+        valueMap.put("byte_as_long", (byte) 1);
+
+        valueMap.put("byte_as_bigint", (byte) 8);
+        valueMap.put("short_as_bigint", (short) 8);
+        valueMap.put("int_as_bigint", 8);
+        valueMap.put("long_as_bigint", 8L);
+
+        valueMap.put("float_as_double", 8.0F);
+
         final Record record = new MapRecord(schema, valueMap);
 
         final SchemaValidationContext validationContext = new SchemaValidationContext(schema, false, true);
@@ -114,6 +149,100 @@ public class TestStandardSchemaValidator {
         assertTrue(result.getValidationErrors().isEmpty());
     }
 
+    @Test
+    public void testIntegerIsNotFittingForDouble() throws ParseException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("test", RecordFieldType.DOUBLE.getDataType()));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+        final Map<String, Object> valueMap = new LinkedHashMap<>();
+        valueMap.put("test", 12345);
+
+        final Record record = new MapRecord(schema, valueMap);
+        final SchemaValidationContext validationContext = new SchemaValidationContext(schema, false, true);
+        final StandardSchemaValidator validator = new StandardSchemaValidator(validationContext);
+
+        final SchemaValidationResult result = validator.validate(record);
+
+        assertFalse(result.isValid());
+
+        final Collection<ValidationError> validationErrors = result.getValidationErrors();
+        assertEquals(1, validationErrors.size());
+
+        final ValidationError validationError = validationErrors.iterator().next();
+        assertEquals("/test", validationError.getFieldName().get());
+        assertEquals(ValidationErrorType.INVALID_FIELD, validationError.getType());
+    }
+
+    @Test
+    public void testStringDoesNotAllowNarrowTypes() throws ParseException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("test", RecordFieldType.STRING.getDataType()));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+        final Map<String, Object> valueMap = new LinkedHashMap<>();
+        valueMap.put("test", 12345);
+
+        final Record record = new MapRecord(schema, valueMap);
+        final SchemaValidationContext validationContext = new SchemaValidationContext(schema, false, true);
+        final StandardSchemaValidator validator = new StandardSchemaValidator(validationContext);
+
+        final SchemaValidationResult result = validator.validate(record);
+
+        assertFalse(result.isValid());
+
+        final Collection<ValidationError> validationErrors = result.getValidationErrors();
+        assertEquals(1, validationErrors.size());
+
+        final ValidationError validationError = validationErrors.iterator().next();
+        assertEquals("/test", validationError.getFieldName().get());
+        assertEquals(ValidationErrorType.INVALID_FIELD, validationError.getType());
+    }
+
+    @Test
+    public void testDoubleWithinFloatIsConsideredValid() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("test", RecordFieldType.FLOAT.getDataType()));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+        final Map<String, Object> valueMap = new LinkedHashMap<>();
+        valueMap.put("test", Double.valueOf("1.5191525220870972d"));
+
+        final Record record = new MapRecord(schema, valueMap);
+        final SchemaValidationContext validationContext = new SchemaValidationContext(schema, false, true);
+        final StandardSchemaValidator validator = new StandardSchemaValidator(validationContext);
+
+        final SchemaValidationResult result = validator.validate(record);
+
+        assertTrue(result.isValid());
+        assertNotNull(result.getValidationErrors());
+        assertTrue(result.getValidationErrors().isEmpty());
+    }
+
+    @Test
+    public void testDoubleOutsideFloatIsConsideredInvalid() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("test", RecordFieldType.FLOAT.getDataType()));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+        final Map<String, Object> valueMap = new LinkedHashMap<>();
+        valueMap.put("test", Double.valueOf("1.519152521525342525215215d"));
+
+        final Record record = new MapRecord(schema, valueMap);
+        final SchemaValidationContext validationContext = new SchemaValidationContext(schema, false, true);
+        final StandardSchemaValidator validator = new StandardSchemaValidator(validationContext);
+
+        final SchemaValidationResult result = validator.validate(record);
+
+        assertFalse(result.isValid());
+
+        final Collection<ValidationError> validationErrors = result.getValidationErrors();
+        assertEquals(1, validationErrors.size());
+
+        final ValidationError validationError = validationErrors.iterator().next();
+        assertEquals("/test", validationError.getFieldName().get());
+        assertEquals(ValidationErrorType.INVALID_FIELD, validationError.getType());
+    }
 
     @Test
     public void testValidateWrongButCoerceableType() throws ParseException {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NIFI-7300
https://issues.apache.org/jira/browse/NIFI-7302

The two tickets are interconnecting and the changes were made around the same piece of code.

As the JSON files are read without considering the schema used for validation, it might happen that a class it uses to store JSON field value differs from the
data type we expect in the validation schema. This is possible even if based on the field value it might be fitting. In order to avoid false-negative schema validation results,
I propose this fix around type validation.

which we expect to be a long is parsed into an integer based on its current value. During validation the AVRO record incorrectly ends up as invalid (because of an integer is not considered as long in this example). This is a fix for allow narrow numeric data types for fit into wider types during schema based validation.

Example for NIFI-7300:

Existing behaviour:
Step 1.: incoming value is 5
Step 2.: record is being read, the representing object will be an Integer
Step 3.: the record is validated against a schema which expect the field to be a Long
Step 4.: the record is invalid as the Integer field is not considered as valid Long

Proposed behaviour:
Step 1-3.: the same as the existing behaviour
Step 4.: as Integer is considered as a narrow data type of Long, the record is considered as valid

Implementation:
Building on top of RecordFieldType's existing "narrowDataTypes" collection, in case of numeric types, I extended the validation check with the check of these narrow types: if the incoming value fits to the original, or any of the narrow types, it is considered as valid.

Note:
Even if String also has a numerous amount of narrow types for example, in order to keep compatibility I did not extended other data types with this fix, only numeric ones. Extending them would be a change of behaviour instead of a fix. See TestValidateRecord#testValidateMissingRequiredArray which for example breaks if narrow types would be allowed for Strings.

Example for NIFI-7302:

Existing behaviour:
Step 1.: incoming value is 1.5191525220870972
Step 2.: record is being read, the representing object will be a Double
Step 3.: the record is validated against a schema which expect the field to be a Float
Step 4.: the record is invalid as the Double field is not considered as valid Float

Proposed behaviour:
Step 1-3.: the same as the existing behaviour
Step 4.: As the incoming value might be represented as Float, is is accepted as valid value.

Implementation:
An intermediate float value is populated with the incoming double and checked against the original double if there was any precision loss during the conversion.


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
