### PR TITLE
NIFI-7292 Preventing file listing from fail because of insufficient privileges

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -48,8 +48,11 @@ import org.apache.nifi.util.Tuple;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.FileStore;
 import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -68,6 +71,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -80,8 +84,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.nifi.expression.ExpressionLanguageScope.VARIABLE_REGISTRY;
 import static org.apache.nifi.processor.util.StandardValidators.POSITIVE_INTEGER_VALIDATOR;
@@ -547,41 +549,73 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
             }
         };
 
-        final Stream<Path> inputStream = getPathStream(basePath, maxDepth, matcher);
-
-        final Stream<FileInfo> listing = inputStream.map(p -> {
-            File file = p.toFile();
-            BasicFileAttributes attributes = lastModifiedMap.get(p);
-
-            final FileInfo fileInfo = new FileInfo.Builder()
-                .directory(false)
-                .filename(file.getName())
-                .fullPathFileName(file.getAbsolutePath())
-                .lastModifiedTime(attributes.lastModifiedTime().toMillis())
-                .size(attributes.size())
-                .build();
-
-            return fileInfo;
-        });
-
-        // Perform the actual listing
         try {
             final long start = System.currentTimeMillis();
-            final List<FileInfo> fileInfos = listing.collect(Collectors.toList());
+            final List<FileInfo> result = new LinkedList<>();
+
+            Files.walkFileTree(basePath, Collections.singleton(FileVisitOption.FOLLOW_LINKS), maxDepth, new FileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attributes) throws IOException {
+                    if (Files.isReadable(dir)) {
+                        return FileVisitResult.CONTINUE;
+                    } else {
+                        getLogger().debug("The following directory is not readable: {}", new Object[] {dir.toString()});
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                }
+
+                @Override
+                public FileVisitResult visitFile(final Path path, final BasicFileAttributes attributes) throws IOException {
+                    if (matcher.test(path, attributes)) {
+                        final File file = path.toFile();
+                        final BasicFileAttributes fileAttributes = lastModifiedMap.get(path);
+                        final FileInfo fileInfo = new FileInfo.Builder()
+                                .directory(false)
+                                .filename(file.getName())
+                                .fullPathFileName(file.getAbsolutePath())
+                                .lastModifiedTime(fileAttributes.lastModifiedTime().toMillis())
+                                .size(fileAttributes.size())
+                                .build();
+
+                        result.add(fileInfo);
+                    }
+
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(final Path path, final IOException e) throws IOException {
+                    if (e instanceof AccessDeniedException) {
+                        getLogger().debug("The following file is not readable: {}", new Object[] {path.toString()});
+                        return FileVisitResult.SKIP_SUBTREE;
+                    } else {
+                        getLogger().error("Error during visiting file {}: {}", new Object[] {path.toString(), e.getMessage()});
+                        e.printStackTrace();
+                        return FileVisitResult.TERMINATE;
+                    }
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(final Path dir, final IOException e) throws IOException {
+                    if (e != null) {
+                        getLogger().error("Error during visiting directory {}: {}", new Object[] {dir.toString(), e.getMessage()});
+                        e.printStackTrace();
+                    }
+
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
             final long millis = System.currentTimeMillis() - start;
 
-            getLogger().debug("Took {} milliseconds to perform listing and gather {} entries", new Object[] {millis, fileInfos.size()});
-            return fileInfos;
+            getLogger().debug("Took {} milliseconds to perform listing and gather {} entries", new Object[] {millis, result.size()});
+            return result;
         } catch (final ProcessorStoppedException pse) {
             getLogger().info("Processor was stopped so will not complete listing of Files");
             return Collections.emptyList();
         } finally {
             performanceTracker.completeActiveDirectory();
         }
-    }
-
-    protected Stream<Path> getPathStream(final Path basePath, final int maxDepth, final BiPredicate<Path, BasicFileAttributes> matcher) throws IOException {
-        return Files.find(basePath, maxDepth, matcher, FileVisitOption.FOLLOW_LINKS);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -589,7 +589,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                         getLogger().debug("The following file is not readable: {}", new Object[] {path.toString()});
                         return FileVisitResult.SKIP_SUBTREE;
                     } else {
-                        getLogger().error("Error during visiting file {}: {}", new Object[] {path.toString(), e.getMessage()});
+                        getLogger().error("Error during visiting file {}: {}", new Object[] {path.toString(), e.getMessage()}, e);
                         e.printStackTrace();
                         return FileVisitResult.TERMINATE;
                     }
@@ -598,7 +598,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 @Override
                 public FileVisitResult postVisitDirectory(final Path dir, final IOException e) throws IOException {
                     if (e != null) {
-                        getLogger().error("Error during visiting directory {}: {}", new Object[] {dir.toString(), e.getMessage()});
+                        getLogger().error("Error during visiting directory {}: {}", new Object[] {dir.toString(), e.getMessage()}, e);
                         e.printStackTrace();
                     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -590,7 +590,6 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                         return FileVisitResult.SKIP_SUBTREE;
                     } else {
                         getLogger().error("Error during visiting file {}: {}", new Object[] {path.toString(), e.getMessage()}, e);
-                        e.printStackTrace();
                         return FileVisitResult.TERMINATE;
                     }
                 }
@@ -599,7 +598,6 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 public FileVisitResult postVisitDirectory(final Path dir, final IOException e) throws IOException {
                     if (e != null) {
                         getLogger().error("Error during visiting directory {}: {}", new Object[] {dir.toString(), e.getMessage()}, e);
-                        e.printStackTrace();
                     }
 
                     return FileVisitResult.CONTINUE;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
@@ -43,8 +43,6 @@ import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -56,10 +54,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -187,60 +183,7 @@ public class TestListFile {
             }
         }
 
-        final BasicFileAttributes basicFileAttributes = new BasicFileAttributes() {
-            @Override
-            public FileTime lastModifiedTime() {
-                return FileTime.fromMillis(System.currentTimeMillis());
-            }
-
-            @Override
-            public FileTime lastAccessTime() {
-                return FileTime.fromMillis(System.currentTimeMillis());
-            }
-
-            @Override
-            public FileTime creationTime() {
-                return FileTime.fromMillis(System.currentTimeMillis());
-            }
-
-            @Override
-            public boolean isRegularFile() {
-                return false;
-            }
-
-            @Override
-            public boolean isDirectory() {
-                return false;
-            }
-
-            @Override
-            public boolean isSymbolicLink() {
-                return false;
-            }
-
-            @Override
-            public boolean isOther() {
-                return false;
-            }
-
-            @Override
-            public long size() {
-                return 0;
-            }
-
-            @Override
-            public Object fileKey() {
-                return null;
-            }
-        };
-
-        processor = new ListFile() {
-            @Override
-            protected Stream<Path> getPathStream(final Path basePath, final int maxDepth, final BiPredicate<Path, BasicFileAttributes> matcher) throws IOException {
-                return paths.stream()
-                    .filter(path -> matcher.test(path, basicFileAttributes));
-            }
-        };
+        processor = new ListFile();
 
         runner = TestRunners.newTestRunner(processor);
         runner.setProperty(AbstractListProcessor.TARGET_SYSTEM_TIMESTAMP_PRECISION, AbstractListProcessor.PRECISION_SECONDS.getValue());
@@ -501,6 +444,60 @@ public class TestListFile {
         final List<MockFlowFile> successFiles2 = runner.getFlowFilesForRelationship(ListFile.REL_SUCCESS);
         assertEquals(1, successFiles2.size());
     }
+
+    @Test
+    public void testListWithUnreadableFiles() throws Exception {
+        final File file1 = new File(TESTDIR + "/unreadable.txt");
+        assertTrue(file1.createNewFile());
+        assertTrue(file1.setReadable(false));
+
+        final File file2 = new File(TESTDIR + "/readable.txt");
+        assertTrue(file2.createNewFile());
+
+        final long now = getTestModifiedTime();
+        assertTrue(file1.setLastModified(now));
+        assertTrue(file2.setLastModified(now));
+
+        runner.setProperty(ListFile.DIRECTORY, testDir.getAbsolutePath());
+        runner.setProperty(ListFile.FILE_FILTER, ".*");
+        runNext();
+
+        final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(ListFile.REL_SUCCESS);
+        assertEquals(1, successFiles.size());
+    }
+
+    @Test
+    public void testListWithinUnreadableDirectory() throws Exception {
+        final File subdir = new File(TESTDIR + "/subdir");
+        assertTrue(subdir.mkdir());
+        assertTrue(subdir.setReadable(false));
+
+        final File file1 = new File(TESTDIR + "/subdir/unreadable.txt");
+        assertTrue(file1.createNewFile());
+        assertTrue(file1.setReadable(false));
+
+        final File file2 = new File(TESTDIR + "/subdir/readable.txt");
+        assertTrue(file2.createNewFile());
+
+        final File file3 = new File(TESTDIR + "/secondReadable.txt");
+        assertTrue(file3.createNewFile());
+
+        final long now = getTestModifiedTime();
+        assertTrue(file1.setLastModified(now));
+        assertTrue(file2.setLastModified(now));
+        assertTrue(file3.setLastModified(now));
+
+        runner.setProperty(ListFile.DIRECTORY, testDir.getAbsolutePath());
+        runner.setProperty(ListFile.FILE_FILTER, ".*");
+        runNext();
+
+        final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(ListFile.REL_SUCCESS);
+        assertEquals(1, successFiles.size());
+        assertEquals("secondReadable.txt", successFiles.get(0).getAttribute("filename"));
+
+        subdir.setReadable(true);
+    }
+
 
     @Test
     public void testFilterFilePattern() throws Exception {


### PR DESCRIPTION
This is a proposal to handle the issues described in [NIFI-7292](https://issues.apache.org/jira/browse/NIFI-7292). The solution proposal aims directly the effects of files and folders are not accessible by NiFi due to insufficient privileges. One of my primary goals was to minimise the change and keep using the -otherwise- properly working `FileTreeWalker` based implementation. In order to this, I did replace the `find` call with `walkFileTree`, which provides a more direct access to the file visiting with tree walker. With this, the code have more control over handling inaccessible files and folders, preventing the tree walker from instantly stopping. With the proposed behaviour in case of insufficient privileges, the listing skips the given files or subfolders.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
