### PR TITLE
NIFI-7304 Disabled-content length filter by default

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -647,8 +647,15 @@ public abstract class NiFiProperties {
         return getProperty(WEB_MAX_HEADER_SIZE, DEFAULT_WEB_MAX_HEADER_SIZE);
     }
 
+    /**
+     * Returns the {@code nifi.web.max.content.size} value from {@code nifi.properties}.
+     * Does not provide a default value because the presence of any value here enables the
+     * {@code ContentLengthFilter}.
+     *
+     * @return the specified max content-length in bytes for an incoming HTTP request
+     */
     public String getWebMaxContentSize() {
-        return getProperty(WEB_MAX_CONTENT_SIZE, DEFAULT_WEB_MAX_CONTENT_SIZE);
+        return getProperty(WEB_MAX_CONTENT_SIZE);
     }
 
     public String getMaxWebRequestsPerSecond() {
@@ -1670,12 +1677,12 @@ public abstract class NiFiProperties {
         if (nfPropertiesFilePath != null) {
             final File propertiesFile = new File(nfPropertiesFilePath.trim());
             if (!propertiesFile.exists()) {
-                throw new RuntimeException("Properties file doesn't exist \'"
-                        + propertiesFile.getAbsolutePath() + "\'");
+                throw new RuntimeException("Properties file doesn't exist '"
+                        + propertiesFile.getAbsolutePath() + "'");
             }
             if (!propertiesFile.canRead()) {
-                throw new RuntimeException("Properties file exists but cannot be read \'"
-                        + propertiesFile.getAbsolutePath() + "\'");
+                throw new RuntimeException("Properties file exists but cannot be read '"
+                        + propertiesFile.getAbsolutePath() + "'");
             }
             InputStream inStream = null;
             try {

--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -652,7 +652,7 @@ public abstract class NiFiProperties {
      * Does not provide a default value because the presence of any value here enables the
      * {@code ContentLengthFilter}.
      *
-     * @return the specified max content-length in bytes for an incoming HTTP request
+     * @return the specified max content-length and units for an incoming HTTP request
      */
     public String getWebMaxContentSize() {
         return getProperty(WEB_MAX_CONTENT_SIZE);

--- a/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/NiFiPropertiesTest.java
+++ b/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/NiFiPropertiesTest.java
@@ -17,8 +17,9 @@
 package org.apache.nifi.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -269,7 +270,7 @@ public class NiFiPropertiesTest {
         }});
 
         // Assert defaults match expectations:
-        assertEquals(properties.getWebMaxContentSize(), "20 MB");
+        assertNull(properties.getWebMaxContentSize());
 
         // Re-arrange with specific values:
         final String size = "size value";

--- a/nifi-framework-api/src/main/java/org/apache/nifi/bundle/Bundle.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/bundle/Bundle.java
@@ -45,4 +45,9 @@ public class Bundle {
     public ClassLoader getClassLoader() {
         return classLoader;
     }
+
+    @Override
+    public String toString() {
+        return bundleDetails.toString();
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/groovy/org/apache/nifi/properties/StandardNiFiPropertiesGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/groovy/org/apache/nifi/properties/StandardNiFiPropertiesGroovyTest.groovy
@@ -958,4 +958,19 @@ class StandardNiFiPropertiesGroovyTest extends GroovyTestCase {
         // Assert
         assert hosts.size() == 0
     }
+
+    @Test
+    void testWebMaxContentSizeShouldDefaultToEmpty() {
+        // Arrange
+        Properties rawProps = new Properties(["nifi.web.max.content.size": ""])
+        NiFiProperties props = new StandardNiFiProperties(rawProps)
+        logger.info("Created a NiFiProperties instance with empty web max content size property")
+
+        // Act
+        String webMaxContentSize = props.getWebMaxContentSize()
+        logger.info("Read from NiFiProperties instance: ${webMaxContentSize}")
+
+        // Assert
+        assert webMaxContentSize == ""
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -144,7 +144,7 @@
         <nifi.web.max.header.size>16 KB</nifi.web.max.header.size>
         <nifi.web.proxy.context.path />
         <nifi.web.proxy.host />
-        <nifi.web.max.content.size>20 MB</nifi.web.max.content.size>
+        <nifi.web.max.content.size/>
         <nifi.web.max.requests.per.second>30000</nifi.web.max.requests.per.second>
         <!-- nifi.properties: security properties -->
         <nifi.security.keystore />

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/StandardPublicPortGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/StandardPublicPortGroovyTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.remote
+
+
+import org.apache.nifi.authorization.Authorizer
+import org.apache.nifi.connectable.Connectable
+import org.apache.nifi.connectable.ConnectableType
+import org.apache.nifi.controller.ProcessScheduler
+import org.apache.nifi.properties.StandardNiFiProperties
+import org.apache.nifi.remote.protocol.CommunicationsSession
+import org.apache.nifi.remote.protocol.ServerProtocol
+import org.apache.nifi.reporting.BulletinRepository
+import org.apache.nifi.util.NiFiProperties
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@RunWith(JUnit4.class)
+class StandardPublicPortGroovyTest extends GroovyTestCase {
+    private static final Logger logger = LoggerFactory.getLogger(StandardPublicPortGroovyTest.class)
+
+    @BeforeClass
+    static void setUpOnce() throws Exception {
+        logger.metaClass.methodMissing = { String name, args ->
+            logger.info("[${name?.toUpperCase()}] ${(args as List).join(" ")}")
+        }
+    }
+
+    @Before
+    void setUp() {
+
+    }
+
+    @After
+    void tearDown() {
+
+    }
+
+    private static PublicPort createPublicPort(NiFiProperties niFiProperties) {
+        Authorizer mockAuthorizer = [:] as Authorizer
+        BulletinRepository mockBulletinRepository = [:] as BulletinRepository
+        ProcessScheduler mockProcessScheduler = [registerEvent: { Connectable worker ->
+            logger.mock("Registered event for worker: ${worker}")
+        }] as ProcessScheduler
+
+        StandardPublicPort spp = new StandardPublicPort("id", "name", TransferDirection.RECEIVE, ConnectableType.INPUT_PORT, mockAuthorizer, mockBulletinRepository, mockProcessScheduler, false, niFiProperties.getBoredYieldDuration(), [])
+        logger.info("Created SPP with mocked collaborators: ${spp}")
+        spp
+    }
+
+    // TODO: Implement test
+    @Ignore("Not yet implemented")
+    @Test
+    void testReceiveFlowFilesShouldHandleBlockedRequestDueToContentLength() {
+        // Arrange
+        Map badProps = [
+                (NiFiProperties.WEB_HTTP_HOST) : "localhost",
+                (NiFiProperties.WEB_HTTPS_HOST): "secure.host.com",
+                (NiFiProperties.WEB_THREADS)   : NiFiProperties.DEFAULT_WEB_THREADS
+        ]
+        NiFiProperties mockProps = [
+                getPort    : { -> 8080 },
+                getSslPort : { -> 8443 },
+                getProperty: { String prop ->
+                    String value = badProps[prop] ?: "no_value"
+                    logger.mock("getProperty(${prop}) -> ${value}")
+                    value
+                },
+        ] as StandardNiFiProperties
+
+        StandardPublicPort port = createPublicPort(mockProps)
+
+        final int LISTEN_SECS = 5
+
+        PeerDescription peerDescription = new PeerDescription("localhost", 8080, false)
+        CommunicationsSession mockCommunicationsSession = [:] as CommunicationsSession
+        Peer peer = new Peer(peerDescription, mockCommunicationsSession, "http://localhost", "")
+        ServerProtocol mockServerProtocol = [getRequestExpiration: { -> 500L }] as ServerProtocol
+
+        // Act
+        port.onSchedulingStart()
+        logger.info("Listening on port for ${LISTEN_SECS} seconds")
+        long end = System.nanoTime() + LISTEN_SECS * 1_000_000_000
+        def responses = []
+        while (System.nanoTime() < end) {
+            responses << port.receiveFlowFiles(peer, mockServerProtocol)
+            logger.info("Received ${responses[-1]} flowfiles")
+        }
+        logger.info("Stopped listening on port")
+        logger.info("Received ${responses.sum()} total flowfiles")
+
+        // Assert
+        assert !responses.isEmpty()
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -598,6 +598,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         webappContext.setMaxFormContentSize(600000);
 
         // add HTTP security headers to all responses
+        // TODO: Allow more granular path configuration (e.g. /nifi-api/site-to-site/ vs. /nifi-api/process-groups)
         final String ALL_PATHS = "/*";
         ArrayList<Class<? extends Filter>> filters = new ArrayList<>(Arrays.asList(XFrameOptionsFilter.class, ContentSecurityPolicyFilter.class, XSSProtectionFilter.class));
         if (props.isHTTPSConfigured()) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -718,7 +718,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
                 logger.debug("Parsed max content length as {} bytes", configuredMaxRequestSize);
                 return configuredMaxRequestSize;
             } else {
-                logger.warn("Can't parse valid max content length from {}", webMaxContentSize);
+                logger.info("Can't parse valid max content length from {}", webMaxContentSize);
             }
         } catch (final IllegalArgumentException e) {
             logger.warn("Exception parsing property {}; disabling content length filter", NiFiProperties.WEB_MAX_CONTENT_SIZE);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
@@ -16,9 +16,12 @@
  */
 package org.apache.nifi.web.server
 
+
 import org.apache.log4j.AppenderSkeleton
 import org.apache.log4j.spi.LoggingEvent
 import org.apache.nifi.bundle.Bundle
+import org.apache.nifi.bundle.BundleCoordinate
+import org.apache.nifi.bundle.BundleDetails
 import org.apache.nifi.properties.StandardNiFiProperties
 import org.apache.nifi.util.NiFiProperties
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -26,6 +29,7 @@ import org.eclipse.jetty.server.Connector
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.servlet.FilterHolder
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Before
@@ -56,6 +60,23 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @Rule
     public final SystemErrRule systemErrRule = new SystemErrRule().enableLog()
 
+    private static final String TEST_LIB_PATH = "./target/lib"
+
+    private static final List<String> REQUIRED_WARS = ["nifi-web-api",
+                                                       "nifi-web-error",
+                                                       "nifi-web-docs",
+                                                       "nifi-web-content-viewer",
+                                                       "nifi-web"]
+
+    private static final String VERSION = "1.12.0-SNAPSHOT"
+    private static final BundleCoordinate DEPENDENCY_COORDINATE = new BundleCoordinate("org.apache.nifi.test", "parent", VERSION)
+    private static final String BRANCH = "branch_test"
+    private static final String JDK = "11.0.6"
+    private static final String REVISION = "revision_test"
+    private static final String TAG = "tag_test"
+    private static final String TIMESTAMP = new Date().toString()
+    private static final String USER = "user_test"
+
     @BeforeClass
     static void setUpOnce() throws Exception {
         Security.addProvider(new BouncyCastleProvider())
@@ -80,6 +101,9 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @After
     void tearDown() throws Exception {
         TestAppender.reset()
+
+        // Clean up target/lib
+        new File(TEST_LIB_PATH).deleteDir()
     }
 
     @Test
@@ -168,16 +192,16 @@ class JettyServerGroovyTest extends GroovyTestCase {
                 (NiFiProperties.WEB_HTTPS_HOST): "secure.host.com",
         ]
         NiFiProperties mockProps = [
-                getPort    : { -> 8080 },
-                getSslPort : { -> 8443 },
-                getProperty: { String prop ->
+                getPort            : { -> 8080 },
+                getSslPort         : { -> 8443 },
+                getProperty        : { String prop ->
                     String value = badProps[prop] ?: "no_value"
                     logger.mock("getProperty(${prop}) -> ${value}")
                     value
                 },
-                getWebThreads: { -> NiFiProperties.DEFAULT_WEB_THREADS },
+                getWebThreads      : { -> NiFiProperties.DEFAULT_WEB_THREADS },
                 getWebMaxHeaderSize: { -> NiFiProperties.DEFAULT_WEB_MAX_HEADER_SIZE },
-                isHTTPSConfigured: { -> true }
+                isHTTPSConfigured  : { -> true }
         ] as StandardNiFiProperties
 
         // The web server should fail to start and exit Java
@@ -187,11 +211,11 @@ class JettyServerGroovyTest extends GroovyTestCase {
                 final String standardErr = systemErrRule.getLog()
                 List<String> errLines = standardErr.split("\n")
 
-                assert errLines.any { it =~ "Failed to start web server: "}
-                assert errLines.any { it =~ "Shutting down..."}
+                assert errLines.any { it =~ "Failed to start web server: " }
+                assert errLines.any { it =~ "Shutting down..." }
             }
         })
-        
+
         // Act
         JettyServer jettyServer = new JettyServer(mockProps, [] as Set<Bundle>)
 
@@ -203,25 +227,149 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @Test
     void testShouldConfigureHTTPSConnector() {
         // Arrange
-       NiFiProperties httpsProps = new StandardNiFiProperties(rawProperties: new Properties([
+        NiFiProperties httpsProps = new StandardNiFiProperties(rawProperties: new Properties([
 //               (NiFiProperties.WEB_HTTP_PORT): null,
 //               (NiFiProperties.WEB_HTTP_HOST): null,
-               (NiFiProperties.WEB_HTTPS_PORT): "8443",
-               (NiFiProperties.WEB_HTTPS_HOST): "secure.host.com",
-       ]))
-        
+(NiFiProperties.WEB_HTTPS_PORT): "8443",
+(NiFiProperties.WEB_HTTPS_HOST): "secure.host.com",
+        ]))
+
         Server internalServer = new Server()
         JettyServer jetty = new JettyServer(internalServer, httpsProps)
 
         // Act
-       jetty.configureHttpsConnector(internalServer, new HttpConfiguration())
-       List<Connector> connectors = Arrays.asList(internalServer.connectors)
+        jetty.configureHttpsConnector(internalServer, new HttpConfiguration())
+        List<Connector> connectors = Arrays.asList(internalServer.connectors)
 
         // Assert
         assert connectors.size() == 1
         ServerConnector connector = connectors.first() as ServerConnector
         assert connector.host == "secure.host.com"
         assert connector.port == 8443
+    }
+
+    @Test
+    void testShouldNotEnableContentLengthFilterIfWebMaxContentSizeEmpty() {
+        // Arrange
+        Map defaultProps = [
+                (NiFiProperties.WEB_HTTP_HOST)        : "localhost",
+                (NiFiProperties.WEB_MAX_CONTENT_SIZE) : NiFiProperties.DEFAULT_WEB_THREADS,
+                (NiFiProperties.NAR_LIBRARY_DIRECTORY): TEST_LIB_PATH,
+                (NiFiProperties.NAR_WORKING_DIRECTORY): "./target/work/nar"
+        ]
+        NiFiProperties mockProps = new StandardNiFiProperties(new Properties(defaultProps))
+
+        // Generate the empty WAR files in the proper location
+        prepareWars(REQUIRED_WARS, mockProps.getNarLibraryDirectories().first().toAbsolutePath().toString())
+
+        // Form the bundles
+        Set<Bundle> narBundles = prepareWARBundles(mockProps)
+        logger.info("Prepared ${narBundles.size()} required bundles: ${narBundles*.bundleDetails*.coordinate}")
+
+
+        def log = TestAppender.getLogLines()
+
+        // Act
+        JettyServer jettyServer = new JettyServer(mockProps, narBundles)
+
+        // Attempt to override WAR loading
+//        JettyServer jettyServer = new JettyServer(mockProps, [] as Set<Bundle>) {
+//            public JettyServer(NiFiProperties props, Set<Bundle> narBundles) {
+//                logger.mock("Overriding normal JettyServer constructor")
+//            }
+//
+//            private Handler loadInitialWars(final Set<Bundle> bundles) {
+//                logger.mock("Overriding normal loadInitialWars() method")
+//
+//                ServletContextHandler context = new ServletContextHandler()
+//                ServletHolder defaultServlet = new ServletHolder("default", DefaultServlet.class)
+////                defaultServlet.setInitParameter("resourceBase",System.getProperty("user.dir"));
+////                defaultServlet.setInitParameter("dirAllowed","true");
+//                context.addServlet(defaultServlet, "/")
+//                context
+//            }
+//        }
+
+        // Attempt to bypass WAR loading
+//        Server internalServer = new Server()
+//        JettyServer jettyServer = new JettyServer(internalServer, mockProps)
+        logger.info("Created JettyServer: ${jettyServer.dump()}")
+
+        // Assert
+        def filters = jettyServer.webApiContext.getServletHandler().getFilters() as List<FilterHolder>
+        logger.info("Web API Context has ${filters.size()} filters: ${filters*.displayName.join(", ")}".toString())
+        assert filters*.displayName.contains("ContentLengthFilter")
+
+        // TODO: Check for log errors (TBA)
+        assert !log.isEmpty()
+        assert log.first() =~ "Both the HTTP and HTTPS connectors are configured in nifi.properties. Only one of these connectors should be configured. See the NiFi Admin Guide for more details"
+    }
+
+    private static void prepareWars(List<String> wars = REQUIRED_WARS, String extensionsPath = "target/lib") {
+        // Create the directory
+        def extensionsDir = new File(extensionsPath)
+        extensionsDir.mkdirs()
+
+        // For each required WAR
+        wars.each { String warName ->
+            // Mock WAR file
+            def mockWarFile = new File(extensionsPath, warName)
+            boolean createdFile = mockWarFile.createNewFile()
+            if (!createdFile) {
+                fail("Could not create ${mockWarFile.path}")
+            } else {
+                logger.info("Created empty WAR file at ${mockWarFile.path}")
+            }
+        }
+    }
+
+    private static Bundle buildBundle(String warName, File workingDirectory, ClassLoader classLoader = ClassLoader.getSystemClassLoader()) {
+        BundleCoordinate coordinate = new BundleCoordinate("org.apache.nifi.test", warName, VERSION)
+        BundleDetails bundleDetails = new BundleDetails.Builder()
+                .coordinate(coordinate)
+//                .dependencyCoordinate(DEPENDENCY_COORDINATE)
+                .workingDir(workingDirectory)
+                .buildBranch(BRANCH)
+                .buildJdk(JDK)
+                .buildRevision(REVISION)
+                .buildTag(TAG)
+                .buildTimestamp(TIMESTAMP)
+                .builtBy(USER)
+                .build()
+        new Bundle(bundleDetails, classLoader)
+    }
+
+    /**
+     * Returns a collection of {@link Bundle} objects required to start the NiFi {@link JettyServer}. Replicates the behavior of {@code new NiFi()}.
+     *
+     * @param mockProps the NiFi properties referencing a test resource directory containing stubbed WARs
+     * @return the parsed Bundles
+     */
+    private static Set<Bundle> prepareWARBundles(StandardNiFiProperties mockProps) {
+        logger.info("Setting up stubbed WAR bundles")
+        logger.info("Current working directory: ${new File(".").absolutePath}")
+        File fwd = mockProps.getFrameworkWorkingDirectory()
+        logger.info("Framework working directory: ${fwd.absolutePath}")
+
+        Set<Bundle> bundles = REQUIRED_WARS.collect { String warName ->
+            def bundle = buildBundle(warName, fwd)
+            logger.info("WAR: ${warName.padLeft(30, " ")} - built bundle: ${bundle}")
+            bundle
+        }
+
+        bundles
+
+//        def rootClassLoader = ClassLoader.getSystemClassLoader()
+//        def systemBundle = SystemBundle.create(mockProps, rootClassLoader)
+//        def extensionMapping = NarUnpacker.unpackNars(mockProps, systemBundle)
+//        def narClassLoaders = NarClassLoadersHolder.getInstance()
+//        narClassLoaders.init(rootClassLoader, mockProps.getFrameworkWorkingDirectory(), mockProps.getExtensionsWorkingDirectory())
+//        def frameworkClassLoader = narClassLoaders.getFrameworkBundle().getClassLoader()
+//        def narBundles = narClassLoaders.getBundles()
+//
+//        Bundle mockWebApiBundle = new Bundle()
+//        Set<Bundle> mockBundles = []
+//        narBundles
     }
 }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
@@ -19,7 +19,6 @@ package org.apache.nifi.web.server
 import org.apache.log4j.AppenderSkeleton
 import org.apache.log4j.spi.LoggingEvent
 import org.apache.nifi.bundle.Bundle
-import org.apache.nifi.bundle.BundleCoordinate
 import org.apache.nifi.processor.DataUnit
 import org.apache.nifi.properties.StandardNiFiProperties
 import org.apache.nifi.util.NiFiProperties
@@ -61,23 +60,6 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @Rule
     public final SystemErrRule systemErrRule = new SystemErrRule().enableLog()
 
-    private static final String TEST_LIB_PATH = "./target/lib"
-
-    private static final List<String> REQUIRED_WARS = ["nifi-web-api",
-                                                       "nifi-web-error",
-                                                       "nifi-web-docs",
-                                                       "nifi-web-content-viewer",
-                                                       "nifi-web"]
-
-    private static final String VERSION = "1.12.0-SNAPSHOT"
-    private static final BundleCoordinate DEPENDENCY_COORDINATE = new BundleCoordinate("org.apache.nifi.test", "parent", VERSION)
-    private static final String BRANCH = "branch_test"
-    private static final String JDK = "11.0.6"
-    private static final String REVISION = "revision_test"
-    private static final String TAG = "tag_test"
-    private static final String TIMESTAMP = new Date().toString()
-    private static final String USER = "user_test"
-
     @BeforeClass
     static void setUpOnce() throws Exception {
         Security.addProvider(new BouncyCastleProvider())
@@ -102,9 +84,6 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @After
     void tearDown() throws Exception {
         TestAppender.reset()
-
-        // Clean up target/lib
-        new File(TEST_LIB_PATH).deleteDir()
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/resources/JettyServerGroovyTest/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/resources/JettyServerGroovyTest/nifi.properties
@@ -1,4 +1,0 @@
-nifi.nar.library.directory=./target/lib
-nifi.nar.library.autoload.directory=./target/extensions
-nifi.nar.working.directory=./target/work/nar/
-nifi.documentation.working.directory=./target/work/docs/components

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/resources/JettyServerGroovyTest/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/resources/JettyServerGroovyTest/nifi.properties
@@ -1,0 +1,4 @@
+nifi.nar.library.directory=./target/lib
+nifi.nar.library.autoload.directory=./target/extensions
+nifi.nar.working.directory=./target/work/nar/
+nifi.documentation.working.directory=./target/work/docs/components

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/logback-test.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/logback-test.xml
@@ -31,6 +31,8 @@
     
     <logger name="org.apache.nifi" level="INFO"/>
     <logger name="org.apache.nifi.web.api" level="DEBUG"/>
+    <logger name="org.apache.nifi.web.server" level="DEBUG"/>
+    <logger name="org.apache.nifi.web.security.requests" level="TRACE"/>
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/requests/ContentLengthFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/requests/ContentLengthFilter.java
@@ -91,6 +91,15 @@ public class ContentLengthFilter implements Filter {
     }
 
     /**
+     * Returns the currently configured max content length in bytes.
+     *
+     * @return the max content length
+     */
+    public int getMaxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
      * Formats a value like {@code 1048576} to {@code 1 MB} for easier human consumption.
      *
      * @param byteSize the size in bytes

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/requests/ContentLengthFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/requests/ContentLengthFilter.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.web.security.requests;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -40,6 +42,8 @@ public class ContentLengthFilter implements Filter {
     public final static int MAX_LENGTH_DEFAULT = 10_000_000;
     private int maxContentLength;
 
+    private static final List<String> BYPASS_URI_PREFIXES = Arrays.asList("/data-transfer", "/site-to-site");
+
     public void init() {
         maxContentLength = MAX_LENGTH_DEFAULT;
         logger.debug("Filter initialized without configuration and set max content length: " + formatSize(maxContentLength));
@@ -60,6 +64,13 @@ public class ContentLengthFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String httpMethod = httpRequest.getMethod();
+
+        // If the request is in the framework allow list, do not evaluate or block based on content length
+        if (!isSubjectToFilter(httpRequest)) {
+            logger.trace("Request {} is not subject to content length checks", httpRequest.getRequestURI());
+            chain.doFilter(request, response);
+            return;
+        }
 
         // Check the HTTP method because the spec says clients don't have to send a content-length header for methods
         // that don't use it.  So even though an attacker may provide a large body in a GET request, the body should go
@@ -97,6 +108,22 @@ public class ContentLengthFilter implements Filter {
      */
     public int getMaxContentLength() {
         return maxContentLength;
+    }
+
+    /**
+     * Returns {@code true} if this request is subject to the filter operation, {@code false} if not.
+     *
+     * @param request the incoming request
+     * @return true if this request should be filtered
+     */
+    private boolean isSubjectToFilter(HttpServletRequest request) {
+        for (String uriPrefix : BYPASS_URI_PREFIXES) {
+            if (request.getRequestURI().startsWith(uriPrefix)) {
+                logger.debug("Incoming request {} matches filter bypass prefix {}; content length filter is not applied", request.getRequestURI(), uriPrefix);
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_NIFI-7154 introduced the `ContentLengthFilter`, which restricted the max content-length on incoming requests. This PR reverts the behavior to disable the filter by default unless an administrator explicitly provides a max size in `nifi.properties` and allows Site-to-Site and cluster communications to bypass the filter._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
