### PR TITLE
NIFI-6394 - frontend queue/connection size limit

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -767,9 +767,10 @@ public interface NiFiServiceFacade {
      *
      * @param connectionId The ID of the connection
      * @param listingRequestId The ID of the listing request
+     * @param maxResults The maximum number of flowfile summary objects to return
      * @return The ListingRequest
      */
-    ListingRequestDTO createFlowFileListingRequest(String connectionId, String listingRequestId);
+    ListingRequestDTO createFlowFileListingRequest(String connectionId, String listingRequestId, int maxResults);
 
     /**
      * Gets a new flow file listing request.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -80,6 +80,7 @@ import org.apache.nifi.controller.Template;
 import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.controller.label.Label;
 import org.apache.nifi.controller.leader.election.LeaderElectionManager;
+import org.apache.nifi.controller.queue.ListFlowFileStatus;
 import org.apache.nifi.controller.repository.claim.ContentDirection;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.controller.service.ControllerServiceReference;
@@ -2004,9 +2005,10 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public ListingRequestDTO createFlowFileListingRequest(final String connectionId, final String listingRequestId) {
+    public ListingRequestDTO createFlowFileListingRequest(final String connectionId, final String listingRequestId, final int maxResults) {
         final Connection connection = connectionDAO.getConnection(connectionId);
-        final ListingRequestDTO listRequest = dtoFactory.createListingRequestDTO(connectionDAO.createFlowFileListingRequest(connectionId, listingRequestId));
+        final ListFlowFileStatus listFlowFileStatus = connectionDAO.createFlowFileListingRequest(connectionId, listingRequestId, maxResults);
+        final ListingRequestDTO listRequest = dtoFactory.createListingRequestDTO(listFlowFileStatus);
 
         // include whether the source and destination are running
         if (connection.getSource() != null) {
@@ -5034,7 +5036,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
             @Override
             public RevisionUpdate<ProcessGroupDTO> update() {
                 // update the Process Group
-                final ProcessGroup updatedProcessGroup = processGroupDAO.updateProcessGroupFlow(groupId, proposedFlowSnapshot, versionControlInfo, componentIdSeed, verifyNotModified, updateSettings,
+                processGroupDAO.updateProcessGroupFlow(groupId, proposedFlowSnapshot, versionControlInfo, componentIdSeed, verifyNotModified, updateSettings,
                     updateDescendantVersionedFlows);
 
                 // update the revisions

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowFileQueueResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowFileQueueResource.java
@@ -319,7 +319,8 @@ public class FlowFileQueueResource extends ApplicationResource {
                     value = "The connection id.",
                     required = true
             )
-            @PathParam("id") final String id) {
+            @PathParam("id") final String id,
+            @QueryParam("max") final int max) {
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.POST);
@@ -327,6 +328,9 @@ public class FlowFileQueueResource extends ApplicationResource {
 
         final ConnectionEntity requestConnectionEntity = new ConnectionEntity();
         requestConnectionEntity.setId(id);
+
+        // max results for flowfile queue listing is 100
+        final int maxResults = max <= 0 ? 100 : max;
 
         return withWriteLock(
                 serviceFacade,
@@ -342,7 +346,7 @@ public class FlowFileQueueResource extends ApplicationResource {
                     final String listingRequestId = generateUuid();
 
                     // submit the listing request
-                    final ListingRequestDTO listingRequest = serviceFacade.createFlowFileListingRequest(connectionEntity.getId(), listingRequestId);
+                    final ListingRequestDTO listingRequest = serviceFacade.createFlowFileListingRequest(connectionEntity.getId(), listingRequestId, maxResults);
                     populateRemainingFlowFileListingContent(connectionEntity.getId(), listingRequest);
 
                     // create the response entity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ConnectionDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ConnectionDAO.java
@@ -101,9 +101,10 @@ public interface ConnectionDAO {
      *
      * @param id connection id
      * @param listingRequestId listing request id
+     * @param maxRedsults the maximum number of flowfile summary objects to return
      * @return The listing request status
      */
-    ListFlowFileStatus createFlowFileListingRequest(String id, String listingRequestId);
+    ListFlowFileStatus createFlowFileListingRequest(String id, String listingRequestId, int maxResults);
 
     /**
      * Verifies the listing can be processed.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
@@ -351,14 +351,14 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
     }
 
     @Override
-    public ListFlowFileStatus createFlowFileListingRequest(String id, String listingRequestId) {
+    public ListFlowFileStatus createFlowFileListingRequest(String id, String listingRequestId, int maxResults) {
         final Connection connection = locateConnection(id);
         final FlowFileQueue queue = connection.getFlowFileQueue();
 
         // ensure we can list
         verifyList(queue);
 
-        return queue.listFlowFiles(listingRequestId, 100);
+        return queue.listFlowFiles(listingRequestId, maxResults);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/queue-listing.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/queue-listing.jsp
@@ -30,6 +30,7 @@
     <div id="queue-listing-refresh-container">
         <button id="queue-listing-refresh-button" class="refresh-button pointer fa fa-refresh" title="Refresh"></button>
         <div id="queue-listing-last-refreshed-container" class="last-refreshed-container">
+            <span>&nbsp;&nbsp;&nbsp; <a href="#" id="queue-listing-view-all">View All</a> &nbsp;&nbsp;&nbsp;</span>
             Last updated:&nbsp;<span id="queue-listing-last-refreshed"></span>
         </div>
         <div id="queue-listing-loading-container" class="loading-container"></div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-queue-listing.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-queue-listing.js
@@ -365,12 +365,17 @@
      * Performs a listing on the specified connection.
      *
      * @param connection the connection
+     * @param maxResults the maximum number of results to display, defaults to 100
      */
-    var performListing = function (connection) {
+    var performListing = function (connection, maxResults) {
         var MAX_DELAY = 4;
         var cancelled = false;
         var listingRequest = null;
         var listingRequestTimer = null;
+
+        if (typeof(maxResults)==='undefined') {
+          maxResults = 100;
+        }
 
         return $.Deferred(function (deferred) {
             // updates the progress bar
@@ -518,7 +523,7 @@
             // issue the request to list the flow files
             $.ajax({
                 type: 'POST',
-                url: '../nifi-api/flowfile-queues/' + connection.id + '/listing-requests',
+                url: '../nifi-api/flowfile-queues/' + connection.id + '/listing-requests?max=' + maxResults,
                 dataType: 'json',
                 contentType: 'application/json'
             }).done(function (response) {
@@ -651,6 +656,12 @@
             $('#queue-listing-refresh-button').click(function () {
                 var connection = $('#queue-listing-table').data('connection');
                 performListing(connection);
+            });
+
+            $('#queue-listing-view-all').click(function(evt) {
+              evt.preventDefault();
+              var connection = $('#queue-listing-table').data('connection');
+              performListing(connection, 100000); // max limit of 100,000 flowfiles for sanity
             });
 
             var queueListingOptions = {


### PR DESCRIPTION
This PR fundamentally removes the hard-coded number of flowfiles in the listing returned by StandardConnectionDAO.java, adding a new parameter called 'maxResults' to the parent interface.  This value can then be consulted and used when calling the backend for the queue listing.  The current hard-coded value of '100' can be limiting in certain use cases, for example, when the queue has a backlog of > 100 flowfiles and the dataflow manager needs to interrogate the 101+ flowfile.

The maxResults parameter is exposed as part of the REST API, so that calling programs (like the UI) can control the number of displayed flowfiles.  By default, the listing size will remain at 100, but a UI option is added to "view all" flowfiles in the queue.  Additionally, the parameter can be controlled by the REST API for custom clients.

This PR is broken into two commits; one for the backend changes, one for the UI changes.  These can be considered separately or can be easily squashed together as desired.

This features closes NIFI-6394
