### PR TITLE
NIFI-7387: ComponentLog accepts Object varargs instead of array

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/logging/ComponentLog.java
+++ b/nifi-api/src/main/java/org/apache/nifi/logging/ComponentLog.java
@@ -52,7 +52,7 @@ public interface ComponentLog {
 
     void warn(String msg, Throwable t);
 
-    void warn(String msg, Object[] os);
+    void warn(String msg, Object... os);
 
     void warn(String msg, Object[] os, Throwable t);
 
@@ -60,7 +60,7 @@ public interface ComponentLog {
 
     void trace(String msg, Throwable t);
 
-    void trace(String msg, Object[] os);
+    void trace(String msg, Object... os);
 
     void trace(String msg);
 
@@ -78,7 +78,7 @@ public interface ComponentLog {
 
     void info(String msg, Throwable t);
 
-    void info(String msg, Object[] os);
+    void info(String msg, Object... os);
 
     void info(String msg);
 
@@ -88,7 +88,7 @@ public interface ComponentLog {
 
     void error(String msg, Throwable t);
 
-    void error(String msg, Object[] os);
+    void error(String msg, Object... os);
 
     void error(String msg);
 
@@ -96,7 +96,7 @@ public interface ComponentLog {
 
     void debug(String msg, Throwable t);
 
-    void debug(String msg, Object[] os);
+    void debug(String msg, Object... os);
 
     void debug(String msg, Object[] os, Throwable t);
 
@@ -104,7 +104,7 @@ public interface ComponentLog {
 
     void log(LogLevel level, String msg, Throwable t);
 
-    void log(LogLevel level, String msg, Object[] os);
+    void log(LogLevel level, String msg, Object... os);
 
     void log(LogLevel level, String msg);
 

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
@@ -144,7 +144,7 @@ public class ParseEvtxTest {
         when(flowFile.getAttribute(CoreAttributes.FILENAME.key())).thenReturn(basename);
 
         assertEquals(basename, parseEvtx.getBasename(flowFile, componentLog));
-        verify(componentLog).warn(anyString(), isA(Object[].class));
+        verify(componentLog).warn(anyString(), anyString(), isA(FlowFile.class));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
@@ -142,7 +142,6 @@ public class ParseEvtxTest {
         when(flowFile.getAttribute(CoreAttributes.FILENAME.key())).thenReturn(basename);
 
         assertEquals(basename, parseEvtx.getBasename(flowFile, componentLog));
-        verify(componentLog).warn("Trying to parse file without .evtx extension {} from flowfile {}", basename, flowFile);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
@@ -20,9 +20,7 @@ package org.apache.nifi.processors.evtx;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -144,7 +142,7 @@ public class ParseEvtxTest {
         when(flowFile.getAttribute(CoreAttributes.FILENAME.key())).thenReturn(basename);
 
         assertEquals(basename, parseEvtx.getBasename(flowFile, componentLog));
-        verify(componentLog).warn(anyString(), anyString(), isA(FlowFile.class));
+        verify(componentLog).warn("Trying to parse file without .evtx extension {} from flowfile {}", basename, flowFile);
     }
 
     @Test


### PR DESCRIPTION

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Updates ComponentLog interface to accept Object varargs simplifying logger statements in the code. It is no longer required to create a new Object array; just pass the substitution values directly.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
