### PR TITLE
NIFI-7403 - PutSQL's transactions support

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/Put.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/Put.java
@@ -54,6 +54,20 @@ public class Put<FC, C extends AutoCloseable> {
             .allowableValues("true", "false")
             .defaultValue("true")
             .build();
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("A FlowFile is routed to this relationship after the database is successfully updated")
+            .build();
+    public static final Relationship REL_RETRY = new Relationship.Builder()
+            .name("retry")
+            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
+            .build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
+                    + "such as an invalid query or an integrity constraint violation")
+            .build();
     /**
      * Put fetched FlowFiles to a data storage.
      * @param context process context passed from a Processor onTrigger.

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/Put.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/Put.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processor.util.pattern;
 
+import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
@@ -44,6 +45,15 @@ public class Put<FC, C extends AutoCloseable> {
     protected PartialFunctions.Cleanup<FC, C> cleanup;
     protected ComponentLog logger;
 
+    public static final PropertyDescriptor SUPPORT_TRANSACTIONS = new PropertyDescriptor.Builder()
+            .name("Support Fragmented Transactions")
+            .description("If true, when a FlowFile is consumed by this Processor, the Processor will first check the fragment.identifier and fragment.count attributes of that FlowFile. "
+                    + "If the fragment.count value is greater than 1, the Processor will not process any FlowFile with that fragment.identifier until all are available; "
+                    + "at that point, it will process all FlowFiles with that fragment.identifier as a single transaction, in the order specified by the FlowFiles' fragment.index attributes. "
+                    + "This Provides atomicity of those SQL statements. If this value is false, these attributes will be ignored and the updates will occur independent of one another.")
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .build();
     /**
      * Put fetched FlowFiles to a data storage.
      * @param context process context passed from a Processor onTrigger.

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/PutHiveQL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/processors/hive/PutHiveQL.java
@@ -99,19 +99,9 @@ public class PutHiveQL extends AbstractHiveQLProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    public static final Relationship REL_SUCCESS = new Relationship.Builder()
-            .name("success")
-            .description("A FlowFile is routed to this relationship after the database is successfully updated")
-            .build();
-    public static final Relationship REL_RETRY = new Relationship.Builder()
-            .name("retry")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
-            .build();
-    public static final Relationship REL_FAILURE = new Relationship.Builder()
-            .name("failure")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
-                    + "such as an invalid query or an integrity constraint violation")
-            .build();
+    public static final Relationship REL_SUCCESS = Put.REL_SUCCESS;
+    public static final Relationship REL_RETRY = Put.REL_RETRY;
+    public static final Relationship REL_FAILURE = Put.REL_FAILURE;
 
 
     private final static List<PropertyDescriptor> propertyDescriptors;

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3QL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/processors/hive/PutHive3QL.java
@@ -99,19 +99,9 @@ public class PutHive3QL extends AbstractHive3QLProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    public static final Relationship REL_SUCCESS = new Relationship.Builder()
-            .name("success")
-            .description("A FlowFile is routed to this relationship after the database is successfully updated")
-            .build();
-    public static final Relationship REL_RETRY = new Relationship.Builder()
-            .name("retry")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
-            .build();
-    public static final Relationship REL_FAILURE = new Relationship.Builder()
-            .name("failure")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
-                    + "such as an invalid query or an integrity constraint violation")
-            .build();
+    public static final Relationship REL_SUCCESS = Put.REL_SUCCESS;
+    public static final Relationship REL_RETRY = Put.REL_RETRY;
+    public static final Relationship REL_FAILURE = Put.REL_FAILURE;
 
 
     private final static List<PropertyDescriptor> propertyDescriptors;

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive_1_1-processors/src/main/java/org/apache/nifi/processors/hive/PutHive_1_1QL.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive_1_1-processors/src/main/java/org/apache/nifi/processors/hive/PutHive_1_1QL.java
@@ -99,19 +99,9 @@ public class PutHive_1_1QL extends AbstractHive_1_1QLProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    public static final Relationship REL_SUCCESS = new Relationship.Builder()
-            .name("success")
-            .description("A FlowFile is routed to this relationship after the database is successfully updated")
-            .build();
-    public static final Relationship REL_RETRY = new Relationship.Builder()
-            .name("retry")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
-            .build();
-    public static final Relationship REL_FAILURE = new Relationship.Builder()
-            .name("failure")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
-                    + "such as an invalid query or an integrity constraint violation")
-            .build();
+    public static final Relationship REL_SUCCESS = Put.REL_SUCCESS;
+    public static final Relationship REL_RETRY = Put.REL_RETRY;
+    public static final Relationship REL_FAILURE = Put.REL_FAILURE;
 
 
     private final static List<PropertyDescriptor> propertyDescriptors;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -128,15 +128,8 @@ public class PutDatabaseRecord extends AbstractSessionFactoryProcessor {
             .description("Successfully created FlowFile from SQL query result set.")
             .build();
 
-    static final Relationship REL_RETRY = new Relationship.Builder()
-            .name("retry")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
-            .build();
-    static final Relationship REL_FAILURE = new Relationship.Builder()
-            .name("failure")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
-                    + "such as an invalid query or an integrity constraint violation")
-            .build();
+    static final Relationship REL_RETRY = Put.REL_RETRY;
+    static final Relationship REL_FAILURE = Put.REL_FAILURE;
 
     protected static Set<Relationship> relationships;
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -171,19 +171,9 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
             .defaultValue("false")
             .build();
 
-    static final Relationship REL_SUCCESS = new Relationship.Builder()
-            .name("success")
-            .description("A FlowFile is routed to this relationship after the database is successfully updated")
-            .build();
-    static final Relationship REL_RETRY = new Relationship.Builder()
-            .name("retry")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
-            .build();
-    static final Relationship REL_FAILURE = new Relationship.Builder()
-            .name("failure")
-            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
-                    + "such as an invalid query or an integrity constraint violation")
-            .build();
+    static final Relationship REL_SUCCESS = Put.REL_SUCCESS;
+    static final Relationship REL_RETRY = Put.REL_RETRY;
+    static final Relationship REL_FAILURE = Put.REL_FAILURE;
 
     private static final String FRAGMENT_ID_ATTR = FragmentAttributes.FRAGMENT_ID.key();
     private static final String FRAGMENT_INDEX_ATTR = FragmentAttributes.FRAGMENT_INDEX.key();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -49,6 +49,7 @@ import org.apache.nifi.processor.util.pattern.PartialFunctions;
 import org.apache.nifi.processor.util.pattern.PartialFunctions.FetchFlowFiles;
 import org.apache.nifi.processor.util.pattern.PartialFunctions.FlowFileGroup;
 import org.apache.nifi.processor.util.pattern.PutGroup;
+import org.apache.nifi.processor.util.pattern.Put;
 import org.apache.nifi.processor.util.pattern.RollbackOnFailure;
 import org.apache.nifi.processor.util.pattern.RoutingResult;
 import org.apache.nifi.stream.io.StreamUtils;
@@ -146,15 +147,8 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
             .defaultValue("false")
             .build();
 
-    static final PropertyDescriptor SUPPORT_TRANSACTIONS = new PropertyDescriptor.Builder()
-            .name("Support Fragmented Transactions")
-            .description("If true, when a FlowFile is consumed by this Processor, the Processor will first check the fragment.identifier and fragment.count attributes of that FlowFile. "
-                    + "If the fragment.count value is greater than 1, the Processor will not process any FlowFile with that fragment.identifier until all are available; "
-                    + "at that point, it will process all FlowFiles with that fragment.identifier as a single transaction, in the order specified by the FlowFiles' fragment.index attributes. "
-                    + "This Provides atomicity of those SQL statements. If this value is false, these attributes will be ignored and the updates will occur independent of one another.")
-            .allowableValues("true", "false")
-            .defaultValue("true")
-            .build();
+    static final PropertyDescriptor SUPPORT_TRANSACTIONS = Put.SUPPORT_TRANSACTIONS;
+
     static final PropertyDescriptor TRANSACTION_TIMEOUT = new PropertyDescriptor.Builder()
             .name("Transaction Timeout")
             .description("If the <Support Fragmented Transactions> property is set to true, specifies how long to wait for all FlowFiles for a particular fragment.identifier attribute "

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -1227,7 +1227,7 @@ public class TestPutSQL {
         runner.enableControllerService(service);
         runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(PutSQL.BATCH_SIZE, "1");
-
+        runner.setProperty(PutSQL.SUPPORT_TRANSACTIONS, "true");
         recreateTable("PERSONS", createPersons);
 
         final Map<String, String> attributes = new HashMap<>();
@@ -1286,7 +1286,7 @@ public class TestPutSQL {
         runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
         runner.setProperty(PutSQL.BATCH_SIZE, "1");
         runner.setProperty(RollbackOnFailure.ROLLBACK_ON_FAILURE, "true");
-
+        runner.setProperty(PutSQL.SUPPORT_TRANSACTIONS, "true");
         recreateTable("PERSONS", createPersons);
 
         final Map<String, String> attributes = new HashMap<>();


### PR DESCRIPTION
NIFI-7403

Put.java improvement(PutSQL's transactions support)

#### Description of PR

PutSQL processor support `<Support Fragmented Transactions>`,if we set this property true, I think it means The PutSQL processor will excute these sqls of one transaction Transactionally!!

But we find that when we set the `<Rollback On Failure>` false, those sqls of one transaction do not excute transactionally,some sucess and some failure. I think it's wrong.

I think, if we set `<Support Fragmented Transactions>` true, it should be executed Transactionally, no matter `<Rollback On Failure>` is true or false.

Maybe we don't need this feature now, especially we generate table data by `select`,but when we exact data from redo log(mysql binlog、Oracle LogMiner ...), we would be likely to transacrionally excute these sqls in the target database. 

I see the code, only PutSQL has the `<Support Fragmented Transactions>`, it maybe improve this feature at a small cost.

modify code design:

step1: Maybe other Processors would support the `<Support Fragmented Transactions>`(such as PutDatabaseRecord), we should move the `<Support Fragmented Transactions>` from PutSQL.java to Put.java( I think it's a rational design that `Put.java` define the `<Support Fragmented Transactions>` property )
```java
public static final PropertyDescriptor SUPPORT_TRANSACTIONS = new PropertyDescriptor.Builder()
            .name("Support Fragmented Transactions")
           ...
```
step2: Additionally, I think the Put.java can extract the RelationShips of the processors those use the Put.java(PutSQL PutDatabaseRecord, PutHiveQL...We can see that these processors who use the Put.java have the same Relationships, I think this is the `Put`'s common feature)

```java
   static final Relationship REL_SUCCESS = new Relationship.Builder()
            .name("success")
            .description("A FlowFile is routed to this relationship after the database is successfully updated")
            .build();
    static final Relationship REL_RETRY = new Relationship.Builder()
            .name("retry")
            .description("A FlowFile is routed to this relationship if the database cannot be updated but attempting the operation again may succeed")
            .build();
    static final Relationship REL_FAILURE = new Relationship.Builder()
            .name("failure")
            .description("A FlowFile is routed to this relationship if the database cannot be updated and retrying the operation will also fail, "
                    + "such as an invalid query or an integrity constraint violation")
            .build();
```
step3: in Put.java `onTrigger` method, after the `putFlowFiles` and before the `onCompleted.apply`, we try to get the value of `<Rollback On Failure>`, if true , check the `transferredFlowFiles` , if there are flowfiles which don't route to `Success`, we should reroute these `transferredFlowFiles`(retry > failure), and do `onFailed` function(if it's not null)

```java
          try {
                    putFlowFiles(context, session, functionContext, connection, flowFiles, result);
                } catch (DiscontinuedException e) {

               }
               ...
               if (context.getProperties().containsKey(SUPPORT_TRANSACTIONS) && context.getProperty(SUPPORT_TRANSACTIONS).asBoolean()) {
                    //TODO   do sth
                }

                if (onCompleted != null) {
                    onCompleted.apply(context, session, functionContext, connection);
                }
```

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ √] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ √] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ √] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [√ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ √] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ √] Have you written or updated unit tests to verify your changes?
- [ √] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [√ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
