### PR TITLE
NIFI-7380 - fix for controller service validation in NiFi Stateless

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-stateless/src/main/java/org/apache/nifi/stateless/core/StatelessControllerServiceConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-stateless/src/main/java/org/apache/nifi/stateless/core/StatelessControllerServiceConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.nifi.stateless.core;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.controller.PropertyConfiguration;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,7 +32,7 @@ public class StatelessControllerServiceConfiguration {
 
     private final AtomicBoolean enabled = new AtomicBoolean(false);
     private String annotationData;
-    private Map<PropertyDescriptor, String> properties = new HashMap<>();
+    private Map<PropertyDescriptor, PropertyConfiguration> properties = new HashMap<>();
 
     public StatelessControllerServiceConfiguration(final ControllerService service, final String name) {
         this.service = service;
@@ -50,20 +51,20 @@ public class StatelessControllerServiceConfiguration {
         return this.enabled.get();
     }
 
-    public void setProperties(final Map<PropertyDescriptor, String> props) {
+    public void setProperties(final Map<PropertyDescriptor, PropertyConfiguration> props) {
         this.properties = new HashMap<>(props);
     }
 
-    public void setProperty(final PropertyDescriptor key, final String value) {
+    public void setProperty(final PropertyDescriptor key, final PropertyConfiguration value) {
         this.properties.put(key, value);
     }
 
     public String getProperty(final PropertyDescriptor descriptor) {
-        final String value = properties.get(descriptor);
+        final PropertyConfiguration value = properties.get(descriptor);
         if (value == null) {
             return descriptor.getDefaultValue();
         } else {
-            return value;
+            return value.getRawValue();
         }
     }
 
@@ -75,7 +76,7 @@ public class StatelessControllerServiceConfiguration {
         return annotationData;
     }
 
-    public Map<PropertyDescriptor, String> getProperties() {
+    public Map<PropertyDescriptor, PropertyConfiguration> getProperties() {
         return Collections.unmodifiableMap(properties);
     }
 


### PR DESCRIPTION
Signed-off-by: Matthieu Cauffiez <matthieu.cauffiez@bell.ca>

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:
This is a quick fix to enable the usage of parameters for controller services.

For consistency, a refactoring of statelessControllerService can be considered in order to have the same architecture as StatelessProcess. 

 
