### PR TITLE
Nifi-7403 PutSQL improvement

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/PartialFunctions.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/PartialFunctions.java
@@ -97,6 +97,12 @@ public class PartialFunctions {
         void rollback(ProcessSession session, Throwable t);
     }
 
+    @FunctionalInterface
+    public interface AdjustFailed {
+        boolean apply(ProcessContext context, RoutingResult result);
+    }
+
+
     /**
      * <p>This method is identical to what {@link org.apache.nifi.processor.AbstractProcessor#onTrigger(ProcessContext, ProcessSession)} does.</p>
      * <p>Create a session from ProcessSessionFactory and execute specified onTrigger function, and commit the session if onTrigger finishes successfully.</p>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/Put.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-processor-utils/src/main/java/org/apache/nifi/processor/util/pattern/Put.java
@@ -42,6 +42,7 @@ public class Put<FC, C extends AutoCloseable> {
     protected PartialFunctions.OnCompleted<FC, C> onCompleted;
     protected PartialFunctions.OnFailed<FC, C> onFailed;
     protected PartialFunctions.Cleanup<FC, C> cleanup;
+    protected PartialFunctions.AdjustFailed adjustFailed;
     protected ComponentLog logger;
 
     /**
@@ -117,8 +118,17 @@ public class Put<FC, C extends AutoCloseable> {
                         .filter(flowFile -> !transferredFlowFiles.contains(flowFile)).collect(Collectors.toList());
                 result.routeTo(unprocessedFlowFiles, Relationship.SELF);
 
+                // Extension point to adjust the result, if the result is failed then process onFailed function
+                boolean failed = false;
+                if (adjustFailed != null) {
+                    failed = adjustFailed.apply(context, result);
+                }
+                if (failed && onFailed != null) {
+                    onFailed.apply(context, session, functionContext, connection,null);
+                }
+
                 // OnCompleted processing.
-                if (onCompleted != null) {
+                if (!failed && onCompleted != null) {
                     onCompleted.apply(context, session, functionContext, connection);
                 }
 
@@ -180,6 +190,15 @@ public class Put<FC, C extends AutoCloseable> {
      */
     public void adjustRoute(PartialFunctions.AdjustRoute<FC> f) {
         this.adjustRoute = f;
+    }
+
+    /**
+     * Specify an optional function that adjust if the result is failed before we call the onFailed or onCompleted function.
+     * If the result is failed, return true and do sth.
+     * @param f Function to be called to adjust if the result is failed
+     */
+    public void adjustFailed(PartialFunctions.AdjustFailed f) {
+        this.adjustFailed = f;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -584,8 +584,9 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
                 if (r.contains(REL_RETRY) || r.contains(REL_FAILURE)) {
                     final List<FlowFile> transferredFlowFiles = r.getRoutedFlowFiles().values().stream()
                             .flatMap(List::stream).collect(Collectors.toList());
+                    Relationship rerouteShip = r.contains(REL_RETRY) ? REL_RETRY : REL_FAILURE;
                     r.getRoutedFlowFiles().clear();
-                    r.routeTo(transferredFlowFiles, r.contains(REL_RETRY) ? REL_RETRY : REL_FAILURE);
+                    r.routeTo(transferredFlowFiles, rerouteShip);
                     return true;
                 }
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -152,7 +152,10 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
             .description("If true, when a FlowFile is consumed by this Processor, the Processor will first check the fragment.identifier and fragment.count attributes of that FlowFile. "
                     + "If the fragment.count value is greater than 1, the Processor will not process any FlowFile with that fragment.identifier until all are available; "
                     + "at that point, it will process all FlowFiles with that fragment.identifier as a single transaction, in the order specified by the FlowFiles' fragment.index attributes. "
-                    + "This Provides atomicity of those SQL statements. If this value is false, these attributes will be ignored and the updates will occur independent of one another.")
+                    + "This Provides atomicity of those SQL statements. Once any statement of this transaction throws exception when executing, this transaction will be rolled back. When "
+                    + "transaction rollback happened, none of these FlowFiles would be routed to 'success'. If the <Rollback On Failure> is set true, these FlowFiles will stay in the input relationship. "
+                    + "When the <Rollback On Failure> is set false,, if any of these FlowFiles will be routed to 'retry', all of these FlowFiles will be routed to 'retry'.Otherwise, they will be "
+                    + "routed to 'failure'. If this value is false, these attributes will be ignored and the updates will occur independent of one another.")
             .allowableValues("true", "false")
             .defaultValue("true")
             .build();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -163,8 +163,27 @@ public class TestPutSQL {
 
 
     @Test
-    public void testFailInMiddleWithBadStatement() throws InitializationException, ProcessException, SQLException, IOException {
+    public void testFailInMiddleWithBadStatementAndSupportTransaction() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
+        testFailInMiddleWithBadStatement(runner);
+        runner.run();
+
+        runner.assertTransferCount(PutSQL.REL_FAILURE, 4);
+        runner.assertTransferCount(PutSQL.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testFailInMiddleWithBadStatementAndNotSupportTransaction() throws InitializationException, ProcessException, SQLException, IOException {
+        final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
+        runner.setProperty(PutSQL.SUPPORT_TRANSACTIONS, "false");
+        testFailInMiddleWithBadStatement(runner);
+        runner.run();
+
+        runner.assertTransferCount(PutSQL.REL_FAILURE, 1);
+        runner.assertTransferCount(PutSQL.REL_SUCCESS, 3);
+    }
+
+    private void testFailInMiddleWithBadStatement(final TestRunner runner) throws InitializationException {
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
         runner.setProperty(PutSQL.OBTAIN_GENERATED_KEYS, "false");
@@ -173,11 +192,9 @@ public class TestPutSQL {
         runner.enqueue("INSERT INTO PERSONS_AI".getBytes()); // intentionally wrong syntax
         runner.enqueue("INSERT INTO PERSONS_AI (NAME, CODE) VALUES ('Tom', 3)".getBytes());
         runner.enqueue("INSERT INTO PERSONS_AI (NAME, CODE) VALUES ('Harry', 44)".getBytes());
-        runner.run();
-
-        runner.assertTransferCount(PutSQL.REL_FAILURE, 1);
-        runner.assertTransferCount(PutSQL.REL_SUCCESS, 3);
     }
+
+
 
     @Test
     public void testFailInMiddleWithBadStatementRollbackOnFailure() throws InitializationException, ProcessException, SQLException, IOException {
@@ -202,10 +219,28 @@ public class TestPutSQL {
         }
     }
 
+    @Test
+    public void testFailInMiddleWithBadParameterTypeAndNotSupportTransaction() throws InitializationException, ProcessException, SQLException, IOException {
+        final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
+        runner.setProperty(PutSQL.SUPPORT_TRANSACTIONS, "false");
+        testFailInMiddleWithBadParameterType(runner);
+        runner.run();
+
+        runner.assertTransferCount(PutSQL.REL_FAILURE, 1);
+        runner.assertTransferCount(PutSQL.REL_SUCCESS, 3);
+    }
 
     @Test
-    public void testFailInMiddleWithBadParameterType() throws InitializationException, ProcessException, SQLException, IOException {
+    public void testFailInMiddleWithBadParameterTypeAndSupportTransaction() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
+        testFailInMiddleWithBadParameterType(runner);
+        runner.run();
+
+        runner.assertTransferCount(PutSQL.REL_FAILURE, 4);
+        runner.assertTransferCount(PutSQL.REL_SUCCESS, 0);
+    }
+
+    private void testFailInMiddleWithBadParameterType(final TestRunner runner) throws InitializationException, ProcessException, SQLException, IOException {
         runner.addControllerService("dbcp", service);
         runner.enableControllerService(service);
         runner.setProperty(PutSQL.OBTAIN_GENERATED_KEYS, "false");
@@ -224,11 +259,6 @@ public class TestPutSQL {
         runner.enqueue(data, badAttributes);
         runner.enqueue(data, goodAttributes);
         runner.enqueue(data, goodAttributes);
-        runner.run();
-
-        runner.assertTransferCount(PutSQL.REL_FAILURE, 1);
-        runner.assertTransferCount(PutSQL.REL_SUCCESS, 3);
-
     }
 
     @Test
@@ -265,28 +295,28 @@ public class TestPutSQL {
     }
 
     @Test
-    public void testFailInMiddleWithBadParameterValue() throws InitializationException, ProcessException, SQLException, IOException {
+    public void testFailInMiddleWithBadParameterValueAndSupportTransaction() throws InitializationException, ProcessException, SQLException, IOException {
         final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
-        runner.addControllerService("dbcp", service);
-        runner.enableControllerService(service);
-        runner.setProperty(PutSQL.OBTAIN_GENERATED_KEYS, "false");
-        runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
+        testFailInMiddleWithBadParameterValue(runner);
+        runner.run();
 
-        recreateTable("PERSONS_AI",createPersonsAutoId);
+        runner.assertTransferCount(PutSQL.REL_SUCCESS, 0);
+        runner.assertTransferCount(PutSQL.REL_FAILURE, 0);
+        runner.assertTransferCount(PutSQL.REL_RETRY, 4);
 
-        final Map<String, String> goodAttributes = new HashMap<>();
-        goodAttributes.put("sql.args.1.type", String.valueOf(Types.INTEGER));
-        goodAttributes.put("sql.args.1.value", "84");
+        try (final Connection conn = service.getConnection()) {
+            try (final Statement stmt = conn.createStatement()) {
+                final ResultSet rs = stmt.executeQuery("SELECT * FROM PERSONS_AI");
+                assertFalse(rs.next());
+            }
+        }
+    }
 
-        final Map<String, String> badAttributes = new HashMap<>();
-        badAttributes.put("sql.args.1.type", String.valueOf(Types.INTEGER));
-        badAttributes.put("sql.args.1.value", "9999");
-
-        final byte[] data = "INSERT INTO PERSONS_AI (NAME, CODE) VALUES ('Mark', ?)".getBytes();
-        runner.enqueue(data, goodAttributes);
-        runner.enqueue(data, badAttributes);
-        runner.enqueue(data, goodAttributes);
-        runner.enqueue(data, goodAttributes);
+    @Test
+    public void testFailInMiddleWithBadParameterValueAndNotSupportTransaction() throws InitializationException, ProcessException, SQLException, IOException {
+        final TestRunner runner = TestRunners.newTestRunner(PutSQL.class);
+        runner.setProperty(PutSQL.SUPPORT_TRANSACTIONS, "false");
+        testFailInMiddleWithBadParameterValue(runner);
         runner.run();
 
         runner.assertTransferCount(PutSQL.REL_SUCCESS, 1);
@@ -303,6 +333,28 @@ public class TestPutSQL {
                 assertFalse(rs.next());
             }
         }
+    }
+
+    private void testFailInMiddleWithBadParameterValue(final TestRunner runner) throws InitializationException, ProcessException, SQLException, IOException {
+        runner.addControllerService("dbcp", service);
+        runner.enableControllerService(service);
+        runner.setProperty(PutSQL.OBTAIN_GENERATED_KEYS, "false");
+        runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
+        recreateTable("PERSONS_AI",createPersonsAutoId);
+
+        final Map<String, String> goodAttributes = new HashMap<>();
+        goodAttributes.put("sql.args.1.type", String.valueOf(Types.INTEGER));
+        goodAttributes.put("sql.args.1.value", "84");
+
+        final Map<String, String> badAttributes = new HashMap<>();
+        badAttributes.put("sql.args.1.type", String.valueOf(Types.INTEGER));
+        badAttributes.put("sql.args.1.value", "9999");
+
+        final byte[] data = "INSERT INTO PERSONS_AI (NAME, CODE) VALUES ('Mark', ?)".getBytes();
+        runner.enqueue(data, goodAttributes);
+        runner.enqueue(data, badAttributes);
+        runner.enqueue(data, goodAttributes);
+        runner.enqueue(data, goodAttributes);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -341,7 +341,6 @@ public class TestPutSQL {
         runner.setProperty(PutSQL.OBTAIN_GENERATED_KEYS, "false");
         runner.setProperty(PutSQL.CONNECTION_POOL, "dbcp");
         recreateTable("PERSONS_AI",createPersonsAutoId);
-
         final Map<String, String> goodAttributes = new HashMap<>();
         goodAttributes.put("sql.args.1.type", String.valueOf(Types.INTEGER));
         goodAttributes.put("sql.args.1.value", "84");


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

NIFI-7403
PutSQL processor support `<Support Fragmented Transactions>`,if we set this property true, I think it means The PutSQL processor will excute these sqls of one transaction Transactionally!!

But we find that when we set the `<Rollback On Failure>` false, those sqls of one transaction do not excute transactionally,some sucess and some failure. I think it's not right.

I think, if we set `<Support Fragmented Transactions>` true, it should be executed Transactionally, no matter `<Rollback On Failure>` is true or false.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

This PR replaces #4239
### For code changes:
- [ √] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ √] Have you written or updated unit tests to verify your changes?
- [ √] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [√ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
