### PR TITLE
NIFI-7456: Ignite Processors - Choose between Thick and Thin Clients

### DIFF
--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>nifi-ignite-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <ignite.version>2.8.0</ignite.version>
+        <ignite.version>2.10.0</ignite.version>
     </properties>
 
     <dependencies>

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/pom.xml
@@ -13,7 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,23 +25,11 @@
 
     <artifactId>nifi-ignite-processors</artifactId>
     <packaging>jar</packaging>
+    <properties>
+        <ignite.version>2.8.0</ignite.version>
+    </properties>
+
     <dependencies>
-        <dependency>
-            <groupId>org.apache.ignite</groupId>
-            <artifactId>ignite-core</artifactId>
-            <version>1.6.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.cache</groupId>
-                    <artifactId>cache-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jcache_1.0_spec</artifactId>
-            <version>1.0-alpha-1</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -49,13 +38,13 @@
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-log4j2</artifactId>
-            <version>1.6.0</version>
+            <version>${ignite.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-spring</artifactId>
-            <version>1.6.0</version>
+            <version>${ignite.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/AbstractIgniteProcessor.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/AbstractIgniteProcessor.java
@@ -18,100 +18,233 @@
  */
 package org.apache.nifi.processors.ignite;
 
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.Ignition;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.internal.util.spring.IgniteSpringHelperImpl;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+
+import java.net.URL;
+import java.util.List;
 
 /**
- * Base class for Ignite processors
+ * Base class for Ignite processors.
  */
-public abstract class AbstractIgniteProcessor extends AbstractProcessor  {
+public abstract class AbstractIgniteProcessor extends AbstractProcessor {
 
     /**
-     * Ignite spring configuration file
+     * Ignite Spring configuration file.
      */
     public static final PropertyDescriptor IGNITE_CONFIGURATION_FILE = new PropertyDescriptor.Builder()
-        .displayName("Ignite Spring Properties Xml File")
-        .name("ignite-spring-properties-xml-file")
-        .description("Ignite spring configuration file, <path>/<ignite-configuration>.xml. If the " +
-            "configuration file is not provided, default Ignite configuration " +
-            "configuration is used which binds to 127.0.0.1:47500..47509")
-        .required(false)
-        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-        .build();
+            .displayName("Ignite Spring Properties XML File")
+            .name("ignite-spring-properties-xml-file")
+            .description("Ignite Spring configuration file, <path>/<ignite-configuration>.xml. If the configuration " +
+                    "file is not provided, default Ignite configuration is used which binds to 127.0.0.1:47500..47509 " +
+                    "in the case of thick client type or 127.0.0.1:10800 in the case of thin client type.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
 
     /**
-     * Success relation
+     * Success relationship.
      */
-    public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success")
-            .description("All FlowFiles that are written to Ignite cache are routed to this relationship").build();
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("All FlowFiles that are written to Ignite Cache are routed to this relationship.")
+            .build();
 
     /**
-     * Failure relation
+     * Failure relationship.
      */
-    public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
-            .description("All FlowFiles that cannot be written to Ignite cache are routed to this relationship").build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("All FlowFiles that cannot be written to Ignite Cache are routed to this relationship.")
+            .build();
 
     /**
-     * The ignite instance
+     * Allowable value for Thick Ignite client.
      */
-    private transient Ignite ignite;
+    private static final AllowableValue THICK = new AllowableValue(ClientType.THICK.name(), ClientType.THICK.getDisplayName(), "Make use of thick Ignite client.");
 
     /**
-     * Get ignite instance
-     * @return ignite instance
+     * Allowable value for Thin Ignite client.
      */
-    protected Ignite getIgnite() {
-        return ignite;
+    private static final AllowableValue THIN = new AllowableValue(ClientType.THIN.name(), ClientType.THIN.getDisplayName(), "Make use of thin Ignite client.");
+
+    /**
+     * Whether to use the thick Ignite client or the thin Ignite client.
+     */
+    public static final PropertyDescriptor IGNITE_CLIENT_TYPE = new PropertyDescriptor.Builder()
+            .displayName("Ignite Client Type")
+            .name("ignite-client-type")
+            .description("Whether to use the thick Ignite client or the thin Ignite client. Defaults to the thick Ignite client.")
+            .required(true)
+            .defaultValue(THICK.getValue())
+            .allowableValues(THICK, THIN)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .build();
+
+    /**
+     * The thick Ignite client instance.
+     */
+    private transient Ignite thickIgniteClient;
+
+    /**
+     * The thin Ignite client instance.
+     */
+    private transient IgniteClient thinIgniteClient;
+
+    /**
+     * Get the thick Ignite client instance.
+     *
+     * @return Thick Ignite client instance.
+     */
+    protected Ignite getThickIgniteClient() {
+        return thickIgniteClient;
     }
 
     /**
-     * Close ignite instance
+     * Get the thin Ignite client instance.
+     *
+     * @return Thin Ignite client instance.
      */
-    public void closeIgnite() {
-        if (ignite != null) {
-            getLogger().info("Closing ignite client");
-            ignite.close();
-            ignite = null;
-        }
+    public IgniteClient getThinIgniteClient() {
+        return thinIgniteClient;
     }
 
     /**
-     * Initialize ignite instance
-     * @param context process context
+     * Initialize the Ignite client instance with respect to the IGNITE_CLIENT_TYPE value, ensuring that only one
+     * client type is active at a given point in time.
+     *
+     * @param context Process context.
      */
-    public void initializeIgnite(ProcessContext context) {
-
-        if ( getIgnite() != null ) {
-            getLogger().info("Ignite already initialized");
-            return;
-        }
-
-
-        synchronized(Ignition.class) {
-            List<Ignite> grids = Ignition.allGrids();
-
-            if ( grids.size() == 1 ) {
-                getLogger().info("Ignite grid already available");
-                ignite = grids.get(0);
+    protected void initializeIgniteClient(final ProcessContext context) {
+        final ClientType clientType = ClientType.valueOf(context.getProperty(IGNITE_CLIENT_TYPE).getValue());
+        if (clientType.equals(ClientType.THICK)) {
+            if (thickIgniteClient != null) {
+                getLogger().info("Thick Ignite client already initialized.");
                 return;
             }
-            Ignition.setClientMode(true);
 
-            String configuration = context.getProperty(IGNITE_CONFIGURATION_FILE).getValue();
-            getLogger().info("Initializing ignite with configuration {} ", new Object[] { configuration });
-            if ( StringUtils.isEmpty(configuration) ) {
-                ignite = Ignition.start();
-            } else {
-                ignite = Ignition.start(configuration);
+            synchronized (Ignition.class) {
+                final List<Ignite> grids = Ignition.allGrids();
+
+                if (grids.size() == 1) {
+                    getLogger().info("Ignite grid already available.");
+                    thickIgniteClient = grids.get(0);
+                    return;
+                }
+                Ignition.setClientMode(true);
+
+                final String configuration = context.getProperty(IGNITE_CONFIGURATION_FILE).getValue();
+                getLogger().info("Initializing thick Ignite client with configuration {}.", new Object[]{configuration});
+                if (StringUtils.isEmpty(configuration)) {
+                    thickIgniteClient = Ignition.start();
+                } else {
+                    thickIgniteClient = Ignition.start(configuration);
+                }
             }
+        } else if (clientType.equals(ClientType.THIN)) {
+            if (thinIgniteClient != null) {
+                getLogger().info("Thin Ignite client already initialized.");
+                return;
+            }
+
+            synchronized (Ignition.class) {
+                final String configuration = context.getProperty(IGNITE_CONFIGURATION_FILE).getValue();
+                getLogger().info("Initializing thin Ignite client with configuration {}.", new Object[]{configuration});
+                if (StringUtils.isEmpty(configuration)) {
+                    final ClientConfiguration clientConfiguration = getDefaultClientConfiguration();
+                    thinIgniteClient = Ignition.startClient(clientConfiguration);
+                } else {
+                    final ClientConfiguration clientConfiguration = getClientConfiguration(configuration);
+                    thinIgniteClient = Ignition.startClient(clientConfiguration);
+                }
+            }
+        }
+    }
+
+    /**
+     * Close the Ignite client instance.
+     */
+    protected void closeIgniteClient() {
+        closeThickIgniteClient();
+        closeThinIgniteClient();
+    }
+
+    /**
+     * Get default thin Ignite client configuration.
+     *
+     * @return Default thin Ignite client configuration.
+     */
+    private ClientConfiguration getDefaultClientConfiguration() {
+        final ClientConfiguration clientConfiguration = new ClientConfiguration();
+        clientConfiguration.setAddresses("127.0.0.1:10800");
+
+        return clientConfiguration;
+    }
+
+    /**
+     * Get thin Ignite client configuration from configuration path.
+     *
+     * @param configurationPath Configuration path.
+     * @return Thin Ignite client configuration.
+     */
+    private ClientConfiguration getClientConfiguration(final String configurationPath) {
+        final ApplicationContext springContext;
+        try {
+            final URL configurationUrl = IgniteUtils.resolveSpringUrl(configurationPath);
+            springContext = IgniteSpringHelperImpl.applicationContext(configurationUrl);
+        } catch (final IgniteCheckedException exception) {
+            throw IgniteUtils.convertException(exception);
+        }
+
+        try {
+            return springContext.getBean(ClientConfiguration.class);
+        } catch (final BeansException exception) {
+            throw IgniteUtils.convertException(new IgniteCheckedException("Failed to instantiate bean [type=" + ClientConfiguration.class + ", err=" + exception.getMessage() + "].", exception));
+        }
+    }
+
+    /**
+     * Close the thick Ignite client instance.
+     */
+    private void closeThickIgniteClient() {
+        if (thickIgniteClient != null) {
+            getLogger().info("Closing thick Ignite client instance.");
+            thickIgniteClient.close();
+            thickIgniteClient = null;
+        } else {
+            getLogger().info("Thick Ignite client instance already closed.");
+        }
+    }
+
+    /**
+     * Close the thin Ignite client instance.
+     */
+    private void closeThinIgniteClient() {
+        if (thinIgniteClient != null) {
+            getLogger().info("Closing thin Ignite client instance.");
+            try {
+                thinIgniteClient.close();
+            } catch (final Exception exception) {
+                getLogger().error("Error occurred when closing thin Ignite client instance.", exception);
+            }
+            thinIgniteClient = null;
+        } else {
+            getLogger().info("Thin Ignite client instance already closed.");
         }
     }
 }

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/ClientType.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/ClientType.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.processors.ignite;
+
+/**
+ * The supported Ignite client types.
+ */
+public enum ClientType {
+
+    /**
+     * Thick client type.
+     */
+    THICK("Thick"),
+
+    /**
+     * Thin client type.
+     */
+    THIN("Thin");
+
+    /**
+     * The display name.
+     */
+    private String displayName;
+
+    ClientType(final String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Get the display name.
+     *
+     * @return The display name.
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/AbstractIgniteCacheProcessor.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/AbstractIgniteCacheProcessor.java
@@ -16,70 +16,58 @@
  */
 package org.apache.nifi.processors.ignite.cache;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.client.ClientCache;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
 import org.apache.nifi.annotation.lifecycle.OnShutdown;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.expression.AttributeExpression.ResultType;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.ignite.AbstractIgniteProcessor;
+import org.apache.nifi.processors.ignite.ClientType;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
- * Base class of Ignite cache based processor
+ * Base class of Ignite cache based processor.
  */
 public abstract class AbstractIgniteCacheProcessor extends AbstractIgniteProcessor {
 
     /**
-     * Ignite cache name
+     * Ignite cache name.
      */
-    protected static final PropertyDescriptor CACHE_NAME = new PropertyDescriptor.Builder()
+    static final PropertyDescriptor CACHE_NAME = new PropertyDescriptor.Builder()
             .displayName("Ignite Cache Name")
             .name("ignite-cache-name")
-            .description("The name of the ignite cache")
+            .description("The name of the Ignite cache.")
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
     /**
-     * The Ignite cache key attribute
+     * The Ignite cache key attribute.
      */
-    public static final PropertyDescriptor IGNITE_CACHE_ENTRY_KEY = new PropertyDescriptor.Builder()
+    static final PropertyDescriptor IGNITE_CACHE_ENTRY_KEY = new PropertyDescriptor.Builder()
             .displayName("Ignite Cache Entry Identifier")
             .name("ignite-cache-entry-identifier")
             .description("A FlowFile attribute, or attribute expression used " +
-                "for determining Ignite cache key for the Flow File content")
+                    "for determining Ignite cache key for the FlowFile content.")
             .required(true)
             .addValidator(StandardValidators.createAttributeExpressionLanguageValidator(ResultType.STRING, true))
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
     /**
-     * Relations
+     * Relationships.
      */
-    protected static Set<Relationship> relationships;
-
-    /**
-     * Ignite cache name
-     */
-    private String cacheName;
-
-    /**
-     * Get ignite cache instance
-     * @return ignite cache instance
-     */
-    protected IgniteCache<String, byte[]> getIgniteCache() {
-         if ( getIgnite() == null )
-            return null;
-         else
-            return getIgnite().getOrCreateCache(cacheName);
-    }
+    private static Set<Relationship> relationships;
 
     static {
         final Set<Relationship> rels = new HashSet<>();
@@ -88,43 +76,76 @@ public abstract class AbstractIgniteCacheProcessor extends AbstractIgniteProcess
         relationships = Collections.unmodifiableSet(rels);
     }
 
+    /**
+     * Ignite cache name.
+     */
+    private String cacheName;
+
+    /**
+     * Get the thick Ignite client cache instance.
+     */
+    IgniteCache<String, byte[]> getThickIgniteClientCache() {
+        if (getThickIgniteClient() == null)
+            return null;
+        else {
+            return getThickIgniteClient().getOrCreateCache(cacheName);
+        }
+    }
+
+    /**
+     * Get the thin Ignite client cache instance.
+     */
+    ClientCache<String, byte[]> getThinIgniteClientCache() {
+        if (getThinIgniteClient() == null)
+            return null;
+        else {
+            return getThinIgniteClient().getOrCreateCache(cacheName);
+        }
+    }
+
+    /**
+     * Get the relationships.
+     *
+     * @return Relationships.
+     */
     @Override
     public Set<Relationship> getRelationships() {
         return relationships;
     }
 
     /**
-     * Initialize the ignite cache instance
-     * @param context process context
-     * @throws ProcessException if there is a problem while scheduling the processor
+     * Initialize the Ignite cache instance.
+     *
+     * @param context Process context.
+     * @throws ProcessException If there is a problem while scheduling the processor.
      */
-    public void initializeIgniteCache(ProcessContext context) throws ProcessException {
-
-        getLogger().info("Initializing Ignite cache");
-
+    void initializeIgniteCache(final ProcessContext context) throws ProcessException {
+        getLogger().info("Initializing Ignite cache.");
+        final ClientType clientType = ClientType.valueOf(context.getProperty(IGNITE_CLIENT_TYPE).getValue());
         try {
-            if ( getIgnite() == null ) {
-                getLogger().info("Initializing ignite as client");
-                super.initializeIgnite(context);
+            if ((clientType.equals(ClientType.THICK) && getThickIgniteClient() == null)
+                    || (clientType.equals(ClientType.THIN) && getThinIgniteClient() == null)) {
+                getLogger().info("Initializing Ignite as client.");
+                initializeIgniteClient(context);
             }
-
             cacheName = context.getProperty(CACHE_NAME).getValue();
-
-        } catch (Exception e) {
-            getLogger().error("Failed to initialize ignite cache due to {}", new Object[] { e }, e);
-            throw new ProcessException(e);
+        } catch (final Exception exception) {
+            getLogger().error("Failed to initialize Ignite cache due to {}.", new Object[]{exception}, exception);
+            throw new ProcessException(exception);
         }
     }
 
     /**
-     * Close Ignite cache instance and calls base class closeIgnite
+     * Close Ignite client cache instance and calls base class closeIgniteClient.
      */
+    @OnStopped
+    @OnDisabled
     @OnShutdown
-    public void closeIgniteCache() {
-        if (getIgniteCache() != null) {
-            getLogger().info("Closing ignite cache");
-            getIgniteCache().close();
+    public void closeIgniteClientCache() {
+        if (getThickIgniteClientCache() != null) {
+            getLogger().info("Closing thick Ignite client cache.");
+            getThickIgniteClientCache().close();
         }
-        super.closeIgnite();
+        closeIgniteClient();
     }
 }

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/PutIgniteCache.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/PutIgniteCache.java
@@ -16,31 +16,21 @@
  */
 package org.apache.nifi.processors.ignite.cache;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ignite.IgniteDataStreamer;
 import org.apache.ignite.lang.IgniteFuture;
 import org.apache.nifi.annotation.behavior.EventDriven;
-import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.SystemResource;
+import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.lifecycle.OnShutdown;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -48,42 +38,62 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.ignite.ClientType;
 import org.apache.nifi.stream.io.StreamUtils;
 
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
- * Put cache processors which pushes the flow file content into Ignite Cache using
- * DataStreamer interface
+ * Put Ignite cache processors which pushes the FlowFile content into Ignite Cache using DataStreamer interface.
  */
 @EventDriven
 @SupportsBatching
-@Tags({ "Ignite", "insert", "update", "stream", "write", "put", "cache", "key" })
+@Tags({"Ignite", "insert", "update", "stream", "write", "put", "cache", "key"})
 @InputRequirement(Requirement.INPUT_REQUIRED)
-@CapabilityDescription("Stream the contents of a FlowFile to Ignite Cache using DataStreamer. " +
-    "The processor uses the value of FlowFile attribute (Ignite cache entry key) as the " +
-    "cache key and the byte array of the FlowFile as the value of the cache entry value.  Both the string key and a " +
-    " non-empty byte array value are required otherwise the FlowFile is transferred to the failure relation. " +
-    "Note - The Ignite Kernel periodically outputs node performance statistics to the logs. This message " +
-    " can be turned off by setting the log level for logger 'org.apache.ignite' to WARN in the logback.xml configuration file.")
+@CapabilityDescription("Stream the contents of a FlowFile to Ignite Cache using DataStreamer in the case of thick Ignite client " +
+        "or puts the contents of a FlowFile to Ignite Cache using thin Ignite client. " +
+        "The processor uses the value of FlowFile attribute (Ignite cache entry key) as the " +
+        "cache key and the byte array of the FlowFile as the value of the cache entry value. Both the string key and a " +
+        "non-empty byte array value are required otherwise the FlowFile is transferred to the failure relation. " +
+        "Note - The Ignite Kernel periodically outputs node performance statistics to the logs. This message " +
+        "can be turned off by setting the log level for logger 'org.apache.ignite' to WARN in the logback.xml configuration file.")
 @WritesAttributes({
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, description = "The total number of FlowFile in the batch"),
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, description = "The item number of FlowFile in the batch"),
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, description = "The successful FlowFile item number"),
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, description = "The number of successful FlowFiles"),
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, description = "The failed FlowFile item number"),
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, description = "The total number of failed FlowFiles in the batch"),
-    @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, description = "The failed reason attribute key")
-    })
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, description = "The total number of FlowFiles in the batch."),
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, description = "The item number of FlowFiles in the batch."),
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, description = "The successful FlowFiles item number."),
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, description = "The number of successful FlowFiles."),
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, description = "The failed FlowFiles item number."),
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, description = "The total number of failed FlowFiles in the batch."),
+        @WritesAttribute(attribute = PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, description = "The failed reason attribute key.")
+})
 @SeeAlso({GetIgniteCache.class})
 @SystemResourceConsideration(resource = SystemResource.MEMORY)
 public class PutIgniteCache extends AbstractIgniteCacheProcessor {
 
     /**
-     * The batch size of flow files to be processed on invocation of onTrigger
+     * FlowFile attribute keys and messages.
      */
-    public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
-            .displayName("Batch Size For Entries")
+    static final String IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE = "The FlowFile key attribute was missing.";
+    static final String IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE = "The FlowFile size was zero.";
+    static final String IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT = "ignite.cache.batch.flow.file.total.count";
+    static final String IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER = "ignite.cache.batch.flow.file.item.number";
+    static final String IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT = "ignite.cache.batch.flow.file.successful.count";
+    static final String IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER = "ignite.cache.batch.flow.file.successful.number";
+    static final String IGNITE_BATCH_FLOW_FILE_FAILED_COUNT = "ignite.cache.batch.flow.file.failed.count";
+    static final String IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER = "ignite.cache.batch.flow.file.failed.number";
+    static final String IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY = "ignite.cache.batch.flow.file.failed.reason";
+
+    /**
+     * The batch size of FlowFiles to be processed on invocation of onTrigger.
+     */
+    static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+            .displayName("Batch Size for Entries")
             .name("batch-size-for-entries")
             .description("Batch size for entries (1-500).")
             .defaultValue("250")
@@ -93,147 +103,132 @@ public class PutIgniteCache extends AbstractIgniteCacheProcessor {
             .build();
 
     /**
-     * Data streamer's per node parallelism
+     * DataStreamer per node buffer size.
      */
-    public static final PropertyDescriptor DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS = new PropertyDescriptor.Builder()
-            .displayName("Data Streamer Per Node Parallel Operations")
-            .name("data-streamer-per-node-parallel-operations")
-            .description("Data streamer per node parallelism")
-            .defaultValue("5")
-            .required(true)
-            .addValidator(StandardValidators.createLongValidator(1, 10, true))
-            .sensitive(false)
-            .build();
-
-    /**
-     * Data streamers per node buffer size
-     */
-    public static final PropertyDescriptor DATA_STREAMER_PER_NODE_BUFFER_SIZE = new PropertyDescriptor.Builder()
-            .displayName("Data Streamer Per Node Buffer Size")
+    static final PropertyDescriptor DATA_STREAMER_PER_NODE_BUFFER_SIZE = new PropertyDescriptor.Builder()
+            .displayName("DataStreamer per Node Buffer Size")
             .name("data-streamer-per-node-buffer-size")
-            .description("Data streamer per node buffer size (1-500).")
+            .description("DataStreamer per node buffer size (1-500). Applies only to thick Ignite client.")
             .defaultValue("250")
-            .required(true)
+            .required(false)
             .addValidator(StandardValidators.createLongValidator(1, 500, true))
             .sensitive(false)
             .build();
 
     /**
-     * Data streamers auto flush frequency
+     * DataStreamer per node parallelism.
      */
-    public static final PropertyDescriptor DATA_STREAMER_AUTO_FLUSH_FREQUENCY = new PropertyDescriptor.Builder()
-            .displayName("Data Streamer Auto Flush Frequency in millis")
-            .name("data-streamer-auto-flush-frequency-in-millis")
-            .description("Data streamer flush interval in millis seconds")
-            .defaultValue("10")
-            .required(true)
-            .addValidator(StandardValidators.createLongValidator(1, 100, true))
+    static final PropertyDescriptor DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS = new PropertyDescriptor.Builder()
+            .displayName("DataStreamer per Node Parallel Operations")
+            .name("data-streamer-per-node-parallel-operations")
+            .description("DataStreamer per node parallelism. Applies only to thick Ignite client.")
+            .defaultValue("5")
+            .required(false)
+            .addValidator(StandardValidators.createLongValidator(1, 10, true))
             .sensitive(false)
             .build();
 
     /**
-     * Data streamers override values property
+     * Override values property.
      */
-    public static final PropertyDescriptor DATA_STREAMER_ALLOW_OVERRIDE = new PropertyDescriptor.Builder()
-            .displayName("Data Streamer Allow Override")
-            .name("data-streamer-allow-override")
-            .description("Whether to override values already in the cache")
+    static final PropertyDescriptor ALLOW_OVERWRITE = new PropertyDescriptor.Builder()
+            .displayName("Allow Overwrite")
+            .name("allow-override")
+            .description("Whether to overwrite values already in the cache.")
             .defaultValue("false")
             .required(true)
             .allowableValues(new AllowableValue("true"), new AllowableValue("false"))
             .sensitive(false)
             .build();
 
-    /** Flow file attribute keys and messages */
-    public static final String IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT = "ignite.cache.batch.flow.file.total.count";
-    public static final String IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER = "ignite.cache.batch.flow.file.item.number";
-    public static final String IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT = "ignite.cache.batch.flow.file.successful.count";
-    public static final String IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER = "ignite.cache.batch.flow.file.successful.number";
-    public static final String IGNITE_BATCH_FLOW_FILE_FAILED_COUNT = "ignite.cache.batch.flow.file.failed.count";
-    public static final String IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER = "ignite.cache.batch.flow.file.failed.number";
-    public static final String IGNITE_BATCH_FLOW_FILE_FAILED_FILE_SIZE = "ignite.cache.batch.flow.file.failed.size";
-    public static final String IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY = "ignite.cache.batch.flow.file.failed.reason";
-    public static final String IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE = "The FlowFile key attribute was missing";
-    public static final String IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE = "The FlowFile size was zero";
-
     /**
-     * Property descriptors
+     * DataStreamer auto flush frequency.
      */
-    protected static final List<PropertyDescriptor> descriptors =
-        Arrays.asList(IGNITE_CONFIGURATION_FILE,CACHE_NAME,BATCH_SIZE,
-            IGNITE_CACHE_ENTRY_KEY,
-            DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS,
-            DATA_STREAMER_PER_NODE_BUFFER_SIZE,
-            DATA_STREAMER_AUTO_FLUSH_FREQUENCY,DATA_STREAMER_ALLOW_OVERRIDE);
+    private static final PropertyDescriptor DATA_STREAMER_AUTO_FLUSH_FREQUENCY = new PropertyDescriptor.Builder()
+            .displayName("DataStreamer Auto Flush Frequency in Millis")
+            .name("data-streamer-auto-flush-frequency-in-millis")
+            .description("DataStreamer flush interval in milliseconds. Applies only to thick Ignite client.")
+            .defaultValue("10")
+            .required(false)
+            .addValidator(StandardValidators.createLongValidator(1, 100, true))
+            .sensitive(false)
+            .build();
 
     /**
-     * Data streamer instance
+     * Property descriptors.
+     */
+    private static final List<PropertyDescriptor> descriptors =
+            Arrays.asList(IGNITE_CLIENT_TYPE, IGNITE_CONFIGURATION_FILE, CACHE_NAME, BATCH_SIZE, IGNITE_CACHE_ENTRY_KEY,
+                    DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS, DATA_STREAMER_PER_NODE_BUFFER_SIZE,
+                    DATA_STREAMER_AUTO_FLUSH_FREQUENCY, ALLOW_OVERWRITE);
+
+    /**
+     * DataStreamer instance.
      */
     private transient IgniteDataStreamer<String, byte[]> igniteDataStreamer;
 
+    /**
+     * Get the supported property descriptors.
+     *
+     * @return The supported property descriptors.
+     */
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return descriptors;
     }
 
     /**
-     * Close data streamer and calls base classes close ignite cache
+     * Get the DataStreamer instance.
+     *
+     * @return The DataStreamer instance.
      */
-    @OnStopped
-    public final void closeIgniteDataStreamer() {
-        if (igniteDataStreamer != null) {
-            getLogger().info("Closing ignite data streamer");
-            igniteDataStreamer.flush();
-            igniteDataStreamer = null;
-        }
-    }
-
-    @OnShutdown
-    public final void closeIgniteDataStreamerAndCache() {
-        closeIgniteDataStreamer();
-        super.closeIgniteCache();
-    }
-
-    /**
-     * Get data streamer
-     * @return data streamer instance
-     */
-    protected IgniteDataStreamer<String, byte[]> getIgniteDataStreamer() {
+    private IgniteDataStreamer<String, byte[]> getIgniteDataStreamer() {
         return igniteDataStreamer;
     }
 
     /**
-     * Initialize ignite cache
+     * Initialise the PutIgniteCache processor.
+     *
+     * @param context Process context.
+     * @throws ProcessException If there is a problem while scheduling the processor.
      */
     @OnScheduled
-    public final void initializeIgniteDataStreamer(ProcessContext context) throws ProcessException {
-        super.initializeIgniteCache(context);
+    public final void initializePutIgniteCacheProcessor(final ProcessContext context) throws ProcessException {
+        initializeIgniteCache(context);
+        final ClientType clientType = ClientType.valueOf(context.getProperty(IGNITE_CLIENT_TYPE).getValue());
 
-        if ( getIgniteDataStreamer() != null ) {
-            return;
-        }
+        if (clientType.equals(ClientType.THICK)) {
+            if (igniteDataStreamer != null) {
+                return;
+            }
+            getLogger().info("Creating thick Ignite client DataStreamer.");
+            try {
+                final int perNodeParallelOperations = context.getProperty(DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS) != null
+                        ? context.getProperty(DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS).asInteger()
+                        : Integer.valueOf(DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS.getDefaultValue());
+                final int perNodeBufferSize = context.getProperty(DATA_STREAMER_PER_NODE_BUFFER_SIZE) != null
+                        ? context.getProperty(DATA_STREAMER_PER_NODE_BUFFER_SIZE).asInteger()
+                        : Integer.valueOf(DATA_STREAMER_PER_NODE_BUFFER_SIZE.getDefaultValue());
+                final int autoFlushFrequency = context.getProperty(DATA_STREAMER_AUTO_FLUSH_FREQUENCY) != null
+                        ? context.getProperty(DATA_STREAMER_AUTO_FLUSH_FREQUENCY).asInteger()
+                        : Integer.valueOf(DATA_STREAMER_AUTO_FLUSH_FREQUENCY.getDefaultValue());
+                final boolean allowOverwrite = context.getProperty(ALLOW_OVERWRITE).asBoolean();
 
-        getLogger().info("Creating Ignite Datastreamer");
-        try {
-            int perNodeParallelOperations = context.getProperty(DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS).asInteger();
-            int perNodeBufferSize = context.getProperty(DATA_STREAMER_PER_NODE_BUFFER_SIZE).asInteger();
-            int autoFlushFrequency = context.getProperty(DATA_STREAMER_AUTO_FLUSH_FREQUENCY).asInteger();
-            boolean allowOverride = context.getProperty(DATA_STREAMER_ALLOW_OVERRIDE).asBoolean();
+                igniteDataStreamer = getThickIgniteClient().dataStreamer(getThickIgniteClientCache().getName());
+                igniteDataStreamer.perNodeBufferSize(perNodeBufferSize);
+                igniteDataStreamer.perNodeParallelOperations(perNodeParallelOperations);
+                igniteDataStreamer.autoFlushFrequency(autoFlushFrequency);
+                igniteDataStreamer.allowOverwrite(allowOverwrite);
 
-            igniteDataStreamer = getIgnite().dataStreamer(getIgniteCache().getName());
-            igniteDataStreamer.perNodeBufferSize(perNodeBufferSize);
-            igniteDataStreamer.perNodeParallelOperations(perNodeParallelOperations);
-            igniteDataStreamer.autoFlushFrequency(autoFlushFrequency);
-            igniteDataStreamer.allowOverwrite(allowOverride);
-
-        } catch (Exception e) {
-            getLogger().error("Failed to schedule PutIgnite due to {}", new Object[] { e }, e);
-            throw new ProcessException(e);
+            } catch (final Exception exception) {
+                getLogger().error("Failed to schedule PutIgniteCache due to {}.", new Object[]{exception}, exception);
+                throw new ProcessException(exception);
+            }
         }
     }
 
     /**
-     * Handle flow files
+     * Handle FlowFiles.
      */
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
@@ -244,52 +239,58 @@ public class PutIgniteCache extends AbstractIgniteCacheProcessor {
             return;
         }
 
-        List<Map.Entry<String, byte[]>> cacheItems = new ArrayList<>();
+        final List<Map.Entry<String, byte[]>> cacheItems = new ArrayList<>();
         List<FlowFile> successfulFlowFiles = new ArrayList<>();
         List<FlowFile> failedFlowFiles = new ArrayList<>();
         try {
-            for (int i = 0; i < flowFiles.size(); i++) {
+            for (final FlowFile file : flowFiles) {
                 FlowFile flowFile = null;
                 try {
-                    flowFile = flowFiles.get(i);
+                    flowFile = file;
 
-                    String key = context.getProperty(IGNITE_CACHE_ENTRY_KEY).evaluateAttributeExpressions(flowFile).getValue();
+                    final String key = context.getProperty(IGNITE_CACHE_ENTRY_KEY).evaluateAttributeExpressions(flowFile).getValue();
 
-                    if ( isFailedFlowFile(flowFile, key) ) {
+                    if (isFailedFlowFile(flowFile, key)) {
                         failedFlowFiles.add(flowFile);
                         continue;
                     }
 
                     final byte[] byteArray = new byte[(int) flowFile.getSize()];
-                    session.read(flowFile, new InputStreamCallback() {
-                        @Override
-                        public void process(final InputStream in) throws IOException {
-                            StreamUtils.fillBuffer(in, byteArray, true);
-                        }
-                    });
-
-                    cacheItems.add(new AbstractMap.SimpleEntry<String,byte[]>(key, byteArray));
+                    session.read(flowFile, inputStream -> StreamUtils.fillBuffer(inputStream, byteArray, true));
+                    cacheItems.add(new SimpleEntry<>(key, byteArray));
                     successfulFlowFiles.add(flowFile);
-
-                } catch (Exception e) {
-                    getLogger().error("Failed to insert {} into IgniteDB due to {}", new Object[] { flowFile, e }, e);
+                } catch (final Exception exception) {
+                    getLogger().error("Failed to insert {} into Ignite cache due to {}.", new Object[]{flowFile, exception}, exception);
                     session.transfer(flowFile, REL_FAILURE);
                     context.yield();
                 }
             }
         } finally {
+            final ClientType clientType = ClientType.valueOf(context.getProperty(IGNITE_CLIENT_TYPE).getValue());
             if (!cacheItems.isEmpty()) {
-                IgniteFuture<?> futures = igniteDataStreamer.addData(cacheItems);
-                Object result = futures.get();
-                getLogger().debug("Result {} of addData", new Object [] {result});
+                if (clientType.equals(ClientType.THICK)) {
+                    final IgniteFuture<?> futures = igniteDataStreamer.addData(cacheItems);
+                    final Object result = futures.get();
+                    getLogger().debug("Result {} of addData.", new Object[]{result});
+                } else if (clientType.equals(ClientType.THIN)) {
+                    final boolean allowOverwrite = context.getProperty(ALLOW_OVERWRITE).asBoolean();
+                    cacheItems.forEach(entry -> {
+                        if (allowOverwrite) {
+                            getThinIgniteClientCache().put(entry.getKey(), entry.getValue());
+                        } else {
+                            getThinIgniteClientCache().putIfAbsent(entry.getKey(), entry.getValue());
+                        }
+                    });
+                }
             }
 
             if (!successfulFlowFiles.isEmpty()) {
                 successfulFlowFiles = updateSuccessfulFlowFileAttributes(flowFiles, successfulFlowFiles, session);
                 session.transfer(successfulFlowFiles, REL_SUCCESS);
-                for (FlowFile flowFile : successfulFlowFiles) {
-                    String key = context.getProperty(IGNITE_CACHE_ENTRY_KEY).evaluateAttributeExpressions(flowFile).getValue();
-                    session.getProvenanceReporter().send(flowFile, "ignite://cache/" + getIgniteCache().getName() + "/" + key);
+                final String name = clientType.equals(ClientType.THICK) ? getThickIgniteClientCache().getName() : getThinIgniteClientCache().getName();
+                for (final FlowFile flowFile : successfulFlowFiles) {
+                    final String key = context.getProperty(IGNITE_CACHE_ENTRY_KEY).evaluateAttributeExpressions(flowFile).getValue();
+                    session.getProvenanceReporter().send(flowFile, "ignite://cache/" + name + "/" + key);
                 }
             }
 
@@ -301,81 +302,83 @@ public class PutIgniteCache extends AbstractIgniteCacheProcessor {
     }
 
     /**
-     * Check if flow if corrupted (either flow file is empty or does not have a key attribute)
-     * @param flowFile the flow file to check
-     * @param key the cache key
-     * @return <code>true</code> if flow file is incomplete
+     * Check if FlowFile is corrupted (either FlowFile is empty or does not have a key attribute).
+     *
+     * @param flowFile The FlowFile to check.
+     * @param key      The cache key.
+     * @return <code>true</code> If FlowFile is incomplete
      */
-    private boolean isFailedFlowFile(FlowFile flowFile, String key) {
-        if ( StringUtils.isEmpty(key) ) {
+    private boolean isFailedFlowFile(final FlowFile flowFile, final String key) {
+        if (StringUtils.isEmpty(key)) {
             return true;
         }
         return flowFile.getSize() == 0;
     }
 
     /**
-     * Add successful flow file attributes
-     * @param flowFiles all flow files
-     * @param successfulFlowFiles list of successful flow files
-     * @param session process session
-     * @return successful flow files with updated attributes
+     * Add successful FlowFile attributes.
+     *
+     * @param flowFiles           All FlowFiles.
+     * @param successfulFlowFiles The list of successful FlowFiles.
+     * @param session             The process session.
+     * @return The successful FlowFiles with updated attributes.
      */
-    protected List<FlowFile> updateSuccessfulFlowFileAttributes(
-            List<FlowFile> flowFiles,
-            List<FlowFile> successfulFlowFiles, ProcessSession session) {
+    private List<FlowFile> updateSuccessfulFlowFileAttributes(final List<FlowFile> flowFiles,
+                                                              final List<FlowFile> successfulFlowFiles,
+                                                              final ProcessSession session) {
 
-        int flowFileCount = flowFiles.size();
-        int flowFileSuccessful = successfulFlowFiles.size();
-        List<FlowFile> updatedSuccessfulFlowFiles = new ArrayList<>();
+        final int flowFileCount = flowFiles.size();
+        final int flowFilesSuccessful = successfulFlowFiles.size();
+        final List<FlowFile> updatedSuccessfulFlowFiles = new ArrayList<>();
 
-        for (int i = 0; i < flowFileSuccessful; i++) {
-            FlowFile flowFile = successfulFlowFiles.get(i);
-            Map<String,String> attributes = new HashMap<>();
+        FlowFile flowFile;
+        final Map<String, String> attributes = new HashMap<>(4);
+        for (int i = 0; i < flowFilesSuccessful; i++) {
+            flowFile = successfulFlowFiles.get(i);
             attributes.put(IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, Integer.toString(i));
             attributes.put(IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, Integer.toString(flowFileCount));
             attributes.put(IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, Integer.toString(flowFiles.indexOf(flowFile)));
-            attributes.put(IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, Integer.toString(flowFileSuccessful));
+            attributes.put(IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, Integer.toString(flowFilesSuccessful));
             flowFile = session.putAllAttributes(flowFile, attributes);
             updatedSuccessfulFlowFiles.add(flowFile);
         }
 
         return updatedSuccessfulFlowFiles;
-
     }
 
     /**
-     * Add failed flow file attributes
-     * @param flowFiles all flow files
-     * @param failedFlowFiles list of failed flow files
-     * @param session process session
-     * @param context the process context
-     * @return failed flow files with updated attributes
+     * Add failed FlowFile attributes.
+     *
+     * @param flowFiles       All FlowFiles.
+     * @param failedFlowFiles The list of failed FlowFiles.
+     * @param session         The process session.
+     * @param context         The process context.
+     * @return The failed FlowFiles with updated attributes.
      */
-    protected List<FlowFile> updateFailedFlowFileAttributes(
-            List<FlowFile> flowFiles,
-            List<FlowFile> failedFlowFiles, ProcessSession session, ProcessContext context) {
+    private List<FlowFile> updateFailedFlowFileAttributes(final List<FlowFile> flowFiles,
+                                                          final List<FlowFile> failedFlowFiles,
+                                                          final ProcessSession session, ProcessContext context) {
 
-        int flowFileCount = flowFiles.size();
-        int flowFileFailed = failedFlowFiles.size();
-        List<FlowFile> updatedFailedFlowFiles = new ArrayList<>();
+        final int flowFileCount = flowFiles.size();
+        final int flowFileFailed = failedFlowFiles.size();
+        final List<FlowFile> updatedFailedFlowFiles = new ArrayList<>();
 
+        FlowFile flowFile;
+        String key;
+        final Map<String, String> attributes = new HashMap<>(5);
         for (int i = 0; i < flowFileFailed; i++) {
-            FlowFile flowFile = failedFlowFiles.get(i);
-
-            Map<String,String> attributes = new HashMap<>();
+            flowFile = failedFlowFiles.get(i);
             attributes.put(IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, Integer.toString(i));
             attributes.put(IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, Integer.toString(flowFileCount));
             attributes.put(IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, Integer.toString(flowFiles.indexOf(flowFile)));
             attributes.put(IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, Integer.toString(flowFileFailed));
 
-            String key = context.getProperty(IGNITE_CACHE_ENTRY_KEY).evaluateAttributeExpressions(flowFile).getValue();
+            key = context.getProperty(IGNITE_CACHE_ENTRY_KEY).evaluateAttributeExpressions(flowFile).getValue();
 
             if (StringUtils.isEmpty(key)) {
-                attributes.put(IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY,
-                        IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
+                attributes.put(IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
             } else if (flowFile.getSize() == 0) {
-                attributes.put(IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY,
-                        IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE);
+                attributes.put(IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE);
             } else {
                 throw new ProcessException("Unknown reason for failing file: " + flowFile);
             }
@@ -385,6 +388,17 @@ public class PutIgniteCache extends AbstractIgniteCacheProcessor {
         }
 
         return updatedFailedFlowFiles;
+    }
 
+    /**
+     * Close the DataStreamer instance.
+     */
+    @OnStopped
+    public void closeThickIgniteClientDataStreamer() {
+        if (igniteDataStreamer != null) {
+            getLogger().info("Closing Ignite DataStreamer.");
+            igniteDataStreamer.flush();
+            igniteDataStreamer = null;
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/resources/default-ignite-client.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/resources/default-ignite-client.xml
@@ -15,18 +15,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/util
-        http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-     <bean abstract="true" id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+    <bean abstract="true" id="thickIgniteClient" class="org.apache.ignite.configuration.IgniteConfiguration">
         <property name="peerClassLoadingEnabled" value="false"/>
-		<property name="clientMode" value="true"/>
         <property name="discoverySpi">
             <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
                 <property name="ipFinder">
@@ -40,6 +35,14 @@
                     </bean>
                 </property>
             </bean>
+        </property>
+    </bean>
+
+    <bean abstract="true" id="thinIgniteClient" class="org.apache.ignite.configuration.ClientConfiguration">
+        <property name="addresses">
+            <list>
+                <value>127.0.0.1:10800</value>
+            </list>
         </property>
     </bean>
 </beans>

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/resources/ignite-client.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/resources/ignite-client.xml
@@ -15,12 +15,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
     <!-- Imports default Ignite configuration -->
-    <import resource="ignite-default-client.xml"/>
+    <import resource="default-ignite-client.xml"/>
 
-    <bean parent="ignite.cfg"/>
+    <bean parent="thickIgniteClient"/>
+    <bean parent="thinIgniteClient"/>
 </beans>

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/java/org/apache/nifi/processors/ignite/cache/ITGetIgniteCache.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/java/org/apache/nifi/processors/ignite/cache/ITGetIgniteCache.java
@@ -16,15 +16,7 @@
  */
 package org.apache.nifi.processors.ignite.cache;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.ignite.IgniteCache;
+import org.apache.nifi.processors.ignite.ClientType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -33,152 +25,207 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for {@link GetIgniteCache}.
+ */
 public class ITGetIgniteCache {
 
     private static final String CACHE_NAME = "testCache";
+
     private static TestRunner runner;
     private static GetIgniteCache getIgniteCache;
-    private static Map<String,String> properties1;
-    private static HashMap<String, String> properties2;
+    private static Map<String, String> properties1;
+    private static Map<String, String> properties2;
 
     @BeforeClass
-    public static void setUp() throws IOException {
+    public static void setUp() {
         getIgniteCache = new GetIgniteCache();
-        properties1 = new HashMap<String,String>();
-        properties2 = new HashMap<String,String>();
+        properties1 = new HashMap<>();
+        properties2 = new HashMap<>();
     }
 
     @AfterClass
     public static void teardown() {
         runner = null;
-        IgniteCache<String, byte[]> cache = getIgniteCache.getIgniteCache();
-        if (cache != null )
-            cache.destroy();
+        if (getIgniteCache.getThickIgniteClientCache() != null) {
+            getIgniteCache.getThickIgniteClientCache().destroy();
+        } else if (getIgniteCache.getThinIgniteClient() != null) {
+            getIgniteCache.getThinIgniteClient().destroyCache(CACHE_NAME);
+        }
         getIgniteCache = null;
     }
 
-    @Test
-    public void testgetIgniteCacheOnTriggerFileConfigurationOneFlowFile() throws IOException, InterruptedException {
+    private static void assertOneFlowFileRetrievedConfigurationProvided(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(getIgniteCache);
         runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        runner.setProperty(GetIgniteCache.IGNITE_CONFIGURATION_FILE,
-                "file:///" + new File(".").getAbsolutePath() + "/src/test/resources/test-ignite.xml");
+        runner.setProperty(GetIgniteCache.IGNITE_CONFIGURATION_FILE, "file:///" + new File(".").getAbsolutePath() + "/src/test/resources/test-ignite-client.xml");
         runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
         properties1.put("igniteKey", "key5");
-        runner.enqueue("test5".getBytes(),properties1);
+        runner.enqueue("test5".getBytes(), properties1);
 
-        getIgniteCache.initialize(runner.getProcessContext());
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getIgniteCache.getIgniteCache().put("key5", "test5".getBytes());
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key5", "test5".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key5", "test5".getBytes());
+        }
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 1);
-        List<MockFlowFile> sucessfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(1, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(1, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
         out.assertContentEquals("test5".getBytes());
-        Assert.assertArrayEquals("test5".getBytes(),(byte[])getIgniteCache.getIgniteCache().get("key5"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test5".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key5"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test5".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key5"));
+        }
+
         runner.shutdown();
     }
 
-    @Test
-    public void testgetIgniteCacheOnTriggerNoConfigurationTwoFlowFile() throws IOException, InterruptedException {
+    private static void assertTwoFlowFilesRetrievedNoConfigurationProvided(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(getIgniteCache);
         runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
         properties1.put("igniteKey", "key51");
-        runner.enqueue("test1".getBytes(),properties1);
+        runner.enqueue("test1".getBytes(), properties1);
         properties2.put("igniteKey", "key52");
-        runner.enqueue("test2".getBytes(),properties2);
-        getIgniteCache.initialize(runner.getProcessContext());
+        runner.enqueue("test2".getBytes(), properties2);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getIgniteCache.getIgniteCache().put("key51", "test51".getBytes());
-        getIgniteCache.getIgniteCache().put("key52", "test52".getBytes());
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key51", "test51".getBytes());
+            getIgniteCache.getThickIgniteClientCache().put("key52", "test52".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key51", "test51".getBytes());
+            getIgniteCache.getThinIgniteClientCache().put("key52", "test52".getBytes());
+        }
         runner.run(2, false, true);
 
         runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
-        List<MockFlowFile> sucessfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(2, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(2, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
         out.assertContentEquals("test51".getBytes());
-        Assert.assertArrayEquals("test51".getBytes(),
-                (byte[])getIgniteCache.getIgniteCache().get("key51"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test51".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key51"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test51".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key51"));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(1);
-
         out2.assertContentEquals("test52".getBytes());
-        Assert.assertArrayEquals("test52".getBytes(),
-                (byte[])getIgniteCache.getIgniteCache().get("key52"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test52".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key52"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test52".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key52"));
+        }
+
+        runner.shutdown();
+    }
+
+    private static void assertTwoFlowFilesRetrievedAfterRestartingTwiceNoConfigurationProvided(final ClientType clientType) {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
+
+        runner.assertValid();
+        properties1.put("igniteKey", "key51");
+        runner.enqueue("test1".getBytes(), properties1);
+        properties2.put("igniteKey", "key52");
+        runner.enqueue("test2".getBytes(), properties2);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
+
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key51", "test51".getBytes());
+            getIgniteCache.getThickIgniteClientCache().put("key52", "test52".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key51", "test51".getBytes());
+            getIgniteCache.getThinIgniteClientCache().put("key52", "test52".getBytes());
+        }
+        runner.run(2, false, true);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
+
+        // Reinitialise and check first time.
+        getIgniteCache.closeIgniteClientCache();
+        runner.clearTransferState();
+        runner.assertValid();
+        properties1.put("igniteKey", "key51");
+        runner.enqueue("test1".getBytes(), properties1);
+        properties2.put("igniteKey", "key52");
+        runner.enqueue("test2".getBytes(), properties2);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
+
+        runner.run(2, false, true);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
+
+        // Reinitialise and check second time.
+        getIgniteCache.closeIgniteClientCache();
+        runner.clearTransferState();
+        runner.assertValid();
+        properties1.put("igniteKey", "key51");
+        runner.enqueue("test1".getBytes(), properties1);
+        properties2.put("igniteKey", "key52");
+        runner.enqueue("test2".getBytes(), properties2);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
+
+        runner.run(2, false, true);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
 
         runner.shutdown();
     }
 
     @Test
-    public void testgetIgniteCacheOnTriggerNoConfigurationTwoFlowFileStopStart2Times() throws IOException, InterruptedException {
-        runner = TestRunners.newTestRunner(getIgniteCache);
-        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+    public void getIgniteCache_configurationProvided_oneFlowFileRetrievedUsingThickIgniteClient() throws IOException {
+        assertOneFlowFileRetrievedConfigurationProvided(ClientType.THICK);
+    }
 
-        runner.assertValid();
-        properties1.put("igniteKey", "key51");
-        runner.enqueue("test1".getBytes(),properties1);
-        properties2.put("igniteKey", "key52");
-        runner.enqueue("test2".getBytes(),properties2);
-        getIgniteCache.initialize(runner.getProcessContext());
+    @Test
+    public void getIgniteCache_configurationProvided_oneFlowFileRetrievedUsingThinIgniteClient() throws IOException {
+        assertOneFlowFileRetrievedConfigurationProvided(ClientType.THIN);
+    }
 
-        getIgniteCache.getIgniteCache().put("key51", "test51".getBytes());
-        getIgniteCache.getIgniteCache().put("key52", "test52".getBytes());
-        runner.run(2, false, true);
+    @Test
+    public void getIgniteCache_noConfigurationProvided_twoFlowFilesRetrievedUsingThickIgniteClient() throws IOException {
+        assertTwoFlowFilesRetrievedNoConfigurationProvided(ClientType.THICK);
+    }
 
-        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
+    @Test
+    public void getIgniteCache_noConfigurationProvided_twoFlowFilesRetrievedUsingThinIgniteClient() throws IOException {
+        assertTwoFlowFilesRetrievedNoConfigurationProvided(ClientType.THIN);
+    }
 
-        getIgniteCache.closeIgniteCache();
+    @Test
+    public void getIgniteCache_noConfigurationProvided_twoFlowFilesRetrievedAfterRestartingTwiceUsingThickClient() {
+        assertTwoFlowFilesRetrievedAfterRestartingTwiceNoConfigurationProvided(ClientType.THICK);
+    }
 
-        runner.clearTransferState();
-
-        // reinit and check first time
-        runner.assertValid();
-        properties1.put("igniteKey", "key51");
-        runner.enqueue("test1".getBytes(),properties1);
-        properties2.put("igniteKey", "key52");
-        runner.enqueue("test2".getBytes(),properties2);
-        getIgniteCache.initialize(runner.getProcessContext());
-
-        runner.run(2, false, true);
-
-        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
-
-        getIgniteCache.closeIgniteCache();
-
-        runner.clearTransferState();
-
-        // reinit and check second time
-        runner.assertValid();
-        properties1.put("igniteKey", "key51");
-        runner.enqueue("test1".getBytes(),properties1);
-        properties2.put("igniteKey", "key52");
-        runner.enqueue("test2".getBytes(),properties2);
-        getIgniteCache.initialize(runner.getProcessContext());
-
-        runner.run(2, false, true);
-
-        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
-
-        getIgniteCache.closeIgniteCache();
-
-        runner.clearTransferState();
-
+    @Test
+    public void getIgniteCache_noConfigurationProvided_twoFlowFilesRetrievedAfterRestartingTwiceUsingThinClient() {
+        assertTwoFlowFilesRetrievedAfterRestartingTwiceNoConfigurationProvided(ClientType.THIN);
     }
 }

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/java/org/apache/nifi/processors/ignite/cache/TestGetIgniteCache.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/java/org/apache/nifi/processors/ignite/cache/TestGetIgniteCache.java
@@ -16,394 +16,500 @@
  */
 package org.apache.nifi.processors.ignite.cache;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.Ignition;
+import org.apache.ignite.client.ClientCache;
+import org.apache.nifi.processors.ignite.ClientType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.ignite.internal.IgnitionEx.loadConfiguration;
+import static org.junit.Assert.assertEquals;
+
 public class TestGetIgniteCache {
 
     private static final String CACHE_NAME = "testCache";
-    private TestRunner getRunner;
+    private static Ignite thickIgniteClient;
+    private TestRunner runner;
     private GetIgniteCache getIgniteCache;
-    private Map<String,String> properties1;
-    private Map<String,String> properties2;
-    private static Ignite ignite;
-
-    // Check if the JDK running these tests is pre-Java 11, so that tests can be ignored if JDK is Java 11+
-    // TODO Once a version of Ignite that supports Java 11 is released, this check can be removed.
-    private static boolean preJava11;
-    static {
-        String javaVersion = System.getProperty("java.version");
-        preJava11 = Integer.parseInt(javaVersion.substring(0, javaVersion.indexOf('.'))) < 11;
-    }
+    private Map<String, String> properties1;
+    private Map<String, String> properties2;
 
     @BeforeClass
-    public static void setUpClass() {
-        if (preJava11) {
-            ignite = Ignition.start("test-ignite.xml");
+    public static void setUpClass() throws IgniteCheckedException {
+        final List<Ignite> grids = Ignition.allGrids();
+        if (grids.size() == 1) {
+            thickIgniteClient = grids.get(0);
+        } else {
+            final String targetFolderPath = Paths.get("target/ignite/work/").toUri().getPath();
+            thickIgniteClient = Ignition.start(loadConfiguration("test-ignite-client.xml").get1().setWorkDirectory(targetFolderPath));
         }
     }
 
     @AfterClass
     public static void tearDownClass() {
-        if (preJava11) {
-            ignite.close();
-            Ignition.stop(true);
-        }
+        thickIgniteClient.close();
+        Ignition.stop(true);
     }
 
     @Before
-    public void setUp() throws IOException {
-        if (preJava11) {
-            getIgniteCache = new GetIgniteCache() {
-                @Override
-                protected Ignite getIgnite() {
-                    return TestGetIgniteCache.ignite;
-                }
-
-            };
-
-            properties1 = new HashMap<String,String>();
-            properties1.put("igniteKey", "key1");
-            properties2 = new HashMap<String,String>();
-            properties2.put("igniteKey", "key2");
-        }
-
+    public void setUp() {
+        getIgniteCache = new GetIgniteCache() {
+            @Override
+            protected Ignite getThickIgniteClient() {
+                return TestGetIgniteCache.thickIgniteClient;
+            }
+        };
+        properties1 = new HashMap<>();
+        properties1.put("igniteKey", "key1");
+        properties2 = new HashMap<>();
+        properties2.put("igniteKey", "key2");
     }
 
     @After
     public void teardown() {
-        if (preJava11) {
-            Assume.assumeTrue(preJava11);
-            getRunner = null;
-            ignite.destroyCache(CACHE_NAME);
-        }
+        runner = null;
+        thickIgniteClient.destroyCache(CACHE_NAME);
     }
 
     @Test
-    public void testGetIgniteCacheDefaultConfOneFlowFileWithPlainKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "mykey");
-
-        getRunner.assertValid();
-        getRunner.enqueue(new byte[] {});
-
-        getIgniteCache.initialize(getRunner.getProcessContext());
-
-        getIgniteCache.getIgniteCache().put("mykey", "test".getBytes());
-
-        getRunner.run(1, false, true);
-
-        getRunner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 1);
-        List<MockFlowFile> getSucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(1, getSucessfulFlowFiles.size());
-        List<MockFlowFile> getFailureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
-        assertEquals(0, getFailureFlowFiles.size());
-
-        final MockFlowFile getOut = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-        getOut.assertContentEquals("test".getBytes());
-
-        getRunner.shutdown();
+    public void getIgniteCache_oneFlowFilePlainKey_retrievedUsingThickIgniteClient() throws IOException {
+        assertOneFlowFilePlainKeyRetrieved(ClientType.THICK);
     }
 
     @Test
-    public void testGetIgniteCacheNullGetCacheThrowsException() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+    public void getIgniteCache_oneFlowFilePlainKey_retrievedUsingThinIgniteClient() throws IOException {
+        assertOneFlowFilePlainKeyRetrieved(ClientType.THIN);
+    }
 
+    @Test
+    public void getIgniteCache_nullThickIgniteClientCache_throwsNullPointerException() {
         getIgniteCache = new GetIgniteCache() {
             @Override
-            protected Ignite getIgnite() {
-                return TestGetIgniteCache.ignite;
+            protected Ignite getThickIgniteClient() {
+                return TestGetIgniteCache.thickIgniteClient;
             }
 
             @Override
-            protected IgniteCache<String, byte[]> getIgniteCache() {
+            protected IgniteCache<String, byte[]> getThickIgniteClientCache() {
                 return null;
             }
-
         };
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "mykey");
+        assertNullPointerExceptionThrownWhenIgniteClientCacheIsNull(ClientType.THICK);
+    }
 
-        getRunner.assertValid();
-        getRunner.enqueue(new byte[] {});
+    @Test
+    public void getIgniteCache_nullThinIgniteClientCache_throwsNullPointerException() {
+        getIgniteCache = new GetIgniteCache() {
+            @Override
+            protected ClientCache<String, byte[]> getThinIgniteClientCache() {
+                return null;
+            }
+        };
+        assertNullPointerExceptionThrownWhenIgniteClientCacheIsNull(ClientType.THIN);
+    }
 
-        getIgniteCache.initialize(getRunner.getProcessContext());
+    @Test
+    public void getIgniteCache_oneFlowFileExpressionKey_retrievedUsingThickIgniteClient() throws IOException {
+        assertOneFlowFileExpressionKeyRetrieved(ClientType.THICK);
+    }
 
-        getRunner.run(1, false, true);
+    @Test
+    public void getIgniteCache_oneFlowFileExpressionKey_retrievedUsingThinIgniteClient() throws IOException {
+        assertOneFlowFileExpressionKeyRetrieved(ClientType.THIN);
+    }
 
-        getRunner.assertAllFlowFilesTransferred(GetIgniteCache.REL_FAILURE, 1);
-        List<MockFlowFile> getSucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(0, getSucessfulFlowFiles.size());
-        List<MockFlowFile> getFailureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+    @Test
+    public void getIgniteCache_twoFlowFilesExpressionKeys_retrievedUsingThickIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysRetrieved(ClientType.THICK);
+    }
+
+    @Test
+    public void getIgniteCache_twoFlowFilesExpressionKeys_retrievedUsingThinIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysRetrieved(ClientType.THIN);
+    }
+
+    @Test
+    public void getIgniteCache_oneFlowFileNoKey_routedToFailureUsingThickIgniteClient() {
+        assertOneFlowFileNoKeyRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void getIgniteCache_oneFlowFileNoKey_routedToFailureUsingThinIgniteClient() {
+        assertOneFlowFileNoKeyRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void getIgniteCache_twoFlowFilesNoKey_routedToFailureUsingThickIgniteClient() {
+        assertTwoFlowFilesNoKeyRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void getIgniteCache_twoFlowFilesNoKey_routedToFailureUsingThinIgniteClient() {
+        assertTwoFlowFilesNoKeyRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void getIgniteCache_firstFlowFileNoKeySecondFlowFileExpressionKey_firstFlowFileRoutedToFailureSecondFlowFileRetrievedUsingThickIgniteClient() throws IOException {
+        assertFlowFileNoKeyRoutedToFailureFlowFileExpressionKeyRetrieved(ClientType.THICK);
+    }
+
+    @Test
+    public void getIgniteCache_firstFlowFileNoKeySecondFlowFileExpressionKey_firstFlowFileRoutedToFailureSecondFlowFileRetrievedUsingThinIgniteClient() throws IOException {
+        assertFlowFileNoKeyRoutedToFailureFlowFileExpressionKeyRetrieved(ClientType.THIN);
+    }
+
+    @Test
+    public void getIgniteCache_firstFlowFileExpressionKeySecondFlowFileNoKey_firstFlowFileRetrievedSecondFlowFileRoutedToFailureUsingThickIgniteClient() throws IOException {
+        assertFlowFileExpressionKeyRetrievedFlowFileNoKeyRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void getIgniteCache_firstFlowFileExpressionKeySecondFlowFileNoKey_firstFlowFileRetrievedSecondFlowFileRoutedToFailureUsingThinIgniteClient() throws IOException {
+        assertFlowFileExpressionKeyRetrievedFlowFileNoKeyRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void getIgniteCache_firstSecondFlowFilesExpressionKeysThirdFlowFileNoKey_firstSecondFlowFilesRetrievedThirdFlowFileRoutedToFailureUsingThickIgniteClient() throws IOException {
+        assertFlowFilesExpressionKeysRetrievedFlowFileNoKeyRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void getIgniteCache_firstSecondFlowFilesExpressionKeysThirdFlowFileNoKey_firstSecondFlowFilesRetrievedThirdFlowFileRoutedToFailureUsingThinIgniteClient() throws IOException {
+        assertFlowFilesExpressionKeysRetrievedFlowFileNoKeyRoutedToFailure(ClientType.THIN);
+    }
+
+    private void assertOneFlowFilePlainKeyRetrieved(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "myKey");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
+
+        runner.assertValid();
+        runner.enqueue(new byte[]{});
+
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
+
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("myKey", "test".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("myKey", "test".getBytes());
+        }
+
+        runner.run(1, false, true);
+
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 1);
+        final List<MockFlowFile> getSuccessfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(1, getSuccessfulFlowFiles.size());
+        final List<MockFlowFile> getFailureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        assertEquals(0, getFailureFlowFiles.size());
+
+        final MockFlowFile getOut = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
+        getOut.assertContentEquals("test".getBytes());
+
+        runner.shutdown();
+    }
+
+    private void assertNullPointerExceptionThrownWhenIgniteClientCacheIsNull(final ClientType clientType) {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "myKey");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
+
+        runner.assertValid();
+        runner.enqueue(new byte[]{});
+
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
+
+        runner.run(1, false, true);
+
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_FAILURE, 1);
+        final List<MockFlowFile> getSuccessfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(0, getSuccessfulFlowFiles.size());
+        final List<MockFlowFile> getFailureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(1, getFailureFlowFiles.size());
 
-        final MockFlowFile getOut = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
-        getOut.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY,
-            GetIgniteCache.IGNITE_GET_FAILED_MESSAGE_PREFIX + "java.lang.NullPointerException");
+        final MockFlowFile getOut = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
+        getOut.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MESSAGE_PREFIX + "java.lang.NullPointerException");
 
-        getRunner.shutdown();
+        runner.shutdown();
     }
 
-    @Test
-    public void testGetIgniteCacheDefaultConfOneFlowFileWithKeyExpression() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+    private void assertOneFlowFileExpressionKeyRetrieved(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.assertValid();
+        runner.enqueue("".getBytes(), properties1);
 
-        getRunner.assertValid();
-        getRunner.enqueue("".getBytes(),properties1);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getIgniteCache.initialize(getRunner.getProcessContext());
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key1", "test".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key1", "test".getBytes());
+        }
 
-        getIgniteCache.getIgniteCache().put("key1", "test".getBytes());
+        runner.run(1, false, true);
 
-        getRunner.run(1, false, true);
-
-        getRunner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 1);
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(1, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 1);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(1, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
-        final MockFlowFile out = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
+        final MockFlowFile out = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
         out.assertContentEquals("test".getBytes());
-        getRunner.shutdown();
+
+        runner.shutdown();
     }
 
-    @Test
-    public void testGetIgniteCacheDefaultConfTwoFlowFilesWithExpressionKeys() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+    private void assertTwoFlowFilesExpressionKeysRetrieved(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.assertValid();
+        runner.enqueue("".getBytes(), properties1);
+        runner.enqueue("".getBytes(), properties2);
 
-        getRunner.assertValid();
-        getRunner.enqueue("".getBytes(),properties1);
-        getRunner.enqueue("".getBytes(),properties2);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getIgniteCache.initialize(getRunner.getProcessContext());
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key1", "test1".getBytes());
+            getIgniteCache.getThickIgniteClientCache().put("key2", "test2".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key1", "test1".getBytes());
+            getIgniteCache.getThinIgniteClientCache().put("key2", "test2".getBytes());
+        }
 
-        getIgniteCache.getIgniteCache().put("key1", "test1".getBytes());
-        getIgniteCache.getIgniteCache().put("key2", "test2".getBytes());
+        runner.run(2, false, true);
 
-        getRunner.run(2, false, true);
-
-        getRunner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
-
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(2, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_SUCCESS, 2);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(2, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
-        final MockFlowFile out1 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
+        final MockFlowFile out1 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
         out1.assertContentEquals("test1".getBytes());
-        Assert.assertEquals("test1",new String(getIgniteCache.getIgniteCache().get("key1")));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertEquals("test1", new String(getIgniteCache.getThickIgniteClientCache().get("key1")));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertEquals("test1", new String(getIgniteCache.getThinIgniteClientCache().get("key1")));
+        }
 
-        final MockFlowFile out2 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(1);
-
+        final MockFlowFile out2 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(1);
         out2.assertContentEquals("test2".getBytes());
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test2".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test2".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])getIgniteCache.getIgniteCache().get("key2"));
-
-        getRunner.shutdown();
+        runner.shutdown();
     }
 
-    @Test
-    public void testGetIgniteCacheDefaultConfOneFlowFileNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+    private void assertOneFlowFileNoKeyRoutedToFailure(final ClientType clientType) {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
-
-        getRunner.assertValid();
+        runner.assertValid();
         properties1.clear();
-        getRunner.enqueue("".getBytes(),properties1);
-        getIgniteCache.initialize(getRunner.getProcessContext());
+        runner.enqueue("".getBytes(), properties1);
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getRunner.run(1, false, true);
+        runner.run(1, false, true);
 
-        getRunner.assertAllFlowFilesTransferred(GetIgniteCache.REL_FAILURE, 1);
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(0, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_FAILURE, 1);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(0, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
-        final MockFlowFile out = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
-
+        final MockFlowFile out = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
         out.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MISSING_KEY_MESSAGE);
 
-        getRunner.shutdown();
+        runner.shutdown();
     }
 
+    private void assertTwoFlowFilesNoKeyRoutedToFailure(final ClientType clientType) {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-
-    @Test
-    public void testGetIgniteCacheDefaultConfTwoFlowFilesNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
-
-        getRunner.assertValid();
+        runner.assertValid();
 
         properties1.clear();
-        getRunner.enqueue("".getBytes(),properties1);
-        getRunner.enqueue("".getBytes(),properties1);
+        runner.enqueue("".getBytes(), properties1);
+        runner.enqueue("".getBytes(), properties1);
 
-        getIgniteCache.initialize(getRunner.getProcessContext());
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getRunner.run(2, false, true);
+        runner.run(2, false, true);
 
-        getRunner.assertAllFlowFilesTransferred(GetIgniteCache.REL_FAILURE, 2);
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(0, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        runner.assertAllFlowFilesTransferred(GetIgniteCache.REL_FAILURE, 2);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(0, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(2, failureFlowFiles.size());
 
-        final MockFlowFile out1 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
+        final MockFlowFile out1 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
         out1.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MISSING_KEY_MESSAGE);
-        final MockFlowFile out2 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(1);
+        final MockFlowFile out2 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(1);
         out2.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MISSING_KEY_MESSAGE);
 
-        getRunner.shutdown();
-
+        runner.shutdown();
     }
 
-    @Test
-    public void testGetIgniteCacheDefaultConfTwoFlowFileFirstNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+    private void assertFlowFileNoKeyRoutedToFailureFlowFileExpressionKeyRetrieved(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.assertValid();
+        runner.enqueue("".getBytes());
+        runner.enqueue("".getBytes(), properties2);
 
-        getRunner.assertValid();
-        getRunner.enqueue("".getBytes());
-        getRunner.enqueue("".getBytes(),properties2);
-        getIgniteCache.initialize(getRunner.getProcessContext());
-        getIgniteCache.getIgniteCache().put("key2", "test2".getBytes());
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getRunner.run(2, false, true);
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key2", "test2".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key2", "test2".getBytes());
+        }
 
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(1, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        runner.run(2, false, true);
+
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(1, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
-        final MockFlowFile out1 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
-
+        final MockFlowFile out1 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
         out1.assertContentEquals("".getBytes());
         out1.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MISSING_KEY_MESSAGE);
 
-        final MockFlowFile out2 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
+        final MockFlowFile out2 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
         out2.assertContentEquals("test2".getBytes());
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])getIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test2".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test2".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
-        getRunner.shutdown();
+        runner.shutdown();
     }
 
-    @Test
-    public void testGetIgniteCacheDefaultConfTwoFlowFileSecondNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+    private void assertFlowFileExpressionKeyRetrievedFlowFileNoKeyRoutedToFailure(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.assertValid();
+        runner.enqueue("".getBytes(), properties1);
+        runner.enqueue("".getBytes());
 
-        getRunner.assertValid();
-        getRunner.enqueue("".getBytes(),properties1);
-        getRunner.enqueue("".getBytes());
-        getIgniteCache.initialize(getRunner.getProcessContext());
+        getIgniteCache.initializeGetIgniteCacheProcessor(runner.getProcessContext());
 
-        getIgniteCache.getIgniteCache().put("key1", "test1".getBytes());
-        getRunner.run(2, false, true);
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key1", "test1".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key1", "test1".getBytes());
+        }
 
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(1, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        runner.run(2, false, true);
+
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(1, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
-        final MockFlowFile out1 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
-
+        final MockFlowFile out1 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
         out1.assertContentEquals("".getBytes());
         out1.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MISSING_KEY_MESSAGE);
 
-        final MockFlowFile out2 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
+        final MockFlowFile out2 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
         out2.assertContentEquals("test1".getBytes());
-        Assert.assertArrayEquals("test1".getBytes(),(byte[])getIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test1".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test1".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
-        getRunner.shutdown();
-
+        runner.shutdown();
     }
 
+    private void assertFlowFilesExpressionKeysRetrievedFlowFileNoKeyRoutedToFailure(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(getIgniteCache);
+        runner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(GetIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
-    @Test
-    public void testGetIgniteCacheDefaultConfThreeFlowFilesOneOkSecondOkThirdNoExpressionKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
+        runner.assertValid();
+        runner.enqueue("".getBytes(), properties1);
+        runner.enqueue("".getBytes(), properties2);
+        runner.enqueue("".getBytes());
 
-        getRunner = TestRunners.newTestRunner(getIgniteCache);
-        getRunner.setProperty(GetIgniteCache.CACHE_NAME, CACHE_NAME);
-        getRunner.setProperty(GetIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        getIgniteCache.initializeIgniteCache(runner.getProcessContext());
 
-        getRunner.assertValid();
-        getRunner.enqueue("".getBytes(),properties1);
-        getRunner.enqueue("".getBytes(),properties2);
-        getRunner.enqueue("".getBytes());
-        getIgniteCache.initialize(getRunner.getProcessContext());
+        if (clientType.equals(ClientType.THICK)) {
+            getIgniteCache.getThickIgniteClientCache().put("key1", "test1".getBytes());
+            getIgniteCache.getThickIgniteClientCache().put("key2", "test2".getBytes());
+        } else if (clientType.equals(ClientType.THIN)) {
+            getIgniteCache.getThinIgniteClientCache().put("key1", "test1".getBytes());
+            getIgniteCache.getThinIgniteClientCache().put("key2", "test2".getBytes());
+        }
 
-        getIgniteCache.getIgniteCache().put("key1", "test1".getBytes());
-        getIgniteCache.getIgniteCache().put("key2", "test2".getBytes());
-        getRunner.run(3, false, true);
+        runner.run(3, false, true);
 
-        List<MockFlowFile> sucessfulFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
-        assertEquals(2, sucessfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS);
+        assertEquals(2, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
-        final MockFlowFile out1 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
-
+        final MockFlowFile out1 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_FAILURE).get(0);
         out1.assertContentEquals("".getBytes());
         out1.assertAttributeEquals(GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, GetIgniteCache.IGNITE_GET_FAILED_MISSING_KEY_MESSAGE);
 
-        final MockFlowFile out2 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
-
+        final MockFlowFile out2 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(0);
         out2.assertContentEquals("test1".getBytes());
-        Assert.assertArrayEquals("test1".getBytes(),(byte[])getIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test1".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test1".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
-        final MockFlowFile out3 = getRunner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(1);
-
+        final MockFlowFile out3 = runner.getFlowFilesForRelationship(GetIgniteCache.REL_SUCCESS).get(1);
         out3.assertContentEquals("test2".getBytes());
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])getIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test2".getBytes(), getIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test2".getBytes(), getIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
-        getRunner.shutdown();
-
+        runner.shutdown();
     }
-
 }

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/java/org/apache/nifi/processors/ignite/cache/TestPutIgniteCache.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/java/org/apache/nifi/processors/ignite/cache/TestPutIgniteCache.java
@@ -16,600 +16,728 @@
  */
 package org.apache.nifi.processors.ignite.cache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.Ignition;
+import org.apache.nifi.processors.ignite.ClientType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.ignite.internal.IgnitionEx.loadConfiguration;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 public class TestPutIgniteCache {
 
     private static final String CACHE_NAME = "testCache";
+    private static Ignite thickIgniteClient;
     private TestRunner runner;
     private PutIgniteCache putIgniteCache;
-    private Map<String,String> properties1;
-    private Map<String,String> properties2;
-    private static Ignite ignite;
-
-    // Check if the JDK running these tests is pre-Java 11, so that tests can be ignored if JDK is Java 11+
-    // TODO Once a version of Ignite that supports Java 11 is released, this check can be removed.
-    private static boolean preJava11;
-    static {
-        String javaVersion = System.getProperty("java.version");
-        preJava11 = Integer.parseInt(javaVersion.substring(0, javaVersion.indexOf('.'))) < 11;
-    }
+    private Map<String, String> properties1;
+    private Map<String, String> properties2;
 
     @BeforeClass
-    public static void setUpClass() {
-        if (preJava11) {
-            List<Ignite> grids = Ignition.allGrids();
-            if ( grids.size() == 1 )
-                ignite = grids.get(0);
-            else
-                ignite = Ignition.start("test-ignite.xml");
+    public static void setUpClass() throws IgniteCheckedException {
+        final List<Ignite> grids = Ignition.allGrids();
+        if (grids.size() == 1) {
+            thickIgniteClient = grids.get(0);
+        } else {
+            final String targetFolderPath = Paths.get("target/ignite/work/").toUri().getPath();
+            thickIgniteClient = Ignition.start(loadConfiguration("test-ignite-client.xml").get1().setWorkDirectory(targetFolderPath));
         }
-
     }
 
     @AfterClass
     public static void tearDownClass() {
-        if (preJava11) {
-            if ( ignite != null )
-                ignite.close();
-            Ignition.stop(true);
-        }
+        thickIgniteClient.close();
+        Ignition.stop(true);
     }
 
     @Before
-    public void setUp() throws IOException {
-        if (preJava11) {
-            putIgniteCache = new PutIgniteCache() {
-                @Override
-                protected Ignite getIgnite() {
-                    return TestPutIgniteCache.ignite;
-                }
-
-            };
-            properties1 = new HashMap<String,String>();
-            properties1.put("igniteKey", "key1");
-            properties2 = new HashMap<String,String>();
-            properties2.put("igniteKey", "key2");
-        }
+    public void setUp() {
+        putIgniteCache = new PutIgniteCache() {
+            @Override
+            protected Ignite getThickIgniteClient() {
+                return TestPutIgniteCache.thickIgniteClient;
+            }
+        };
+        properties1 = new HashMap<>();
+        properties1.put("igniteKey", "key1");
+        properties2 = new HashMap<>();
+        properties2.put("igniteKey", "key2");
     }
 
     @After
     public void teardown() {
-        if (preJava11) {
-            runner = null;
-            ignite.destroyCache(CACHE_NAME);
+        runner = null;
+        thickIgniteClient.destroyCache(CACHE_NAME);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFilePlainKey_putUsingThickIgniteClient() throws IOException {
+        assertOneFlowFilePlainKeyPut(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFilePlainKey_putUsingThinIgniteClient() throws IOException {
+        assertOneFlowFilePlainKeyPut(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFileExpressionKey_putUsingThickIgniteClient() throws IOException {
+        assertOneFlowFileExpressionKeyPut(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFileExpressionKey_putUsingThinIgniteClient() throws IOException {
+        assertOneFlowFileExpressionKeyPut(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesExpressionKeysFalseAllowOverwrite_putNotUpdatedUsingThickIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysFalseAllowOverwritePutNotUpdated(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesExpressionKeysFalseAllowOverwrite_putNotUpdatedUsingThinIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysFalseAllowOverwritePutNotUpdated(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesExpressionKeysTrueAllowOverwrite_putUpdatedUsingThickIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysTrueAllowOverwritePutUpdated(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesExpressionKeysTrueAllowOverwrite_putUpdatedUsingThinIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysTrueAllowOverwritePutUpdated(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFileNoKey_routedToFailureUsingThickIgniteClient() throws IOException {
+        assertOneFlowFileNoKeyRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFileNoKey_routedToFailureUsingThinIgniteClient() throws IOException {
+        assertOneFlowFileNoKeyRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFileZeroBytes_routedToFailureUsingThickIgniteClient() throws IOException {
+        assertOneFlowFileZeroBytesRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_oneFlowFileZeroBytes_routedToFailureUsingThinIgniteClient() throws IOException {
+        assertOneFlowFileZeroBytesRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesExpressionKeys_putUsingThickIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysPut(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesExpressionKeys_putUsingThinIgniteClient() throws IOException {
+        assertTwoFlowFilesExpressionKeysPut(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesNoKeys_routedToFailureUsingThickIgniteClient() throws IOException {
+        assertTwoFlowFilesNoKeysRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_twoFlowFilesNoKeys_routedToFailureUsingThinIgniteClient() throws IOException {
+        assertTwoFlowFilesNoKeysRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileNoKeySecondFlowFileExpressionKey_firstFlowFileRoutedToFailureSecondFlowFilePutUsingThickIgniteClient() throws IOException {
+        assertFlowFileNoKeyRoutedToFailureFlowFileExpressionKeyPut(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileNoKeySecondFlowFileExpressionKey_firstFlowFileRoutedToFailureSecondFlowFilePutUsingThinIgniteClient() throws IOException {
+        assertFlowFileNoKeyRoutedToFailureFlowFileExpressionKeyPut(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileExpressionKeySecondFlowFileNoKey_firstFlowFilePutSecondFlowFileRoutedToFailureUsingThickIgniteClient() throws IOException {
+        assertFlowFileExpressionKeyPutFlowFileNoKeyRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileExpressionKeySecondFlowFileNoKey_firstFlowFilePutSecondFlowFileRoutedToFailureUsingThinIgniteClient() throws IOException {
+        assertFlowFileExpressionKeyPutFlowFileNoKeyRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileNoKeySecondFlowFileZeroBytes_routedToFailureUsingThickIgniteClient() throws IOException {
+        assertFlowFileNoKeyFlowFileZeroBytesRoutedToFailure(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileNoKeySecondFlowFileZeroBytes_routedToFailureUsingThinIgniteClient() throws IOException {
+        assertFlowFileNoKeyFlowFileZeroBytesRoutedToFailure(ClientType.THIN);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileNoKeySecondFlowFileExpressionKeyThirdFlowFileZeroBytes_firstThirdFlowFilesRoutedToFailureSecondFlowFilePutUsingThickIgniteClient() throws IOException {
+        assertFirstFlowFileNoKeyThirdFlowFileZeroBytesRoutedToFailureSecondFlowFileExpressionKeyPut(ClientType.THICK);
+    }
+
+    @Test
+    public void putIgniteCache_firstFlowFileNoKeySecondFlowFileExpressionKeyThirdFlowFileZeroBytes_firstThirdFlowFilesRoutedToFailureSecondFlowFilePutUsingThinIgniteClient() throws IOException {
+        assertFirstFlowFileNoKeyThirdFlowFileZeroBytesRoutedToFailureSecondFlowFileExpressionKeyPut(ClientType.THIN);
+    }
+
+    private void assertOneFlowFilePlainKeyPut(final ClientType clientType) throws IOException {
+        runner = TestRunners.newTestRunner(putIgniteCache);
+        runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
+        runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
+        runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
+        runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "myKey");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
+
+        runner.assertValid();
+        runner.enqueue("test".getBytes(), properties1);
+
+        runner.run(1, false, true);
+
+        runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_SUCCESS, 1);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        assertEquals(1, successfulFlowFiles.size());
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        assertEquals(0, failureFlowFiles.size());
+
+        final MockFlowFile out = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
+        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
+        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "1");
+        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "1");
+        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
+        out.assertContentEquals("test".getBytes());
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test".getBytes(), putIgniteCache.getThickIgniteClientCache().get("myKey"));
+        } else {
+            Assert.assertArrayEquals("test".getBytes(), putIgniteCache.getThinIgniteClientCache().get("myKey"));
         }
+
+        runner.shutdown();
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationOneFlowFileWithPlainKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertOneFlowFileExpressionKeyPut(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
-        runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "mykey");
+        runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-        runner.enqueue("test".getBytes(),properties1);
+        runner.enqueue("test".getBytes(), properties1);
+
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_SUCCESS, 1);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(1, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "1");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "1");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out.assertContentEquals("test".getBytes());
-        Assert.assertArrayEquals("test".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("mykey"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test".getBytes(), putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test".getBytes(), putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
+
         runner.shutdown();
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationOneFlowFile() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertTwoFlowFilesExpressionKeysFalseAllowOverwritePutNotUpdated(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS, "1");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-        runner.enqueue("test".getBytes(),properties1);
-        runner.run(1, false, true);
+        runner.enqueue("test1".getBytes(), properties1);
+        runner.enqueue("test2".getBytes(), properties1);
 
-        runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_SUCCESS, 1);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
-        assertEquals(1, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
-        assertEquals(0, failureFlowFiles.size());
-
-        final MockFlowFile out = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
-        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
-        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "1");
-        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "1");
-        out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
-        out.assertContentEquals("test".getBytes());
-        Assert.assertArrayEquals("test".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key1"));
-        runner.shutdown();
-    }
-
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFilesAllowOverrideDefaultFalse() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
-        runner = TestRunners.newTestRunner(putIgniteCache);
-        runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
-        runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
-        runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
-        runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
-
-        runner.assertValid();
-        runner.enqueue("test1".getBytes(),properties1);
-        runner.enqueue("test2".getBytes(),properties1);
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_SUCCESS, 2);
-
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(2, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        Assert.assertEquals("test1",new String(putIgniteCache.getIgniteCache().get("key1")));
+        if (clientType.equals(ClientType.THICK)) {
+            assertEquals("test1", new String(putIgniteCache.getThickIgniteClientCache().get("key1")));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertEquals("test1", new String(putIgniteCache.getThinIgniteClientCache().get("key1")));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(1);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "2");
-
         out2.assertContentEquals("test2".getBytes());
-        Assert.assertArrayEquals("test1".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertEquals("test1", new String(putIgniteCache.getThickIgniteClientCache().get("key1")));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertEquals("test1", new String(putIgniteCache.getThinIgniteClientCache().get("key1")));
+        }
 
         runner.shutdown();
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFilesAllowOverrideTrue() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertTwoFlowFilesExpressionKeysTrueAllowOverwritePutUpdated(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
-        runner.setProperty(PutIgniteCache.DATA_STREAMER_ALLOW_OVERRIDE, "true");
+        runner.setProperty(PutIgniteCache.ALLOW_OVERWRITE, "true");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_PARALLEL_OPERATIONS, "1");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-        runner.enqueue("test1".getBytes(),properties1);
-        runner.enqueue("test2".getBytes(),properties1);
+        runner.enqueue("test1".getBytes(), properties1);
+        runner.enqueue("test2".getBytes(), properties1);
+
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_SUCCESS, 2);
-
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(2, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        Assert.assertEquals("test2",new String(putIgniteCache.getIgniteCache().get("key1")));
+        if (clientType.equals(ClientType.THICK)) {
+            assertEquals("test2", new String(putIgniteCache.getThickIgniteClientCache().get("key1")));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertEquals("test2", new String(putIgniteCache.getThinIgniteClientCache().get("key1")));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(1);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "2");
-
         out2.assertContentEquals("test2".getBytes());
-
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test2".getBytes(), putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test2".getBytes(), putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
         runner.shutdown();
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationOneFlowFileNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertOneFlowFileNoKeyRoutedToFailure(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
         properties1.clear();
-        runner.enqueue("test".getBytes(),properties1);
+        runner.enqueue("test".getBytes(), properties1);
+
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_FAILURE, 1);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(0, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "1");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "1");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
-
         out.assertContentEquals("test".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
+
         runner.shutdown();
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationOneFlowFileNoBytes() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertOneFlowFileZeroBytesRoutedToFailure(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-        runner.enqueue("".getBytes(),properties1);
+        runner.enqueue("".getBytes(), properties1);
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_FAILURE, 1);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(0, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "1");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "1");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
         out.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE);
-
         out.assertContentEquals("".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key1"));
+
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
+
         runner.shutdown();
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFiles() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertTwoFlowFilesExpressionKeysPut(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-        runner.enqueue("test1".getBytes(),properties1);
-        runner.enqueue("test2".getBytes(),properties2);
+        runner.enqueue("test1".getBytes(), properties1);
+        runner.enqueue("test2".getBytes(), properties2);
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_SUCCESS, 2);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(2, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(0, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        Assert.assertArrayEquals("test1".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test1".getBytes(), putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test1".getBytes(), putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(1);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "2");
-
         out2.assertContentEquals("test2".getBytes());
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test2".getBytes(), putIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test2".getBytes(), putIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
         runner.shutdown();
-
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFilesNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertTwoFlowFilesNoKeysRoutedToFailure(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-
         runner.enqueue("test1".getBytes());
         runner.enqueue("test2".getBytes());
+
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_FAILURE, 2);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(0, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(2, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(1);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
-
         out2.assertContentEquals("test2".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
         runner.shutdown();
-
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFileFirstNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertFlowFileNoKeyRoutedToFailureFlowFileExpressionKeyPut(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
         runner.enqueue("test1".getBytes());
-        runner.enqueue("test2".getBytes(),properties2);
+        runner.enqueue("test2".getBytes(), properties2);
+
         runner.run(1, false, true);
 
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(1, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "1");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
-
         out2.assertContentEquals("test2".getBytes());
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test2".getBytes(), putIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test2".getBytes(), putIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
         runner.shutdown();
-
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFileSecondNoKey() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertFlowFileExpressionKeyPutFlowFileNoKeyRoutedToFailure(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-
-        runner.enqueue("test1".getBytes(),properties1);
+        runner.enqueue("test1".getBytes(), properties1);
         runner.enqueue("test2".getBytes());
+
         runner.run(1, false, true);
 
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(1, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(1, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "1");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        Assert.assertArrayEquals("test1".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            Assert.assertArrayEquals("test1".getBytes(), putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            Assert.assertArrayEquals("test1".getBytes(), putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
-
         out2.assertContentEquals("test2".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key2"));
-
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
         runner.shutdown();
-
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFilesOneNoKeyOneNoBytes() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertFlowFileNoKeyFlowFileZeroBytesRoutedToFailure(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
-
         runner.enqueue("test1".getBytes());
-        runner.enqueue("".getBytes(),properties2);
+        runner.enqueue("".getBytes(), properties2);
+
         runner.run(1, false, true);
 
         runner.assertAllFlowFilesTransferred(PutIgniteCache.REL_FAILURE, 2);
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(0, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(2, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key1"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key1"));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(1);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "2");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE);
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
-
         out2.assertContentEquals("".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
         runner.shutdown();
-
     }
 
-    @Test
-    public void testPutIgniteCacheOnTriggerDefaultConfigurationTwoFlowFilesOneNoKeySecondOkThirdNoBytes() throws IOException, InterruptedException {
-        Assume.assumeTrue(preJava11);
-
+    private void assertFirstFlowFileNoKeyThirdFlowFileZeroBytesRoutedToFailureSecondFlowFileExpressionKeyPut(final ClientType clientType) throws IOException {
         runner = TestRunners.newTestRunner(putIgniteCache);
         runner.setProperty(PutIgniteCache.BATCH_SIZE, "5");
         runner.setProperty(PutIgniteCache.CACHE_NAME, CACHE_NAME);
         runner.setProperty(PutIgniteCache.DATA_STREAMER_PER_NODE_BUFFER_SIZE, "1");
         runner.setProperty(PutIgniteCache.IGNITE_CACHE_ENTRY_KEY, "${igniteKey}");
+        runner.setProperty(PutIgniteCache.IGNITE_CLIENT_TYPE, clientType.name());
 
         runner.assertValid();
         runner.enqueue("test1".getBytes());
-        runner.enqueue("test2".getBytes(),properties1);
-        runner.enqueue("".getBytes(),properties2);
+        runner.enqueue("test2".getBytes(), properties1);
+        runner.enqueue("".getBytes(), properties2);
+
         runner.run(1, false, true);
 
-        List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
+        final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS);
         assertEquals(1, successfulFlowFiles.size());
-        List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
+        final List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE);
         assertEquals(2, failureFlowFiles.size());
 
         final MockFlowFile out1 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(0);
-
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "0");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "3");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "2");
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_MISSING_KEY_MESSAGE);
         out1.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "0");
-
         out1.assertContentEquals("test1".getBytes());
-        assertEquals("test2", new String(putIgniteCache.getIgniteCache().get("key1")));
+        if (clientType.equals(ClientType.THICK)) {
+            assertEquals("test2", new String(putIgniteCache.getThickIgniteClientCache().get("key1")));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertEquals("test2", new String(putIgniteCache.getThinIgniteClientCache().get("key1")));
+        }
 
         final MockFlowFile out2 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_SUCCESS).get(0);
-
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_ITEM_NUMBER, "0");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "3");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "1");
         out2.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_SUCCESSFUL_COUNT, "1");
-
         out2.assertContentEquals("test2".getBytes());
-        Assert.assertArrayEquals("test2".getBytes(),(byte[])putIgniteCache.getIgniteCache().get("key1"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertEquals("test2", new String(putIgniteCache.getThickIgniteClientCache().get("key1")));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertEquals("test2", new String(putIgniteCache.getThinIgniteClientCache().get("key1")));
+        }
 
         final MockFlowFile out3 = runner.getFlowFilesForRelationship(PutIgniteCache.REL_FAILURE).get(1);
-
         out3.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ITEM_NUMBER, "1");
         out3.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_TOTAL_COUNT, "3");
         out3.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_COUNT, "2");
         out3.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_REASON_ATTRIBUTE_KEY, PutIgniteCache.IGNITE_BATCH_FLOW_FILE_FAILED_ZERO_SIZE_MESSAGE);
         out3.assertAttributeEquals(PutIgniteCache.IGNITE_BATCH_FLOW_FILE_ITEM_NUMBER, "2");
-
         out3.assertContentEquals("".getBytes());
-        assertNull((byte[])putIgniteCache.getIgniteCache().get("key2"));
+        if (clientType.equals(ClientType.THICK)) {
+            assertNull(putIgniteCache.getThickIgniteClientCache().get("key2"));
+        } else if (clientType.equals(ClientType.THIN)) {
+            assertNull(putIgniteCache.getThinIgniteClientCache().get("key2"));
+        }
 
         runner.shutdown();
-
     }
 }

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/resources/test-default-ignite-client.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/resources/test-default-ignite-client.xml
@@ -15,30 +15,34 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/util
-        http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <bean abstract="true" id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+    <bean abstract="true" id="thickIgniteClient" class="org.apache.ignite.configuration.IgniteConfiguration">
         <property name="peerClassLoadingEnabled" value="false"/>
-
         <property name="discoverySpi">
             <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
                 <property name="ipFinder">
                     <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
                         <property name="addresses">
                             <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
                                 <value>127.0.0.1:47500..47509</value>
                             </list>
                         </property>
                     </bean>
                 </property>
             </bean>
+        </property>
+    </bean>
+
+    <bean abstract="true" id="thinIgniteClient" class="org.apache.ignite.configuration.ClientConfiguration">
+        <property name="addresses">
+            <list>
+                <value>127.0.0.1:10800</value>
+            </list>
         </property>
     </bean>
 </beans>

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/resources/test-ignite-client.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/test/resources/test-ignite-client.xml
@@ -15,12 +15,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
     <!-- Imports default Ignite configuration -->
-    <import resource="test-default.xml"/>
+    <import resource="test-default-ignite-client.xml"/>
 
-    <bean parent="ignite.cfg"/>
+    <bean parent="thickIgniteClient"/>
+    <bean parent="thinIgniteClient"/>
 </beans>


### PR DESCRIPTION
#### Description of PR

The current implementation of the Ignite processors forces one to make use of the Thick Ignite client. This may be problematic in cases where Ignite resides within a Kubernetes cluster while NiFi is outside of the Kubernetes cluster. Also, it may be the case that for certain scenarios the thin Ignite client might be a better fit than the thick Ignite client.
 
With this feature the possibility of choosing between the two clients will be allowed.

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? 

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [X] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?