### PR TITLE
NIFI-7463 - Write empty flowfile for RunMongoAggregation empty results

### DIFF
--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
@@ -70,11 +70,6 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
             .description("The result set of the aggregation will be sent to this relationship.")
             .name("results")
             .build();
-    static final Relationship REL_EMPTY = new Relationship.Builder()
-            .description("If the result of aggregation if empty an empty flowfile will be sent to this relationship.")
-            .name("empty")
-            .autoTerminateDefault(true)
-            .build();
 
     static final List<Bson> buildAggregationQuery(String query) throws IOException {
         List<Bson> result = new ArrayList<>();
@@ -126,7 +121,6 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
 
         final Set<Relationship> _relationships = new HashSet<>();
         _relationships.add(REL_RESULTS);
-        _relationships.add(REL_EMPTY);
         _relationships.add(REL_ORIGINAL);
         _relationships.add(REL_FAILURE);
         relationships = Collections.unmodifiableSet(_relationships);
@@ -204,8 +198,8 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
                 // Something remains in batch list, write it to RESULT
                 writeBatch(buildBatch(batch), flowFile, context, session, attrs, REL_RESULTS);
             } else if (! doneSomething) {
-                // The batch list is empty and no batch was written (empty result!), so write it to EMPTY
-                writeBatch("", flowFile, context, session, attrs, REL_EMPTY);
+                // The batch list is empty and no batch was written (empty result!), so write empty string to RESULT
+                writeBatch("", flowFile, context, session, attrs, REL_RESULTS);
             }
 
             if (flowFile != null) {

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
@@ -70,6 +70,10 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
             .description("The result set of the aggregation will be sent to this relationship.")
             .name("results")
             .build();
+    static final Relationship REL_EMPTY = new Relationship.Builder()
+            .description("If the result of aggregation if empty an empty flowfile will be sent to this relationship.")
+            .name("empty")
+            .build();
 
     static final List<Bson> buildAggregationQuery(String query) throws IOException {
         List<Bson> result = new ArrayList<>();
@@ -121,6 +125,7 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
 
         final Set<Relationship> _relationships = new HashSet<>();
         _relationships.add(REL_RESULTS);
+        _relationships.add(REL_EMPTY);
         _relationships.add(REL_ORIGINAL);
         _relationships.add(REL_FAILURE);
         relationships = Collections.unmodifiableSet(_relationships);
@@ -194,6 +199,8 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
 
             if (batch.size() > 0) {
                 writeBatch(buildBatch(batch), flowFile, context, session, attrs, REL_RESULTS);
+            } else {
+                writeBatch("", flowFile, context, session, attrs, REL_EMPTY);
             }
 
             if (flowFile != null) {

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/RunMongoAggregationIT.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/RunMongoAggregationIT.java
@@ -43,8 +43,7 @@ import java.util.Map;
 
 public class RunMongoAggregationIT {
 
-    //private static final String MONGO_URI = "mongodb://localhost";
-    private static final String MONGO_URI = "mongodb://192.168.25.80";
+    private static final String MONGO_URI = "mongodb://localhost";
     private static final String DB_NAME   = String.format("agg_test-%s", Calendar.getInstance().getTimeInMillis());
     private static final String COLLECTION_NAME = "agg_test_data";
     private static final String AGG_ATTR = "mongo.aggregation.query";

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/RunMongoAggregationIT.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/RunMongoAggregationIT.java
@@ -263,4 +263,32 @@ public class RunMongoAggregationIT {
 
         runner.assertTransferCount(RunMongoAggregation.REL_RESULTS, mappings.size());
     }
+
+    @Test
+    public void testEmptyResponseRel() throws Exception {
+        final String queryInput = "[\n" +
+                "  {\n" +
+                "    \"$match\": {\n" +
+                "      \"val\": \"no_exists\"\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"$group\": {\n" +
+                "      \"_id\": \"null\",\n" +
+                "      \"doc_count\": {\n" +
+                "        \"$sum\": 1\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "]";
+
+        runner.setProperty(RunMongoAggregation.QUERY, queryInput);
+        runner.enqueue("test");
+        runner.run(1, true, true);
+
+        runner.assertTransferCount(RunMongoAggregation.REL_ORIGINAL, 1);
+        runner.assertTransferCount(RunMongoAggregation.REL_FAILURE, 0);
+        runner.assertTransferCount(RunMongoAggregation.REL_RESULTS, 0);
+        runner.assertTransferCount(RunMongoAggregation.REL_EMPTY, 1);
+    }
 }

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/RunMongoAggregationIT.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/RunMongoAggregationIT.java
@@ -43,7 +43,8 @@ import java.util.Map;
 
 public class RunMongoAggregationIT {
 
-    private static final String MONGO_URI = "mongodb://localhost";
+    //private static final String MONGO_URI = "mongodb://localhost";
+    private static final String MONGO_URI = "mongodb://192.168.25.80";
     private static final String DB_NAME   = String.format("agg_test-%s", Calendar.getInstance().getTimeInMillis());
     private static final String COLLECTION_NAME = "agg_test_data";
     private static final String AGG_ATTR = "mongo.aggregation.query";
@@ -265,7 +266,7 @@ public class RunMongoAggregationIT {
     }
 
     @Test
-    public void testEmptyResponseRel() throws Exception {
+    public void testEmptyResponse() throws Exception {
         final String queryInput = "[\n" +
                 "  {\n" +
                 "    \"$match\": {\n" +
@@ -288,7 +289,6 @@ public class RunMongoAggregationIT {
 
         runner.assertTransferCount(RunMongoAggregation.REL_ORIGINAL, 1);
         runner.assertTransferCount(RunMongoAggregation.REL_FAILURE, 0);
-        runner.assertTransferCount(RunMongoAggregation.REL_RESULTS, 0);
-        runner.assertTransferCount(RunMongoAggregation.REL_EMPTY, 1);
+        runner.assertTransferCount(RunMongoAggregation.REL_RESULTS, 1);
     }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

In RunMongoAggregation processor, when the aggregation returns no value the processor only returns the original flowfile in its relationship. In this case we have to create an auxiliary flow to handle each case. This PR creates an "empty" relationship, sending to it a empty flowfile if the aggragations result is empty as well.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on both JDK 8 and JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
