### PR TITLE
NIFI-7498 Adding unique prefix to every swagger operationId

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>com.github.kongchen</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>3.1.5</version>
+                <version>3.1.8</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>
@@ -97,7 +97,9 @@
                                     </info>
                                     <templatePath>classpath:/templates/index.html.hbs</templatePath>
                                     <outputPath>${project.build.directory}/${project.artifactId}-${project.version}/docs/rest-api/index.html</outputPath>
+                                    <outputFormats>json</outputFormats>
                                     <swaggerDirectory>${project.build.directory}/swagger-ui</swaggerDirectory>
+                                    <operationIdFormat>{{packageName}}.{{className}}_{{methodName}}</operationIdFormat>
                                 </apiSource>
                             </apiSources>
                         </configuration>


### PR DESCRIPTION
#### Description of PR

Adds a prefix consisting of package and class name to every operationId to ensure it is unique.
The problem this fixes is desribed in [NIFI-7498](https://issues.apache.org/jira/browse/NIFI-7498).

The prefix can be excluded in the method name when generating a client by using the flag _--remove-operation-id-prefix_ (both openapi-generator and swagger-codegen).

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?
- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 