### PR TITLE
NIFI-7500 Update nf-context-menu.js for an intuitive road to parameters

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
@@ -103,6 +103,29 @@
         return false;
     };
 
+     /**
+     * Determines whether the component in the specified selection has the potential of a parameter context but none yet.
+     *
+     * @param {selection} selection         The selection of currently selected components
+     */
+    var hasParameterContextPotential = function (selection) {
+        var parameterContext;
+        if (selection.empty()) {
+            if (nfCommon.isDefinedAndNotNull(parameterContext)) {
+            	return false
+        	}
+            return true
+        } else if (nfCanvasUtils.isProcessGroup(selection)) {
+            var pg = selection.datum();
+            parameterContext = pg.parameterContext;
+            if (nfCommon.isDefinedAndNotNull(parameterContext)) {
+            	return false
+        	}
+        	return true
+        }
+        return false
+    };    
+    
     /**
      * Determines whether the component in the specified selection has configuration details.
      *
@@ -784,6 +807,7 @@
         {id: 'leave-group-menu-item', condition: isNotRootGroup, menuItem: {clazz: 'fa fa-level-up', text: 'Leave group', action: 'leaveGroup'}},
         {separator: true},
         {id: 'show-configuration-menu-item', condition: isConfigurable, menuItem: {clazz: 'fa fa-gear', text: 'Configure', action: 'showConfiguration'}},
+        {id: 'show-configuration-menu-item2', condition: hasParameterContextPotential, menuItem: {clazz: 'fa fa-gear', text: 'Configure Parameter Context', action: 'showConfiguration'}},
         {id: 'show-details-menu-item', condition: hasDetails, menuItem: {clazz: 'fa fa-gear', text: 'View configuration', action: 'showDetails'}},
         {id: 'parameters-menu-item', condition: hasParameterContext, menuItem: {clazz: 'fa', text: 'Parameters', action: 'openParameterContext'}},
         {id: 'variable-registry-menu-item', condition: hasVariables, menuItem: {clazz: 'fa', text: 'Variables', action: 'openVariableRegistry'}},


### PR DESCRIPTION
When rightclicking a process group the variables are shown, but parameters are not. This makes sense as they have a prerequisite, in the form of a parameter context. This change gives a more consistent experience for finding the functionality regarding parameters by ensuring the contextmenu shows the possibility to configure a parameter context. Once the paramater context has been created for a process group, the parameters text shows, so this is no longer visible. People would then need to click configure to change the context, just as they would be required to do now.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

When rightclicking a process group the variables are shown, but parameters are not. This makes sense as they have a prerequisite, in the form of a parameter context. This change gives a more consistent experience for finding the functionality regarding parameters by ensuring the contextmenu shows the possibility to configure a parameter context. Once the paramater context has been created for a process group, the parameters text shows, so this is no longer visible. People would then need to click configure to change the context, just as they would be required to do now.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?
NIFI-7500
- [x ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
Executed , there was a faillure in nifi-standard-processors but this should be independent of the change proposed. After continuing from nifi-framework-nar this part (which was actually changed) passed the tests succesfully, later other faillures occured in the unrelated nifi-email-processors
- [ ] Have you written or updated unit tests to verify your changes?
- [x ] Have you verified that the full build is successful on JDK 8?
Build succesfull on JDK 8
- [ ] Have you verified that the full build is successful on JDK 11?
- [ x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
No additional dependencies
- [x ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
No impact on license
- [ x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
No impact on notice
- [x ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?
No new properties

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
