### PR TITLE
NIFI-7508: Reset classloader after running TestStandardControllerServiceInvocationHandler

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceInvocationHandler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceInvocationHandler.java
@@ -20,6 +20,7 @@ package org.apache.nifi.controller.service;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.nar.ExtensionManager;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -35,11 +36,20 @@ import static org.junit.Assert.assertTrue;
 
 public class TestStandardControllerServiceInvocationHandler {
 
+    private ClassLoader originalClassLoader;
+
     @Before
-    public void setClassLoader() {
+    public void setEmptyClassLoader() {
+        this.originalClassLoader = Thread.currentThread().getContextClassLoader();
+
         // Change context class loader to a new, empty class loader so that calls to Controller Service will need to proxy returned objects.
         final URLClassLoader classLoader = new URLClassLoader(new URL[] {}, null);
         Thread.currentThread().setContextClassLoader(classLoader);
+    }
+
+    @After
+    public void setOriginalClassLoaderBack() {
+        if (originalClassLoader != null) Thread.currentThread().setContextClassLoader(originalClassLoader);
     }
 
     @Test

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.regex.Matcher;


### PR DESCRIPTION
This PR resets the classloader after running `TestStandardControllerServiceInvocationHandler` in nifi-framework-core and fixes a checkstyle violation on `NiFiSystemIT`. The classloader reset is to correct build failures on Java 11 that occur depending on the order the tests run in. See the JIRA for the details.

- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?