### PR TITLE
NIFI-7514: Ensure groupId is set accordingly

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -2157,7 +2157,8 @@
         },
 
         /**
-         * Sets the current group id.
+         * Sets the current group id. This is used to indicate where inline Controller Services are created
+         * and to obtain the parameter context.
          */
         setGroupId: function (currentGroupId) {
             return this.each(function () {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1246,6 +1246,17 @@
     };
 
     var initPropertiesTable = function (table, options) {
+        // function for closing the dialog
+        var closeDialog = function () {
+            // close the dialog
+            var dialog = table.closest('.dialog');
+            if (dialog.hasClass('modal')) {
+                dialog.modal('hide');
+            } else {
+                dialog.hide();
+            }
+        }
+
         // function for formatting the property name
         var nameFormatter = function (row, cell, value, columnDef, dataContext) {
             var nameWidthOffset = 30;
@@ -1386,7 +1397,7 @@
             }
 
             if (referencesParam && canReadParamContext) {
-                markup += '<div title="Go to parameter" class="goto-to-parameter pointer fa fa-long-arrow-right"></div>';
+                markup += '<div title="Go to parameter" class="go-to-parameter pointer fa fa-long-arrow-right"></div>';
             }
 
             if (options.readOnly !== true) {
@@ -1510,12 +1521,7 @@
                 dataType: 'json'
             }).done(function (controllerServiceEntity) {
                 // close the dialog
-                var dialog = table.closest('.dialog');
-                if (dialog.hasClass('modal')) {
-                    dialog.modal('hide');
-                } else {
-                    dialog.hide();
-                }
+                closeDialog();
 
                 var controllerService = controllerServiceEntity.component;
                 $.Deferred(function (deferred) {
@@ -1616,7 +1622,7 @@
                                 propertyData.updateItem(property.id, updatedItem);
                             });
                     }
-                } else if (target.hasClass('goto-to-parameter')) {
+                } else if (target.hasClass('go-to-parameter')) {
                     var parameterContext;
                     if (_.isFunction(options.getParameterContext)) {
                         parameterContext = options.getParameterContext(groupId);
@@ -1627,6 +1633,9 @@
                             var paramRefsRegex = /#{([a-zA-Z0-9-_. ]+)}/;
                             var result = property.value.match(paramRefsRegex);
                             if (!_.isEmpty(result) && result.length === 2) {
+                                // close the dialog since we are sending the user to the parameter context
+                                closeDialog();
+
                                 var parameterName = result[1];
                                 nfParameterContexts.showParameterContext(parameterContext.id, null, parameterName);
                             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
@@ -1589,8 +1589,8 @@
         }).promise();
     };
 
-    var getParameterContext = function (groupId, controllerServiceEntity) {
-        if (_.isNil(controllerServiceEntity.parentGroupId)) {
+    var getParameterContext = function (groupId) {
+        if (_.isNil(groupId)) {
             return null;
         }
 
@@ -1598,7 +1598,7 @@
 
         // attempt to identify the parameter context, conditional based on whether
         // the user is configuring the current process group
-        if (_.isNil(groupId) || groupId === nfCanvasUtils.getGroupId()) {
+        if (groupId === nfCanvasUtils.getGroupId()) {
             parameterContext = nfCanvasUtils.getParameterContext();
         } else {
             var parentProcessGroup = nfCanvasUtils.getComponentByType('ProcessGroup').get(groupId);
@@ -1896,7 +1896,7 @@
                         return goToServiceFromProperty(serviceTable);
                     },
                     getParameterContext: function (groupId) {
-                        return getParameterContext(groupId, controllerServiceEntity);
+                        return getParameterContext(groupId);
                     }
                 });
 
@@ -2083,7 +2083,7 @@
                     supportsGoTo: true,
                     readOnly: true,
                     getParameterContext: function (groupId) {
-                        return getParameterContext(groupId, controllerServiceEntity);
+                        return getParameterContext(groupId);
                     }
                 });
 
@@ -2185,7 +2185,9 @@
                 controllerServiceDialog.modal('setButtonModel', buttons);
 
                 // load the property table
-                $('#controller-service-properties').propertytable('loadProperties', controllerService.properties, controllerService.descriptors, controllerServiceHistory.propertyHistory);
+                $('#controller-service-properties')
+                    .propertytable('setGroupId', controllerService.parentGroupId)
+                    .propertytable('loadProperties', controllerService.properties, controllerService.descriptors, controllerServiceHistory.propertyHistory);
 
                 // show the details
                 controllerServiceDialog.modal('show');

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
@@ -601,7 +601,7 @@
 
                 // load the property table
                 $('#reporting-task-properties')
-                    .propertytable('setGroupId', reportingTask.parentGroupId)
+                    .propertytable('setGroupId', null)
                     .propertytable('loadProperties', reportingTask.properties, reportingTask.descriptors, reportingTaskHistory.propertyHistory);
 
                 // show the details
@@ -721,7 +721,9 @@
                 reportingTaskDialog.modal('setButtonModel', buttons).modal('show');
 
                 // load the property table
-                $('#reporting-task-properties').propertytable('loadProperties', reportingTask.properties, reportingTask.descriptors, reportingTaskHistory.propertyHistory);
+                $('#reporting-task-properties')
+                    .propertytable('setGroupId', null)
+                    .propertytable('loadProperties', reportingTask.properties, reportingTask.descriptors, reportingTaskHistory.propertyHistory);
 
                 // show the details
                 reportingTaskDialog.modal('show');

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
@@ -174,13 +174,13 @@
             }
 
             // initialize the properties
-            
+
             $('#read-only-processor-properties').propertytable(Object.assign({
                     supportsGoTo: config.supportsGoTo,
                     readOnly: true
-                }, 
+                },
                 //incase of summary window, nfCanvasUtils module wont be loaded
-                nfCanvasUtils && { 
+                nfCanvasUtils && {
                     getParameterContext: function (groupId) {
                         // processors being configured must be in the current group
                         return nfCanvasUtils.getParameterContext();
@@ -289,7 +289,9 @@
                 var selection;
 
                 // load the properties
-                $('#read-only-processor-properties').propertytable('loadProperties', processor.config.properties, processor.config.descriptors, history.propertyHistory);
+                $('#read-only-processor-properties')
+                    .propertytable('setGroupId', processor.parentGroupId)
+                    .propertytable('loadProperties', processor.config.properties, processor.config.descriptors, history.propertyHistory);
 
                 var buttons = [{
                     buttonText: 'Ok',


### PR DESCRIPTION
NIFI-7514:
- Ensuring the group id is always set in the properties table when loading properties.
- Using a common approach to getting parameters in nfControllerService.
- Code clean up.