### PR TITLE
NIFI-6128 UnpackContent: Store unpacked file data

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -109,6 +111,11 @@ public class UnpackContent extends AbstractProcessor {
     public static final String FLOWFILE_TAR_FORMAT_NAME = "flowfile-tar-v1";
 
     public static final String OCTET_STREAM = "application/octet-stream";
+
+    public static final String FILE_INNER_PERMISSION = "file.inner.permission";
+    public static final String FILE_INNER_OWNER = "file.inner.owner";
+    public static final String FILE_INNER_GROUP = "file.inner.group";
+    public static final String FILE_INNER_LAST_MODIFIED_TIME = "file.inner.lastModifiedTime";
 
     public static final PropertyDescriptor PACKAGING_FORMAT = new PropertyDescriptor.Builder()
             .name("Packaging Format")
@@ -320,6 +327,15 @@ public class UnpackContent extends AbstractProcessor {
                                 attributes.put(CoreAttributes.PATH.key(), filePathString);
                                 attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), absPathString);
                                 attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
+
+                                attributes.put(FILE_INNER_PERMISSION, String.valueOf(tarEntry.getMode()));
+                                attributes.put(FILE_INNER_OWNER, String.valueOf(tarEntry.getUserName()));
+                                attributes.put(FILE_INNER_GROUP, String.valueOf(tarEntry.getGroupName()));
+
+                                String timePattern = "yyyy-MM-dd'T'HH:mm:ssZ";
+                                DateFormat df = new SimpleDateFormat(timePattern);
+                                String timeAsString = df.format(tarEntry.getModTime());
+                                attributes.put(FILE_INNER_LAST_MODIFIED_TIME, timeAsString);
 
                                 attributes.put(FRAGMENT_ID, fragmentId);
                                 attributes.put(FRAGMENT_INDEX, String.valueOf(++fragmentCount));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -96,8 +96,7 @@ import org.apache.nifi.util.FlowFileUnpackagerV3;
     @WritesAttribute(attribute = "fragment.count", description = "The number of unpacked FlowFiles generated from the parent FlowFile"),
     @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile. Extensions of .tar, .zip or .pkg are removed because "
             + "the MergeContent processor automatically adds those extensions if it is used to rebuild the original FlowFile"),
-    @WritesAttribute(attribute = "file.lastModifiedTime", description = "The date and time that the unpacked file was last modified (tar only)."
-            + "file systems"),
+    @WritesAttribute(attribute = "file.lastModifiedTime", description = "The date and time that the unpacked file was last modified (tar only)."),
     @WritesAttribute(attribute = "file.owner", description = "The owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = "file.group", description = "The group owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the unpacked file (tar only)")})

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -97,6 +97,7 @@ import org.apache.nifi.util.FlowFileUnpackagerV3;
     @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile. Extensions of .tar, .zip or .pkg are removed because "
             + "the MergeContent processor automatically adds those extensions if it is used to rebuild the original FlowFile"),
     @WritesAttribute(attribute = "file.lastModifiedTime", description = "The date and time that the unpacked file was last modified (tar only)."),
+    @WritesAttribute(attribute = "file.creationTime", description = "The date and time that the file was created. This attribute holds always the same value as file.lastModifiedTime (tar only)."),
     @WritesAttribute(attribute = "file.owner", description = "The owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = "file.group", description = "The group owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the unpacked file (tar only)")})
@@ -118,6 +119,7 @@ public class UnpackContent extends AbstractProcessor {
     public static final String OCTET_STREAM = "application/octet-stream";
 
     public static final String FILE_LAST_MODIFIED_TIME_ATTRIBUTE = "file.lastModifiedTime";
+    public static final String FILE_CREATION_TIME_ATTRIBUTE = "file.creationTime";
     public static final String FILE_OWNER_ATTRIBUTE = "file.owner";
     public static final String FILE_GROUP_ATTRIBUTE = "file.group";
     public static final String FILE_PERMISSIONS_ATTRIBUTE = "file.permissions";
@@ -343,6 +345,7 @@ public class UnpackContent extends AbstractProcessor {
 
                                 final String timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getModTime().toInstant());
                                 attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
+                                attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
 
                                 attributes.put(FRAGMENT_ID, fragmentId);
                                 attributes.put(FRAGMENT_INDEX, String.valueOf(++fragmentCount));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileInfo.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileInfo.java
@@ -44,6 +44,8 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
     private static final String OWNER = "owner";
     private static final String GROUP = "group";
 
+    private static final char[] PERMISSION_MODIFIER_CHARS = "xwrxwrxwr".toCharArray();
+
     static {
         final List<RecordField> recordFields = new ArrayList<>();
         recordFields.add(new RecordField(FILENAME, RecordFieldType.STRING.getDataType(), false));
@@ -219,12 +221,11 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
 
     public static String permissionToString(int fileModeOctal) {
         if (fileModeOctal > 0777 || fileModeOctal < 00) {
-            throw new RuntimeException("Invalid permission numerals");
+            throw new IllegalArgumentException("Invalid permission numerals");
         }
-        final char[] PERM = "xwrxwrxwr".toCharArray();
 
         StringBuilder sb = new StringBuilder();
-        for (char p : PERM) {
+        for (char p : PERMISSION_MODIFIER_CHARS) {
             sb.append((fileModeOctal & 1) == 1 ? p : '-');
             fileModeOctal >>= 1;
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileInfo.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileInfo.java
@@ -217,6 +217,20 @@ public class FileInfo implements Comparable<FileInfo>, Serializable, ListableEnt
         }
     }
 
+    public static String permissionToString(int fileModeOctal) {
+        if (fileModeOctal > 0777 || fileModeOctal < 00) {
+            throw new RuntimeException("Invalid permission numerals");
+        }
+        final char[] PERM = "xwrxwrxwr".toCharArray();
+
+        StringBuilder sb = new StringBuilder();
+        for (char p : PERM) {
+            sb.append((fileModeOctal & 1) == 1 ? p : '-');
+            fileModeOctal >>= 1;
+        }
+        return sb.reverse().toString();
+    }
+
     @Override
     public String getName() {
         return getFileName();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -81,9 +81,15 @@ public class TestUnpackContent {
             assertEquals("rw-r--r--", flowFile.getAttribute("file.permissions"));
             assertEquals("jmcarey", flowFile.getAttribute("file.owner"));
             assertEquals("mkpasswd", flowFile.getAttribute("file.group"));
-            String timeAsString = flowFile.getAttribute("file.lastModifiedTime");
+            String modifiedTimeAsString = flowFile.getAttribute("file.lastModifiedTime");
             try {
-                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(timeAsString);
+                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(modifiedTimeAsString);
+            } catch (DateTimeParseException e) {
+                fail();
+            }
+            String creationTimeAsString = flowFile.getAttribute("file.creationTime");
+            try {
+                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(creationTimeAsString);
             } catch (DateTimeParseException e) {
                 fail();
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -70,10 +70,14 @@ public class TestUnpackContent {
         autoUnpackRunner.assertTransferCount(UnpackContent.REL_FAILURE, 0);
 
         final List<MockFlowFile> unpacked = unpackRunner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
+
         for (final MockFlowFile flowFile : unpacked) {
             final String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
             final String folder = flowFile.getAttribute(CoreAttributes.PATH.key());
             final Path path = dataPath.resolve(folder).resolve(filename);
+            assertEquals(flowFile.getAttribute("file.inner.permission"),"420");
+            assertEquals("jmcarey", flowFile.getAttribute("file.inner.owner"));
+            assertEquals("mkpasswd", flowFile.getAttribute("file.inner.group"));
             assertTrue(Files.exists(path));
 
             flowFile.assertContentEquals(path.toFile());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,13 +78,13 @@ public class TestUnpackContent {
             final String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
             final String folder = flowFile.getAttribute(CoreAttributes.PATH.key());
             final Path path = dataPath.resolve(folder).resolve(filename);
-            assertEquals(flowFile.getAttribute("file.inner.permission"),"420");
-            assertEquals("jmcarey", flowFile.getAttribute("file.inner.owner"));
-            assertEquals("mkpasswd", flowFile.getAttribute("file.inner.group"));
-            String timeAsString = flowFile.getAttribute("file.inner.lastModifiedTime");
+            assertEquals("rw-r--r--", flowFile.getAttribute("file.permissions"));
+            assertEquals("jmcarey", flowFile.getAttribute("file.owner"));
+            assertEquals("mkpasswd", flowFile.getAttribute("file.group"));
+            String timeAsString = flowFile.getAttribute("file.lastModifiedTime");
             try {
-                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(timeAsString);
-            } catch (ParseException e) {
+                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(timeAsString);
+            } catch (DateTimeParseException e) {
                 fail();
             }
             assertTrue(Files.exists(path));

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -20,11 +20,14 @@ import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_COUNT;
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +81,12 @@ public class TestUnpackContent {
             assertEquals(flowFile.getAttribute("file.inner.permission"),"420");
             assertEquals("jmcarey", flowFile.getAttribute("file.inner.owner"));
             assertEquals("mkpasswd", flowFile.getAttribute("file.inner.group"));
+            String timeAsString = flowFile.getAttribute("file.inner.lastModifiedTime");
+            try {
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(timeAsString);
+            } catch (ParseException e) {
+                fail();
+            }
             assertTrue(Files.exists(path));
 
             flowFile.assertContentEquals(path.toFile());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestFileInfo.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestFileInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.standard.util;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TestFileInfo {
+
+    @Test
+    public void testPermissionModeToString() {
+        String rwxPerm = FileInfo.permissionToString(0567);
+        assertEquals("r-xrw-rwx", rwxPerm);
+
+        rwxPerm = FileInfo.permissionToString(03);
+        assertEquals("-------wx", rwxPerm);
+
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPermissionModeToStringInvalidFourDigits() {
+        FileInfo.permissionToString(01000);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPermissionModeToStringInvalidNegative() {
+        FileInfo.permissionToString(-1);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestFileInfo.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestFileInfo.java
@@ -32,12 +32,12 @@ public class TestFileInfo {
 
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testPermissionModeToStringInvalidFourDigits() {
         FileInfo.permissionToString(01000);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testPermissionModeToStringInvalidNegative() {
         FileInfo.permissionToString(-1);
     }


### PR DESCRIPTION
Tar format allows us to archive files with their original permission,
owner, group name and last modification time.

When unpacking with Tar unpacker, these information are stored in new
attributes with names: "file.inner.\*". This way, it preserves backward
compatibility when using parallel with GetFile processor (which stores
information in "file.\*").

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
