### PR TITLE
NIFI-7600 - Defining JMS attribute types breaks due to invalid charac…

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
@@ -108,6 +108,13 @@ final class JMSPublisher extends JMSWorker {
                         }
                     } else {
                         // not a special attribute handled above, so send it as a property using the specified property type
+                        String key=entry.getKey();
+                        if (key.endsWith(".type")){
+                            if (flowFileAttributes.containsKey(key.substring(0,key.length()-".type".length()))){
+                                // this attribute name is metadata that defines a type for another attribute, we dont add it to the jms record
+                                continue;
+                            }
+                        }
                         String type = flowFileAttributes.getOrDefault(entry.getKey().concat(".type"), "unknown").toLowerCase();
                         propertySetterMap.getOrDefault(type, JmsPropertySetterEnum.STRING)
                                 .setProperty(message, entry.getKey(), entry.getValue());


### PR DESCRIPTION
…ters

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

fixes bug NIFI-7600. _
Removed '.type' attributes being added to JMS properties. These attributes act only as meta data and cause JMS Exceptions as they contain invalid characters (e.g. the dot)

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [YES  ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ NO] Have you written or updated unit tests to verify your changes?
- [ YES] Have you verified that the full build is successful on JDK 8?
- [ YES] Have you verified that the full build is successful on JDK 11?
- [ N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ N/A] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ N/A] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ N/A] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
