### PR TITLE
NIFI-7255 Cleaning up obsolete nodes when connecting to cluster

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/ClusterCoordinator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/ClusterCoordinator.java
@@ -111,9 +111,9 @@ public interface ClusterCoordinator {
      * Removes the given disconnected node from the cluster
      *
      * @param nodeId the node to remove
-     * @param userDn the DN of the user requesting that the node be removed
+     * @param event the reason for the node to be removed
      */
-    void removeNode(NodeIdentifier nodeId, String userDn);
+    void removeNode(NodeIdentifier nodeId, String event);
 
     /**
      * Returns the current status of the node with the given identifier

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
@@ -82,6 +82,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -574,8 +575,8 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
     }
 
     @Override
-    public void removeNode(final NodeIdentifier nodeId, final String userDn) {
-        reportEvent(nodeId, Severity.INFO, "User " + userDn + " requested that node be removed from cluster");
+    public void removeNode(final NodeIdentifier nodeId, final String event) {
+        reportEvent(nodeId, Severity.INFO, event);
         notifyOthersOfNodeStatusChange(new NodeConnectionStatus(nodeId, NodeConnectionState.REMOVED));
         removeNode(nodeId);
 
@@ -1157,6 +1158,10 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
         // Resolve Node identifier.
         registerNodeId(nodeIdentifier);
 
+        // Remove obsolete identifier. In case the node's identifier has changed, after restart the obsolete version remains in the
+        // local storage in DISCONNECTED state. This prevents cluster members from properly syncing. The obsolete nodes must be removed.
+        removeObsoleteNodeVersion(nodeIdentifier);
+
         if (isBlockedByFirewall(nodeIdentities)) {
             // if the socket address is not listed in the firewall, then return a null response
             logger.info("Firewall blocked connection request from node " + nodeIdentifier + " with Node Identities " + nodeIdentities);
@@ -1180,6 +1185,21 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
         logger.info("Received Connection Request from {}; responding with my DataFlow", withNodeIdentities);
         return createConnectionResponse(requestWithNodeIdentities, nodeIdentifier);
     }
+
+    private void removeObsoleteNodeVersion(final NodeIdentifier resolvedNodeId) {
+        // The identification of the change is depending on the full description. Equation of the class id defined by using ID.
+        final Optional<NodeIdentifier> candidate = nodeStatuses.values()
+                .stream()
+                .map(s -> s.getNodeIdentifier())
+                .filter(i -> resolvedNodeId.getId().equals(i.getId()) && !resolvedNodeId.getFullDescription().equals(i.getFullDescription()))
+                .findFirst();
+
+        if (candidate.isPresent()) {
+            logger.warn("Node {} is removed due to it is an obsolete version of a joining node", candidate.get().getFullDescription());
+            removeNode(candidate.get());
+        }
+    }
+
 
     private ConnectionResponseMessage createFlowElectionInProgressResponse() {
         final ConnectionResponseMessage responseMessage = new ConnectionResponseMessage();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -5485,7 +5485,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                     " because it is not disconnected or offloaded, current state = " + nodeConnectionStatus.getState());
         }
 
-        clusterCoordinator.removeNode(nodeIdentifier, userDn);
+        clusterCoordinator.removeNode(nodeIdentifier, "User " + userDn + " requested that node be removed from cluster");
         heartbeatMonitor.removeHeartbeat(nodeIdentifier);
     }
 


### PR DESCRIPTION
[NIFI-7255](https://issues.apache.org/jira/browse/NIFI-7255)

Problem statement: In case the connection details of a node changes in a NiFi cluster and restarted, it might occur that the nodes with the old parameters remain in the "node list" of the nodes combined with the new version, thus duplicating the nodes. This results unreachable nodes and fail of replication in the end.

Solution proposal: both the node coordinator needs to clean up obsolete nodes, both the other nodes. This happens with comparing existing information from the local storage and incoming information from connection messages. As the id remains during these property changes that is considered as the key of comparison. Note: due to the equals method of the NodeIdentifier is based on only the id, that was not satisfying for check changes. I went with comparing getFullDescription as changing the equals would affect behaviour outside of this fix.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
