### PR TITLE
NIFI-7429 Adding status history for system level metrics

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/NodeStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/NodeStatus.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.status;
+
+/**
+ * The status of a NiFi node.
+ */
+public class NodeStatus implements Cloneable {
+    private long createdAtInMs;
+
+    private long freeHeap;
+    private long usedHeap;
+    private long heapUtilization;
+    private long freeNonHeap;
+    private long usedNonHeap;
+
+    private long openFileHandlers;
+    private double processorLoadAverage;
+    private long uptime;
+    private long totalThreads;
+
+    private long flowFileRepositoryFreeSpace;
+    private long flowFileRepositoryUsedSpace;
+
+    private long contentRepositoryFreeSpace;
+    private long contentRepositoryUsedSpace;
+
+    private long provenanceRepositoryFreeSpace;
+    private long provenanceRepositoryUsedSpace;
+
+    public long getCreatedAtInMs() {
+        return createdAtInMs;
+    }
+
+    public void setCreatedAtInMs(final long createdAtInMs) {
+        this.createdAtInMs = createdAtInMs;
+    }
+
+    public long getFreeHeap() {
+        return freeHeap;
+    }
+
+    public void setFreeHeap(final long freeHeap) {
+        this.freeHeap = freeHeap;
+    }
+
+    public long getUsedHeap() {
+        return usedHeap;
+    }
+
+    public void setUsedHeap(final long usedHeap) {
+        this.usedHeap = usedHeap;
+    }
+
+    public long getHeapUtilization() {
+        return heapUtilization;
+    }
+
+    public void setHeapUtilization(final long heapUtilization) {
+        this.heapUtilization = heapUtilization;
+    }
+
+    public long getFreeNonHeap() {
+        return freeNonHeap;
+    }
+
+    public void setFreeNonHeap(final long freeNonHeap) {
+        this.freeNonHeap = freeNonHeap;
+    }
+
+    public long getUsedNonHeap() {
+        return usedNonHeap;
+    }
+
+    public void setUsedNonHeap(final long usedNonHeap) {
+        this.usedNonHeap = usedNonHeap;
+    }
+
+    public long getOpenFileHandlers() {
+        return openFileHandlers;
+    }
+
+    public void setOpenFileHandlers(final long openFileHandlers) {
+        this.openFileHandlers = openFileHandlers;
+    }
+
+    public double getProcessorLoadAverage() {
+        return processorLoadAverage;
+    }
+
+    public void setProcessorLoadAverage(final double processorLoadAverage) {
+        this.processorLoadAverage = processorLoadAverage;
+    }
+
+    public long getUptime() {
+        return uptime;
+    }
+
+    public void setUptime(final long uptime) {
+        this.uptime = uptime;
+    }
+
+    public long getTotalThreads() {
+        return totalThreads;
+    }
+
+    public void setTotalThreads(final long totalThreads) {
+        this.totalThreads = totalThreads;
+    }
+
+    public long getFlowFileRepositoryFreeSpace() {
+        return flowFileRepositoryFreeSpace;
+    }
+
+    public void setFlowFileRepositoryFreeSpace(final long flowFileRepositoryFreeSpace) {
+        this.flowFileRepositoryFreeSpace = flowFileRepositoryFreeSpace;
+    }
+
+    public long getFlowFileRepositoryUsedSpace() {
+        return flowFileRepositoryUsedSpace;
+    }
+
+    public void setFlowFileRepositoryUsedSpace(final long flowFileRepositoryUsedSpace) {
+        this.flowFileRepositoryUsedSpace = flowFileRepositoryUsedSpace;
+    }
+
+    public long getContentRepositoryFreeSpace() {
+        return contentRepositoryFreeSpace;
+    }
+
+    public void setContentRepositoryFreeSpace(final long contentRepositoryFreeSpace) {
+        this.contentRepositoryFreeSpace = contentRepositoryFreeSpace;
+    }
+
+    public long getContentRepositoryUsedSpace() {
+        return contentRepositoryUsedSpace;
+    }
+
+    public void setContentRepositoryUsedSpace(final long contentRepositoryUsedSpace) {
+        this.contentRepositoryUsedSpace = contentRepositoryUsedSpace;
+    }
+
+    public long getProvenanceRepositoryFreeSpace() {
+        return provenanceRepositoryFreeSpace;
+    }
+
+    public void setProvenanceRepositoryFreeSpace(final long provenanceRepositoryFreeSpace) {
+        this.provenanceRepositoryFreeSpace = provenanceRepositoryFreeSpace;
+    }
+
+    public long getProvenanceRepositoryUsedSpace() {
+        return provenanceRepositoryUsedSpace;
+    }
+
+    public void setProvenanceRepositoryUsedSpace(final long provenanceRepositoryUsedSpace) {
+        this.provenanceRepositoryUsedSpace = provenanceRepositoryUsedSpace;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder("NodeStatus{");
+        builder.append("createdAtInMs=").append(createdAtInMs);
+        builder.append(", freeHeap=").append(freeHeap);
+        builder.append(", usedHeap=").append(usedHeap);
+        builder.append(", heapUtilization=").append(heapUtilization);
+        builder.append(", freeNonHeap=").append(freeNonHeap);
+        builder.append(", usedNonHeap=").append(usedNonHeap);
+        builder.append(", openFileHandlers=").append(openFileHandlers);
+        builder.append(", processorLoadAverage=").append(processorLoadAverage);
+        builder.append(", uptime=").append(uptime);
+        builder.append(", totalThreads=").append(totalThreads);
+        builder.append(", flowFileRepositoryFreeSpace=").append(flowFileRepositoryFreeSpace);
+        builder.append(", flowFileRepositoryUsedSpace=").append(flowFileRepositoryUsedSpace);
+        builder.append(", contentRepositoryFreeSpace=").append(contentRepositoryFreeSpace);
+        builder.append(", contentRepositoryUsedSpace=").append(contentRepositoryUsedSpace);
+        builder.append(", provenanceRepositoryFreeSpace=").append(provenanceRepositoryFreeSpace);
+        builder.append(", provenanceRepositoryUsedSpace=").append(provenanceRepositoryUsedSpace);
+        builder.append('}');
+        return builder.toString();
+    }
+}

--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/NodeStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/NodeStatus.java
@@ -33,11 +33,10 @@ public class NodeStatus implements Cloneable {
 
     private long openFileHandlers;
     private double processorLoadAverage;
-    private long uptime;
 
     private long totalThreads;
     private long eventDrivenThreads;
-    private long timeDrivenThreads;
+    private long timerDrivenThreads;
 
     private long flowFileRepositoryFreeSpace;
     private long flowFileRepositoryUsedSpace;
@@ -109,14 +108,6 @@ public class NodeStatus implements Cloneable {
         this.processorLoadAverage = processorLoadAverage;
     }
 
-    public long getUptime() {
-        return uptime;
-    }
-
-    public void setUptime(final long uptime) {
-        this.uptime = uptime;
-    }
-
     public long getTotalThreads() {
         return totalThreads;
     }
@@ -133,12 +124,12 @@ public class NodeStatus implements Cloneable {
         this.eventDrivenThreads = eventDrivenThreads;
     }
 
-    public long getTimeDrivenThreads() {
-        return timeDrivenThreads;
+    public long getTimerDrivenThreads() {
+        return timerDrivenThreads;
     }
 
-    public void setTimeDrivenThreads(final long timeDrivenThreads) {
-        this.timeDrivenThreads = timeDrivenThreads;
+    public void setTimerDrivenThreads(final long timerDrivenThreads) {
+        this.timerDrivenThreads = timerDrivenThreads;
     }
 
     public long getFlowFileRepositoryFreeSpace() {
@@ -186,10 +177,9 @@ public class NodeStatus implements Cloneable {
         clonedObj.usedNonHeap = usedNonHeap;
         clonedObj.openFileHandlers = openFileHandlers;
         clonedObj.processorLoadAverage = processorLoadAverage;
-        clonedObj.uptime = uptime;
         clonedObj.totalThreads = totalThreads;
         clonedObj.eventDrivenThreads = eventDrivenThreads;
-        clonedObj.timeDrivenThreads = timeDrivenThreads;
+        clonedObj.timerDrivenThreads = timerDrivenThreads;
         clonedObj.flowFileRepositoryFreeSpace = flowFileRepositoryFreeSpace;
         clonedObj.flowFileRepositoryUsedSpace = flowFileRepositoryUsedSpace;
 
@@ -215,10 +205,9 @@ public class NodeStatus implements Cloneable {
         sb.append(", usedNonHeap=").append(usedNonHeap);
         sb.append(", openFileHandlers=").append(openFileHandlers);
         sb.append(", processorLoadAverage=").append(processorLoadAverage);
-        sb.append(", uptime=").append(uptime);
         sb.append(", totalThreads=").append(totalThreads);
         sb.append(", eventDrivenThreads=").append(eventDrivenThreads);
-        sb.append(", timeDrivenThreads=").append(timeDrivenThreads);
+        sb.append(", timerDrivenThreads=").append(timerDrivenThreads);
         sb.append(", flowFileRepositoryFreeSpace=").append(flowFileRepositoryFreeSpace);
         sb.append(", flowFileRepositoryUsedSpace=").append(flowFileRepositoryUsedSpace);
         sb.append(", contentRepositories=").append(contentRepositories);

--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/NodeStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/NodeStatus.java
@@ -16,6 +16,9 @@
  */
 package org.apache.nifi.controller.status;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * The status of a NiFi node.
  */
@@ -31,16 +34,16 @@ public class NodeStatus implements Cloneable {
     private long openFileHandlers;
     private double processorLoadAverage;
     private long uptime;
+
     private long totalThreads;
+    private long eventDrivenThreads;
+    private long timeDrivenThreads;
 
     private long flowFileRepositoryFreeSpace;
     private long flowFileRepositoryUsedSpace;
 
-    private long contentRepositoryFreeSpace;
-    private long contentRepositoryUsedSpace;
-
-    private long provenanceRepositoryFreeSpace;
-    private long provenanceRepositoryUsedSpace;
+    private List<StorageStatus> contentRepositories = new ArrayList<>();
+    private List<StorageStatus> provenanceRepositories = new ArrayList<>();
 
     public long getCreatedAtInMs() {
         return createdAtInMs;
@@ -122,6 +125,22 @@ public class NodeStatus implements Cloneable {
         this.totalThreads = totalThreads;
     }
 
+    public long getEventDrivenThreads() {
+        return eventDrivenThreads;
+    }
+
+    public void setEventDrivenThreads(final long eventDrivenThreads) {
+        this.eventDrivenThreads = eventDrivenThreads;
+    }
+
+    public long getTimeDrivenThreads() {
+        return timeDrivenThreads;
+    }
+
+    public void setTimeDrivenThreads(final long timeDrivenThreads) {
+        this.timeDrivenThreads = timeDrivenThreads;
+    }
+
     public long getFlowFileRepositoryFreeSpace() {
         return flowFileRepositoryFreeSpace;
     }
@@ -138,58 +157,73 @@ public class NodeStatus implements Cloneable {
         this.flowFileRepositoryUsedSpace = flowFileRepositoryUsedSpace;
     }
 
-    public long getContentRepositoryFreeSpace() {
-        return contentRepositoryFreeSpace;
+    public List<StorageStatus> getContentRepositories() {
+        return contentRepositories;
     }
 
-    public void setContentRepositoryFreeSpace(final long contentRepositoryFreeSpace) {
-        this.contentRepositoryFreeSpace = contentRepositoryFreeSpace;
+    public void setContentRepositories(final List<StorageStatus> contentRepositories) {
+        this.contentRepositories = new ArrayList<>();
+        this.contentRepositories.addAll(contentRepositories);
     }
 
-    public long getContentRepositoryUsedSpace() {
-        return contentRepositoryUsedSpace;
+    public List<StorageStatus> getProvenanceRepositories() {
+        return provenanceRepositories;
     }
 
-    public void setContentRepositoryUsedSpace(final long contentRepositoryUsedSpace) {
-        this.contentRepositoryUsedSpace = contentRepositoryUsedSpace;
+    public void setProvenanceRepositories(final List<StorageStatus> provenanceRepositories) {
+        this.provenanceRepositories = new ArrayList<>();
+        this.provenanceRepositories.addAll(provenanceRepositories);
     }
 
-    public long getProvenanceRepositoryFreeSpace() {
-        return provenanceRepositoryFreeSpace;
-    }
+    @Override
+    protected NodeStatus clone() {
+        final NodeStatus clonedObj = new NodeStatus();
+        clonedObj.createdAtInMs = createdAtInMs;
+        clonedObj.freeHeap = freeHeap;
+        clonedObj.usedHeap = usedHeap;
+        clonedObj.heapUtilization = heapUtilization;
+        clonedObj.freeNonHeap = freeNonHeap;
+        clonedObj.usedNonHeap = usedNonHeap;
+        clonedObj.openFileHandlers = openFileHandlers;
+        clonedObj.processorLoadAverage = processorLoadAverage;
+        clonedObj.uptime = uptime;
+        clonedObj.totalThreads = totalThreads;
+        clonedObj.eventDrivenThreads = eventDrivenThreads;
+        clonedObj.timeDrivenThreads = timeDrivenThreads;
+        clonedObj.flowFileRepositoryFreeSpace = flowFileRepositoryFreeSpace;
+        clonedObj.flowFileRepositoryUsedSpace = flowFileRepositoryUsedSpace;
 
-    public void setProvenanceRepositoryFreeSpace(final long provenanceRepositoryFreeSpace) {
-        this.provenanceRepositoryFreeSpace = provenanceRepositoryFreeSpace;
-    }
+        final List<StorageStatus> clonedContentRepositories = new ArrayList<>();
+        contentRepositories.stream().map(r -> r.clone()).forEach(r -> clonedContentRepositories.add(r));
+        clonedObj.contentRepositories = clonedContentRepositories;
 
-    public long getProvenanceRepositoryUsedSpace() {
-        return provenanceRepositoryUsedSpace;
-    }
+        final List<StorageStatus> clonedProvenanceRepositories = new ArrayList<>();
+        provenanceRepositories.stream().map(r -> r.clone()).forEach(r -> clonedProvenanceRepositories.add(r));
+        clonedObj.provenanceRepositories = clonedProvenanceRepositories;
 
-    public void setProvenanceRepositoryUsedSpace(final long provenanceRepositoryUsedSpace) {
-        this.provenanceRepositoryUsedSpace = provenanceRepositoryUsedSpace;
+        return clonedObj;
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder("NodeStatus{");
-        builder.append("createdAtInMs=").append(createdAtInMs);
-        builder.append(", freeHeap=").append(freeHeap);
-        builder.append(", usedHeap=").append(usedHeap);
-        builder.append(", heapUtilization=").append(heapUtilization);
-        builder.append(", freeNonHeap=").append(freeNonHeap);
-        builder.append(", usedNonHeap=").append(usedNonHeap);
-        builder.append(", openFileHandlers=").append(openFileHandlers);
-        builder.append(", processorLoadAverage=").append(processorLoadAverage);
-        builder.append(", uptime=").append(uptime);
-        builder.append(", totalThreads=").append(totalThreads);
-        builder.append(", flowFileRepositoryFreeSpace=").append(flowFileRepositoryFreeSpace);
-        builder.append(", flowFileRepositoryUsedSpace=").append(flowFileRepositoryUsedSpace);
-        builder.append(", contentRepositoryFreeSpace=").append(contentRepositoryFreeSpace);
-        builder.append(", contentRepositoryUsedSpace=").append(contentRepositoryUsedSpace);
-        builder.append(", provenanceRepositoryFreeSpace=").append(provenanceRepositoryFreeSpace);
-        builder.append(", provenanceRepositoryUsedSpace=").append(provenanceRepositoryUsedSpace);
-        builder.append('}');
-        return builder.toString();
+        final StringBuilder sb = new StringBuilder("NodeStatus{");
+        sb.append("createdAtInMs=").append(createdAtInMs);
+        sb.append(", freeHeap=").append(freeHeap);
+        sb.append(", usedHeap=").append(usedHeap);
+        sb.append(", heapUtilization=").append(heapUtilization);
+        sb.append(", freeNonHeap=").append(freeNonHeap);
+        sb.append(", usedNonHeap=").append(usedNonHeap);
+        sb.append(", openFileHandlers=").append(openFileHandlers);
+        sb.append(", processorLoadAverage=").append(processorLoadAverage);
+        sb.append(", uptime=").append(uptime);
+        sb.append(", totalThreads=").append(totalThreads);
+        sb.append(", eventDrivenThreads=").append(eventDrivenThreads);
+        sb.append(", timeDrivenThreads=").append(timeDrivenThreads);
+        sb.append(", flowFileRepositoryFreeSpace=").append(flowFileRepositoryFreeSpace);
+        sb.append(", flowFileRepositoryUsedSpace=").append(flowFileRepositoryUsedSpace);
+        sb.append(", contentRepositories=").append(contentRepositories);
+        sb.append(", provenanceRepositories=").append(provenanceRepositories);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/StorageStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/StorageStatus.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.status;
+
+/**
+ * The status of a storage repository.
+ */
+public class StorageStatus {
+    private String name;
+    private long freeSpace;
+    private long usedSpace;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public long getFreeSpace() {
+        return freeSpace;
+    }
+
+    public void setFreeSpace(final long freeSpace) {
+        this.freeSpace = freeSpace;
+    }
+
+    public long getUsedSpace() {
+        return usedSpace;
+    }
+
+    public void setUsedSpace(final long usedSpace) {
+        this.usedSpace = usedSpace;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder("StorageStatus{");
+        builder.append("name='").append(name).append('\'');
+        builder.append(", freeSpace=").append(freeSpace);
+        builder.append(", usedSpace=").append(usedSpace);
+        builder.append('}');
+        return builder.toString();
+    }
+
+    @Override
+    public StorageStatus clone() {
+        final StorageStatus clonedObj = new StorageStatus();
+        clonedObj.name = name;
+        clonedObj.freeSpace = freeSpace;
+        clonedObj.usedSpace = usedSpace;
+        return clonedObj;
+    }
+}

--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/StorageStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/StorageStatus.java
@@ -19,7 +19,7 @@ package org.apache.nifi.controller.status;
 /**
  * The status of a storage repository.
  */
-public class StorageStatus {
+public class StorageStatus implements Cloneable {
     private String name;
     private long freeSpace;
     private long usedSpace;

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -3090,7 +3090,7 @@ adjust the flow as needed to fix the problem. While NiFi does not have an "undo"
 dataflow that will fix the problem.
 
 Select Node Status History to view instance specific metrics from the last 24 hours or if the instance runs for less time, then
-since it has been started. The status history can help the DFM in troubleshooting performance barriers and provides a general
+since it has been started. The status history can help the DFM in troubleshooting performance issues and provides a general
 view on the health of the node. The status history includes information about the memory usage and disk usage among other things.
 
 Two other tools in the Global Menu are Controller Settings and Users. The Controller Settings page provides the ability to change

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -3089,6 +3089,10 @@ recent change to the dataflow has caused a problem and needs to be fixed. The DF
 adjust the flow as needed to fix the problem. While NiFi does not have an "undo" feature, the DFM can make new changes to the
 dataflow that will fix the problem.
 
+Select Node Status History to view instance specific metrics from the last 24 hours or if the instance runs for less time, then
+since it has been started. The status history can help the DFM in troubleshooting performance barriers and provides a general
+view on the health of the node. The status history includes information about the memory usage and disk usage among other things.
+
 Two other tools in the Global Menu are Controller Settings and Users. The Controller Settings page provides the ability to change
 the name of the NiFi instance, add comments describing the NiFi instance, and set the maximum number of threads that are available
 to the application. It also provides tabs where DFMs may add and configure <<Controller_Services>> and <<Reporting_Tasks>>. The Users page is used to manage user access, which is described in

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/status/history/ComponentStatusRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/status/history/ComponentStatusRepository.java
@@ -19,6 +19,7 @@ package org.apache.nifi.controller.status.history;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.nifi.controller.status.NodeStatus;
 import org.apache.nifi.controller.status.ProcessGroupStatus;
 
 /**
@@ -38,21 +39,23 @@ public interface ComponentStatusRepository {
     /**
      * Captures the status information provided in the given report
      *
-     * @param rootGroupStatus status of root group
+     * @param nodeStatus status of the node
+     * @param rootGroupStatus status of root group and it's content
      * @param garbageCollectionStatus status of garbage collection
      */
-    void capture(ProcessGroupStatus rootGroupStatus, List<GarbageCollectionStatus> garbageCollectionStatus);
+    void capture(NodeStatus nodeStatus, ProcessGroupStatus rootGroupStatus, List<GarbageCollectionStatus> garbageCollectionStatus);
 
     /**
      * Captures the status information provided in the given report, providing a
      * timestamp that indicates the time at which the status report was
      * generated. This can be used to replay historical values.
      *
-     * @param rootGroupStatus status
+     * @param nodeStatus status of the node
+     * @param rootGroupStatus status of the root group and it's content
      * @param timestamp timestamp of capture
      * @param garbageCollectionStatus status of garbage collection
      */
-    void capture(ProcessGroupStatus rootGroupStatus, List<GarbageCollectionStatus> garbageCollectionStatus, Date timestamp);
+    void capture(NodeStatus nodeStatus, ProcessGroupStatus rootGroupStatus, List<GarbageCollectionStatus> garbageCollectionStatus, Date timestamp);
 
     /**
      * @return the Date at which the latest capture was performed
@@ -130,6 +133,14 @@ public interface ComponentStatusRepository {
      * period
      */
     StatusHistory getRemoteProcessGroupStatusHistory(String remoteGroupId, Date start, Date end, int preferredDataPoints);
+
+    /**
+     * Returns the status history of the actual node
+     *
+     * @return a {@link StatusHistory} that provides the status information
+     * about the NiFi node from the period stored in the status repository.
+     */
+    StatusHistory getNodeStatusHistory();
 
     GarbageCollectionHistory getGarbageCollectionHistory(Date start, Date end);
 }

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/status/history/MetricDescriptor.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/status/history/MetricDescriptor.java
@@ -23,10 +23,19 @@ package org.apache.nifi.controller.status.history;
  */
 public interface MetricDescriptor<T> {
 
+    /**
+     * Used during creation of metric instance with {@link Formatter#FRACTION} formatting. The expected way is to multiply
+     * the floating point metric value with it before converting into long. By this, enough of the fractional part might be
+     * kept for visualisation. In order to show the correct number the result must be divided with the same number before
+     * presenting.
+     */
+    int FRACTION_MULTIPLIER = 1_000_000;
+
     enum Formatter {
         COUNT,
         DURATION,
-        DATA_SIZE
+        DATA_SIZE,
+        FRACTION
     };
 
     int getMetricIdentifier();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/StatusHistoryEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/StatusHistoryEndpointMerger.java
@@ -24,6 +24,7 @@ import org.apache.nifi.controller.status.history.ConnectionStatusDescriptor;
 import org.apache.nifi.controller.status.history.CounterMetricDescriptor;
 import org.apache.nifi.controller.status.history.MetricDescriptor;
 import org.apache.nifi.controller.status.history.MetricDescriptor.Formatter;
+import org.apache.nifi.controller.status.history.NodeStatusDescriptor;
 import org.apache.nifi.controller.status.history.ProcessGroupStatusDescriptor;
 import org.apache.nifi.controller.status.history.ProcessorStatusDescriptor;
 import org.apache.nifi.controller.status.history.RemoteProcessGroupStatusDescriptor;
@@ -56,6 +57,7 @@ public class StatusHistoryEndpointMerger implements EndpointResponseMerger {
     public static final Pattern PROCESS_GROUP_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/process-groups/(?:(?:root)|(?:[a-f0-9\\-]{36}))/status/history");
     public static final Pattern REMOTE_PROCESS_GROUP_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/remote-process-groups/[a-f0-9\\-]{36}/status/history");
     public static final Pattern CONNECTION_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/connections/[a-f0-9\\-]{36}/status/history");
+    public static final Pattern NODE_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/node/status/history");
 
     private final long componentStatusSnapshotMillis;
 
@@ -82,6 +84,10 @@ public class StatusHistoryEndpointMerger implements EndpointResponseMerger {
             }
         } else if (CONNECTION_STATUS_HISTORY_URI_PATTERN.matcher(path).matches()) {
             for (final ConnectionStatusDescriptor descriptor : ConnectionStatusDescriptor.values()) {
+                metricDescriptors.put(descriptor.getField(), descriptor.getDescriptor());
+            }
+        } else if (NODE_STATUS_HISTORY_URI_PATTERN.matcher(path).matches()) {
+            for (final NodeStatusDescriptor descriptor : NodeStatusDescriptor.values()) {
                 metricDescriptors.put(descriptor.getField(), descriptor.getDescriptor());
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/StatusHistoryEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/StatusHistoryEndpointMerger.java
@@ -57,7 +57,7 @@ public class StatusHistoryEndpointMerger implements EndpointResponseMerger {
     public static final Pattern PROCESS_GROUP_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/process-groups/(?:(?:root)|(?:[a-f0-9\\-]{36}))/status/history");
     public static final Pattern REMOTE_PROCESS_GROUP_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/remote-process-groups/[a-f0-9\\-]{36}/status/history");
     public static final Pattern CONNECTION_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/connections/[a-f0-9\\-]{36}/status/history");
-    public static final Pattern NODE_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/flow/node/status/history");
+    public static final Pattern NODE_STATUS_HISTORY_URI_PATTERN = Pattern.compile("/nifi-api/controller/status/history");
 
     private final long componentStatusSnapshotMillis;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -2996,14 +2996,11 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
         result.setProcessorLoadAverage(systemDiagnostics.getProcessorLoadAverage());
         result.setTotalThreads(systemDiagnostics.getTotalThreads());
         result.setEventDrivenThreads(getActiveEventDrivenThreadCount());
-        result.setTimeDrivenThreads(getActiveTimerDrivenThreadCount());
+        result.setTimerDrivenThreads(getActiveTimerDrivenThreadCount());
         result.setFlowFileRepositoryFreeSpace(systemDiagnostics.getFlowFileRepositoryStorageUsage().getFreeSpace());
         result.setFlowFileRepositoryUsedSpace(systemDiagnostics.getFlowFileRepositoryStorageUsage().getUsedSpace());
         result.setContentRepositories(systemDiagnostics.getContentRepositoryStorageUsage().entrySet().stream().map(e -> getStorageStatus(e)).collect(Collectors.toList()));
         result.setProvenanceRepositories(systemDiagnostics.getProvenanceRepositoryStorageUsage().entrySet().stream().map(e -> getStorageStatus(e)).collect(Collectors.toList()));
-
-        // Used only for building component details
-        result.setUptime(systemDiagnostics.getUptime());
 
         return result;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
@@ -36,7 +36,7 @@ public enum NodeStatusDescriptor {
     HEAP_UTILIZATION(
             "heapUtilization",
             "Heap Utilization",
-            "The percentage of available heap currently used by the Java virtual machine",
+            "The percentage of available heap currently used by the Java virtual machine.",
             MetricDescriptor.Formatter.COUNT,
             s -> s.getHeapUtilization(),
             new ValueReducer<StatusSnapshot, Long>() {
@@ -81,7 +81,7 @@ public enum NodeStatusDescriptor {
     PROCESSOR_LOAD_AVERAGE(
             "processorLoadAverage",
             "Processor Load Average",
-            "The processor load. Every measurement point represents te system load average for the last minute",
+            "The processor load. Every measurement point represents te system load average for the last minute.",
             MetricDescriptor.Formatter.FRACTION,
             s -> Double.valueOf(s.getProcessorLoadAverage() * MetricDescriptor.FRACTION_MULTIPLIER).longValue(),
             new ValueReducer<StatusSnapshot, Long>() {
@@ -111,6 +111,18 @@ public enum NodeStatusDescriptor {
             "The current number of live threads in the Java virtual machine (both daemon and non-daemon threads).",
             MetricDescriptor.Formatter.COUNT,
             s -> s.getTotalThreads()),
+    EVENT_DRIVEN_THREADS(
+            "eventDrivenThreads",
+            "Number of event driven threads",
+            "The current number of active threads in the event driven thread pool.",
+            MetricDescriptor.Formatter.COUNT,
+            s -> s.getEventDrivenThreads()),
+    TIME_DRIVEN_THREADS(
+            "timeDrivenThreads",
+            "Number of time driven threads",
+            "The current number of active threads in the time driven thread pool.",
+            MetricDescriptor.Formatter.COUNT,
+            s -> s.getTimeDrivenThreads()),
     FLOW_FILE_REPOSITORY_FREE_SPACE(
             "flowFileRepositoryFreeSpace",
             "Flow File Repository Free Space",
@@ -125,28 +137,28 @@ public enum NodeStatusDescriptor {
             s -> s.getFlowFileRepositoryUsedSpace()),
     CONTENT_REPOSITORY_FREE_SPACE(
             "contentRepositoryFreeSpace",
-            "Content Repository Free Space",
+            "Sum content Repository Free Space",
             "The usable space available for use by the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getContentRepositoryFreeSpace()),
+            s -> s.getContentRepositories().stream().map(r -> r.getFreeSpace()).reduce(0L, (a, b) -> a + b)),
     CONTENT_REPOSITORY_USED_SPACE(
             "contentRepositoryUsedSpace",
-            "Content Repository Used Space",
+            "Sum content Repository Used Space",
             "The space in use on the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getContentRepositoryUsedSpace()),
+            s -> s.getContentRepositories().stream().map(r -> r.getUsedSpace()).reduce(0L, (a, b) -> a + b)),
     PROVENANCE_REPOSITORY_FREE_SPACE(
             "provenanceRepositoryFreeSpace",
-            "Provenance Repository Free Space",
+            "Sum provenance Repository Free Space",
             "The usable space available for use by the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getProvenanceRepositoryFreeSpace()),
+            s -> s.getProvenanceRepositories().stream().map(r -> r.getFreeSpace()).reduce(0L, (a, b) -> a + b)),
     PROVENANCE_REPOSITORY_USED_SPACE(
             "provenanceRepositoryUsedSpace",
-            "Provenance Repository Used Space",
+            "Sum provenance Repository Used Space",
             "The space in use on the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getProvenanceRepositoryUsedSpace());
+            s -> s.getProvenanceRepositories().stream().map(r -> r.getUsedSpace()).reduce(0L, (a, b) -> a + b));
 
     private final MetricDescriptor<NodeStatus> descriptor;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
@@ -19,6 +19,7 @@ package org.apache.nifi.controller.status.history;
 import org.apache.nifi.controller.status.NodeStatus;
 
 import java.util.List;
+import java.util.Objects;
 
 public enum NodeStatusDescriptor {
     FREE_HEAP(
@@ -42,22 +43,12 @@ public enum NodeStatusDescriptor {
             new ValueReducer<StatusSnapshot, Long>() {
                 @Override
                 public Long reduce(final List<StatusSnapshot> values) {
-                    long sumUtilization = 0L;
-                    int invocations = 0;
-
-                    for (final StatusSnapshot snapshot : values) {
-                        final Long utilization = snapshot.getStatusMetric(HEAP_UTILIZATION.getDescriptor());
-                        if (utilization != null) {
-                            sumUtilization += utilization.longValue();
-                            invocations++;
-                        }
-                    }
-
-                    if (invocations == 0) {
-                        return 0L;
-                    }
-
-                    return sumUtilization / invocations;
+                    return (long) values.stream()
+                            .map(snapshot -> snapshot.getStatusMetric(HEAP_UTILIZATION.getDescriptor()))
+                            .filter(Objects::nonNull)
+                            .mapToLong(value -> value)
+                            .average()
+                            .orElse(0L);
                 }
             }),
     FREE_NON_HEAP(
@@ -69,13 +60,13 @@ public enum NodeStatusDescriptor {
     USED_NON_HEAP(
             "usedNonHeap",
             "Used Non Heap",
-            "The current memory usage of non-heap memory that is used by the Java virtual machine.",
+            "The current usage of non-heap memory that is used by the Java virtual machine.",
             MetricDescriptor.Formatter.DATA_SIZE,
             s -> s.getUsedNonHeap()),
-    OPEN_FILE_HANDLERS(
-            "openFileHandlers",
-            "Open File Handlers",
-            "The current number of open file descriptors used by the Java virtual machine.",
+    OPEN_FILE_HANDLES(
+            "openFileHandles",
+            "Open File Handles",
+            "The current number of open file handles used by the Java virtual machine.",
             MetricDescriptor.Formatter.COUNT,
             s -> s.getOpenFileHandlers()),
     PROCESSOR_LOAD_AVERAGE(
@@ -87,22 +78,12 @@ public enum NodeStatusDescriptor {
             new ValueReducer<StatusSnapshot, Long>() {
                 @Override
                 public Long reduce(final List<StatusSnapshot> values) {
-                    long sumLoad = 0L;
-                    int invocations = 0;
-
-                    for (final StatusSnapshot snapshot : values) {
-                        final Long load = snapshot.getStatusMetric(PROCESSOR_LOAD_AVERAGE.getDescriptor());
-                        if (load != null) {
-                            sumLoad += load.longValue();
-                            invocations++;
-                        }
-                    }
-
-                    if (invocations == 0) {
-                        return 0L;
-                    }
-
-                    return sumLoad / invocations;
+                    return (long) values.stream()
+                            .map(snapshot -> snapshot.getStatusMetric(HEAP_UTILIZATION.getDescriptor()))
+                            .filter(Objects::nonNull)
+                            .mapToLong(value -> value)
+                            .average()
+                            .orElse(0L);
                 }
             }),
     TOTAL_THREADS(
@@ -122,11 +103,11 @@ public enum NodeStatusDescriptor {
             "Number of time driven threads",
             "The current number of active threads in the time driven thread pool.",
             MetricDescriptor.Formatter.COUNT,
-            s -> s.getTimeDrivenThreads()),
+            s -> s.getTimerDrivenThreads()),
     FLOW_FILE_REPOSITORY_FREE_SPACE(
             "flowFileRepositoryFreeSpace",
             "Flow File Repository Free Space",
-            "The usable space available for use by the underlying storage mechanism.",
+            "The usable space available for file repositories on the underlying storage mechanism",
             MetricDescriptor.Formatter.DATA_SIZE,
             s -> s.getFlowFileRepositoryFreeSpace()),
     FLOW_FILE_REPOSITORY_USED_SPACE(
@@ -138,27 +119,27 @@ public enum NodeStatusDescriptor {
     CONTENT_REPOSITORY_FREE_SPACE(
             "contentRepositoryFreeSpace",
             "Sum content Repository Free Space",
-            "The usable space available for use by the underlying storage mechanisms.",
+            "The usable space available for content repositories on the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getContentRepositories().stream().map(r -> r.getFreeSpace()).reduce(0L, (a, b) -> a + b)),
+            s -> s.getContentRepositories().stream().mapToLong(r -> r.getFreeSpace()).sum()),
     CONTENT_REPOSITORY_USED_SPACE(
             "contentRepositoryUsedSpace",
             "Sum content Repository Used Space",
             "The space in use on the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getContentRepositories().stream().map(r -> r.getUsedSpace()).reduce(0L, (a, b) -> a + b)),
+            s -> s.getContentRepositories().stream().mapToLong(r -> r.getUsedSpace()).sum()),
     PROVENANCE_REPOSITORY_FREE_SPACE(
             "provenanceRepositoryFreeSpace",
             "Sum provenance Repository Free Space",
             "The usable space available for use by the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getProvenanceRepositories().stream().map(r -> r.getFreeSpace()).reduce(0L, (a, b) -> a + b)),
+            s -> s.getProvenanceRepositories().stream().mapToLong(r -> r.getFreeSpace()).sum()),
     PROVENANCE_REPOSITORY_USED_SPACE(
             "provenanceRepositoryUsedSpace",
             "Sum provenance Repository Used Space",
             "The space in use on the underlying storage mechanisms.",
             MetricDescriptor.Formatter.DATA_SIZE,
-            s -> s.getProvenanceRepositories().stream().map(r -> r.getUsedSpace()).reduce(0L, (a, b) -> a + b));
+            s -> s.getProvenanceRepositories().stream().mapToLong(r -> r.getUsedSpace()).sum());
 
     private final MetricDescriptor<NodeStatus> descriptor;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.status.history;
+
+import org.apache.nifi.controller.status.NodeStatus;
+
+import java.util.List;
+
+public enum NodeStatusDescriptor {
+    FREE_HEAP(
+            "freeHeap",
+            "Free Heap",
+            "The amount of free memory in the heap that can be used by the Java virtual machine.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getFreeHeap()),
+    USED_HEAP(
+            "usedHeap",
+            "Used Heap",
+            "The amount of used memory in the heap that is used by the Java virtual machine.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getUsedHeap()),
+    HEAP_UTILIZATION(
+            "heapUtilization",
+            "Heap Utilization",
+            "The percentage of available heap currently used by the Java virtual machine",
+            MetricDescriptor.Formatter.COUNT,
+            s -> s.getHeapUtilization(),
+            new ValueReducer<StatusSnapshot, Long>() {
+                @Override
+                public Long reduce(final List<StatusSnapshot> values) {
+                    long sumUtilization = 0L;
+                    int invocations = 0;
+
+                    for (final StatusSnapshot snapshot : values) {
+                        final Long utilization = snapshot.getStatusMetric(HEAP_UTILIZATION.getDescriptor());
+                        if (utilization != null) {
+                            sumUtilization += utilization.longValue();
+                            invocations++;
+                        }
+                    }
+
+                    if (invocations == 0) {
+                        return 0L;
+                    }
+
+                    return sumUtilization / invocations;
+                }
+            }),
+    FREE_NON_HEAP(
+            "freeNonHeap",
+            "Free Non Heap",
+            "The currently available non-heap memory that can be used by the Java virtual machine.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getFreeNonHeap()),
+    USED_NON_HEAP(
+            "usedNonHeap",
+            "Used Non Heap",
+            "The current memory usage of non-heap memory that is used by the Java virtual machine.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getUsedNonHeap()),
+    OPEN_FILE_HANDLERS(
+            "openFileHandlers",
+            "Open File Handlers",
+            "The current number of open file descriptors used by the Java virtual machine.",
+            MetricDescriptor.Formatter.COUNT,
+            s -> s.getOpenFileHandlers()),
+    PROCESSOR_LOAD_AVERAGE(
+            "processorLoadAverage",
+            "Processor Load Average",
+            "The processor load. Every measurement point represents te system load average for the last minute",
+            MetricDescriptor.Formatter.FRACTION,
+            s -> Double.valueOf(s.getProcessorLoadAverage() * MetricDescriptor.FRACTION_MULTIPLIER).longValue(),
+            new ValueReducer<StatusSnapshot, Long>() {
+                @Override
+                public Long reduce(final List<StatusSnapshot> values) {
+                    long sumLoad = 0L;
+                    int invocations = 0;
+
+                    for (final StatusSnapshot snapshot : values) {
+                        final Long load = snapshot.getStatusMetric(PROCESSOR_LOAD_AVERAGE.getDescriptor());
+                        if (load != null) {
+                            sumLoad += load.longValue();
+                            invocations++;
+                        }
+                    }
+
+                    if (invocations == 0) {
+                        return 0L;
+                    }
+
+                    return sumLoad / invocations;
+                }
+            }),
+    TOTAL_THREADS(
+            "totalThreads",
+            "Number of total threads",
+            "The current number of live threads in the Java virtual machine (both daemon and non-daemon threads).",
+            MetricDescriptor.Formatter.COUNT,
+            s -> s.getTotalThreads()),
+    FLOW_FILE_REPOSITORY_FREE_SPACE(
+            "flowFileRepositoryFreeSpace",
+            "Flow File Repository Free Space",
+            "The usable space available for use by the underlying storage mechanism.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getFlowFileRepositoryFreeSpace()),
+    FLOW_FILE_REPOSITORY_USED_SPACE(
+            "flowFileRepositoryUsedSpace",
+            "Flow File Repository Used Space",
+            "The space in use on the underlying storage mechanism.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getFlowFileRepositoryUsedSpace()),
+    CONTENT_REPOSITORY_FREE_SPACE(
+            "contentRepositoryFreeSpace",
+            "Content Repository Free Space",
+            "The usable space available for use by the underlying storage mechanisms.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getContentRepositoryFreeSpace()),
+    CONTENT_REPOSITORY_USED_SPACE(
+            "contentRepositoryUsedSpace",
+            "Content Repository Used Space",
+            "The space in use on the underlying storage mechanisms.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getContentRepositoryUsedSpace()),
+    PROVENANCE_REPOSITORY_FREE_SPACE(
+            "provenanceRepositoryFreeSpace",
+            "Provenance Repository Free Space",
+            "The usable space available for use by the underlying storage mechanisms.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getProvenanceRepositoryFreeSpace()),
+    PROVENANCE_REPOSITORY_USED_SPACE(
+            "provenanceRepositoryUsedSpace",
+            "Provenance Repository Used Space",
+            "The space in use on the underlying storage mechanisms.",
+            MetricDescriptor.Formatter.DATA_SIZE,
+            s -> s.getProvenanceRepositoryUsedSpace());
+
+    private final MetricDescriptor<NodeStatus> descriptor;
+
+    NodeStatusDescriptor(
+            final String field,
+            final String label,
+            final String description,
+            final MetricDescriptor.Formatter formatter,
+            final ValueMapper<NodeStatus> valueFunction) {
+        this.descriptor = new StandardMetricDescriptor<>(this::ordinal, field, label, description, formatter, valueFunction);
+    }
+
+    NodeStatusDescriptor(
+            final String field,
+            final String label,
+            final String description,
+            final MetricDescriptor.Formatter formatter,
+            final ValueMapper<NodeStatus> valueFunction,
+            final ValueReducer<StatusSnapshot, Long> reducer) {
+        this.descriptor = new StandardMetricDescriptor<>(this::ordinal, field, label, description, formatter, valueFunction, reducer);
+    }
+
+
+    public String getField() {
+        return descriptor.getField();
+    }
+
+    public MetricDescriptor<NodeStatus> getDescriptor() {
+        return descriptor;
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/NodeStatusDescriptor.java
@@ -81,7 +81,7 @@ public enum NodeStatusDescriptor {
     PROCESSOR_LOAD_AVERAGE(
             "processorLoadAverage",
             "Processor Load Average",
-            "The processor load. Every measurement point represents te system load average for the last minute.",
+            "The processor load. Every measurement point represents the system load average for the last minute.",
             MetricDescriptor.Formatter.FRACTION,
             s -> Double.valueOf(s.getProcessorLoadAverage() * MetricDescriptor.FRACTION_MULTIPLIER).longValue(),
             new ValueReducer<StatusSnapshot, Long>() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/StatusHistoryUtil.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/StatusHistoryUtil.java
@@ -76,14 +76,14 @@ public class StatusHistoryUtil {
 
     public static List<StatusDescriptorDTO> createFieldDescriptorDtos(final Collection<MetricDescriptor<?>> metricDescriptors) {
         final List<StatusDescriptorDTO> dtos = new ArrayList<>();
+        final Map<Integer, MetricDescriptor<?>> orderedDescriptors = new HashMap<>();
 
-        final Set<MetricDescriptor<?>> allDescriptors = new LinkedHashSet<>();
         for (final MetricDescriptor<?> metricDescriptor : metricDescriptors) {
-            allDescriptors.add(metricDescriptor);
+            orderedDescriptors.put(metricDescriptor.getMetricIdentifier(), metricDescriptor);
         }
 
-        for (final MetricDescriptor<?> metricDescriptor : allDescriptors) {
-            dtos.add(createStatusDescriptorDto(metricDescriptor));
+        for (int i = 0; i < metricDescriptors.size(); i++) {
+            dtos.add(createStatusDescriptorDto(orderedDescriptors.get(i)));
         }
 
         return dtos;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/StatusHistoryUtil.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/StatusHistoryUtil.java
@@ -21,6 +21,7 @@ import org.apache.nifi.web.api.dto.status.StatusHistoryDTO;
 import org.apache.nifi.web.api.dto.status.StatusSnapshotDTO;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -75,18 +76,13 @@ public class StatusHistoryUtil {
     }
 
     public static List<StatusDescriptorDTO> createFieldDescriptorDtos(final Collection<MetricDescriptor<?>> metricDescriptors) {
-        final List<StatusDescriptorDTO> dtos = new ArrayList<>();
-        final Map<Integer, MetricDescriptor<?>> orderedDescriptors = new HashMap<>();
+        final StatusDescriptorDTO[] result = new StatusDescriptorDTO[metricDescriptors.size()];
 
         for (final MetricDescriptor<?> metricDescriptor : metricDescriptors) {
-            orderedDescriptors.put(metricDescriptor.getMetricIdentifier(), metricDescriptor);
+            result[metricDescriptor.getMetricIdentifier()] = createStatusDescriptorDto(metricDescriptor);
         }
 
-        for (int i = 0; i < metricDescriptors.size(); i++) {
-            dtos.add(createStatusDescriptorDto(orderedDescriptors.get(i)));
-        }
-
-        return dtos;
+        return Arrays.asList(result);
     }
 
     public static List<StatusDescriptorDTO> createFieldDescriptorDtos(final StatusHistory statusHistory) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/StatusHistoryUtilTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/StatusHistoryUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.status.history;
+
+import org.apache.nifi.web.api.dto.status.StatusDescriptorDTO;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class StatusHistoryUtilTest {
+
+    @Test
+    public void testCreateFieldDescriptorDtos() {
+        // given
+        final Collection<MetricDescriptor<?>> metricDescriptors = Arrays.asList(
+                new StandardMetricDescriptor<>(() -> 1, "field2",  "Field2", "Field 2", MetricDescriptor.Formatter.COUNT, __ -> 2L),
+                new StandardMetricDescriptor<>(() -> 0, "field1", "Field1", "Field 1", MetricDescriptor.Formatter.COUNT, __ -> 1L)
+        );
+
+        final List<StatusDescriptorDTO> expected = Arrays.asList(
+                new StatusDescriptorDTO("field1", "Field1", "Field 1", MetricDescriptor.Formatter.COUNT.name()),
+                new StatusDescriptorDTO("field2", "Field2", "Field 2", MetricDescriptor.Formatter.COUNT.name())
+        );
+
+        // when
+        final List<StatusDescriptorDTO> result = StatusHistoryUtil.createFieldDescriptorDtos(metricDescriptors);
+
+        // then
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testCreateFieldDescriptorDtosWhenNotConsecutive() {
+        // given
+        final Collection<MetricDescriptor<?>> metricDescriptors = Arrays.asList(
+                new StandardMetricDescriptor<>(() -> 3, "field2",  "Field2", "Field 2", MetricDescriptor.Formatter.COUNT, __ -> 2L),
+                new StandardMetricDescriptor<>(() -> 0, "field1", "Field1", "Field 1", MetricDescriptor.Formatter.COUNT, __ -> 1L)
+        );
+
+        // when
+        StatusHistoryUtil.createFieldDescriptorDtos(metricDescriptors);
+    }
+
+    @Test
+    public void testCreateFieldDescriptorDtosWhenEmpty() {
+        // given
+        final Collection<MetricDescriptor<?>> metricDescriptors = new ArrayList<>();
+        final List<StatusDescriptorDTO> expected = new ArrayList<>();
+
+        // when
+        final List<StatusDescriptorDTO> result = StatusHistoryUtil.createFieldDescriptorDtos(metricDescriptors);
+
+        // then
+        Assert.assertEquals(expected, result);
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/VolatileComponentStatusRepositoryTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/VolatileComponentStatusRepositoryTest.java
@@ -238,7 +238,7 @@ public class VolatileComponentStatusRepositoryTest {
   }
 
   @Test
-  public void testNodeHistory() {
+  public void testNodeStatusHistory() {
     // given
     final VolatileComponentStatusRepository testSubject = createRepo(BUFSIZE3);
     final List<NodeStatus> nodeStatuses = Arrays.asList(
@@ -253,9 +253,6 @@ public class VolatileComponentStatusRepositoryTest {
     final StatusHistory result = testSubject.getNodeStatusHistory();
 
     // then
-    // checking on component details
-    Assert.assertEquals("8ms", result.getComponentDetails().get("Uptime"));
-
     // checking on snapshots
     Assert.assertEquals(nodeStatuses.size(), result.getStatusSnapshots().size());;
 
@@ -269,13 +266,13 @@ public class VolatileComponentStatusRepositoryTest {
       Assert.assertEquals(nodeStatus.getHeapUtilization(), snapshot.getStatusMetric(NodeStatusDescriptor.HEAP_UTILIZATION.getDescriptor()).longValue());
       Assert.assertEquals(nodeStatus.getFreeNonHeap(), snapshot.getStatusMetric(NodeStatusDescriptor.FREE_NON_HEAP.getDescriptor()).longValue());
       Assert.assertEquals(nodeStatus.getUsedNonHeap(), snapshot.getStatusMetric(NodeStatusDescriptor.USED_NON_HEAP.getDescriptor()).longValue());
-      Assert.assertEquals(nodeStatus.getOpenFileHandlers(), snapshot.getStatusMetric(NodeStatusDescriptor.OPEN_FILE_HANDLERS.getDescriptor()).longValue());
+      Assert.assertEquals(nodeStatus.getOpenFileHandlers(), snapshot.getStatusMetric(NodeStatusDescriptor.OPEN_FILE_HANDLES.getDescriptor()).longValue());
       Assert.assertEquals(
               Double.valueOf(nodeStatus.getProcessorLoadAverage() * MetricDescriptor.FRACTION_MULTIPLIER).longValue(),
               snapshot.getStatusMetric(NodeStatusDescriptor.PROCESSOR_LOAD_AVERAGE.getDescriptor()).longValue());
       Assert.assertEquals(nodeStatus.getTotalThreads(), snapshot.getStatusMetric(NodeStatusDescriptor.TOTAL_THREADS.getDescriptor()).longValue());
       Assert.assertEquals(nodeStatus.getEventDrivenThreads(), snapshot.getStatusMetric(NodeStatusDescriptor.EVENT_DRIVEN_THREADS.getDescriptor()).longValue());
-      Assert.assertEquals(nodeStatus.getTimeDrivenThreads(), snapshot.getStatusMetric(NodeStatusDescriptor.TIME_DRIVEN_THREADS.getDescriptor()).longValue());
+      Assert.assertEquals(nodeStatus.getTimerDrivenThreads(), snapshot.getStatusMetric(NodeStatusDescriptor.TIME_DRIVEN_THREADS.getDescriptor()).longValue());
       Assert.assertEquals(nodeStatus.getFlowFileRepositoryFreeSpace(), snapshot.getStatusMetric(NodeStatusDescriptor.FLOW_FILE_REPOSITORY_FREE_SPACE.getDescriptor()).longValue());
       Assert.assertEquals(nodeStatus.getFlowFileRepositoryUsedSpace(), snapshot.getStatusMetric(NodeStatusDescriptor.FLOW_FILE_REPOSITORY_USED_SPACE.getDescriptor()).longValue());
       Assert.assertEquals(
@@ -305,12 +302,12 @@ public class VolatileComponentStatusRepositoryTest {
 
     // metrics based on GarbageCollectionStatus (The ordinal numbers are true for setup, in production it might differ)
     final int g0TimeOrdinal = 24;
-    final int g0TimeDiffOrdinal = 25;
-    final int g0CountOrdinal = 26;
+    final int g0CountOrdinal = 25;
+    final int g0TimeDiffOrdinal = 26;
     final int g0CountDiffOrdinal = 27;
     final int g1TimeOrdinal = 28;
-    final int g1TimeDiffOrdinal = 29;
-    final int g1CountOrdinal = 30;
+    final int g1CountOrdinal = 29;
+    final int g1TimeDiffOrdinal = 30;
     final int g1CountDiffOrdinal = 31;
 
     final StatusSnapshot snapshot1 = result.getStatusSnapshots().get(0);
@@ -358,10 +355,9 @@ public class VolatileComponentStatusRepositoryTest {
     result.setUsedNonHeap(5 + number);
     result.setOpenFileHandlers(6 + number);
     result.setProcessorLoadAverage(7.1d + number);
-    result.setUptime(8); // This goes to component details so no increment is needed
     result.setTotalThreads(9 + number);
     result.setEventDrivenThreads(20 + number);
-    result.setTimeDrivenThreads(21 + number);
+    result.setTimerDrivenThreads(21 + number);
     result.setFlowFileRepositoryFreeSpace(10 + number);
     result.setFlowFileRepositoryUsedSpace(11 + number);
     result.setContentRepositories(Arrays.asList(

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -108,8 +108,8 @@ import org.apache.nifi.web.api.entity.ProcessGroupFlowEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupStatusEntity;
 import org.apache.nifi.web.api.entity.ProcessorDiagnosticsEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
-import org.apache.nifi.web.api.entity.ProcessorsRunStatusDetailsEntity;
 import org.apache.nifi.web.api.entity.ProcessorStatusEntity;
+import org.apache.nifi.web.api.entity.ProcessorsRunStatusDetailsEntity;
 import org.apache.nifi.web.api.entity.RegistryClientEntity;
 import org.apache.nifi.web.api.entity.RegistryEntity;
 import org.apache.nifi.web.api.entity.RemoteProcessGroupEntity;
@@ -582,6 +582,15 @@ public interface NiFiServiceFacade {
      * @return history
      */
     StatusHistoryEntity getProcessorStatusHistory(String id);
+
+    // ----------------------------------------
+    // System diagnostics history
+    // ----------------------------------------
+
+    /**
+     * @return the system diagnostics history
+     */
+    StatusHistoryEntity getNodeStatusHistory();
 
     /**
      * Get the descriptor for the specified property of the specified processor.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -269,9 +269,9 @@ import org.apache.nifi.web.api.entity.ProcessGroupStatusEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupStatusSnapshotEntity;
 import org.apache.nifi.web.api.entity.ProcessorDiagnosticsEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
-import org.apache.nifi.web.api.entity.ProcessorsRunStatusDetailsEntity;
 import org.apache.nifi.web.api.entity.ProcessorRunStatusDetailsEntity;
 import org.apache.nifi.web.api.entity.ProcessorStatusEntity;
+import org.apache.nifi.web.api.entity.ProcessorsRunStatusDetailsEntity;
 import org.apache.nifi.web.api.entity.RegistryClientEntity;
 import org.apache.nifi.web.api.entity.RegistryEntity;
 import org.apache.nifi.web.api.entity.RemoteProcessGroupEntity;
@@ -3451,6 +3451,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final ProcessorNode processor = processorDAO.getProcessor(id);
         final PermissionsDTO permissions = dtoFactory.createPermissionsDto(processor);
         final StatusHistoryDTO dto = controllerFacade.getProcessorStatusHistory(id);
+        return entityFactory.createStatusHistoryEntity(dto, permissions);
+    }
+
+    @Override
+    public StatusHistoryEntity getNodeStatusHistory() {
+        final PermissionsDTO permissions = dtoFactory.createPermissionsDto(controllerFacade, NiFiUserUtils.getNiFiUser());
+        final StatusHistoryDTO dto = controllerFacade.getNodeStatusHistory();
         return entityFactory.createStatusHistoryEntity(dto, permissions);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerResource.java
@@ -41,6 +41,7 @@ import org.apache.nifi.web.api.dto.RegistryDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
 import org.apache.nifi.web.api.entity.BulletinEntity;
 import org.apache.nifi.web.api.entity.ClusterEntity;
+import org.apache.nifi.web.api.entity.ComponentHistoryEntity;
 import org.apache.nifi.web.api.entity.ControllerConfigurationEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.Entity;
@@ -1056,6 +1057,39 @@ public class ControllerResource extends ApplicationResource {
     // -------
     // history
     // -------
+
+    @GET
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("status/history")
+    @ApiOperation(
+            value = "Gets configuration history for the node",
+            notes = NON_GUARANTEED_ENDPOINT,
+            response = ComponentHistoryEntity.class,
+            authorizations = {
+                    @Authorization(value = "Read - /controller")
+            }
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(code = 400, message = "NiFi was unable to complete the request because it was invalid. The request should not be retried without modification."),
+                    @ApiResponse(code = 401, message = "Client could not be authenticated."),
+                    @ApiResponse(code = 403, message = "Client is not authorized to make this request."),
+                    @ApiResponse(code = 404, message = "The specified resource could not be found."),
+                    @ApiResponse(code = 409, message = "The request was valid but NiFi was not in the appropriate state to process it. Retrying the same request later may be successful.")
+            }
+    )
+    public Response getNodeHistory() {
+        authorizeController(RequestAction.READ);
+
+        // replicate if cluster manager
+        if (isReplicateRequest()) {
+            return replicate(HttpMethod.GET);
+        }
+
+        // generate the response
+        return generateOkResponse(serviceFacade.getNodeStatusHistory()).build();
+    }
 
     /**
      * Deletes flow history from the specified end date.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerResource.java
@@ -1063,7 +1063,7 @@ public class ControllerResource extends ApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("status/history")
     @ApiOperation(
-            value = "Gets configuration history for the node",
+            value = "Gets status history for the node",
             notes = NON_GUARANTEED_ENDPOINT,
             response = ComponentHistoryEntity.class,
             authorizations = {
@@ -1079,7 +1079,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(code = 409, message = "The request was valid but NiFi was not in the appropriate state to process it. Retrying the same request later may be successful.")
             }
     )
-    public Response getNodeHistory() {
+    public Response getNodeStatusHistory() {
         authorizeController(RequestAction.READ);
 
         // replicate if cluster manager

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
@@ -2691,39 +2691,6 @@ public class FlowResource extends ApplicationResource {
         return generateOkResponse(entity).build();
     }
 
-    @GET
-    @Consumes(MediaType.WILDCARD)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("node/status/history")
-    @ApiOperation(
-            value = "Gets configuration history for the node",
-            notes = NON_GUARANTEED_ENDPOINT,
-            response = ComponentHistoryEntity.class,
-            authorizations = {
-                    @Authorization(value = "Read - /flow")
-            }
-    )
-    @ApiResponses(
-            value = {
-                    @ApiResponse(code = 400, message = "NiFi was unable to complete the request because it was invalid. The request should not be retried without modification."),
-                    @ApiResponse(code = 401, message = "Client could not be authenticated."),
-                    @ApiResponse(code = 403, message = "Client is not authorized to make this request."),
-                    @ApiResponse(code = 404, message = "The specified resource could not be found."),
-                    @ApiResponse(code = 409, message = "The request was valid but NiFi was not in the appropriate state to process it. Retrying the same request later may be successful.")
-            }
-    )
-    public Response getNodeHistory() {
-        authorizeFlow();
-
-        // replicate if cluster manager
-        if (isReplicateRequest()) {
-            return replicate(HttpMethod.GET);
-        }
-
-        // generate the response
-        return generateOkResponse(serviceFacade.getNodeStatusHistory()).build();
-    }
-
     /**
      * Gets the actions for the specified component.
      *

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
@@ -2691,6 +2691,39 @@ public class FlowResource extends ApplicationResource {
         return generateOkResponse(entity).build();
     }
 
+    @GET
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("node/status/history")
+    @ApiOperation(
+            value = "Gets configuration history for the node",
+            notes = NON_GUARANTEED_ENDPOINT,
+            response = ComponentHistoryEntity.class,
+            authorizations = {
+                    @Authorization(value = "Read - /flow")
+            }
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(code = 400, message = "NiFi was unable to complete the request because it was invalid. The request should not be retried without modification."),
+                    @ApiResponse(code = 401, message = "Client could not be authenticated."),
+                    @ApiResponse(code = 403, message = "Client is not authorized to make this request."),
+                    @ApiResponse(code = 404, message = "The specified resource could not be found."),
+                    @ApiResponse(code = 409, message = "The request was valid but NiFi was not in the appropriate state to process it. Retrying the same request later may be successful.")
+            }
+    )
+    public Response getNodeHistory() {
+        authorizeFlow();
+
+        // replicate if cluster manager
+        if (isReplicateRequest()) {
+            return replicate(HttpMethod.GET);
+        }
+
+        // generate the response
+        return generateOkResponse(serviceFacade.getNodeStatusHistory()).build();
+    }
+
     /**
      * Gets the actions for the specified component.
      *

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -279,6 +279,22 @@ public class ControllerFacade implements Authorizable {
     }
 
     /**
+     * Returns the status history for the node.
+     *
+     * @return status history
+     */
+    public StatusHistoryDTO getNodeStatusHistory() {
+        final boolean authorized = isAuthorized(authorizer, RequestAction.READ, NiFiUserUtils.getNiFiUser());
+        final StatusHistoryDTO statusHistory = flowController.getNodeStatusHistory();
+
+        if (!authorized)  {
+            statusHistory.getComponentDetails().put(ComponentStatusRepository.COMPONENT_DETAIL_TYPE, "Node");
+        }
+
+        return statusHistory;
+    }
+
+    /**
      * Returns the status history for the specified processor.
      *
      * @param processorId processor id

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
@@ -52,10 +52,13 @@ import org.apache.nifi.web.api.dto.DtoFactory;
 import org.apache.nifi.web.api.dto.EntityFactory;
 import org.apache.nifi.web.api.dto.action.HistoryDTO;
 import org.apache.nifi.web.api.dto.action.HistoryQueryDTO;
+import org.apache.nifi.web.api.dto.status.StatusHistoryDTO;
 import org.apache.nifi.web.api.entity.ActionEntity;
+import org.apache.nifi.web.api.entity.StatusHistoryEntity;
 import org.apache.nifi.web.controller.ControllerFacade;
 import org.apache.nifi.web.dao.ProcessGroupDAO;
 import org.apache.nifi.web.security.token.NiFiAuthenticationToken;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -63,6 +66,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
@@ -242,6 +246,25 @@ public class StandardNiFiServiceFacadeTest {
             verify(authorizer, times(1)).authorize(argThat(o -> o.getResource().getIdentifier().endsWith(PROCESSOR_ID_1)));
             verify(authorizer, times(0)).authorize(argThat(o -> o.getResource().equals(ResourceFactory.getControllerResource())));
         }
+    }
+
+    @Test
+    public void testGetStatusHistory() {
+        // given
+        final Date generated = new Date();
+        final StatusHistoryDTO dto = new StatusHistoryDTO();
+        dto.setGenerated(generated);
+        final ControllerFacade controllerFacade = mock(ControllerFacade.class);
+        Mockito.when(controllerFacade.getNodeStatusHistory()).thenReturn(dto);
+        serviceFacade.setControllerFacade(controllerFacade);
+
+        // when
+        final StatusHistoryEntity result = serviceFacade.getNodeStatusHistory();
+
+        // then
+        Mockito.verify(controllerFacade).getNodeStatusHistory();
+        Assert.assertNotNull(result);
+        Assert.assertEquals(generated, result.getStatusHistory().getGenerated());
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/canvas-header.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/canvas-header.jsp
@@ -152,6 +152,12 @@
                             <i class="fa fa-history"></i>Flow Configuration History
                         </a>
                     </md-menu-item>
+                    <md-menu-item layout-align="space-around center">
+                        <a id="status-history-link"
+                           ng-click="appCtrl.serviceProvider.headerCtrl.globalMenuCtrl.nodeStatusHistory.shell.launch();">
+                            <i class="fa fa-area-chart"></i>Node Status History
+                        </a>
+                    </md-menu-item>
                     <md-menu-divider ng-if="appCtrl.nf.CanvasUtils.isManagedAuthorizer()"></md-menu-divider>
                     <md-menu-item layout-align="space-around center" ng-if="appCtrl.nf.CanvasUtils.isManagedAuthorizer()">
                         <a id="users-link" layout="row"

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-global-menu-controller.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-global-menu-controller.js
@@ -26,11 +26,12 @@
                 'nf.ParameterContexts',
                 'nf.PolicyManagement',
                 'nf.ClusterSummary',
+                'nf.StatusHistory',
                 'nf.ErrorHandler',
                 'nf.Settings',
                 'nf.CanvasUtils'],
-            function ($, nfCommon, nfQueueListing, nfShell, nfParameterContexts, nfPolicyManagement, nfClusterSummary, nfErrorHandler, nfSettings, nfCanvasUtils) {
-                return (nf.ng.Canvas.GlobalMenuCtrl = factory($, nfCommon, nfQueueListing, nfShell, nfPolicyManagement, nfClusterSummary, nfErrorHandler, nfSettings, nfCanvasUtils));
+            function ($, nfCommon, nfQueueListing, nfShell, nfParameterContexts, nfPolicyManagement, nfClusterSummary, nfStatusHistory, nfErrorHandler, nfSettings, nfCanvasUtils) {
+                return (nf.ng.Canvas.GlobalMenuCtrl = factory($, nfCommon, nfQueueListing, nfShell, nfPolicyManagement, nfClusterSummary, nfStatusHistory, nfErrorHandler, nfSettings, nfCanvasUtils));
             });
     } else if (typeof exports === 'object' && typeof module === 'object') {
         module.exports = (nf.ng.Canvas.GlobalMenuCtrl =
@@ -41,6 +42,7 @@
                 require('nf.ParameterContexts'),
                 require('nf.PolicyManagement'),
                 require('nf.ClusterSummary'),
+                require('nf.StatusHistory'),
                 require('nf.ErrorHandler'),
                 require('nf.Settings'),
                 require('nf.CanvasUtils')));
@@ -52,11 +54,12 @@
             root.nf.ParameterContexts,
             root.nf.PolicyManagement,
             root.nf.ClusterSummary,
+            root.nf.StatusHistory,
             root.nf.ErrorHandler,
             root.nf.Settings,
             root.nf.CanvasUtils);
     }
-}(this, function ($, nfCommon, nfQueueListing, nfShell, nfParameterContexts, nfPolicyManagement, nfClusterSummary, nfErrorHandler, nfSettings, nfCanvasUtils) {
+}(this, function ($, nfCommon, nfQueueListing, nfShell, nfParameterContexts, nfPolicyManagement, nfClusterSummary, nfStatusHistory, nfErrorHandler, nfSettings, nfCanvasUtils) {
     'use strict';
 
     return function (serviceProvider) {
@@ -234,6 +237,26 @@
                      */
                     launch: function () {
                         nfShell.showPage('history');
+                    }
+                }
+            };
+
+
+            /**
+             * The node status history menu item controller.
+             */
+            this.nodeStatusHistory = {
+
+                /**
+                 * The node status history menu item's shell controller.
+                 */
+                shell: {
+
+                    /**
+                     * Launch the history shell.
+                     */
+                    launch: function () {
+                        nfStatusHistory.showNodeChart();
                     }
                 }
             };

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-status-history.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-status-history.js
@@ -1176,7 +1176,7 @@
         showNodeChart: function () {
             $.ajax({
                 type: 'GET',
-                url: config.urls.api + '/flow/node/status/history',
+                url: config.urls.api + '/controller/status/history',
                 dataType: 'json'
             }).done(function (response) {
                 handleNodeStatusHistoryResponse(response.statusHistory);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-status-history.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-status-history.js
@@ -53,7 +53,8 @@
             connection: 'Connection',
             funnel: 'Funnel',
             template: 'Template',
-            label: 'Label'
+            label: 'Label',
+            node: 'Node'
         },
         urls: {
             api: '../nifi-api'
@@ -78,6 +79,9 @@
         },
         'DATA_SIZE': function (d) {
             return nfCommon.formatDataSize(d);
+        },
+        'FRACTION': function (d) {
+            return nfCommon.formatFloat(d / 1000000);
         }
     };
 
@@ -126,6 +130,62 @@
         var descriptors = componentStatusHistory.fieldDescriptors;
         statusHistory.details = componentStatusHistory.componentDetails;
         statusHistory.selectedDescriptor = nfCommon.isUndefined(selectedDescriptor) ? descriptors[0] : selectedDescriptor;
+
+        // ensure enough status snapshots
+        if (nfCommon.isDefinedAndNotNull(componentStatusHistory.aggregateSnapshots) && componentStatusHistory.aggregateSnapshots.length > 1) {
+            statusHistory.instances.push({
+                id: config.nifiInstanceId,
+                label: config.nifiInstanceLabel,
+                snapshots: componentStatusHistory.aggregateSnapshots
+            });
+        } else {
+            insufficientHistory();
+            return;
+        }
+
+        // get the status for each node in the cluster if applicable
+        $.each(componentStatusHistory.nodeSnapshots, function (_, nodeSnapshots) {
+            // ensure enough status snapshots
+            if (nfCommon.isDefinedAndNotNull(nodeSnapshots.statusSnapshots) && nodeSnapshots.statusSnapshots.length > 1) {
+                statusHistory.instances.push({
+                    id: nodeSnapshots.nodeId,
+                    label: nodeSnapshots.address + ':' + nodeSnapshots.apiPort,
+                    snapshots: nodeSnapshots.statusSnapshots
+                });
+            }
+        });
+
+        // ensure we found eligible status history
+        if (statusHistory.instances.length > 0) {
+            // store the status history
+            $('#status-history-dialog').data('status-history', statusHistory);
+
+            // chart the status history
+            chart(statusHistory, descriptors);
+        } else {
+            insufficientHistory();
+        }
+    };
+
+    /**
+     * Handles the status history response for node status history.
+     *
+     * @param {object} componentStatusHistory
+     */
+    var handleNodeStatusHistoryResponse = function (componentStatusHistory) {
+        // update the last refreshed
+        $('#status-history-last-refreshed').text(componentStatusHistory.generated);
+
+        // initialize the status history
+        var statusHistory = {
+            type: 'Node',
+            instances: []
+        };
+
+        // get the descriptors
+        var descriptors = componentStatusHistory.fieldDescriptors;
+        statusHistory.details = componentStatusHistory.componentDetails;
+        statusHistory.selectedDescriptor = descriptors[0];
 
         // ensure enough status snapshots
         if (nfCommon.isDefinedAndNotNull(componentStatusHistory.aggregateSnapshots) && componentStatusHistory.aggregateSnapshots.length > 1) {
@@ -1024,6 +1084,8 @@
                         nfStatusHistory.showProcessGroupChart(statusHistory.groupId, statusHistory.id, statusHistory.selectedDescriptor);
                     } else if (statusHistory.type === config.type.remoteProcessGroup) {
                         nfStatusHistory.showRemoteProcessGroupChart(statusHistory.groupId, statusHistory.id, statusHistory.selectedDescriptor);
+                    } else if (statusHistory.type === config.type.node) {
+                        nfStatusHistory.showNodeChart();
                     } else {
                         nfStatusHistory.showConnectionChart(statusHistory.groupId, statusHistory.id, statusHistory.selectedDescriptor);
                     }
@@ -1105,6 +1167,19 @@
                 dataType: 'json'
             }).done(function (response) {
                 handleStatusHistoryResponse(groupId, processorId, response.statusHistory, config.type.processor, selectedDescriptor);
+            }).fail(nfErrorHandler.handleAjaxError);
+        },
+
+        /**
+         * Shows the status history for the node.
+         */
+        showNodeChart: function () {
+            $.ajax({
+                type: 'GET',
+                url: config.urls.api + '/flow/node/status/history',
+                dataType: 'json'
+            }).done(function (response) {
+                handleNodeStatusHistoryResponse(response.statusHistory);
             }).fail(nfErrorHandler.handleAjaxError);
         },
 


### PR DESCRIPTION
[NIFI-7429](https://issues.apache.org/jira/browse/NIFI-7429)

This is a proposal for having historical data about the NiFi node’s status appearing in the NiFi UI. The main purpose was to provide a simple tool makes it possible to check basic performance metrics on the UI.

From implementation perspective the solution is based on the existing status history function which was applied for components like processors. In front end side, the existing code is reused as much as possible, only some minor extension and duplication were needed. The main differences compared to the existing uses were the different trigger (this is reachable from the global menu) and the lack of some parameters like id or group.

The backend side builds on top of VolatileComponentStatusRepository which already responsible for such functions. I tried to add is as an integral part of the existing metric collection, so the frequency of the measurements and the way of triggering is not separated. The metrics themselves are distilled from the SystemDiagnostics and the already collected GarbageCollectionStatus.

Creating the snapshots came with three non-trivial cases I would like to highlight:

1. The GC metrics are not predefined as the type of GC is depending on the running environment and on the actual collectors. This prevented pre-defining the descriptors for them, thus these are created during requests.
2. Also, some GC metrics (time spent, counters) are growing in monotonous way as the metric collection stores the value shows the accumulated value from the start of the instance. In order to be able to provide the increment since the last measurement, the collection of the GC metrics are using the previous snapshot as baseline.
3. The processor load average (usually in the form of “2.3” or alike) does not fit into the “long” format used by the functionality without significant information loss. In order to avoid bigger refactors, I introduced a new formatter type, named “FRACTION”. By convention the server side multiplies these metrics using a predefined number (1_000_000 for now) and during visualisation the frontend divides the metric value with the same number. By this, we shift the relevant digits into long value range. Of course, this still comes with precision loss, but for visualisation purposes, this looks sufficient.

Thank you for your time and response!


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
