### PR TITLE
NIFI-6332 - Add Cache Control property to PutS3Object processor

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -156,7 +156,7 @@ public class PutS3Object extends AbstractS3Processor {
     public static final PropertyDescriptor CACHE_CONTROL = new PropertyDescriptor.Builder()
             .name("Cache Control")
             .displayName("Cache Control")
-            .description("Sets the Cache-Control HTTP header. Multiple directives are comma-separated.")
+            .description("Sets the Cache-Control HTTP header indicating the caching directives of the associated object. Multiple directives are comma-separated.")
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -158,6 +158,7 @@ public class PutS3Object extends AbstractS3Processor {
             .displayName("Cache Control")
             .description("Sets the Cache-Control HTTP header indicating the caching directives of the associated object. Multiple directives are comma-separated.")
             .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
@@ -471,7 +472,8 @@ public class PutS3Object extends AbstractS3Processor {
                             attributes.put(S3_CONTENT_TYPE, contentType);
                         }
 
-                        final String cacheControl = context.getProperty(CACHE_CONTROL).getValue();
+                        final String cacheControl = context.getProperty(CACHE_CONTROL)
+                                .evaluateAttributeExpressions(ff).getValue();
                         if (cacheControl != null) {
                             objectMetadata.setCacheControl(cacheControl);
                             attributes.put(S3_CACHE_CONTROL, cacheControl);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -117,6 +117,7 @@ import com.amazonaws.services.s3.model.UploadPartResult;
     @WritesAttribute(attribute = "s3.contenttype", description = "The S3 content type of the S3 Object that put in S3"),
     @WritesAttribute(attribute = "s3.version", description = "The version of the S3 Object that was put to S3"),
     @WritesAttribute(attribute = "s3.etag", description = "The ETag of the S3 Object"),
+    @WritesAttribute(attribute = "s3.cachecontrol", description = "The cache-control header of the S3 Object"),
     @WritesAttribute(attribute = "s3.uploadId", description = "The uploadId used to upload the Object to S3"),
     @WritesAttribute(attribute = "s3.expiration", description = "A human-readable form of the expiration date of " +
             "the S3 object, if one is set"),
@@ -151,6 +152,14 @@ public class PutS3Object extends AbstractS3Processor {
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build();
+
+    public static final PropertyDescriptor CACHE_CONTROL = new PropertyDescriptor.Builder()
+            .name("Cache Control")
+            .displayName("Cache Control")
+            .description("Sets the Cache-Control HTTP header. Multiple directives are comma-separated.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
 
     public static final PropertyDescriptor STORAGE_CLASS = new PropertyDescriptor.Builder()
         .name("Storage Class")
@@ -232,7 +241,7 @@ public class PutS3Object extends AbstractS3Processor {
             .build();
 
     public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
-        Arrays.asList(KEY, BUCKET, CONTENT_TYPE, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, AWS_CREDENTIALS_PROVIDER_SERVICE, OBJECT_TAGS_PREFIX, REMOVE_TAG_PREFIX,
+        Arrays.asList(KEY, BUCKET, CONTENT_TYPE, CACHE_CONTROL, ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, AWS_CREDENTIALS_PROVIDER_SERVICE, OBJECT_TAGS_PREFIX, REMOVE_TAG_PREFIX,
             STORAGE_CLASS, REGION, TIMEOUT, EXPIRATION_RULE_ID, FULL_CONTROL_USER_LIST, READ_USER_LIST, WRITE_USER_LIST, READ_ACL_LIST, WRITE_ACL_LIST, OWNER,
             CANNED_ACL, SSL_CONTEXT_SERVICE, ENDPOINT_OVERRIDE, SIGNER_OVERRIDE, MULTIPART_THRESHOLD, MULTIPART_PART_SIZE, MULTIPART_S3_AGEOFF_INTERVAL,
             MULTIPART_S3_MAX_AGE, SERVER_SIDE_ENCRYPTION, ENCRYPTION_SERVICE, USE_CHUNKED_ENCODING, USE_PATH_STYLE_ACCESS,
@@ -244,6 +253,7 @@ public class PutS3Object extends AbstractS3Processor {
     final static String S3_UPLOAD_ID_ATTR_KEY = "s3.uploadId";
     final static String S3_VERSION_ATTR_KEY = "s3.version";
     final static String S3_ETAG_ATTR_KEY = "s3.etag";
+    final static String S3_CACHE_CONTROL = "s3.cachecontrol";
     final static String S3_EXPIRATION_ATTR_KEY = "s3.expiration";
     final static String S3_STORAGECLASS_ATTR_KEY = "s3.storeClass";
     final static String S3_STORAGECLASS_META_KEY = "x-amz-storage-class";
@@ -459,6 +469,12 @@ public class PutS3Object extends AbstractS3Processor {
                         if (contentType != null) {
                             objectMetadata.setContentType(contentType);
                             attributes.put(S3_CONTENT_TYPE, contentType);
+                        }
+
+                        final String cacheControl = context.getProperty(CACHE_CONTROL).getValue();
+                        if (cacheControl != null) {
+                            objectMetadata.setCacheControl(cacheControl);
+                            attributes.put(S3_CACHE_CONTROL, cacheControl);
                         }
 
                         final String expirationRule = context.getProperty(EXPIRATION_RULE_ID)

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -293,6 +293,22 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
+    public void testCacheControl() throws IOException {
+        TestRunner runner = initTestRunner();
+
+        runner.setProperty(PutS3Object.CACHE_CONTROL, "no-cache");
+
+        runner.enqueue(getResourcePath(SAMPLE_FILE_RESOURCE_NAME));
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS, 1);
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(PutS3Object.REL_SUCCESS);
+        MockFlowFile ff1 = flowFiles.get(0);
+        ff1.assertAttributeEquals(PutS3Object.S3_CACHE_CONTROL, "no-cache");
+    }
+
+    @Test
     public void testPutInFolder() throws IOException {
         TestRunner runner = initTestRunner();
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -209,7 +209,7 @@ public class TestPutS3Object {
     public void testGetPropertyDescriptors() {
         PutS3Object processor = new PutS3Object();
         List<PropertyDescriptor> pd = processor.getSupportedPropertyDescriptors();
-        assertEquals("size should be eq", 36, pd.size());
+        assertEquals("size should be eq", 37, pd.size());
         assertTrue(pd.contains(PutS3Object.ACCESS_KEY));
         assertTrue(pd.contains(PutS3Object.AWS_CREDENTIALS_PROVIDER_SERVICE));
         assertTrue(pd.contains(PutS3Object.BUCKET));
@@ -242,6 +242,7 @@ public class TestPutS3Object {
         assertTrue(pd.contains(PutS3Object.OBJECT_TAGS_PREFIX));
         assertTrue(pd.contains(PutS3Object.REMOVE_TAG_PREFIX));
         assertTrue(pd.contains(PutS3Object.CONTENT_TYPE));
+        assertTrue(pd.contains(PutS3Object.CACHE_CONTROL));
         assertTrue(pd.contains(PutS3Object.MULTIPART_THRESHOLD));
         assertTrue(pd.contains(PutS3Object.MULTIPART_PART_SIZE));
         assertTrue(pd.contains(PutS3Object.MULTIPART_S3_AGEOFF_INTERVAL));


### PR DESCRIPTION
Add new property 'Cache Control' to allow user to
set the cache-control http header on the S3 object.

This property is not required, and has no default value.

The implementation is similar to the Content-Type property,
except that this property does not allow Expression Language.
