### PR TITLE
NIFI-7664 - Add Content Disposition property to PutS3Object processor

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -119,7 +119,7 @@ public class FetchS3Object extends AbstractS3Processor {
                         .explanation(encryptionService.getStrategyDisplayName() + " is not a valid encryption strategy for fetching objects. Decryption will be handled automatically " +
                                 "during the fetch of S3 objects encrypted with " + encryptionService.getStrategyDisplayName())
                         .build()
-                );
+                    );
             }
         }
 
@@ -166,13 +166,18 @@ public class FetchS3Object extends AbstractS3Processor {
             final ObjectMetadata metadata = s3Object.getObjectMetadata();
             if (metadata.getContentDisposition() != null) {
                 final String fullyQualified = metadata.getContentDisposition();
-                final int lastSlash = fullyQualified.lastIndexOf("/");
-                if (lastSlash > -1 && lastSlash < fullyQualified.length() - 1) {
-                    attributes.put(CoreAttributes.PATH.key(), fullyQualified.substring(0, lastSlash));
-                    attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), fullyQualified);
-                    attributes.put(CoreAttributes.FILENAME.key(), fullyQualified.substring(lastSlash + 1));
+
+                if (fullyQualified.equals(PutS3Object.CONTENT_DISPOSITION_INLINE) || fullyQualified.equals(PutS3Object.CONTENT_DISPOSITION_ATTACHMENT)) {
+                    attributes.put(CoreAttributes.FILENAME.key(), key);
                 } else {
-                    attributes.put(CoreAttributes.FILENAME.key(), metadata.getContentDisposition());
+                    final int lastSlash = fullyQualified.lastIndexOf("/");
+                    if (lastSlash > -1 && lastSlash < fullyQualified.length() - 1) {
+                        attributes.put(CoreAttributes.PATH.key(), fullyQualified.substring(0, lastSlash));
+                        attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), fullyQualified);
+                        attributes.put(CoreAttributes.FILENAME.key(), fullyQualified.substring(lastSlash + 1));
+                    } else {
+                        attributes.put(CoreAttributes.FILENAME.key(), metadata.getContentDisposition());
+                    }
                 }
             }
             if (metadata.getContentMD5() != null) {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -119,7 +119,7 @@ public class FetchS3Object extends AbstractS3Processor {
                         .explanation(encryptionService.getStrategyDisplayName() + " is not a valid encryption strategy for fetching objects. Decryption will be handled automatically " +
                                 "during the fetch of S3 objects encrypted with " + encryptionService.getStrategyDisplayName())
                         .build()
-                    );
+                );
             }
         }
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -165,16 +165,16 @@ public class FetchS3Object extends AbstractS3Processor {
 
             final ObjectMetadata metadata = s3Object.getObjectMetadata();
             if (metadata.getContentDisposition() != null) {
-                final String fullyQualified = metadata.getContentDisposition();
+                final String contentDisposition = metadata.getContentDisposition();
 
-                if (fullyQualified.equals(PutS3Object.CONTENT_DISPOSITION_INLINE) || fullyQualified.equals(PutS3Object.CONTENT_DISPOSITION_ATTACHMENT)) {
+                if (contentDisposition.equals(PutS3Object.CONTENT_DISPOSITION_INLINE) || contentDisposition.startsWith("attachment; filename=")) {
                     attributes.put(CoreAttributes.FILENAME.key(), key);
                 } else {
-                    final int lastSlash = fullyQualified.lastIndexOf("/");
-                    if (lastSlash > -1 && lastSlash < fullyQualified.length() - 1) {
-                        attributes.put(CoreAttributes.PATH.key(), fullyQualified.substring(0, lastSlash));
-                        attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), fullyQualified);
-                        attributes.put(CoreAttributes.FILENAME.key(), fullyQualified.substring(lastSlash + 1));
+                    final int lastSlash = contentDisposition.lastIndexOf("/");
+                    if (lastSlash > -1 && lastSlash < contentDisposition.length() - 1) {
+                        attributes.put(CoreAttributes.PATH.key(), contentDisposition.substring(0, lastSlash));
+                        attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), contentDisposition);
+                        attributes.put(CoreAttributes.FILENAME.key(), contentDisposition.substring(lastSlash + 1));
                     } else {
                         attributes.put(CoreAttributes.FILENAME.key(), metadata.getContentDisposition());
                     }

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -229,8 +229,7 @@ public class FetchS3Object extends AbstractS3Processor {
         session.getProvenanceReporter().fetch(flowFile, "http://" + bucket + ".amazonaws.com/" + key, transferMillis);
     }
 
-    protected void setFilePathAttributes(Map<String, String> attributes, String filePathName)
-    {
+    protected void setFilePathAttributes(Map<String, String> attributes, String filePathName) {
         final int lastSlash = filePathName.lastIndexOf("/");
         if (lastSlash > -1 && lastSlash < filePathName.length() - 1) {
             attributes.put(CoreAttributes.PATH.key(), filePathName.substring(0, lastSlash));

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -168,16 +168,9 @@ public class FetchS3Object extends AbstractS3Processor {
                 final String contentDisposition = metadata.getContentDisposition();
 
                 if (contentDisposition.equals(PutS3Object.CONTENT_DISPOSITION_INLINE) || contentDisposition.startsWith("attachment; filename=")) {
-                    attributes.put(CoreAttributes.FILENAME.key(), key);
+                    setFilePathAttributes(attributes, key);
                 } else {
-                    final int lastSlash = contentDisposition.lastIndexOf("/");
-                    if (lastSlash > -1 && lastSlash < contentDisposition.length() - 1) {
-                        attributes.put(CoreAttributes.PATH.key(), contentDisposition.substring(0, lastSlash));
-                        attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), contentDisposition);
-                        attributes.put(CoreAttributes.FILENAME.key(), contentDisposition.substring(lastSlash + 1));
-                    } else {
-                        attributes.put(CoreAttributes.FILENAME.key(), metadata.getContentDisposition());
-                    }
+                    setFilePathAttributes(attributes, contentDisposition);
                 }
             }
             if (metadata.getContentMD5() != null) {
@@ -236,4 +229,15 @@ public class FetchS3Object extends AbstractS3Processor {
         session.getProvenanceReporter().fetch(flowFile, "http://" + bucket + ".amazonaws.com/" + key, transferMillis);
     }
 
+    protected void setFilePathAttributes(Map<String, String> attributes, String filePathName)
+    {
+        final int lastSlash = filePathName.lastIndexOf("/");
+        if (lastSlash > -1 && lastSlash < filePathName.length() - 1) {
+            attributes.put(CoreAttributes.PATH.key(), filePathName.substring(0, lastSlash));
+            attributes.put(CoreAttributes.ABSOLUTE_PATH.key(), filePathName);
+            attributes.put(CoreAttributes.FILENAME.key(), filePathName.substring(lastSlash + 1));
+        } else {
+            attributes.put(CoreAttributes.FILENAME.key(), filePathName);
+        }
+    }
 }

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -17,7 +17,7 @@
 package org.apache.nifi.processors.aws.s3;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -172,11 +172,12 @@ public class TestPutS3Object {
 
         runner.run(1);
 
-        runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS, 1);
-        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(PutS3Object.REL_SUCCESS);
-        MockFlowFile ff = flowFiles.get(0);
+        ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
+        Mockito.verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
+        PutObjectRequest request = captureRequest.getValue();
 
-        assertEquals("Iñtërnâtiônàližætiøn.txt", URLDecoder.decode(ff.getAttribute(CoreAttributes.FILENAME.key()), "UTF-8"));
+        ObjectMetadata objectMetadata = request.getMetadata();
+        assertEquals(URLEncoder.encode("Iñtërnâtiônàližætiøn.txt", "UTF-8"), objectMetadata.getContentDisposition());
     }
 
     private void prepareTest() {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -64,6 +64,7 @@ public class TestPutS3Object {
     public void setUp() {
         mockS3Client = Mockito.mock(AmazonS3Client.class);
         putS3Object = new PutS3Object() {
+            @Override
             protected AmazonS3Client getClient() {
                 return mockS3Client;
             }
@@ -171,12 +172,11 @@ public class TestPutS3Object {
 
         runner.run(1);
 
-        ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
-        PutObjectRequest request = captureRequest.getValue();
+        runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS, 1);
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(PutS3Object.REL_SUCCESS);
+        MockFlowFile ff = flowFiles.get(0);
 
-        ObjectMetadata objectMetadata = request.getMetadata();
-        assertEquals("Iñtërnâtiônàližætiøn.txt", URLDecoder.decode(objectMetadata.getContentDisposition(), "UTF-8"));
+        assertEquals("Iñtërnâtiônàližætiøn.txt", URLDecoder.decode(ff.getAttribute(CoreAttributes.FILENAME.key()), "UTF-8"));
     }
 
     private void prepareTest() {
@@ -209,7 +209,7 @@ public class TestPutS3Object {
     public void testGetPropertyDescriptors() {
         PutS3Object processor = new PutS3Object();
         List<PropertyDescriptor> pd = processor.getSupportedPropertyDescriptors();
-        assertEquals("size should be eq", 37, pd.size());
+        assertEquals("size should be eq", 38, pd.size());
         assertTrue(pd.contains(PutS3Object.ACCESS_KEY));
         assertTrue(pd.contains(PutS3Object.AWS_CREDENTIALS_PROVIDER_SERVICE));
         assertTrue(pd.contains(PutS3Object.BUCKET));
@@ -242,6 +242,7 @@ public class TestPutS3Object {
         assertTrue(pd.contains(PutS3Object.OBJECT_TAGS_PREFIX));
         assertTrue(pd.contains(PutS3Object.REMOVE_TAG_PREFIX));
         assertTrue(pd.contains(PutS3Object.CONTENT_TYPE));
+        assertTrue(pd.contains(PutS3Object.CONTENT_DISPOSITION));
         assertTrue(pd.contains(PutS3Object.CACHE_CONTROL));
         assertTrue(pd.contains(PutS3Object.MULTIPART_THRESHOLD));
         assertTrue(pd.contains(PutS3Object.MULTIPART_PART_SIZE));


### PR DESCRIPTION
Add new property 'Content Disposition' to allow user
to set the content-disposition http header on the S3 object.

Allowed values are 'inline' (default) and 'attachment'.
If 'attachment' is selected, the filename will be set to the S3 Object key.
