### PR TITLE
NIFI-7691: Validate request object to be not null.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
@@ -634,6 +634,10 @@ public class FlowResource extends ApplicationResource {
                     required = true
             ) final ScheduleComponentsEntity requestScheduleComponentsEntity) {
 
+        if (requestScheduleComponentsEntity == null) {
+            throw new IllegalArgumentException("Schedule Component must be specified.");
+        }
+
         // ensure the same id is being used
         if (!id.equals(requestScheduleComponentsEntity.getId())) {
             throw new IllegalArgumentException(String.format("The process group id (%s) in the request body does "
@@ -820,6 +824,10 @@ public class FlowResource extends ApplicationResource {
             @PathParam("id") String id,
             @ApiParam(value = "The request to schedule or unschedule. If the comopnents in the request are not specified, all authorized components will be considered.", required = true)
             final ActivateControllerServicesEntity requestEntity) {
+
+        if (requestEntity == null) {
+            throw new IllegalArgumentException("Controller service must be specified.");
+        }
 
         // ensure the same id is being used
         if (!id.equals(requestEntity.getId())) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
@@ -328,6 +328,10 @@ public class ParameterContextResource extends ApplicationResource {
         @PathParam("contextId") final String contextId,
         @ApiParam(value = "The updated version of the parameter context.", required = true) final ParameterContextEntity requestEntity) {
 
+        if (requestEntity == null) {
+            throw new IllegalArgumentException("Parameter Context must be specified.");
+        }
+
         // Verify the request
         final RevisionDTO revisionDto = requestEntity.getRevision();
         if (revisionDto == null) {
@@ -618,6 +622,10 @@ public class ParameterContextResource extends ApplicationResource {
     public Response submitValidationRequest(
         @PathParam("contextId") final String contextId,
         @ApiParam(value = "The validation request", required=true) final ParameterContextValidationRequestEntity requestEntity) {
+
+        if (requestEntity == null) {
+            throw new IllegalArgumentException("Parameter Context must be specified.");
+        }
 
         final ParameterContextValidationRequestDTO requestDto = requestEntity.getRequest();
         if (requestDto == null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -3531,7 +3531,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                     required = true
             ) final CreateTemplateRequestEntity requestCreateTemplateRequestEntity) {
 
-        if (requestCreateTemplateRequestEntity.getSnippetId() == null) {
+        if (requestCreateTemplateRequestEntity == null || requestCreateTemplateRequestEntity.getSnippetId() == null) {
             throw new IllegalArgumentException("The snippet identifier must be specified.");
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/VersionsResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/VersionsResource.java
@@ -468,6 +468,10 @@ public class VersionsResource extends FlowUpdateResource<VersionControlInformati
         @ApiParam("The process group id.") @PathParam("id") final String groupId,
         @ApiParam(value = "The versioned flow details.", required = true) final StartVersionControlRequestEntity requestEntity) {
 
+        if (requestEntity == null) {
+            throw new IllegalArgumentException("Version control request must be specified.");
+        }
+
         // Verify the request
         final RevisionDTO revisionDto = requestEntity.getProcessGroupRevision();
         if (revisionDto == null) {
@@ -1004,6 +1008,10 @@ public class VersionsResource extends FlowUpdateResource<VersionControlInformati
         @ApiParam("The process group id.") @PathParam("id") final String groupId,
         @ApiParam(value = "The controller service configuration details.", required = true) final VersionControlInformationEntity requestEntity) {
 
+        if (requestEntity == null) {
+            throw new IllegalArgumentException("Version control information must be specified.");
+        }
+
         // validate version control info
         final VersionControlInformationDTO requestVersionControlInfoDto = requestEntity.getVersionControlInformation();
         if (requestVersionControlInfoDto == null) {
@@ -1067,6 +1075,10 @@ public class VersionsResource extends FlowUpdateResource<VersionControlInformati
     })
     public Response initiateRevertFlowVersion(@ApiParam("The process group id.") @PathParam("id") final String groupId,
         @ApiParam(value = "The controller service configuration details.", required = true) final VersionControlInformationEntity requestEntity) {
+
+        if (requestEntity == null) {
+            throw new IllegalArgumentException("Version control information must be specified.");
+        }
 
         // Verify the request
         final RevisionDTO revisionDto = requestEntity.getProcessGroupRevision();


### PR DESCRIPTION
#### Description of PR

Validate request object to be not null to fix NullPointerException fixes bug NIFI-7691.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
