### PR TITLE
NIFI-7715: Added IntelliJ generated `.ipr` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ nb-configuration.xml
 .idea/
 *.iml
 *.iws
+*.ipr
 *~
 
 .vscode/


### PR DESCRIPTION
#### Description of PR

- IntelliJ generates a `.ipr` Project File when exec the `mvn` goals
`mvn idea:idea` and `mvn idea:project`
  - [Maven `idea` Doc](https://maven.apache.org/plugins/maven-idea-plugin/usage.html)



Signed-off-by: ben <git@benjamin.ie>
