### PR TITLE
NIFI-7714: QueryCassandra loses precision when converting timestamps to JSON

### DIFF
--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -39,6 +39,7 @@ import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.lifecycle.OnShutdown;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -68,6 +69,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
@@ -130,6 +132,23 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .defaultValue(AVRO_FORMAT)
             .build();
 
+    public static final PropertyDescriptor DATE_FORMAT_PATTERN = new PropertyDescriptor.Builder()
+            .name("Date Format Pattern for JSON output")
+            .description("Pattern to use when converting date fields to JSON")
+            .required(true)
+            .defaultValue("yyyy-MM-dd HH:mm:ssZ")
+            .addValidator((subject, input, context) -> {
+                final ValidationResult.Builder vrb = new ValidationResult.Builder().subject(subject).input(input);
+                try {
+                    new SimpleDateFormat(input).format(new Date());
+                    vrb.valid(true).explanation("Valid date format pattern");
+                } catch (Exception ex) {
+                    vrb.valid(false).explanation("the pattern is invalid: " + ex.getMessage());
+                }
+                return vrb.build();
+            })
+            .build();
+
     private final static List<PropertyDescriptor> propertyDescriptors;
 
     private final static Set<Relationship> relationships;
@@ -145,6 +164,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         _propertyDescriptors.add(QUERY_TIMEOUT);
         _propertyDescriptors.add(FETCH_SIZE);
         _propertyDescriptors.add(OUTPUT_FORMAT);
+        _propertyDescriptors.add(DATE_FORMAT_PATTERN);
         propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
 
         Set<Relationship> _relationships = new HashSet<>();
@@ -220,14 +240,14 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                             if (AVRO_FORMAT.equals(outputFormat)) {
                                 nrOfRows.set(convertToAvroStream(resultSet, out, queryTimeout, TimeUnit.MILLISECONDS));
                             } else if (JSON_FORMAT.equals(outputFormat)) {
-                                nrOfRows.set(convertToJsonStream(resultSet, out, charset, queryTimeout, TimeUnit.MILLISECONDS));
+                                nrOfRows.set(convertToJsonStream(Optional.of(context), resultSet, out, charset, queryTimeout, TimeUnit.MILLISECONDS));
                             }
                         } else {
                             resultSet = queryFuture.getUninterruptibly();
                             if (AVRO_FORMAT.equals(outputFormat)) {
                                 nrOfRows.set(convertToAvroStream(resultSet, out, 0, null));
                             } else if (JSON_FORMAT.equals(outputFormat)) {
-                                nrOfRows.set(convertToJsonStream(resultSet, out, charset, 0, null));
+                                nrOfRows.set(convertToJsonStream(Optional.of(context), resultSet, out, charset, 0, null));
                             }
                         }
 
@@ -366,6 +386,12 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         }
     }
 
+    public static long convertToJsonStream(final ResultSet rs, final OutputStream outStream,
+                                           Charset charset, long timeout, TimeUnit timeUnit)
+        throws IOException, InterruptedException, TimeoutException, ExecutionException {
+        return convertToJsonStream(Optional.empty(), rs, outStream, charset, timeout, timeUnit);
+    }
+
     /**
      * Converts a result set into an Json object and writes it to the given stream using the specified character set.
      *
@@ -379,7 +405,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
      * @throws TimeoutException     If a result set fetch has taken longer than the specified timeout
      * @throws ExecutionException   If any error occurs during the result set fetch
      */
-    public static long convertToJsonStream(final ResultSet rs, final OutputStream outStream,
+    public static long convertToJsonStream(final Optional<ProcessContext> context, final ResultSet rs, final OutputStream outStream,
                                            Charset charset, long timeout, TimeUnit timeUnit)
             throws IOException, InterruptedException, TimeoutException, ExecutionException {
 
@@ -425,7 +451,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                                         if (!first) {
                                             sb.append(",");
                                         }
-                                        sb.append(getJsonElement(element));
+                                        sb.append(getJsonElement(context, element));
                                         first = false;
                                     }
                                     sb.append("]");
@@ -441,15 +467,15 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                                         if (!first) {
                                             sb.append(",");
                                         }
-                                        sb.append(getJsonElement(mapKey));
+                                        sb.append(getJsonElement(context, mapKey));
                                         sb.append(":");
-                                        sb.append(getJsonElement(mapValue));
+                                        sb.append(getJsonElement(context, mapValue));
                                         first = false;
                                     }
                                     sb.append("}");
                                     valueString = sb.toString();
                                 } else {
-                                    valueString = getJsonElement(value);
+                                    valueString = getJsonElement(context, value);
                                 }
                                 outStream.write(("\"" + colName + "\":"
                                         + valueString + "").getBytes(charset));
@@ -467,17 +493,31 @@ public class QueryCassandra extends AbstractCassandraProcessor {
     }
 
     protected static String getJsonElement(Object value) {
+        return getJsonElement(Optional.empty(), value);
+    }
+
+    protected static String getJsonElement(final Optional<ProcessContext> context, Object value) {
         if (value instanceof Number) {
             return value.toString();
         } else if (value instanceof Date) {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ");
-            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-            return "\"" + dateFormat.format((Date) value) + "\"";
+            return "\"" + getFormattedDate(context, (Date) value) + "\"";
         } else if (value instanceof String) {
             return "\"" + StringEscapeUtils.escapeJson((String) value) + "\"";
         } else {
             return "\"" + value.toString() + "\"";
         }
+    }
+
+    private static String getFormattedDate(final Optional<ProcessContext> context, Date value) {
+        final String dateFormatPattern;
+        if (context.isPresent()) {
+            dateFormatPattern = context.get().getProperty(DATE_FORMAT_PATTERN).getValue();
+        } else {
+            dateFormatPattern = DATE_FORMAT_PATTERN.getDefaultValue();
+        }
+        SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatPattern);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.format(value);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -133,8 +133,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .defaultValue(AVRO_FORMAT)
             .build();
 
-    public static final PropertyDescriptor JSON_TIMESTAMP_FORMAT_PATTERN = new PropertyDescriptor.Builder()
-            .name("json-timestamp-format-pattern")
+    public static final PropertyDescriptor TIMESTAMP_FORMAT_PATTERN = new PropertyDescriptor.Builder()
+            .name("timestamp-format-pattern")
             .displayName("Timestamp Format Pattern for JSON output")
             .description("Pattern to use when converting timestamp fields to JSON. Note: the formatted timestamp will be in UTC timezone.")
             .required(true)
@@ -166,7 +166,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         _propertyDescriptors.add(QUERY_TIMEOUT);
         _propertyDescriptors.add(FETCH_SIZE);
         _propertyDescriptors.add(OUTPUT_FORMAT);
-        _propertyDescriptors.add(JSON_TIMESTAMP_FORMAT_PATTERN);
+        _propertyDescriptors.add(TIMESTAMP_FORMAT_PATTERN);
         propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
 
         Set<Relationship> _relationships = new HashSet<>();
@@ -513,8 +513,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
 
     private static String getFormattedDate(final Optional<ProcessContext> context, Date value) {
         final String dateFormatPattern = context
-                .map(_context -> _context.getProperty(JSON_TIMESTAMP_FORMAT_PATTERN).getValue())
-                .orElse(JSON_TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
+                .map(_context -> _context.getProperty(TIMESTAMP_FORMAT_PATTERN).getValue())
+                .orElse(TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
         SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatPattern);
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return dateFormat.format(value);

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -133,7 +133,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .build();
 
     public static final PropertyDescriptor DATE_FORMAT_PATTERN = new PropertyDescriptor.Builder()
-            .name("Date Format Pattern for JSON output")
+            .name("date-format-pattern")
+            .displayName("Date Format Pattern for JSON output")
             .description("Pattern to use when converting date fields to JSON")
             .required(true)
             .defaultValue("yyyy-MM-dd HH:mm:ssZ")
@@ -509,12 +510,9 @@ public class QueryCassandra extends AbstractCassandraProcessor {
     }
 
     private static String getFormattedDate(final Optional<ProcessContext> context, Date value) {
-        final String dateFormatPattern;
-        if (context.isPresent()) {
-            dateFormatPattern = context.get().getProperty(DATE_FORMAT_PATTERN).getValue();
-        } else {
-            dateFormatPattern = DATE_FORMAT_PATTERN.getDefaultValue();
-        }
+        final String dateFormatPattern = context
+                .map(_context -> _context.getProperty(DATE_FORMAT_PATTERN).getValue())
+                .orElse(DATE_FORMAT_PATTERN.getDefaultValue());
         SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatPattern);
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return dateFormat.format(value);

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -25,6 +25,7 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.QueryExecutionException;
 import com.datastax.driver.core.exceptions.QueryValidationException;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
@@ -387,12 +388,6 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         }
     }
 
-    public static long convertToJsonStream(final ResultSet rs, final OutputStream outStream,
-                                           Charset charset, long timeout, TimeUnit timeUnit)
-        throws IOException, InterruptedException, TimeoutException, ExecutionException {
-        return convertToJsonStream(Optional.empty(), rs, outStream, charset, timeout, timeUnit);
-    }
-
     /**
      * Converts a result set into an Json object and writes it to the given stream using the specified character set.
      *
@@ -406,7 +401,14 @@ public class QueryCassandra extends AbstractCassandraProcessor {
      * @throws TimeoutException     If a result set fetch has taken longer than the specified timeout
      * @throws ExecutionException   If any error occurs during the result set fetch
      */
-    public static long convertToJsonStream(final Optional<ProcessContext> context, final ResultSet rs, final OutputStream outStream,
+    public static long convertToJsonStream(final ResultSet rs, final OutputStream outStream,
+                                           Charset charset, long timeout, TimeUnit timeUnit)
+        throws IOException, InterruptedException, TimeoutException, ExecutionException {
+        return convertToJsonStream(Optional.empty(), rs, outStream, charset, timeout, timeUnit);
+    }
+
+    @VisibleForTesting
+    static long convertToJsonStream(final Optional<ProcessContext> context, final ResultSet rs, final OutputStream outStream,
                                            Charset charset, long timeout, TimeUnit timeUnit)
             throws IOException, InterruptedException, TimeoutException, ExecutionException {
 

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -132,8 +132,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .defaultValue(AVRO_FORMAT)
             .build();
 
-    public static final PropertyDescriptor DATE_FORMAT_PATTERN = new PropertyDescriptor.Builder()
-            .name("timestamp-format-pattern")
+    public static final PropertyDescriptor JSON_TIMESTAMP_FORMAT_PATTERN = new PropertyDescriptor.Builder()
+            .name("json-timestamp-format-pattern")
             .displayName("Timestamp Format Pattern for JSON output")
             .description("Pattern to use when converting timestamp fields to JSON. Note: the formatted timestamp will be in UTC timezone.")
             .required(true)
@@ -165,7 +165,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         _propertyDescriptors.add(QUERY_TIMEOUT);
         _propertyDescriptors.add(FETCH_SIZE);
         _propertyDescriptors.add(OUTPUT_FORMAT);
-        _propertyDescriptors.add(DATE_FORMAT_PATTERN);
+        _propertyDescriptors.add(JSON_TIMESTAMP_FORMAT_PATTERN);
         propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
 
         Set<Relationship> _relationships = new HashSet<>();
@@ -511,8 +511,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
 
     private static String getFormattedDate(final Optional<ProcessContext> context, Date value) {
         final String dateFormatPattern = context
-                .map(_context -> _context.getProperty(DATE_FORMAT_PATTERN).getValue())
-                .orElse(DATE_FORMAT_PATTERN.getDefaultValue());
+                .map(_context -> _context.getProperty(JSON_TIMESTAMP_FORMAT_PATTERN).getValue())
+                .orElse(JSON_TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
         SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatPattern);
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return dateFormat.format(value);

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -133,9 +133,9 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .build();
 
     public static final PropertyDescriptor DATE_FORMAT_PATTERN = new PropertyDescriptor.Builder()
-            .name("date-format-pattern")
-            .displayName("Date Format Pattern for JSON output")
-            .description("Pattern to use when converting date fields to JSON")
+            .name("timestamp-format-pattern")
+            .displayName("Timestamp Format Pattern for JSON output")
+            .description("Pattern to use when converting timestamp fields to JSON. Note: the formatted timestamp will be in UTC timezone.")
             .required(true)
             .defaultValue("yyyy-MM-dd HH:mm:ssZ")
             .addValidator((subject, input, context) -> {

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/CassandraQueryTestUtil.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/CassandraQueryTestUtil.java
@@ -27,8 +27,10 @@ import org.mockito.stubbing.Answer;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +47,15 @@ import static org.mockito.Mockito.when;
  * Utility methods for Cassandra processors' unit tests
  */
 public class CassandraQueryTestUtil {
+
+    static final Date TEST_DATE;
+    static {
+        Calendar c = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+        c.set(2020, Calendar.JANUARY, 1, 10, 10, 10);
+        c.set(Calendar.MILLISECOND, 10);
+        TEST_DATE = c.getTime();
+    }
+
     public static ResultSet createMockResultSet() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
         ColumnDefinitions columnDefinitions = mock(ColumnDefinitions.class);
@@ -131,6 +142,27 @@ public class CassandraQueryTestUtil {
                 createRow("user1"),
                 createRow("user2")
         );
+
+        when(resultSet.iterator()).thenReturn(rows.iterator());
+        when(resultSet.all()).thenReturn(rows);
+        when(resultSet.getAvailableWithoutFetching()).thenReturn(rows.size());
+        when(resultSet.isFullyFetched()).thenReturn(false).thenReturn(true);
+        when(resultSet.getColumnDefinitions()).thenReturn(columnDefinitions);
+        return resultSet;
+    }
+
+    public static ResultSet createMockDateResultSet() throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        ColumnDefinitions columnDefinitions = mock(ColumnDefinitions.class);
+
+        when(columnDefinitions.size()).thenReturn(1);
+        when(columnDefinitions.getName(anyInt())).thenReturn("date");
+        when(columnDefinitions.getTable(0)).thenReturn("users");
+        when(columnDefinitions.getType(anyInt())).thenReturn(DataType.timestamp());
+
+        Row row = mock(Row.class);
+        when(row.getTimestamp(0)).thenReturn(TEST_DATE);
+        List<Row> rows = Collections.singletonList(row);
 
         when(resultSet.iterator()).thenReturn(rows.iterator());
         when(resultSet.all()).thenReturn(rows);

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/CassandraQueryTestUtil.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/CassandraQueryTestUtil.java
@@ -50,7 +50,7 @@ public class CassandraQueryTestUtil {
 
     static final Date TEST_DATE;
     static {
-        Calendar c = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar c = GregorianCalendar.getInstance(TimeZone.getTimeZone("PST"));
         c.set(2020, Calendar.JANUARY, 1, 10, 10, 10);
         c.set(Calendar.MILLISECOND, 10);
         TEST_DATE = c.getTime();

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
@@ -39,16 +39,23 @@ import com.datastax.driver.core.exceptions.ReadTimeoutException;
 import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.net.ssl.SSLContext;
 import org.apache.avro.Schema;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -74,6 +81,11 @@ public class QueryCassandraTest {
         testRunner.setProperty(AbstractCassandraProcessor.PASSWORD, "password");
         testRunner.assertNotValid();
         testRunner.setProperty(AbstractCassandraProcessor.USERNAME, "username");
+        testRunner.assertValid();
+
+        testRunner.setProperty(QueryCassandra.DATE_FORMAT_PATTERN, "invalid format");
+        testRunner.assertNotValid();
+        testRunner.setProperty(QueryCassandra.DATE_FORMAT_PATTERN, "yyyy-MM-dd HH:mm:ss.SSSZ");
         testRunner.assertValid();
     }
 
@@ -366,6 +378,42 @@ public class QueryCassandraTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         long numberOfRows = QueryCassandra.convertToJsonStream(rs, baos, StandardCharsets.UTF_8, 0, null);
         assertEquals(2, numberOfRows);
+    }
+
+    @Test
+    public void testDefaultDateFormatInConvertToJSONStream() throws Exception {
+        ResultSet rs = CassandraQueryTestUtil.createMockDateResultSet();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        DateFormat df = new SimpleDateFormat(QueryCassandra.DATE_FORMAT_PATTERN.getDefaultValue());
+        df.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(testRunner.getProcessContext()), rs, baos,
+            StandardCharsets.UTF_8, 0, null);
+        assertEquals(1, numberOfRows);
+
+        Map<String, List<Map<String, String>>> map = new ObjectMapper().readValue(baos.toByteArray(), HashMap.class);
+        String date = map.get("results").get(0).get("date");
+        assertEquals(df.format(CassandraQueryTestUtil.TEST_DATE), date);
+    }
+
+    @Test
+    public void testCustomDateFormatInConvertToJSONStream() throws Exception {
+        MockProcessContext context = (MockProcessContext) testRunner.getProcessContext();
+        ResultSet rs = CassandraQueryTestUtil.createMockDateResultSet();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        final String customDateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ";
+        context.setProperty(QueryCassandra.DATE_FORMAT_PATTERN, customDateFormat);
+        DateFormat df = new SimpleDateFormat(customDateFormat);
+        df.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(context), rs, baos, StandardCharsets.UTF_8, 0, null);
+        assertEquals(1, numberOfRows);
+
+        Map<String, List<Map<String, String>>> map = new ObjectMapper().readValue(baos.toByteArray(), HashMap.class);
+        String date = map.get("results").get(0).get("date");
+        assertEquals(df.format(CassandraQueryTestUtil.TEST_DATE), date);
     }
 
     private void setUpStandardProcessorConfig() {

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
@@ -83,9 +83,9 @@ public class QueryCassandraTest {
         testRunner.setProperty(AbstractCassandraProcessor.USERNAME, "username");
         testRunner.assertValid();
 
-        testRunner.setProperty(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN, "invalid format");
+        testRunner.setProperty(QueryCassandra.TIMESTAMP_FORMAT_PATTERN, "invalid format");
         testRunner.assertNotValid();
-        testRunner.setProperty(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN, "yyyy-MM-dd HH:mm:ss.SSSZ");
+        testRunner.setProperty(QueryCassandra.TIMESTAMP_FORMAT_PATTERN, "yyyy-MM-dd HH:mm:ss.SSSZ");
         testRunner.assertValid();
     }
 
@@ -385,7 +385,7 @@ public class QueryCassandraTest {
         ResultSet rs = CassandraQueryTestUtil.createMockDateResultSet();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        DateFormat df = new SimpleDateFormat(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
+        DateFormat df = new SimpleDateFormat(QueryCassandra.TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(testRunner.getProcessContext()), rs, baos,
@@ -404,7 +404,7 @@ public class QueryCassandraTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         final String customDateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ";
-        context.setProperty(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN, customDateFormat);
+        context.setProperty(QueryCassandra.TIMESTAMP_FORMAT_PATTERN, customDateFormat);
         DateFormat df = new SimpleDateFormat(customDateFormat);
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
@@ -83,9 +83,9 @@ public class QueryCassandraTest {
         testRunner.setProperty(AbstractCassandraProcessor.USERNAME, "username");
         testRunner.assertValid();
 
-        testRunner.setProperty(QueryCassandra.DATE_FORMAT_PATTERN, "invalid format");
+        testRunner.setProperty(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN, "invalid format");
         testRunner.assertNotValid();
-        testRunner.setProperty(QueryCassandra.DATE_FORMAT_PATTERN, "yyyy-MM-dd HH:mm:ss.SSSZ");
+        testRunner.setProperty(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN, "yyyy-MM-dd HH:mm:ss.SSSZ");
         testRunner.assertValid();
     }
 
@@ -385,7 +385,7 @@ public class QueryCassandraTest {
         ResultSet rs = CassandraQueryTestUtil.createMockDateResultSet();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        DateFormat df = new SimpleDateFormat(QueryCassandra.DATE_FORMAT_PATTERN.getDefaultValue());
+        DateFormat df = new SimpleDateFormat(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(testRunner.getProcessContext()), rs, baos,
@@ -404,7 +404,7 @@ public class QueryCassandraTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         final String customDateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ";
-        context.setProperty(QueryCassandra.DATE_FORMAT_PATTERN, customDateFormat);
+        context.setProperty(QueryCassandra.JSON_TIMESTAMP_FORMAT_PATTERN, customDateFormat);
         DateFormat df = new SimpleDateFormat(customDateFormat);
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Using QueryCassandra with JSON output format strips the milliseconds from timestamp fields.
Added a new property where the user can customize the format pattern for these fields.


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
