### PR TITLE
NIFI-4303 Add routingKey to ConsumeAMQP processor

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -64,7 +64,8 @@ import com.rabbitmq.client.GetResponse;
     @WritesAttribute(attribute = "amqp$type", description = "The type of message"),
     @WritesAttribute(attribute = "amqp$userId", description = "The ID of the user"),
     @WritesAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
-    @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message")
+    @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message"),
+    @WritesAttribute(attribute = "amqp$exchange", description = "The exchange from which AMQP Message was received")
 })
 public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     private static final String ATTRIBUTES_PREFIX = "amqp$";
@@ -148,7 +149,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
             flowFile = session.write(flowFile, out -> out.write(response.getBody()));
 
             final BasicProperties amqpProperties = response.getProps();
-            Envelope envelope = response.getEnvelope();
+            final Envelope envelope = response.getEnvelope();
             final Map<String, String> attributes = buildAttributes(amqpProperties, envelope);
             flowFile = session.putAllAttributes(flowFile, attributes);
 
@@ -180,6 +181,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "routingKey",  envelope.getRoutingKey());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "exchange",  envelope.getExchange());
         return attributes;
     }
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -42,6 +42,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.GetResponse;
 
 @Tags({"amqp", "rabbit", "get", "message", "receive", "consume"})
@@ -63,6 +64,7 @@ import com.rabbitmq.client.GetResponse;
     @WritesAttribute(attribute = "amqp$type", description = "The type of message"),
     @WritesAttribute(attribute = "amqp$userId", description = "The ID of the user"),
     @WritesAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
+    @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message")
 })
 public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     private static final String ATTRIBUTES_PREFIX = "amqp$";
@@ -146,7 +148,8 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
             flowFile = session.write(flowFile, out -> out.write(response.getBody()));
 
             final BasicProperties amqpProperties = response.getProps();
-            final Map<String, String> attributes = buildAttributes(amqpProperties);
+            Envelope envelope = response.getEnvelope();
+            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope);
             flowFile = session.putAllAttributes(flowFile, attributes);
 
             session.getProvenanceReporter().receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
@@ -160,7 +163,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         }
     }
 
-    private Map<String, String> buildAttributes(final BasicProperties properties) {
+    private Map<String, String> buildAttributes(final BasicProperties properties, final Envelope envelope) {
         final Map<String, String> attributes = new HashMap<>();
         addAttribute(attributes, ATTRIBUTES_PREFIX + "appId", properties.getAppId());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding", properties.getContentEncoding());
@@ -176,6 +179,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         addAttribute(attributes, ATTRIBUTES_PREFIX + "type", properties.getType());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "routingKey",  envelope.getRoutingKey());
         return attributes;
     }
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.ConsumeAMQP/additionalDetails.html
@@ -40,7 +40,7 @@
     The following is the list of available standard AMQP properties which may come with the message: <i>("amqp$contentType", "amqp$contentEncoding",
             "amqp$headers", "amqp$deliveryMode", "amqp$priority", "amqp$correlationId", "amqp$replyTo",
             "amqp$expiration", "amqp$messageId", "amqp$timestamp", "amqp$type", "amqp$userId", "amqp$appId",
-            "amqp$clusterId")</i>
+            "amqp$clusterId", "amqp$routingKey")</i>
 </p>
 <h2>Configuration Details</h2>
 <p>

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -63,11 +63,9 @@ public class ConsumeAMQPTest {
 
             final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
             helloFF.assertContentEquals("hello");
-            helloFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             final MockFlowFile worldFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(1);
             worldFF.assertContentEquals("world");
-            worldFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             // A single cumulative ack should be used
             assertFalse(((TestChannel) connection.createChannel()).isAck(0));
@@ -96,11 +94,9 @@ public class ConsumeAMQPTest {
 
             final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
             helloFF.assertContentEquals("hello");
-            helloFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             final MockFlowFile worldFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(1);
             worldFF.assertContentEquals("world");
-            worldFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             // A single cumulative ack should be used
             assertTrue(((TestChannel) connection.createChannel()).isAck(0));
@@ -160,6 +156,8 @@ public class ConsumeAMQPTest {
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
+            successFF.assertAttributeEquals("amqp$routingKey", "key1");
+            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
         }
     }
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -63,9 +63,11 @@ public class ConsumeAMQPTest {
 
             final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
             helloFF.assertContentEquals("hello");
+            helloFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             final MockFlowFile worldFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(1);
             worldFF.assertContentEquals("world");
+            worldFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             // A single cumulative ack should be used
             assertFalse(((TestChannel) connection.createChannel()).isAck(0));
@@ -94,9 +96,11 @@ public class ConsumeAMQPTest {
 
             final MockFlowFile helloFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
             helloFF.assertContentEquals("hello");
+            helloFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             final MockFlowFile worldFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(1);
             worldFF.assertContentEquals("world");
+            worldFF.assertAttributeEquals("amqp$routingKey", "key1");
 
             // A single cumulative ack should be used
             assertTrue(((TestChannel) connection.createChannel()).isAck(0));

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -44,7 +44,7 @@ public class ConsumeAMQPTest {
 
     @Test
     public void testMessageAcked() throws TimeoutException, IOException {
-        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Collections.singletonList("queue1"));
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
@@ -75,7 +75,7 @@ public class ConsumeAMQPTest {
 
     @Test
     public void testBatchSizeAffectsAcks() throws TimeoutException, IOException {
-        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Collections.singletonList("queue1"));
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
@@ -106,7 +106,7 @@ public class ConsumeAMQPTest {
 
     @Test
     public void testConsumerStopped() throws TimeoutException, IOException {
-        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Collections.singletonList("queue1"));
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final Connection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);


### PR DESCRIPTION
#### Description of PR

_Adds routing key in ConsumeAMQP processor NIFI-4303_

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
