### PR TITLE
NIFI-7733 change EL scope for REMOTE_PATH to FLOWFILE_ATTRIBUTES

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FileTransfer.java
@@ -111,7 +111,7 @@ public interface FileTransfer extends Closeable {
         .description("The path on the remote system from which to pull or push files")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
     public static final PropertyDescriptor CREATE_DIRECTORY = new PropertyDescriptor.Builder()
         .name("Create Directory")

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
@@ -81,6 +81,7 @@ public class TestPutSFTP {
 
         Map<String,String> attributes = new HashMap<>();
         attributes.put("filename", "testfile.txt");
+        attributes.put("remote_path", testFile);
 
         putSFTPRunner.enqueue(Paths.get(testFile), attributes);
         putSFTPRunner.run();
@@ -90,6 +91,21 @@ public class TestPutSFTP {
         //verify directory exists
         Path newDirectory = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/");
         Path newFile = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/testfile.txt");
+        Assert.assertTrue("New directory not created.", newDirectory.toAbsolutePath().toFile().exists());
+        Assert.assertTrue("New File not created.", newFile.toAbsolutePath().toFile().exists());
+        putSFTPRunner.clearTransferState();
+
+        //Test with EL scope FLOWFILE
+        putSFTPRunner.setProperty(SFTPTransfer.REMOTE_PATH, "${remote_path}");
+
+        putSFTPRunner.enqueue(Paths.get(testFile), attributes);
+        putSFTPRunner.run();
+
+        putSFTPRunner.assertTransferCount(PutSFTP.REL_SUCCESS, 1);
+
+        //verify directory exists
+        newDirectory = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/");
+        newFile = Paths.get(sshTestServer.getVirtualFileSystemPath() + "nifi_test/testfile.txt");
         Assert.assertTrue("New directory not created.", newDirectory.toAbsolutePath().toFile().exists());
         Assert.assertTrue("New File not created.", newFile.toAbsolutePath().toFile().exists());
         putSFTPRunner.clearTransferState();


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

change EL scope for REMOTE_PATH to FLOWFILE_ATTRIBUTES

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
