### PR TITLE
NIFI-7599 Make noLocal flag on the JMS consumer false

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
@@ -51,7 +51,7 @@ final class JMSConsumer extends JMSWorker {
 
     JMSConsumer(CachingConnectionFactory connectionFactory, JmsTemplate jmsTemplate, ComponentLog logger) {
         super(connectionFactory, jmsTemplate, logger);
-        logger.debug("Created Message Consumer for '{}'", new Object[] {jmsTemplate});
+        if (logger.isDebugEnabled()) logger.debug("Created Message Consumer for '{}'", new Object[] {jmsTemplate});
     }
 
 
@@ -71,16 +71,12 @@ final class JMSConsumer extends JMSWorker {
                 } catch (AbstractMethodError e) {
                     throw new ProcessException("Failed to create a shared consumer. Make sure the target broker is JMS 2.0 compliant.", e);
                 }
-            } else {
-                if (durable) {
-                    return session.createDurableConsumer((Topic) destination, subscriptionName, messageSelector, JMSConsumer.this.jmsTemplate.isPubSubDomain());
-                } else {
-                    return session.createConsumer(destination, messageSelector, JMSConsumer.this.jmsTemplate.isPubSubDomain());
-                }
+            } else if (durable) {
+                return session.createDurableConsumer((Topic) destination, subscriptionName, messageSelector, false);
             }
-        } else {
-            return session.createConsumer(destination, messageSelector, JMSConsumer.this.jmsTemplate.isPubSubDomain());
         }
+
+        return session.createConsumer(destination, messageSelector);
     }
 
 


### PR DESCRIPTION
#### Description of PR

This changes the noLocal flag on the JMS consumer to false. It was previously being set to true for all Topic destinations which is unnecessary and breaks with some brokers.

It's unnecessary because each ConsumeJMS and PublishJMS processor creates its own new connections and they don't get (re)used for both sending and receiving; i.e., so noLocal doesn't really apply to the connections being used. And in many brokers it's either unsupported and ignored, or unsupported and treated as an error.

Since noLocal doesn't do anything beneficial here and setting it to false results in the same behavior, it doesn't seem necessary to expose it in a property.

This was tested on ActiveMQ, Azure Service Bus, and RabbitMQ JMS.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
