### PR TITLE
NIFI-7167 Fixing resource leaks in IdentifyMimeType

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
@@ -177,8 +177,9 @@ public class IdentifyMimeType extends AbstractProcessor {
             }
 
         } else {
-            try {
-                this.detector = MimeTypesFactory.create(new FileInputStream(configFile));
+            try (final FileInputStream fis = new FileInputStream(configFile);
+                 final InputStream bis = new BufferedInputStream(fis)) {
+                this.detector = MimeTypesFactory.create(bis);
                 this.mimeTypes = (MimeTypes)this.detector;
             } catch (Exception e) {
                 context.yield();
@@ -212,8 +213,8 @@ public class IdentifyMimeType extends AbstractProcessor {
         session.read(flowFile, new InputStreamCallback() {
             @Override
             public void process(final InputStream stream) throws IOException {
-                try (final InputStream in = new BufferedInputStream(stream)) {
-                    TikaInputStream tikaStream = TikaInputStream.get(in);
+                try (final InputStream in = new BufferedInputStream(stream);
+                     final TikaInputStream tikaStream = TikaInputStream.get(in)) {
                     Metadata metadata = new Metadata();
 
                     if (filename != null && context.getProperty(USE_FILENAME_IN_DETECTION).asBoolean()) {


### PR DESCRIPTION
The TikaInputStream and FileInputStream instances utilized in IdentifyMimeType are now explicitly closed. The FileInputStream is additionally wrapped by a BufferedInputStream.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-7167._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
