### PR TITLE
NIFI-7780: Unify passage of disconnectedNodeAcknowledged param

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -3820,7 +3820,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                     value = "Acknowledges that this node is disconnected to allow for mutable requests to proceed.",
                     required = false
             )
-            @FormDataParam(DISCONNECTED_NODE_ACKNOWLEDGED) @DefaultValue("false") final Boolean disconnectedNodeAcknowledged,
+            @QueryParam(DISCONNECTED_NODE_ACKNOWLEDGED) @DefaultValue("false") final Boolean disconnectedNodeAcknowledged,
             @FormDataParam("template") final InputStream in) throws InterruptedException {
 
         // unmarshal the template

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-operate-controller.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/controllers/nf-ng-canvas-operate-controller.js
@@ -156,14 +156,10 @@
                             url: '../nifi-api/process-groups/',
                             dataType: 'xml',
                             beforeSubmit: function (formData, $form, options) {
-                                // indicate if a disconnected node is acknowledged
-                                formData.push({
-                                    name: 'disconnectedNodeAcknowledged',
-                                    value: nfStorage.isDisconnectionAcknowledged()
-                                });
-
                                 // ensure uploading to the current process group
-                                options.url += (encodeURIComponent(nfCanvasUtils.getGroupId()) + '/templates/upload');
+                                options.url += (encodeURIComponent(nfCanvasUtils.getGroupId()) + '/templates/upload' + '?'
+                                    // indicate if a disconnected node is acknowledged
+                                    + $.param({'disconnectedNodeAcknowledged': nfStorage.isDisconnectionAcknowledged()}));
                             },
                             success: function (response, statusText, xhr, form) {
                                 // see if the import was successful and inform the user


### PR DESCRIPTION
Please consider unifying passing disconnectedNodeAcknowledged as query parameter everywhere.
Multipart form data support in Swagger 2.0 ain't that great.