### PR TITLE
NIFI-7775 exclude OCR Parser from ExtreactMediaMetadata Processor

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
@@ -49,6 +49,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
 
+import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -155,7 +156,8 @@ public class ExtractMediaMetadata extends AbstractProcessor {
 
     @SuppressWarnings("unused")
     @OnScheduled
-    public void onScheduled(ProcessContext context) {
+    public void onScheduled(ProcessContext context) throws TikaException, IOException, SAXException {
+        TikaConfig tikaConfig = new TikaConfig(getClass().getResource("/excludeOCRParser.xml"));
         String metadataKeyFilterInput = context.getProperty(METADATA_KEY_FILTER).getValue();
         if (metadataKeyFilterInput != null && metadataKeyFilterInput.length() > 0) {
             metadataKeyFilterRef.set(Pattern.compile(metadataKeyFilterInput));
@@ -163,7 +165,7 @@ public class ExtractMediaMetadata extends AbstractProcessor {
             metadataKeyFilterRef.set(null);
         }
 
-        autoDetectParser = new AutoDetectParser();
+        autoDetectParser = new AutoDetectParser(tikaConfig);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/resources/excludeOCRParser.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/resources/excludeOCRParser.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<properties>
+    <parsers>
+        <parser class="org.apache.tika.parser.DefaultParser">
+            <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
+        </parser>
+    </parsers>
+</properties>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/resources/excludeOCRParser.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/resources/excludeOCRParser.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <properties>
     <parsers>
         <parser class="org.apache.tika.parser.DefaultParser">


### PR DESCRIPTION
#### Description of PR

To extract Media Metadata is Apache Tika in use.

Tika uses also TesseractOCRParser as DefaultParser - for this case it doesnt needed and there are such runtime improvements.
With TikaConfig File could be exclude TesseractOCRParser 

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?
    https://issues.apache.org/jira/browse/NIFI-7775
- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
