### PR TITLE
NIFI-7754 Support HTTP Proxy for JettyWebSocketClient

### DIFF
--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketClient.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketClient.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class TestJettyWebSocketClient {
@@ -59,4 +60,41 @@ public class TestJettyWebSocketClient {
         assertEquals(JettyWebSocketClient.WS_URI.getName(), result.getSubject());
     }
 
+    @Test
+    public void testValidationProxyHostOnly() throws Exception {
+        final JettyWebSocketClient service = new JettyWebSocketClient();
+        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
+        context.setCustomValue(JettyWebSocketClient.WS_URI, "wss://localhost:9001/test");
+        context.setCustomValue(JettyWebSocketClient.PROXY_HOST, "localhost");
+        service.initialize(context.getInitializationContext());
+        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
+        assertEquals(1, results.size());
+        final ValidationResult result = results.iterator().next();
+        assertTrue(result.getSubject().contains("Proxy"));
+    }
+
+    @Test
+    public void testValidationProxyPortOnly() throws Exception {
+        final JettyWebSocketClient service = new JettyWebSocketClient();
+        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
+        context.setCustomValue(JettyWebSocketClient.WS_URI, "wss://localhost:9001/test");
+        context.setCustomValue(JettyWebSocketClient.PROXY_PORT, "3128");
+        service.initialize(context.getInitializationContext());
+        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
+        assertEquals(1, results.size());
+        final ValidationResult result = results.iterator().next();
+        assertTrue(result.getSubject().contains("Proxy"));
+    }
+
+    @Test
+    public void testValidationSuccessWithProxy() throws Exception {
+        final JettyWebSocketClient service = new JettyWebSocketClient();
+        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
+        context.setCustomValue(JettyWebSocketClient.WS_URI, "wss://localhost:9001/test");
+        context.setCustomValue(JettyWebSocketClient.PROXY_HOST, "localhost");
+        context.setCustomValue(JettyWebSocketClient.PROXY_PORT, "3128");
+        service.initialize(context.getInitializationContext());
+        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
+        assertEquals(0, results.size());
+    }
 }


### PR DESCRIPTION
#### Description of PR

Enables supporting an HTTP Proxy for JettyWebSocketClient; fixes bug NIFI-7754.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?

