### PR TITLE
NIFI-7794 Adding a property to PutAzureStorageBlob to determine whether to check the existence of a container and create it if necessary

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -80,8 +80,10 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
             .required(true)
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .allowableValues("true", "false")
-            .defaultValue("true")
-            .description("Specifies whether to check if the container exists and to automatically create it if it does not.  Permission to list containers is required.  If false, this check is not made, but the Put operation will fail if the container does not exist.")
+            .defaultValue("false")
+            .description("Specifies whether to check if the container exists and to automatically create it if it does not.  " +
+                  "Permission to list containers is required.  If false, this check is not made, but the Put operation " +
+                  "will fail if the container does not exist.")
             .build();
 
     @Override

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -73,11 +73,23 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
             .required(true)
             .build();
 
+    public static final PropertyDescriptor CREATE_CONTAINER = new PropertyDescriptor.Builder()
+            .name("azure-create-container")
+            .displayName("Create Container")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .description("Specifies whether to check if the container exists and to automatically create it if it does not.  Permission to list containers is required.  If false, this check is not made, but the Put operation will fail if the container does not exist.")
+            .build();
+
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         List<PropertyDescriptor> properties = new ArrayList<>(super.getSupportedPropertyDescriptors());
         properties.remove(BLOB);
         properties.add(BLOB_NAME);
+        properties.add(CREATE_CONTAINER);
         return properties;
     }
 
@@ -93,11 +105,15 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
 
         String blobPath = context.getProperty(BLOB_NAME).evaluateAttributeExpressions(flowFile).getValue();
 
+        final boolean createContainer = context.getProperty(CREATE_CONTAINER).asBoolean();
+
         AtomicReference<Exception> storedException = new AtomicReference<>();
         try {
             CloudBlobClient blobClient = AzureStorageUtils.createCloudBlobClient(context, getLogger(), flowFile);
             CloudBlobContainer container = blobClient.getContainerReference(containerName);
-            container.createIfNotExists();
+
+            if (createContainer)
+                container.createIfNotExists();
 
             CloudBlob blob = container.getBlockBlobReference(blobPath);
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
@@ -109,7 +109,7 @@ public final class AzureStorageUtils {
     public static final PropertyDescriptor CONTAINER = new PropertyDescriptor.Builder()
             .name("container-name")
             .displayName("Container Name")
-            .description("Name of the Azure storage container. In case of PutAzureBlobStorage processor, container will be created if it does not exist.")
+            .description("Name of the Azure storage container. In case of PutAzureBlobStorage processor, container can be created if it does not exist.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(true)


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Resolves NIFI-7794 by adding a boolean property to determine whether to check for the existence of the Azure container before attempting the Put operation.  Backwards compatibility with 1.12.0 is maintained by defaulting this Property to true.


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message? Yes

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [X] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
