### PR TITLE
NIFI-7817: Fix ParquetReader instantiation error

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardConfigurationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/StandardConfigurationContext.java
@@ -78,7 +78,9 @@ public class StandardConfigurationContext implements ConfigurationContext {
         // We need to get the 'canonical representation' of the property descriptor from the component itself,
         // since the supplied PropertyDescriptor may not have the proper default value.
         final PropertyDescriptor resolvedDescriptor = component.getPropertyDescriptor(property.getName());
-        final String resolvedValue = (configuredValue == null) ? resolvedDescriptor.getDefaultValue() : configuredValue;
+        final String resolvedValue = (configuredValue == null)
+                ? ((resolvedDescriptor.getDefaultValue() == null) ? property.getDefaultValue() : resolvedDescriptor.getDefaultValue())
+                : configuredValue;
 
         return new StandardPropertyValue(resolvedValue, serviceLookup, component.getParameterLookup(), preparedQueries.get(property), variableRegistry);
     }


### PR DESCRIPTION
Fixes bug NIFI-7817.

The creation of a ParquetReader is failing due to a null value returned
by:

context.getProperty(ParquetUtils.COMPRESSION_TYPE)

Commit https://github.com/apache/nifi/commit/4f11e3626093d3090f97c0efc5e229d83b6006e4#diff-782335ecee68f6939c3724dba3983d3d
addressed the issue where the property value was being read from the
property parameter instead of the ComponentNode. However, when the
ComponentNode default value is null, the property's default value is
being ignored.

This commit, aims to preserve the original aim of the fix for NIFI-7635,
but it addresses the case where the ComponentNode's default value is
null.

The resolvedValue priority will be resolved in this order:
- configuredValue
- default value from the ComponentNode
- default value from the PropertyDescriptor
