### PR TITLE
NIFI-7565 - Support for Kudu DATE type

### DIFF
--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-controller-service/pom.xml
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-controller-service/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <exclude.tests>None</exclude.tests>
-        <kudu.version>1.12.0</kudu.version>
+        <kudu.version>1.13.0</kudu.version>
     </properties>
     <build>
         <extensions>

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-controller-service/src/main/java/org/apache/nifi/controller/kudu/KuduLookupService.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-controller-service/src/main/java/org/apache/nifi/controller/kudu/KuduLookupService.java
@@ -333,6 +333,9 @@ public class KuduLookupService extends AbstractControllerService implements Reco
                 case FLOAT:
                     fields.add(new RecordField(cs.getName(), RecordFieldType.FLOAT.getDataType()));
                     break;
+                case DATE:
+                    fields.add(new RecordField(cs.getName(), RecordFieldType.DATE.getDataType()));
+                    break;
             }
         }
         return new SimpleRecordSchema(fields);

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <exclude.tests>None</exclude.tests>
-        <kudu.version>1.12.0</kudu.version>
+        <kudu.version>1.13.0</kudu.version>
     </properties>
     <build>
         <extensions>

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -299,7 +299,6 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
             if (colIdx != -1) {
                 ColumnSchema colSchema = schema.getColumnByIndex(colIdx);
                 Type colType = colSchema.getType();
-
                 if (record.getValue(recordFieldName) == null) {
                     if (schema.getColumnByIndex(colIdx).isKey()) {
                         throw new IllegalArgumentException(String.format("Can't set primary key column %s to null ", colName));
@@ -352,6 +351,9 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
                         case VARCHAR:
                             row.addVarchar(colIdx, DataTypeUtils.toString(value, recordFieldName));
                             break;
+                        case DATE:
+                            row.addDate(colIdx, DataTypeUtils.toDate(value, () -> DataTypeUtils.getDateFormat("yyyy-MM-dd"), recordFieldName));
+                            break;
                         default:
                             throw new IllegalStateException(String.format("unknown column type %s", colType));
                     }
@@ -386,6 +388,8 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
             case CHAR:
             case STRING:
                 return Type.STRING;
+            case DATE:
+                return Type.DATE;
             default:
                 throw new IllegalArgumentException(String.format("unsupported type %s", nifiType));
         }

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -352,7 +352,7 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
                             row.addVarchar(colIdx, DataTypeUtils.toString(value, recordFieldName));
                             break;
                         case DATE:
-                            row.addDate(colIdx, DataTypeUtils.toDate(value, () -> DataTypeUtils.getDateFormat("yyyy-MM-dd"), recordFieldName));
+                            row.addDate(colIdx, DataTypeUtils.toDate(value, () -> DataTypeUtils.getDateFormat(RecordFieldType.DATE.getDefaultFormat()), recordFieldName));
                             break;
                         default:
                             throw new IllegalStateException(String.format("unknown column type %s", colType));


### PR DESCRIPTION
NIFI-7565 Add support for DATE to Kudu NAR bundle
- update Kudu dependencies to Kudu 1.13.0
- add support for passing java.sql.Date for Kudu DATE columns
- add tests for passing java.sql.Date to DATE columns

more about DATE type support in Kudu:
https://issues.apache.org/jira/browse/KUDU-2632