### PR TITLE
NIFI-7845 Better handling on malformed/empty strings

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -255,7 +255,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
     private Map<String, Object> validateAMQPHeaderProperty(String amqpPropValue) {
         Map<String, Object> headers = new HashMap<>();
         
-        amqpPropValueLen = amqpPropValue.length();
+        int amqpPropValueLen = amqpPropValue.length();
         if (amqpPropValue.charAt(0) == '{' && amqpPropValue.charAt(amqpPropValueLen-1) == '}') {
             getLogger().debug("Detected { and } at beginning and end of amqpPropValue string, so removing");
             amqpPropValue = amqpPropValue.substring(1,amqpPropValueLen-1);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -255,7 +255,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
     private Map<String, Object> validateAMQPHeaderProperty(String amqpPropValue) {
         Map<String, Object> headers = new HashMap<>();
         
-        amqpPropValueLen = amqpPropValue.length()
+        amqpPropValueLen = amqpPropValue.length();
         if (amqpPropValue.charAt(0) == '{' && amqpPropValue.charAt(amqpPropValueLen-1) == '}') {
             getLogger().debug("Detected { and } at beginning and end of amqpPropValue string, so removing");
             amqpPropValue = amqpPropValue.substring(1,amqpPropValueLen-1);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -263,7 +263,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             getLogger().debug("Detected empty amqpPropValue string, so returning empty HashMap");
             return headers;
         }
-        String[] strEntries = amqpPropValue.split(",");        
+        String[] strEntries = amqpPropValue.split(",");
         for (String strEntry : strEntries) {
             String[] kv = strEntry.split("=");
             if (kv.length == 2) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -253,8 +253,21 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
      * @return {@link Map} if valid otherwise null
      */
     private Map<String, Object> validateAMQPHeaderProperty(String amqpPropValue) {
-        String[] strEntries = amqpPropValue.split(",");
         Map<String, Object> headers = new HashMap<>();
+        
+        amqpPropValueLen = amqpPropValue.length()
+        if (amqpPropValue.charAt(0) == '{' && amqpPropValue.charAt(amqpPropValueLen-1) == '}') {
+            getLogger().debug("Detected { and } at beginning and end of amqpPropValue string, so removing");
+            amqpPropValue = amqpPropValue.substring(1,amqpPropValueLen-1);
+        }
+        
+        if (amqpPropValue.isEmpty()) {
+            getLogger().debug("Detected empty amqpPropValue string, so returning empty HashMap");
+            return headers;
+        }
+        
+        String[] strEntries = amqpPropValue.split(",");
+
         for (String strEntry : strEntries) {
             String[] kv = strEntry.split("=");
             if (kv.length == 2) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -254,20 +254,16 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
      */
     private Map<String, Object> validateAMQPHeaderProperty(String amqpPropValue) {
         Map<String, Object> headers = new HashMap<>();
-        
         int amqpPropValueLen = amqpPropValue.length();
         if (amqpPropValue.charAt(0) == '{' && amqpPropValue.charAt(amqpPropValueLen-1) == '}') {
             getLogger().debug("Detected { and } at beginning and end of amqpPropValue string, so removing");
             amqpPropValue = amqpPropValue.substring(1,amqpPropValueLen-1);
         }
-        
         if (amqpPropValue.isEmpty()) {
             getLogger().debug("Detected empty amqpPropValue string, so returning empty HashMap");
             return headers;
         }
-        
-        String[] strEntries = amqpPropValue.split(",");
-
+        String[] strEntries = amqpPropValue.split(",");        
         for (String strEntry : strEntries) {
             String[] kv = strEntry.split("=");
             if (kv.length == 2) {


### PR DESCRIPTION
_Better handling on malformed/empty strings_

#### Description of PR

At the moment, the `validateAMQPHeaderProperty()` does not handle `amqpPropValues` that are appended and prepended by curly braces, like `{a=b}`.

Nor does the function deal with an empty `amqpPropValues` properly.

This is particularly a problem because if the AMQP queue you're reading from with the `ConsumeAMQP.java` processor has a message with an *empty* header, then `ConsumeAMQP.java` creates a flowfile-attribute `ampq$header` of the form `{}` - which causes `validateAMQPHeaderProperty()` to pollute the NiFi error box.

According to [1] the AMQP header attribute is optional anyway, so we need to handle blank entries.

[1]: https://www.rabbitmq.com/tutorials/amqp-concepts.html#messages

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
