### PR TITLE
NIFI-7844 - substring should return empty instead of throwing IndexOu…

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/SubstringEvaluator.java
@@ -46,12 +46,16 @@ public class SubstringEvaluator extends StringEvaluator {
         if (subjectValue == null) {
             return new StringQueryResult("");
         }
-        final int startIndexValue = startIndex.evaluate(evaluationContext).getValue().intValue();
-        if (endIndex == null) {
-            return new StringQueryResult(subjectValue.substring(startIndexValue));
-        } else {
-            final int endIndexValue = endIndex.evaluate(evaluationContext).getValue().intValue();
-            return new StringQueryResult(subjectValue.substring(startIndexValue, endIndexValue));
+        try {
+            final int startIndexValue = startIndex.evaluate(evaluationContext).getValue().intValue();
+            if (endIndex == null) {
+                return new StringQueryResult(subjectValue.substring(startIndexValue));
+            } else {
+                final int endIndexValue = endIndex.evaluate(evaluationContext).getValue().intValue();
+                return new StringQueryResult(subjectValue.substring(startIndexValue, endIndexValue));
+            }
+        } catch (IndexOutOfBoundsException e) {
+            return new StringQueryResult("");
         }
     }
 

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -1637,6 +1637,17 @@ public class TestQuery {
     }
 
     @Test
+    public void testSubstringOOB() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("filename", "file-255");
+
+        verifyEquals("${filename:substring(10, 20)}", attributes, "");
+        verifyEquals("${filename:substring(10)}", attributes, "");
+        verifyEquals("${filename:substring(-2)}", attributes, "");
+        verifyEquals("${filename:substring(2, -2)}", attributes, "");
+    }
+
+    @Test
     public void testToRadix() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("filename", "file-255");

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -652,7 +652,7 @@ Each of the following functions manipulates a String in some way.
 [.description]#If the _starting index_ is larger than the _ending index_, this function call will result in an error.#
 
 [.description]#If the _starting index_ or the _ending index_ is greater than the length of the Subject or has a value
-	less than 0, this function call will result in an error.#
+	less than 0, this function call will return an empty string.#
 
 
 *Subject Type*: [.subject]#String#


### PR DESCRIPTION
…tOfBoundsException

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

**In the expression language, right now, for the substring function:**

> If the starting index or the ending index is greater than the length of the Subject or has a value less than 0, this function call will result in an error.

**I suggest to change this behavior and return an empty string instead. Reason being that with the current behavior, an UpdateAttribute would fail and roll back the flow file in the incoming relationship, this could cause back pressure and completely block the whole flow to be running.**

**It might be worth mentioning it in the migration guide as this changes the current behavior but I still think this is a reasonable change.**

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
