### PR TITLE
NIFI-7777 Added Password property to UnpackContent for decrypting Zip archives

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -1946,6 +1946,11 @@ The following binary components are provided under the Apache Software License v
       Apache FtpServer Core 1.1.1
       Copyright 2003-2017 The Apache Software Foundation
 
+  (ASLv2) Zip4j
+    The following NOTICE information applies:
+      Zip4j 2.6.3.
+      Copyright 2020 Srikanth Reddy Lingala
+
 ************************
 Common Development and Distribution License 1.1
 ************************

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -293,6 +293,11 @@
             <artifactId>snappy-java</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -35,10 +35,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+
+import net.lingala.zip4j.model.LocalFileHeader;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -53,6 +54,8 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.flowfile.attributes.FragmentAttributes;
@@ -72,6 +75,7 @@ import org.apache.nifi.util.FlowFileUnpackager;
 import org.apache.nifi.util.FlowFileUnpackagerV1;
 import org.apache.nifi.util.FlowFileUnpackagerV2;
 import org.apache.nifi.util.FlowFileUnpackagerV3;
+import net.lingala.zip4j.io.inputstream.ZipInputStream;
 
 @EventDriven
 @SideEffectFree
@@ -100,7 +104,8 @@ import org.apache.nifi.util.FlowFileUnpackagerV3;
     @WritesAttribute(attribute = "file.creationTime", description = "The date and time that the file was created. This attribute holds always the same value as file.lastModifiedTime (tar only)."),
     @WritesAttribute(attribute = "file.owner", description = "The owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = "file.group", description = "The group owner of the unpacked file (tar only)"),
-    @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the unpacked file (tar only)")})
+    @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the unpacked file (tar only)"),
+    @WritesAttribute(attribute = "file.encryptionMethod", description = "The encryption method for entries in Zip archives")})
 @SeeAlso(MergeContent.class)
 public class UnpackContent extends AbstractProcessor {
     // attribute keys
@@ -123,6 +128,7 @@ public class UnpackContent extends AbstractProcessor {
     public static final String FILE_OWNER_ATTRIBUTE = "file.owner";
     public static final String FILE_GROUP_ATTRIBUTE = "file.group";
     public static final String FILE_PERMISSIONS_ATTRIBUTE = "file.permissions";
+    public static final String FILE_ENCRYPTION_METHOD_ATTRIBUTE = "file.encryptionMethod";
 
     public static final String FILE_MODIFIED_DATE_ATTR_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(FILE_MODIFIED_DATE_ATTR_FORMAT).withZone(ZoneId.systemDefault());
@@ -143,6 +149,16 @@ public class UnpackContent extends AbstractProcessor {
             .required(true)
             .defaultValue(".*")
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor PASSWORD = new PropertyDescriptor.Builder()
+            .name("Password")
+            .displayName("Password")
+            .description("Password used for decrypting archive entries. Supports Zip files encrypted with ZipCrypto or AES")
+            .required(false)
+            .sensitive(true)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -177,6 +193,7 @@ public class UnpackContent extends AbstractProcessor {
         final List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(PACKAGING_FORMAT);
         properties.add(FILE_FILTER);
+        properties.add(PASSWORD);
         this.properties = Collections.unmodifiableList(properties);
     }
 
@@ -200,7 +217,13 @@ public class UnpackContent extends AbstractProcessor {
         if (fileFilter == null) {
             fileFilter = Pattern.compile(context.getProperty(FILE_FILTER).getValue());
             tarUnpacker = new TarUnpacker(fileFilter);
-            zipUnpacker = new ZipUnpacker(fileFilter);
+
+            char[] password = null;
+            final PropertyValue passwordProperty = context.getProperty(PASSWORD);
+            if (passwordProperty.isSet()) {
+                password = passwordProperty.evaluateAttributeExpressions().getValue().toCharArray();
+            }
+            zipUnpacker = new ZipUnpacker(fileFilter, password);
         }
     }
 
@@ -301,8 +324,12 @@ public class UnpackContent extends AbstractProcessor {
 
         abstract void unpack(ProcessSession session, FlowFile source, List<FlowFile> unpacked);
 
-        protected boolean fileMatches(ArchiveEntry entry) {
-            return fileFilter == null || fileFilter.matcher(entry.getName()).find();
+        protected boolean fileMatches(final ArchiveEntry entry) {
+            return fileMatches(entry.getName());
+        }
+
+        protected boolean fileMatches(final String entryName) {
+            return fileFilter == null || fileFilter.matcher(entryName).find();
         }
     }
 
@@ -370,8 +397,11 @@ public class UnpackContent extends AbstractProcessor {
     }
 
     private static class ZipUnpacker extends Unpacker {
-        public ZipUnpacker(Pattern fileFilter) {
+        private char[] password;
+
+        public ZipUnpacker(final Pattern fileFilter, final char[] password) {
             super(fileFilter);
+            this.password = password;
         }
 
         @Override
@@ -381,13 +411,14 @@ public class UnpackContent extends AbstractProcessor {
                 @Override
                 public void process(final InputStream in) throws IOException {
                     int fragmentCount = 0;
-                    try (final ZipArchiveInputStream zipIn = new ZipArchiveInputStream(new BufferedInputStream(in))) {
-                        ArchiveEntry zipEntry;
+                    try (final ZipInputStream zipIn = new ZipInputStream(new BufferedInputStream(in), password)) {
+                        LocalFileHeader zipEntry;
                         while ((zipEntry = zipIn.getNextEntry()) != null) {
-                            if (zipEntry.isDirectory() || !fileMatches(zipEntry)) {
+                            final String zipEntryName = zipEntry.getFileName();
+                            if (zipEntry.isDirectory() || !fileMatches(zipEntryName)) {
                                 continue;
                             }
-                            final File file = new File(zipEntry.getName());
+                            final File file = new File(zipEntryName);
                             final String parentDirectory = (file.getParent() == null) ? "/" : file.getParent();
                             final Path absPath = file.toPath().toAbsolutePath();
                             final String absPathString = absPath.getParent().toString() + "/";
@@ -402,6 +433,9 @@ public class UnpackContent extends AbstractProcessor {
 
                                 attributes.put(FRAGMENT_ID, fragmentId);
                                 attributes.put(FRAGMENT_INDEX, String.valueOf(++fragmentCount));
+
+                                final String encryptionMethod = zipEntry.getEncryptionMethod().toString();
+                                attributes.put(FILE_ENCRYPTION_METHOD_ATTRIBUTE, encryptionMethod);
 
                                 unpackedFile = session.putAllAttributes(unpackedFile, attributes);
                                 unpackedFile = session.write(unpackedFile, new OutputStreamCallback() {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -158,7 +158,6 @@ public class UnpackContent extends AbstractProcessor {
             .required(false)
             .sensitive(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -221,7 +220,7 @@ public class UnpackContent extends AbstractProcessor {
             char[] password = null;
             final PropertyValue passwordProperty = context.getProperty(PASSWORD);
             if (passwordProperty.isSet()) {
-                password = passwordProperty.evaluateAttributeExpressions().getValue().toCharArray();
+                password = passwordProperty.getValue().toCharArray();
             }
             zipUnpacker = new ZipUnpacker(fileFilter, password);
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -55,7 +55,6 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
-import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.flowfile.attributes.FragmentAttributes;


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

NIFI-7777 Added optional Password property to UnpackContent to support decrypting Zip archives using either standard ZipCrypto or AES.  The implementation replaces Apache Commons Compress ZipArchiveInputStream with the Zip4j ZipInputStream.  The Zip4j implementation takes a password, which can be null, and is used only when reading encrypted archives, so existing unpacking capabilities work without any other changes.  The Zip4j implementation introduces a new dependency on net.lingala.zip4j:zip4j 2.6.3 that is licensed under the Apache License 2.0.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [X] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [X] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
