### PR TITLE
NIFI-7863 - Recursively create directories, in case of a missing parent directory

### DIFF
--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/PutSmbFileTest.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/PutSmbFileTest.java
@@ -62,6 +62,7 @@ public class PutSmbFileTest {
     private final static String HOSTNAME = "smbhostname";
     private final static String SHARE = "smbshare";
     private final static String DIRECTORY = "smbdirectory\\subdir";
+    private final static String DIRECTORY_WITH_PARENT = "smbdirectory\\parentdir\\childdir";
     private final static String DOMAIN = "mydomain";
     private final static String USERNAME = "myusername";
     private final static String PASSWORD = "mypassword";
@@ -104,14 +105,14 @@ public class PutSmbFileTest {
         PutSmbFile.initSmbClient(smbClient);
     }
 
-    private void testDirectoryCreation(String dirFlag, int times) throws IOException {
+    private void testDirectoryCreation(String dirFlag, int times, String directory) throws IOException {
         when(diskShare.folderExists(DIRECTORY)).thenReturn(false);
 
         testRunner.setProperty(PutSmbFile.CREATE_DIRS, dirFlag);
         testRunner.enqueue("data");
         testRunner.run();
 
-        verify(diskShare, times(times)).mkdir(DIRECTORY);
+        verify(diskShare, times(times)).mkdir(directory);
     }
 
     private Set<SMB2ShareAccess> testOpenFileShareAccess() throws IOException {
@@ -164,12 +165,18 @@ public class PutSmbFileTest {
 
     @Test
     public void testDirExistsWithoutCreate() throws IOException {
-        testDirectoryCreation("false", 0);
+        testDirectoryCreation("false", 0, DIRECTORY);
     }
 
     @Test
     public void testDirExistsWithCreate() throws IOException {
-        testDirectoryCreation("true", 1);
+        testDirectoryCreation("true", 1, DIRECTORY);
+    }
+
+    @Test
+    public void testDirExistsWithRecursiveCreate() throws IOException {
+        testRunner.setProperty(PutSmbFile.DIRECTORY, DIRECTORY_WITH_PARENT);
+        testDirectoryCreation("true", 1, DIRECTORY_WITH_PARENT);
     }
 
     @Test


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Fixes issue described in NIFI-7863
https://issues.apache.org/jira/browse/NIFI-7863
Since samba does not allow recursive creation of directories, I modified the PutSmbFile processor to recursively create directories if it is missing,

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
