### PR TITLE
NIFI-7891 Default types in avro schemas when inferring schema

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroRecordSetWriter.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/avro/AvroRecordSetWriter.java
@@ -60,8 +60,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 @Tags({"avro", "result", "set", "writer", "serializer", "record", "recordset", "row"})
 @CapabilityDescription("Writes the contents of a RecordSet in Binary Avro format.")
 
-@DynamicProperty(name = "default.type.<Type>", value = "Type to set the default value for",
-        expressionLanguageScope = ExpressionLanguageScope.NONE, description = "Set a type...Write more...")
+@DynamicProperty(name = "default.type.<Type>", value = "Provide a default value for a given data type",
+        expressionLanguageScope = ExpressionLanguageScope.NONE, description = "For each Type provided as a property, the supplied default value "
+                        + "will be added to the built avro schema in the field's 'default' property. E.g. default.type.string with a value 'hello' will "
+                        + "add 'default':'hello' to each field of type String.")
 
 public class AvroRecordSetWriter extends SchemaRegistryRecordSetWriter implements RecordSetWriterFactory {
 


### PR DESCRIPTION
Initial attempt at adding default types for inferred avro schemas.

Adds dynamic properties to AvroRecordSetWriter prefixed with 'default.type' to specify default as desired

If you supply a value that can't convert in to the specific type .e.g (long and "hello") it will fail with

"Could not determine the Avro Schema to use for writing the content"

Seems like a valid error msg, but I suppose we could check the type conversion at the property validation point instead and fail earlier?

Welcome your feedback
