### PR TITLE
NIFI-7929: connectionTimeout and readTimeout options are not exposed …

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/JerseyExtendedNiFiRegistryClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/JerseyExtendedNiFiRegistryClient.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.bucket.BucketItem;
 import org.apache.nifi.registry.client.BucketClient;
@@ -70,7 +71,9 @@ public class JerseyExtendedNiFiRegistryClient implements ExtendedNiFiRegistryCli
     static final int DEFAULT_READ_TIMEOUT = 10000;
 
     private final NiFiRegistryClient delegate;
-    private final Client client;
+
+    @VisibleForTesting
+    final Client client;
     private final WebTarget baseTarget;
     private final TenantsClient tenantsClient;
     private final PoliciesClient policiesClient;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyNiFiClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyNiFiClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.security.util.ProxiedEntitiesUtils;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.ConnectionClient;
@@ -69,7 +70,8 @@ public class JerseyNiFiClient implements NiFiClient {
     static final String AUTHORIZATION_HEADER = "Authorization";
     static final String BEARER = "Bearer";
 
-    private final Client client;
+    @VisibleForTesting
+    public final Client client;
     private final WebTarget baseTarget;
 
     private JerseyNiFiClient(final Builder builder) {

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/AbstractCommand.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/AbstractCommand.java
@@ -66,6 +66,9 @@ public abstract class AbstractCommand<R extends Result> implements Command<R> {
         options.addOption(CommandOption.URL.createOption());
         options.addOption(CommandOption.PROPERTIES.createOption());
 
+        options.addOption(CommandOption.CONNECTION_TIMEOUT.createOption());
+        options.addOption(CommandOption.READ_TIMEOUT.createOption());
+
         options.addOption(CommandOption.KEYSTORE.createOption());
         options.addOption(CommandOption.KEYSTORE_TYPE.createOption());
         options.addOption(CommandOption.KEYSTORE_PASSWORD.createOption());

--- a/nifi-toolkit/nifi-toolkit-cli/src/test/java/org/apache/nifi/toolkit/cli/impl/client/TestClientTimeout.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/test/java/org/apache/nifi/toolkit/cli/impl/client/TestClientTimeout.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.client;
+
+import org.apache.nifi.registry.client.NiFiRegistryClient;
+import org.apache.nifi.toolkit.cli.api.ClientFactory;
+import org.apache.nifi.toolkit.cli.api.Command;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.api.Result;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.JerseyNiFiClient;
+import org.apache.nifi.toolkit.cli.impl.command.CommandProcessor;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.command.registry.AbstractNiFiRegistryCommand;
+import org.apache.nifi.toolkit.cli.impl.context.StandardContext;
+import org.apache.nifi.toolkit.cli.impl.session.InMemorySession;
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.client.Client;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class TestClientTimeout {
+
+    private Context context;
+    private ClientFactory<NiFiClient> nifiClientFactory;
+    private ClientFactory<NiFiRegistryClient> nifiRegClientFactory;
+    private final Client[] client = new Client[1];
+
+    @Before
+    public void setUp() throws Exception {
+        nifiClientFactory = Mockito.spy(new NiFiClientFactory());
+        Mockito.doAnswer(invocationOnMock -> {
+            final JerseyNiFiClient nifiClient = Mockito.spy((JerseyNiFiClient) invocationOnMock.callRealMethod());
+            Mockito.doNothing().when(nifiClient).close(); // avoid closing the client before getting the configuration in the test method
+            client[0] = nifiClient.client;
+            return nifiClient;
+        }).when(nifiClientFactory).createClient(Mockito.any(Properties.class));
+
+        nifiRegClientFactory = Mockito.spy(new NiFiRegistryClientFactory());
+        Mockito.doAnswer(invocationOnMock -> {
+            final JerseyExtendedNiFiRegistryClient nifiRegistryClient = Mockito.spy((JerseyExtendedNiFiRegistryClient) invocationOnMock.callRealMethod());
+            Mockito.doNothing().when(nifiRegistryClient).close(); // avoid closing the client before getting the configuration in the test method
+            client[0] = nifiRegistryClient.client;
+            return nifiRegistryClient;
+        }).when(nifiRegClientFactory).createClient(Mockito.any(Properties.class));
+
+        context = new StandardContext.Builder()
+                .output(System.out)
+                .session(new InMemorySession())
+                .nifiClientFactory(nifiClientFactory)
+                .nifiRegistryClientFactory(nifiRegClientFactory)
+                .interactive(false)
+                .build();
+    }
+
+    @After
+    public void tearDown() {
+        if (client[0] != null) {
+            try {
+                client[0].close();
+            } catch (Throwable th) {
+            }
+            client[0] = null;
+        }
+    }
+
+    @Test
+    public void testNiFiClientTimeoutSettings() {
+        testClientTimeoutSettings(new AbstractNiFiCommand<Result>("test", Result.class) {
+            @Override
+            public Result doExecute(NiFiClient client, Properties properties) {
+                return null;
+            }
+
+            @Override
+            public String getDescription() {
+                return "";
+            }
+        });
+    }
+
+    @Test
+    public void testNiFiRegistryClientTimeoutSettings() {
+        testClientTimeoutSettings(new AbstractNiFiRegistryCommand<Result>("test", Result.class) {
+            @Override
+            public Result doExecute(NiFiRegistryClient client, Properties properties) {
+                return null;
+            }
+
+            @Override
+            public String getDescription() {
+                return "";
+            }
+        });
+    }
+
+    private void testClientTimeoutSettings(Command<?> command) {
+        command.initialize(context);
+        final CommandProcessor processor = new CommandProcessor(Collections.singletonMap("test", command), Collections.emptyMap(), context);
+        processor.process(new String[] { "test", "-cto", "1", "-rto", "2", "-baseUrl", "http://localhost:9999" });
+
+        Assert.assertNotNull(client[0]);
+        final Map<String, Object> clientProperties = client[0].getConfiguration().getProperties();
+        Assert.assertEquals(1, clientProperties.get(ClientProperties.CONNECT_TIMEOUT));
+        Assert.assertEquals(2, clientProperties.get(ClientProperties.READ_TIMEOUT));
+    }
+
+}


### PR DESCRIPTION
…in the CLI

- added the connectionTimeout and readTimeout parameters to AbstractCommand#createBaseOptions
- added new tests to test if the proper timeout values are passed to the JAX-RS client in the NiFi and NiFiRegistry clients

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
