### PR TITLE
NIFI-7943 - Implement application properties for Event Hub messages

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -20,8 +20,8 @@
     <artifactId>nifi-azure-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <azure-eventhubs.version>3.1.1</azure-eventhubs.version>
-        <azure-eventhubs-eph.version>3.1.1</azure-eventhubs-eph.version>
+        <azure-eventhubs.version>3.2.1</azure-eventhubs.version>
+        <azure-eventhubs-eph.version>3.2.1</azure-eventhubs-eph.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -77,7 +77,8 @@ import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
         @WritesAttribute(attribute = "eventhub.offset", description = "The offset into the partition at which the message was stored"),
         @WritesAttribute(attribute = "eventhub.sequence", description = "The Azure sequence number associated with the message"),
         @WritesAttribute(attribute = "eventhub.name", description = "The name of the event hub from which the message was pulled"),
-        @WritesAttribute(attribute = "eventhub.partition", description = "The name of the event hub partition from which the message was pulled")
+        @WritesAttribute(attribute = "eventhub.partition", description = "The name of the event hub partition from which the message was pulled"),
+        @WritesAttribute(attribute = "eventhub.property.*", description = "The application properties of this message. IE: 'application' would be 'eventhub.property.application'")
 })
 public class GetAzureEventHub extends AbstractProcessor {
     static final PropertyDescriptor EVENT_HUB_NAME = new PropertyDescriptor.Builder()
@@ -374,6 +375,9 @@ public class GetAzureEventHub extends AbstractProcessor {
                         attributes.put("eventhub.offset", systemProperties.getOffset());
                         attributes.put("eventhub.sequence", String.valueOf(systemProperties.getSequenceNumber()));
                     }
+
+                    final Map<String,String> applicationProperties = AzureEventHubUtils.getApplicationProperties(eventData);
+                    attributes.putAll(applicationProperties);
 
                     attributes.put("eventhub.name", context.getProperty(EVENT_HUB_NAME).getValue());
                     attributes.put("eventhub.partition", partitionId);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/AzureEventHubUtils.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/AzureEventHubUtils.java
@@ -18,8 +18,11 @@ package org.apache.nifi.processors.azure.eventhub.utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
+import com.microsoft.azure.eventhubs.EventData;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
@@ -86,5 +89,18 @@ public final class AzureEventHubUtils {
                     .setEventHubName(eventHubName)
                     .setSasKeyName(sasName)
                     .setSasKey(sasKey).toString();
+    }
+
+    public static Map<String, String> getApplicationProperties(EventData eventData) {
+        final Map<String, String> properties = new HashMap<>();
+
+        final Map<String,Object> applicationProperties = eventData.getProperties();
+        if (null != applicationProperties) {
+            for (Map.Entry<String, Object> property : applicationProperties.entrySet()) {
+                properties.put(String.format("eventhub.property.%s", property.getKey()), property.getValue().toString());
+            }
+        }
+
+        return properties;
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHubTest.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHubTest.java
@@ -145,6 +145,19 @@ public class GetAzureEventHubTest {
     }
 
     @Test
+    public void testNormalFlowWithApplicationProperties() throws Exception {
+        setUpStandardTestConfig();
+        testRunner.run(1, true);
+        testRunner.assertAllFlowFilesTransferred(GetAzureEventHub.REL_SUCCESS, 10);
+
+        MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(GetAzureEventHub.REL_SUCCESS).get(0);
+        flowFile.assertAttributeEquals("eventhub.property.event-sender", "Apache NiFi");
+        flowFile.assertAttributeEquals("eventhub.property.application", "TestApp");
+
+        testRunner.clearTransferState();
+    }
+
+    @Test
     public void testNormalNotReceivedEventsFlow() throws Exception {
         setUpStandardTestConfig();
         processor.received = false;
@@ -193,6 +206,8 @@ public class GetAzureEventHubTest {
             final LinkedList<EventData> receivedEvents = new LinkedList<>();
             for(int i = 0; i < 10; i++){
                 EventData eventData = EventData.create(String.format("test event number: %d", i).getBytes());
+                eventData.getProperties().put("event-sender", "Apache NiFi");
+                eventData.getProperties().put("application", "TestApp");
                 if (received) {
                     HashMap<String, Object> properties = new HashMap<>();
                     properties.put(AmqpConstants.PARTITION_KEY_ANNOTATION_NAME, PARTITION_KEY_VALUE);


### PR DESCRIPTION
#### Description of PR

  EventData coming from the Event Hub bus may contain application properties. These could be useful in NiFi to determine
what kind of processing to execute.

  This PR introduces the application properties in the flow as `eventhub.property.*`. For example, the property `application` would 
be available in the flow as attribute `eventhub.property.application`.

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:

- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
