### PR TITLE
NIFI-7942 Fixing ordering issue when counter based metrics are added …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/StatusHistoryUtilTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/StatusHistoryUtilTest.java
@@ -71,4 +71,30 @@ public class StatusHistoryUtilTest {
         // then
         Assert.assertEquals(expected, result);
     }
+
+    @Test
+    public void testCreateFieldDescriptorDtosWhenCounterTypeAppears() {
+        // given
+        final Collection<MetricDescriptor<?>> metricDescriptors = Arrays.asList(
+                new CounterMetricDescriptor<>("fieldCounter1", "FieldCounter1", "Field Counter 1", MetricDescriptor.Formatter.COUNT, __ -> 3L),
+                new StandardMetricDescriptor<>(() -> 1, "field2",  "Field2", "Field 2", MetricDescriptor.Formatter.COUNT, __ -> 2L),
+                new CounterMetricDescriptor<>("fieldCounter2", "FieldCounter2", "Field Counter 2", MetricDescriptor.Formatter.COUNT, __ -> 4L),
+                new StandardMetricDescriptor<>(() -> 0, "field1", "Field1", "Field 1", MetricDescriptor.Formatter.COUNT, __ -> 1L),
+                new CounterMetricDescriptor<>("fieldCounter3", "FieldCounter3", "Field Counter 3", MetricDescriptor.Formatter.COUNT, __ -> 5L)
+        );
+
+        final List<StatusDescriptorDTO> expected = Arrays.asList(
+                new StatusDescriptorDTO("field1", "Field1", "Field 1", MetricDescriptor.Formatter.COUNT.name()),
+                new StatusDescriptorDTO("field2", "Field2", "Field 2", MetricDescriptor.Formatter.COUNT.name()),
+                new StatusDescriptorDTO("fieldCounter1", "FieldCounter1", "Field Counter 1", MetricDescriptor.Formatter.COUNT.name()),
+                new StatusDescriptorDTO("fieldCounter2", "FieldCounter2", "Field Counter 2", MetricDescriptor.Formatter.COUNT.name()),
+                new StatusDescriptorDTO("fieldCounter3", "FieldCounter3", "Field Counter 3", MetricDescriptor.Formatter.COUNT.name())
+        );
+
+        // when
+        final List<StatusDescriptorDTO> result = StatusHistoryUtil.createFieldDescriptorDtos(metricDescriptors);
+
+        // then
+        Assert.assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
…by component

[NIFI-7942](https://issues.apache.org/jira/browse/NIFI-7942l)

Fixes an issues with metrics changes causes trouble when component status history with counter based metrics appears.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
