### PR TITLE
NIFI-7225 FetchSFTP processor routing to not.found error given when P…

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -824,9 +824,15 @@ public class StandardValidators {
     public static class FileExistsValidator implements Validator {
 
         private final boolean allowEL;
+        private final boolean allowFileOnly;
 
         public FileExistsValidator(final boolean allowExpressionLanguage) {
+            this(allowExpressionLanguage,false);
+        }
+
+        public FileExistsValidator(final boolean allowExpressionLanguage, final boolean fileOnly) {
             this.allowEL = allowExpressionLanguage;
+            this.allowFileOnly = fileOnly;
         }
 
         @Override
@@ -848,9 +854,13 @@ public class StandardValidators {
             }
 
             final File file = new File(substituted);
-            final boolean valid = file.exists();
-            final String explanation = valid ? null : "File " + file + " does not exist";
-            return new ValidationResult.Builder().subject(subject).input(value).valid(valid).explanation(explanation).build();
+            if (!file.exists()) {
+                return new ValidationResult.Builder().subject(subject).input(value).valid(false).explanation("File " + file + " does not exist").build();
+            }
+            if (allowFileOnly && !file.isFile()) {
+                return new ValidationResult.Builder().subject(subject).input(value).valid(false).explanation(file + " is not a file").build();
+            }
+            return new ValidationResult.Builder().subject(subject).input(value).valid(true).build();
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -86,7 +86,7 @@ public class SFTPTransfer implements FileTransfer {
         .name("Private Key Path")
         .description("The fully qualified path to the Private Key file")
         .required(false)
-        .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+        .addValidator(new StandardValidators.FileExistsValidator(true,true))
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
     public static final PropertyDescriptor PRIVATE_KEY_PASSPHRASE = new PropertyDescriptor.Builder()
@@ -103,7 +103,7 @@ public class SFTPTransfer implements FileTransfer {
                 " otherwise, if 'Strict Host Key Checking' property is applied (set to true)" +
                 " then uses the 'known_hosts' and 'known_hosts2' files from ~/.ssh directory" +
                 " else no host key file will be used")
-        .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+        .addValidator(new StandardValidators.FileExistsValidator(true,true))
         .required(false)
         .build();
     public static final PropertyDescriptor STRICT_HOST_KEY_CHECKING = new PropertyDescriptor.Builder()


### PR DESCRIPTION
…rivate Key Path property is invalid

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR 
The FetchSFTP processor utilized StandardValidator FileExistsValidator which allowed for directory names to be valid and not full path name to a file resulting in "not.found" errors being generated on PrivateKey path value. Corrected StandardValidators.FileExistsValidator to declare validation as "false" if path is to a directory. This change required modification of Junit tests that were using "./" as file path values, replacing values with valid "junk" file path.

 Fixes bug NIFI-7225._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
