### PR TITLE
NIFI-7964 Force PutAzureBlobStorage to stream writes

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.processors.azure.storage;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.FilterInputStream;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -135,9 +135,9 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
                 // If markSupported() is true and a file length is provided,
                 // Blobs are not uploaded in blocks resulting in OOME for large
                 // files. The UnmarkableInputStream wrapper class disables
-                // marking to help force uploading files in smaller chunks.
+                // mark() and reset() to help force uploading files in chunks.
                 if (in.markSupported()) {
-                    in = new UnmarkableInputStream(in);
+                    in = UnmarkableInputStream.newInstance(in);
                 }
 
                 try {
@@ -176,19 +176,26 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
     }
 
     // Used to help force Azure Blob SDK to write in blocks
-    private class UnmarkableInputStream extends FilterInputStream {
-        public UnmarkableInputStream(InputStream in) {
+    private static class UnmarkableInputStream extends FilterInputStream {
+        private UnmarkableInputStream(InputStream in) {
             super(in);
         }
 
         @Override
         public void mark(int readlimit) {
-            // do nothing
+        }
+
+        @Override
+        public void reset() throws IOException {
         }
 
         @Override
         public boolean markSupported() {
             return false;
+        }
+
+        public static UnmarkableInputStream newInstance(final InputStream in) {
+            return new UnmarkableInputStream(in);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -137,7 +137,7 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
                 // files. The UnmarkableInputStream wrapper class disables
                 // mark() and reset() to help force uploading files in chunks.
                 if (in.markSupported()) {
-                    in = UnmarkableInputStream.newInstance(in);
+                    in = new UnmarkableInputStream(in);
                 }
 
                 try {
@@ -177,7 +177,7 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
 
     // Used to help force Azure Blob SDK to write in blocks
     private static class UnmarkableInputStream extends FilterInputStream {
-        private UnmarkableInputStream(InputStream in) {
+        public UnmarkableInputStream(InputStream in) {
             super(in);
         }
 
@@ -192,10 +192,6 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
         @Override
         public boolean markSupported() {
             return false;
-        }
-
-        public static UnmarkableInputStream newInstance(final InputStream in) {
-            return new UnmarkableInputStream(in);
         }
     }
 }


### PR DESCRIPTION
This forces PutAzureBlobStorage to stream writes to avoid OOMEs; fixes NIFI-7964.

~~**NOTE**: I've marked this as a draft because it'd be helpful to see if anyone sees a performance impact by applying this in all cases.~~

**NOTE**: It'd be nice to have an IT for this but the `TestRunner` reads everything into memory for enqueuing, so it can't be tested that way. If you're looking to replicate the problem and the fix you can create a flow with `[GetFile] --> [PutAzureBlobStorage]` and generate a test file as follows; the resulting file should be slightly over 512MB:

```sh
openssl rand -out /tmp/nifi/blob/test.txt -base64 402653184
```

I've tested the following scenarios:
* Putting files > heap on any version < 1.12.1 results in an OOME.
* Putting files >= heap for heap sizes of 512MB and 4GB is successful with the change.
* There is no noticeable throughput difference between 1.12.1 and this change. With small files > 50 MB/s on a single node is achievable without any tuning.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
