### PR TITLE
NIFI-7994: Fixed ReplaceText concurrency issue

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
@@ -494,7 +494,6 @@ public class ReplaceText extends AbstractProcessor {
 
     private static class RegexReplace implements ReplacementStrategyExecutor {
         private final int numCapturingGroups;
-        private final Map<String, String> additionalAttrs;
 
         // back references are not supported in the evaluated expression
         private final AttributeValueDecorator escapeBackRefDecorator = new AttributeValueDecorator() {
@@ -507,7 +506,6 @@ public class ReplaceText extends AbstractProcessor {
 
         public RegexReplace(final String regex) {
             numCapturingGroups = Pattern.compile(regex).matcher("").groupCount();
-            additionalAttrs = new HashMap<>(numCapturingGroups);
         }
 
         @Override
@@ -516,6 +514,7 @@ public class ReplaceText extends AbstractProcessor {
 
             final String searchRegex = context.getProperty(SEARCH_VALUE).evaluateAttributeExpressions(flowFile, quotedAttributeDecorator).getValue();
             final Pattern searchPattern = Pattern.compile(searchRegex);
+            final Map<String, String> additionalAttrs = new HashMap<>(numCapturingGroups);
 
             FlowFile updatedFlowFile;
             if (evaluateMode.equalsIgnoreCase(ENTIRE_TEXT)) {
@@ -526,7 +525,6 @@ public class ReplaceText extends AbstractProcessor {
                 session.read(flowFile, in -> StreamUtils.fillBuffer(in, buffer, false));
 
                 final String contentString = new String(buffer, 0, flowFileSize, charset);
-                additionalAttrs.clear();
                 final Matcher matcher = searchPattern.matcher(contentString);
 
                 final PropertyValue replacementValueProperty = context.getProperty(REPLACEMENT_VALUE);
@@ -560,8 +558,7 @@ public class ReplaceText extends AbstractProcessor {
                 final Matcher matcher = searchPattern.matcher("");
                 updatedFlowFile = session.write(flowFile, new StreamReplaceCallback(charset, maxBufferSize, context.getProperty(LINE_BY_LINE_EVALUATION_MODE).getValue(),
                     (bw, oneLine) -> {
-                        additionalAttrs.clear();
-                            matcher.reset(oneLine);
+                        matcher.reset(oneLine);
 
                         int matches = 0;
                         StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
Moving RegexReplace.additionalAttrs field to local variable in replace() method.
Concurrent usage of the additionalAttrs map caused data corruption.

https://issues.apache.org/jira/browse/NIFI-7994

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
