### PR TITLE
NIFI-7972 TailFile NFS improvement

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -76,6 +76,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
@@ -220,6 +221,19 @@ public class TailFile extends AbstractProcessor {
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
+    static final PropertyDescriptor REREAD_ON_NUL = new PropertyDescriptor.Builder()
+            .name("reread-on-nul")
+            .displayName("Reread when NUL encountered")
+            .description("If this option is set to 'true', when a NUL character is read, the processor will yield and try to read the same part again later. "
+                + "The purpose of this flag is to allow users to handle cases where reading a file may return temporary NUL values. "
+                + "NFS for example may send file contents out of order. In this case the missing parts are temporarily replaced by NUL values. "
+                + "CAUTION! If the file contains legitimate NUL values, setting this flag causes this processor to get stuck indefinitely. "
+                + "For this reason users should refrain from using this feature if they can help it and try to avoid having the target file on a file system where reads are unreliable.")
+            .required(false)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .build();
+
     static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("All FlowFiles are routed to this Relationship.")
@@ -242,6 +256,7 @@ public class TailFile extends AbstractProcessor {
         properties.add(RECURSIVE);
         properties.add(LOOKUP_FREQUENCY);
         properties.add(MAXIMUM_AGE);
+        properties.add(REREAD_ON_NUL);
         return properties;
     }
 
@@ -610,7 +625,13 @@ public class TailFile extends AbstractProcessor {
         }
 
         for (String tailFile : states.keySet()) {
-            processTailFile(context, session, tailFile);
+            try {
+                processTailFile(context, session, tailFile);
+            } catch (NulCharacterEncounteredException e) {
+                getLogger().warn("NUL character encountered in " + tailFile + " and '" + REREAD_ON_NUL.getDisplayName() + "' is set to 'true', yielding.");
+                context.yield();
+                return;
+            }
         }
     }
 
@@ -760,14 +781,25 @@ public class TailFile extends AbstractProcessor {
 
         final FileChannel fileReader = reader;
         final AtomicLong positionHolder = new AtomicLong(position);
+        Boolean reReadOnNul = context.getProperty(REREAD_ON_NUL).asBoolean();
+
+        AtomicReference<NulCharacterEncounteredException> abort = new AtomicReference<>();
         flowFile = session.write(flowFile, new OutputStreamCallback() {
             @Override
             public void process(final OutputStream rawOut) throws IOException {
                 try (final OutputStream out = new BufferedOutputStream(rawOut)) {
-                    positionHolder.set(readLines(fileReader, currentState.getBuffer(), out, chksum));
+                    positionHolder.set(readLines(fileReader, currentState.getBuffer(), out, chksum, reReadOnNul));
+                } catch (NulCharacterEncounteredException e) {
+                    positionHolder.set(e.getRePos());
+                    abort.set(e);
                 }
             }
         });
+
+        if (abort.get() != null) {
+            session.remove(flowFile);
+            throw abort.get();
+        }
 
         // If there ended up being no data, just remove the FlowFile
         if (flowFile.getSize() == 0) {
@@ -823,11 +855,15 @@ public class TailFile extends AbstractProcessor {
      * @param out the OutputStream to copy the data to
      * @param checksum the Checksum object to use in order to calculate checksum
      * for recovery purposes
+     * @param reReadOnNul If set to 'true', ASCII NUL characters will be treated as
+     * temporary values and a NulCharacterEncounteredException is thrown.
+     * This allows the caller to re-attempt a read from the same position.
+     * If set to 'false' these characters will be treated as regular content.
      *
      * @return The new position after the lines have been read
      * @throws java.io.IOException if an I/O error occurs.
      */
-    private long readLines(final FileChannel reader, final ByteBuffer buffer, final OutputStream out, final Checksum checksum) throws IOException {
+    private long readLines(final FileChannel reader, final ByteBuffer buffer, final OutputStream out, final Checksum checksum, Boolean reReadOnNul) throws IOException {
         getLogger().debug("Reading lines starting at position {}", new Object[]{reader.position()});
 
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
@@ -865,6 +901,11 @@ public class TailFile extends AbstractProcessor {
                             baos.write(ch);
                             seenCR = true;
                             break;
+                        }
+                        case '\0': {
+                            if (reReadOnNul) {
+                                throw new NulCharacterEncounteredException(rePos);
+                            }
                         }
                         default: {
                             if (seenCR) {
@@ -1363,6 +1404,18 @@ public class TailFile extends AbstractProcessor {
             map.put(prefix + StateKeys.TIMESTAMP, String.valueOf(timestamp));
             map.put(prefix + StateKeys.CHECKSUM, checksum == null ? null : String.valueOf(checksum.getValue()));
             return map;
+        }
+    }
+
+    static class NulCharacterEncounteredException extends RuntimeException {
+        private final long rePos;
+
+        public NulCharacterEncounteredException(long rePos) {
+            this.rePos = rePos;
+        }
+
+        public long getRePos() {
+            return rePos;
         }
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -225,6 +225,7 @@ public class TailFile extends AbstractProcessor {
             .name("reread-on-nul")
             .displayName("Reread when NUL encountered")
             .description("If this option is set to 'true', when a NUL character is read, the processor will yield and try to read the same part again later. "
+                + "(Note: Yielding may delay the processing of other files tailed by this processor, not just the one with the NUL character.) "
                 + "The purpose of this flag is to allow users to handle cases where reading a file may return temporary NUL values. "
                 + "NFS for example may send file contents out of order. In this case the missing parts are temporarily replaced by NUL values. "
                 + "CAUTION! If the file contains legitimate NUL values, setting this flag causes this processor to get stuck indefinitely. "
@@ -781,7 +782,7 @@ public class TailFile extends AbstractProcessor {
 
         final FileChannel fileReader = reader;
         final AtomicLong positionHolder = new AtomicLong(position);
-        Boolean reReadOnNul = context.getProperty(REREAD_ON_NUL).asBoolean();
+        final Boolean reReadOnNul = context.getProperty(REREAD_ON_NUL).asBoolean();
 
         AtomicReference<NulCharacterEncounteredException> abort = new AtomicReference<>();
         flowFile = session.write(flowFile, new OutputStreamCallback() {
@@ -1416,6 +1417,11 @@ public class TailFile extends AbstractProcessor {
 
         public long getRePos() {
             return rePos;
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
         }
     }
 }


### PR DESCRIPTION
Add a boolean property by which the user can tell the processor to yield (and try again later) whenever it encounters a NUL character.

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
