### PR TITLE
NIFI-8019 Added TlsPlatform to provide runtime default TLS Protocols

### DIFF
--- a/nifi-commons/nifi-security-utils-api/src/main/java/org/apache/nifi/security/util/TlsPlatform.java
+++ b/nifi-commons/nifi-security-utils-api/src/main/java/org/apache/nifi/security/util/TlsPlatform.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.security.util;
+
+import static java.util.Collections.unmodifiableSet;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Transport Layer Security Platform provides runtime protocol configuration information
+ */
+public class TlsPlatform {
+    private static final Pattern PROTOCOL_VERSION = Pattern.compile("TLSv(\\d+\\.?\\d*)");
+
+    private static final int FIRST_GROUP = 1;
+
+    private static final List<String> LEGACY_PROTOCOLS = Arrays.asList("TLSv1", "TLSv1.1");
+
+    private static final SortedMap<Float, String> SORTED_PROTOCOLS = getDefaultSslContextProtocols();
+
+    private static final Set<String> DEFAULT_PROTOCOLS = unmodifiableSet(new TreeSet<>(SORTED_PROTOCOLS.values()).descendingSet());
+
+    private static final Set<String> PREFERRED_PROTOCOLS = unmodifiableSet(
+            DEFAULT_PROTOCOLS.stream()
+            .filter(protocol -> !LEGACY_PROTOCOLS.contains(protocol))
+            .collect(Collectors.toSet())
+    );
+
+    /**
+     * Get Default Protocols based on Java Security configuration
+     *
+     * @return Set of Transport Layer Security Protocol names
+     */
+    public static Set<String> getDefaultProtocols() {
+        return DEFAULT_PROTOCOLS;
+    }
+
+    /**
+     * Get Preferred Protocols based on default protocols with legacy protocols removed
+     *
+     * @return Set of Preferred Transport Layer Security Protocol names
+     */
+    public static Set<String> getPreferredProtocols() {
+        return PREFERRED_PROTOCOLS;
+    }
+
+    /**
+     * Get Latest Protocol based on high version number from default protocols in Java Security configuration
+     *
+     * @return Latest Transport Layer Security Protocol
+     */
+    public static String getLatestProtocol() {
+        return SORTED_PROTOCOLS.get(SORTED_PROTOCOLS.lastKey());
+    }
+
+    private static SortedMap<Float, String> getDefaultSslContextProtocols() {
+        final SSLContext defaultContext = getDefaultSslContext();
+        final SSLParameters defaultParameters = defaultContext.getDefaultSSLParameters();
+
+        final SortedMap<Float, String> sslContextProtocols = new TreeMap<>();
+        final String[] protocols = defaultParameters.getProtocols();
+        for (final String protocol : protocols) {
+            final Matcher protocolVersionMatcher = PROTOCOL_VERSION.matcher(protocol);
+            if (protocolVersionMatcher.matches()) {
+                final String protocolVersion = protocolVersionMatcher.group(FIRST_GROUP);
+                final float version = Float.parseFloat(protocolVersion);
+                sslContextProtocols.put(version, protocol);
+            }
+        }
+
+        return sslContextProtocols;
+    }
+
+    private static SSLContext getDefaultSslContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (final NoSuchAlgorithmException e) {
+            throw new RuntimeException("SSLContext.getDefault() Failed", e);
+        }
+    }
+}

--- a/nifi-commons/nifi-security-utils-api/src/main/java/org/apache/nifi/security/util/TlsPlatform.java
+++ b/nifi-commons/nifi-security-utils-api/src/main/java/org/apache/nifi/security/util/TlsPlatform.java
@@ -44,25 +44,25 @@ public class TlsPlatform {
 
     private static final SortedMap<Float, String> SORTED_PROTOCOLS = getDefaultSslContextProtocols();
 
-    private static final Set<String> DEFAULT_PROTOCOLS = unmodifiableSet(new TreeSet<>(SORTED_PROTOCOLS.values()).descendingSet());
+    private static final Set<String> SUPPORTED_PROTOCOLS = unmodifiableSet(new TreeSet<>(SORTED_PROTOCOLS.values()).descendingSet());
 
     private static final Set<String> PREFERRED_PROTOCOLS = unmodifiableSet(
-            DEFAULT_PROTOCOLS.stream()
+            SUPPORTED_PROTOCOLS.stream()
             .filter(protocol -> !LEGACY_PROTOCOLS.contains(protocol))
             .collect(Collectors.toSet())
     );
 
     /**
-     * Get Default Protocols based on Java Security configuration
+     * Get all supported protocols based on Java Security configuration
      *
-     * @return Set of Transport Layer Security Protocol names
+     * @return Set of all supported Transport Layer Security Protocol names available on the JVM
      */
-    public static Set<String> getDefaultProtocols() {
-        return DEFAULT_PROTOCOLS;
+    public static Set<String> getSupportedProtocols() {
+        return SUPPORTED_PROTOCOLS;
     }
 
     /**
-     * Get Preferred Protocols based on default protocols with legacy protocols removed
+     * Get Preferred Protocols based on supported protocols with legacy protocols removed
      *
      * @return Set of Preferred Transport Layer Security Protocol names
      */

--- a/nifi-commons/nifi-security-utils-api/src/test/java/org/apache/nifi/security/util/TlsPlatformTest.java
+++ b/nifi-commons/nifi-security-utils-api/src/test/java/org/apache/nifi/security/util/TlsPlatformTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.security.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+public class TlsPlatformTest {
+    private static final int ZERO_LENGTH = 0;
+
+    private static final String TLS_1_3 = "TLSv1.3";
+
+    private static final String TLS_1_2 = "TLSv1.2";
+
+    private static final String TLS_1_1 = "TLSv1.1";
+
+    private static final String TLS_1 = "TLSv1";
+
+    private static final String UNEXPECTED_LATEST_PROTOCOL = "Unexpected Latest Protocol [%s]";
+
+    @Test
+    public void testGetDefaultProtocolsFound() {
+        final Set<String> defaultProtocols = TlsPlatform.getDefaultProtocols();
+        assertFalse(defaultProtocols.isEmpty());
+    }
+
+    @Test
+    public void testGetPreferredProtocolsFound() {
+        final Set<String> preferredProtocols = TlsPlatform.getPreferredProtocols();
+        assertFalse(preferredProtocols.isEmpty());
+    }
+
+    @Test
+    public void testGetPreferredProtocolsShouldNotIncludeLegacyProtocols() {
+        final Set<String> preferredProtocols = TlsPlatform.getPreferredProtocols();
+        assertFalse(preferredProtocols.contains(TLS_1_1));
+        assertFalse(preferredProtocols.contains(TLS_1));
+    }
+
+    @Test
+    public void testGetLatestProtocolFound() {
+        final String latestProtocol = TlsPlatform.getLatestProtocol();
+        assertNotNull(latestProtocol);
+        assertNotEquals(ZERO_LENGTH, latestProtocol.length());
+    }
+
+    @Test
+    public void testGetLatestProtocolMostRecentVersion() {
+        final Set<String> defaultProtocols = TlsPlatform.getDefaultProtocols();
+        final String latestProtocol = TlsPlatform.getLatestProtocol();
+        if (defaultProtocols.contains(TLS_1_3)) {
+            assertEquals(TLS_1_3, latestProtocol);
+        } else if (defaultProtocols.contains(TLS_1_2)) {
+            assertEquals(TLS_1_2, latestProtocol);
+        } else {
+            fail(String.format(UNEXPECTED_LATEST_PROTOCOL, latestProtocol));
+        }
+    }
+}

--- a/nifi-commons/nifi-security-utils-api/src/test/java/org/apache/nifi/security/util/TlsPlatformTest.java
+++ b/nifi-commons/nifi-security-utils-api/src/test/java/org/apache/nifi/security/util/TlsPlatformTest.java
@@ -40,9 +40,9 @@ public class TlsPlatformTest {
     private static final String UNEXPECTED_LATEST_PROTOCOL = "Unexpected Latest Protocol [%s]";
 
     @Test
-    public void testGetDefaultProtocolsFound() {
-        final Set<String> defaultProtocols = TlsPlatform.getDefaultProtocols();
-        assertFalse(defaultProtocols.isEmpty());
+    public void testGetSupportedProtocolsFound() {
+        final Set<String> supportedProtocols = TlsPlatform.getSupportedProtocols();
+        assertFalse(supportedProtocols.isEmpty());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class TlsPlatformTest {
 
     @Test
     public void testGetLatestProtocolMostRecentVersion() {
-        final Set<String> defaultProtocols = TlsPlatform.getDefaultProtocols();
+        final Set<String> defaultProtocols = TlsPlatform.getSupportedProtocols();
         final String latestProtocol = TlsPlatform.getLatestProtocol();
         if (defaultProtocols.contains(TLS_1_3)) {
             assertEquals(TLS_1_3, latestProtocol);

--- a/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/SslContextFactoryTest.groovy
+++ b/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/SslContextFactoryTest.groovy
@@ -44,11 +44,7 @@ class SslContextFactoryTest extends GroovyTestCase {
     private static final String TRUSTSTORE_PASSWORD = "truststorepassword"
     private static final KeystoreType TRUSTSTORE_TYPE = KeystoreType.JKS
 
-    private static final String PROTOCOL = TlsConfiguration.getHighestCurrentSupportedTlsProtocolVersion()
-
-    // The default TLS protocol versions for different Java versions
-    private static final List<String> JAVA_8_TLS_PROTOCOL_VERSIONS = ["TLSv1.2", "TLSv1.1", "TLSv1"]
-    private static final List<String> JAVA_11_TLS_PROTOCOL_VERSIONS = ["TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1"]
+    private static final String CONFIGURED_TLS_PROTOCOL = "TLSv1.2"
 
     private static final Map<String, String> DEFAULT_PROPS = [
             (NiFiProperties.SECURITY_KEYSTORE)         : KEYSTORE_PATH,
@@ -83,14 +79,6 @@ class SslContextFactoryTest extends GroovyTestCase {
 
     }
 
-    static List<String> getCurrentTlsProtocolVersions() {
-        if (TlsConfiguration.getJavaVersion() < 11) {
-            return JAVA_8_TLS_PROTOCOL_VERSIONS
-        } else {
-            return JAVA_11_TLS_PROTOCOL_VERSIONS
-        }
-    }
-
     /**
      * Asserts that the protocol versions are correct. In recent versions of Java, this enforces order as well, but in older versions, it just enforces presence.
      *
@@ -119,7 +107,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, getCurrentTlsProtocolVersions())
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
         assert !defaultSSLParameters.needClientAuth
         assert !defaultSSLParameters.wantClientAuth
 
@@ -149,7 +137,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, getCurrentTlsProtocolVersions())
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
         assert !defaultSSLParameters.needClientAuth
         assert !defaultSSLParameters.wantClientAuth
 
@@ -226,7 +214,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, getCurrentTlsProtocolVersions())
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
         assert !defaultSSLParameters.needClientAuth
         assert !defaultSSLParameters.wantClientAuth
 
@@ -285,13 +273,13 @@ class SslContextFactoryTest extends GroovyTestCase {
     void assertSocketProtocols(SSLContext sslContext) {
         SSLServerSocket sslSocket = sslContext.serverSocketFactory.createServerSocket() as SSLServerSocket
         logger.info("Created SSL (server) socket: ${sslSocket}")
-        assert sslSocket.enabledProtocols.contains("TLSv1.2")
+        assert sslSocket.enabledProtocols.contains(CONFIGURED_TLS_PROTOCOL)
 
         // Override the SSL parameters protocol version
         SSLServerSocket customSslSocket = sslContext.serverSocketFactory.createServerSocket() as SSLServerSocket
         def customParameters = customSslSocket.getSSLParameters()
-        customParameters.setProtocols(["TLSv1.2"] as String[])
+        customParameters.setProtocols([CONFIGURED_TLS_PROTOCOL] as String[])
         customSslSocket.setSSLParameters(customParameters)
-        assertProtocolVersions(customSslSocket.enabledProtocols, ["TLSv1.2"])
+        assertProtocolVersions(customSslSocket.enabledProtocols, [CONFIGURED_TLS_PROTOCOL])
     }
 }

--- a/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/SslContextFactoryTest.groovy
+++ b/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/SslContextFactoryTest.groovy
@@ -107,7 +107,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
         assert !defaultSSLParameters.needClientAuth
         assert !defaultSSLParameters.wantClientAuth
 
@@ -137,7 +137,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
         assert !defaultSSLParameters.needClientAuth
         assert !defaultSSLParameters.wantClientAuth
 
@@ -214,7 +214,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
         assert !defaultSSLParameters.needClientAuth
         assert !defaultSSLParameters.wantClientAuth
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServerTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServerTest.groovy
@@ -117,7 +117,7 @@ class ConnectionLoadBalanceServerTest extends GroovyTestCase {
         // Assert that the default parameters (which can't be modified) still have legacy protocols and no client auth
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
         assert !defaultSSLParameters.needClientAuth
 
         // Assert that the actual socket is set correctly due to the override in the LB server

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServerTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServerTest.groovy
@@ -24,6 +24,7 @@ import org.apache.nifi.security.util.KeystoreType
 import org.apache.nifi.security.util.SslContextFactory
 import org.apache.nifi.security.util.StandardTlsConfiguration
 import org.apache.nifi.security.util.TlsConfiguration
+import org.apache.nifi.security.util.TlsPlatform
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.After
 import org.junit.Before
@@ -85,17 +86,13 @@ class ConnectionLoadBalanceServerTest extends GroovyTestCase {
     }
 
     /**
-     * Asserts that the protocol versions in the parameters object are correct. In recent versions of Java, this enforces order as well, but in older versions, it just enforces presence.
+     * Asserts that the protocol versions in the parameters object are correct.
      *
      * @param enabledProtocols the actual protocols, either in {@code String[]} or {@code Collection<String>} form
      * @param expectedProtocols the specific protocol versions to be present (ordered as desired)
      */
     void assertProtocolVersions(def enabledProtocols, def expectedProtocols) {
-        if (TlsConfiguration.getJavaVersion() > 8) {
-            assert enabledProtocols == expectedProtocols as String[]
-        } else {
-            assert enabledProtocols as Set == expectedProtocols as Set
-        }
+        assert enabledProtocols as Set == expectedProtocols as Set
     }
 
     @Test
@@ -120,13 +117,13 @@ class ConnectionLoadBalanceServerTest extends GroovyTestCase {
         // Assert that the default parameters (which can't be modified) still have legacy protocols and no client auth
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsConfiguration.getCurrentSupportedTlsProtocolVersions() + ["TLSv1.1", "TLSv1"])
+        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.defaultProtocols)
         assert !defaultSSLParameters.needClientAuth
 
         // Assert that the actual socket is set correctly due to the override in the LB server
         SSLServerSocket socket = lbServer.serverSocket as SSLServerSocket
         logger.info("Created SSL server socket: ${KeyStoreUtils.sslServerSocketToString(socket)}" as String)
-        assertProtocolVersions(socket.enabledProtocols, TlsConfiguration.getCurrentSupportedTlsProtocolVersions())
+        assertProtocolVersions(socket.enabledProtocols, TlsPlatform.preferredProtocols)
         assert socket.needClientAuth
 
         // Clean up

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/SocketRemoteSiteListenerTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/SocketRemoteSiteListenerTest.groovy
@@ -23,6 +23,7 @@ import org.apache.nifi.security.util.KeystoreType
 import org.apache.nifi.security.util.SslContextFactory
 import org.apache.nifi.security.util.StandardTlsConfiguration
 import org.apache.nifi.security.util.TlsConfiguration
+import org.apache.nifi.security.util.TlsPlatform
 import org.apache.nifi.util.NiFiProperties
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.After
@@ -133,7 +134,7 @@ class SocketRemoteSiteListenerTest extends GroovyTestCase {
         // Assert that the default parameters (which can't be modified) still have legacy protocols and no client auth
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.getProtocols(), TlsConfiguration.getCurrentSupportedTlsProtocolVersions().sort().reverse() + ["TLSv1.1", "TLSv1"])
+        assertProtocolVersions(defaultSSLParameters.getProtocols(), TlsPlatform.defaultProtocols)
         assert !defaultSSLParameters.needClientAuth
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/SocketRemoteSiteListenerTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/SocketRemoteSiteListenerTest.groovy
@@ -134,7 +134,7 @@ class SocketRemoteSiteListenerTest extends GroovyTestCase {
         // Assert that the default parameters (which can't be modified) still have legacy protocols and no client auth
         def defaultSSLParameters = sslContext.defaultSSLParameters
         logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.getProtocols(), TlsPlatform.defaultProtocols)
+        assertProtocolVersions(defaultSSLParameters.getProtocols(), TlsPlatform.supportedProtocols)
         assert !defaultSSLParameters.needClientAuth
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
@@ -345,7 +345,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @Test
     void testShouldSupportTLSv1_3WhenProtocolFound() {
         // Arrange
-        Assume.assumeTrue("This test should only run when TLSv1.3 is found in the set of default protocols", TlsPlatform.defaultProtocols.contains(TLS_1_3_PROTOCOL))
+        Assume.assumeTrue("This test should only run when TLSv1.3 is found in the set of default protocols", TlsPlatform.supportedProtocols.contains(TLS_1_3_PROTOCOL))
 
         Server internalServer = new Server()
         JettyServer jetty = new JettyServer(internalServer, httpsProps)
@@ -378,7 +378,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @Test
     void testShouldNotSupportTLSv1_3WhenProtocolNotFound() {
         // Arrange
-        Assume.assumeTrue("This test should only run when TLSv1.3 is not found in the set of default protocols", !TlsPlatform.defaultProtocols.contains(TLS_1_3_PROTOCOL))
+        Assume.assumeTrue("This test should only run when TLSv1.3 is not found in the set of default protocols", !TlsPlatform.supportedProtocols.contains(TLS_1_3_PROTOCOL))
 
         Server internalServer = new Server()
         JettyServer jetty = new JettyServer(internalServer, httpsProps)

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
@@ -26,6 +26,7 @@ import org.apache.nifi.processor.DataUnit
 import org.apache.nifi.properties.StandardNiFiProperties
 import org.apache.nifi.security.util.StandardTlsConfiguration
 import org.apache.nifi.security.util.TlsConfiguration
+import org.apache.nifi.security.util.TlsPlatform
 import org.apache.nifi.util.NiFiProperties
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.eclipse.jetty.server.Connector
@@ -79,13 +80,12 @@ class JettyServerGroovyTest extends GroovyTestCase {
     private static final String STORE_PASSWORD = "passwordpassword"
     private static final String STORE_TYPE = "JKS"
 
-    private static final String TLS_1_2_PROTOCOL = "TLSv1.2"
     private static final String TLS_1_3_PROTOCOL = "TLSv1.3"
     private static final List<String> TLS_1_3_CIPHER_SUITES = ["TLS_AES_128_GCM_SHA256"]
 
     // Depending if the test is run on Java 8 or Java 11, these values change (TLSv1.2 vs. TLSv1.3)
-    private static final CURRENT_TLS_PROTOCOL_VERSION = TlsConfiguration.getHighestCurrentSupportedTlsProtocolVersion()
-    private static final List<String> CURRENT_TLS_PROTOCOL_VERSIONS = TlsConfiguration.getCurrentSupportedTlsProtocolVersions()
+    private static final CURRENT_TLS_PROTOCOL_VERSION = TlsPlatform.latestProtocol
+    private static final List<String> CURRENT_TLS_PROTOCOL_VERSIONS = new ArrayList<>(TlsPlatform.preferredProtocols)
 
     // These protocol versions should not ever be supported
     static private final List<String> LEGACY_TLS_PROTOCOLS = ["TLS", "TLSv1", "TLSv1.1", "SSL", "SSLv2", "SSLv2Hello", "SSLv3"]
@@ -273,7 +273,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
         jetty.start()
 
         // Assert
-        assertServerConnector(connectors, "TLS", CURRENT_TLS_PROTOCOL_VERSIONS, CURRENT_TLS_PROTOCOL_VERSIONS, externalHostname, HTTPS_PORT)
+        assertServerConnector(connectors, "TLS", CURRENT_TLS_PROTOCOL_VERSIONS, externalHostname, HTTPS_PORT)
 
         // Clean up
         jetty.stop()
@@ -305,7 +305,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
         jetty.start()
 
         // Assert
-        assertServerConnector(connectors, "TLS", CURRENT_TLS_PROTOCOL_VERSIONS, CURRENT_TLS_PROTOCOL_VERSIONS, externalHostname, HTTPS_PORT)
+        assertServerConnector(connectors, "TLS", CURRENT_TLS_PROTOCOL_VERSIONS, externalHostname, HTTPS_PORT)
 
         // Clean up
         jetty.stop()
@@ -339,13 +339,13 @@ class JettyServerGroovyTest extends GroovyTestCase {
         List<Connector> connectors = Arrays.asList(internalServer.connectors)
 
         // Assert
-        assertServerConnector(connectors, "TLS", CURRENT_TLS_PROTOCOL_VERSIONS, CURRENT_TLS_PROTOCOL_VERSIONS, externalHostname, HTTPS_PORT)
+        assertServerConnector(connectors, "TLS", CURRENT_TLS_PROTOCOL_VERSIONS, externalHostname, HTTPS_PORT)
     }
 
     @Test
-    void testShouldSupportTLSv1_3OnJava11() {
+    void testShouldSupportTLSv1_3WhenProtocolFound() {
         // Arrange
-        Assume.assumeTrue("This test should only run on Java 11+", TlsConfiguration.getJavaVersion() >= 11)
+        Assume.assumeTrue("This test should only run when TLSv1.3 is found in the set of default protocols", TlsPlatform.defaultProtocols.contains(TLS_1_3_PROTOCOL))
 
         Server internalServer = new Server()
         JettyServer jetty = new JettyServer(internalServer, httpsProps)
@@ -369,16 +369,16 @@ class JettyServerGroovyTest extends GroovyTestCase {
         assert response =~ "HTTP/1.1 400"
 
         // Assert that the connector prefers TLSv1.3 but the JVM supports TLSv1.2 as well
-        assertServerConnector(connectors, "TLS", [CURRENT_TLS_PROTOCOL_VERSION], CURRENT_TLS_PROTOCOL_VERSIONS)
+        assertServerConnector(connectors, "TLS", [CURRENT_TLS_PROTOCOL_VERSION])
 
         // Clean up
         internalServer.stop()
     }
 
     @Test
-    void testShouldNotSupportTLSv1_3OnJava8() {
+    void testShouldNotSupportTLSv1_3WhenProtocolNotFound() {
         // Arrange
-        Assume.assumeTrue("This test should only run on Java 8 (prior to update 262 if from the Azul Zulu provider)", shouldRunOnStandardJava8())
+        Assume.assumeTrue("This test should only run when TLSv1.3 is not found in the set of default protocols", !TlsPlatform.defaultProtocols.contains(TLS_1_3_PROTOCOL))
 
         Server internalServer = new Server()
         JettyServer jetty = new JettyServer(internalServer, httpsProps)
@@ -396,7 +396,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
         // Act
         String tls12Response = makeTLSRequest(defaultSocket, "This is a default socket request")
 
-        def msg = shouldFail(IllegalArgumentException) {
+        def msg = shouldFail() {
             // Create a (client) socket which only supports TLSv1.3
             SSLSocketFactory tls13SocketFactory = org.apache.nifi.security.util.SslContextFactory.createSSLSocketFactory(tlsConfiguration)
 
@@ -404,50 +404,18 @@ class JettyServerGroovyTest extends GroovyTestCase {
             tls13Socket.setEnabledProtocols([TLS_1_3_PROTOCOL] as String[])
             tls13Socket.setEnabledCipherSuites(TLS_1_3_CIPHER_SUITES as String[])
 
-            String tls13Response = makeTLSRequest(tls13Socket, "This is a TLSv1.3 socket request")
+            makeTLSRequest(tls13Socket, "This is a TLSv1.3 socket request")
         }
-        // The IAE message is just the invalid argument (i.e. "TLSv1.3")
         logger.expected(msg)
 
         // Assert
         assert tls12Response =~ "HTTP"
-        assert msg == "TLSv1.3"
 
         // Assert that the connector only accepts TLSv1.2
-        assertServerConnector(connectors, "TLS", [CURRENT_TLS_PROTOCOL_VERSION], CURRENT_TLS_PROTOCOL_VERSIONS)
+        assertServerConnector(connectors, "TLS", [CURRENT_TLS_PROTOCOL_VERSION])
 
         // Clean up
         internalServer.stop()
-    }
-
-    /**
-     * The Azul Zulu JDK 8 vendor followed Oracle and OpenJDK in adding support for
-     * TLS v1.3 in update 262 of JDK 8, but throws a different exception type
-     * ({@code SSLHandshakeException} vs. {@code IllegalArgumentException}). This
-     * method returns {@code true} if the TLS 1.3 tests should run on <em>this</em>
-     * version of Java 8.
-     *
-     * @return true if the current JVM is Java 8 (or below) AND is either prior to update 262 OR is a non-Zulu vendor
-     */
-    private static boolean shouldRunOnStandardJava8() {
-        final String ZULU_RE = /(?i)azul|zulu/
-        String javaVersion = System.getProperty("java.version")
-        logger.info("Complete Java version: ${javaVersion}")
-
-        String vendor = System.getProperty("java.vendor")
-        logger.info("Java vendor: ${vendor}")
-        String vendorVersion = System.getProperty("jdk.vendor.version")
-        logger.info("Java vendor version: ${vendorVersion}")
-        def isZulu = vendor =~ ZULU_RE || vendorVersion =~ ZULU_RE
-        logger.info("Vendor is Azul/Zulu: ${isZulu}")
-
-        def majorJavaVersion = TlsConfiguration.getJavaVersion()
-        logger.info("Detected major Java version: ${majorJavaVersion}")
-
-        // JDK 8 update 262 adds TLS 1.3 support to Java 8, and the Azul vendor throws a different exception than expected
-        def beforeUpdate262 = majorJavaVersion <= 8 && Integer.parseInt(javaVersion.tokenize("_")[-1]) < 262
-        logger.info("Java 8 before update 262: ${beforeUpdate262}")
-        majorJavaVersion <= 8 && (beforeUpdate262 || !isZulu)
     }
 
     /**
@@ -477,8 +445,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
 
     private static void assertServerConnector(List<Connector> connectors,
                                               String EXPECTED_TLS_PROTOCOL = "TLS",
-                                              List<String> EXPECTED_INCLUDED_PROTOCOLS = TlsConfiguration.getCurrentSupportedTlsProtocolVersions(),
-                                              List<String> EXPECTED_SELECTED_PROTOCOLS = TlsConfiguration.getCurrentSupportedTlsProtocolVersions(),
+                                              List<String> EXPECTED_INCLUDED_PROTOCOLS = TlsPlatform.preferredProtocols,
                                               String EXPECTED_HOSTNAME = HTTPS_HOSTNAME,
                                               int EXPECTED_PORT = HTTPS_PORT) {
         // Assert the server connector is correct

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestPostHTTPGroovy.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestPostHTTPGroovy.groovy
@@ -64,7 +64,7 @@ class TestPostHTTPGroovy extends GroovyTestCase {
     private static final String TLSv1 = "TLSv1"
     private static final String TLSv1_1 = "TLSv1.1"
     private static final String TLSv1_2 = "TLSv1.2"
-    private static final List DEFAULT_PROTOCOLS = new ArrayList(TlsPlatform.defaultProtocols)
+    private static final List DEFAULT_PROTOCOLS = new ArrayList(TlsPlatform.supportedProtocols)
 
     private static final SSLContext SSL_CONTEXT = SSLContext.default
     private static final SSLEngine SSL_ENGINE = SSL_CONTEXT.createSSLEngine()

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestPostHTTPGroovy.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestPostHTTPGroovy.groovy
@@ -17,6 +17,7 @@
 package org.apache.nifi.processors.standard
 
 import groovy.servlet.GroovyServlet
+import org.apache.nifi.security.util.TlsPlatform
 import org.apache.nifi.ssl.SSLContextService
 import org.apache.nifi.ssl.StandardSSLContextService
 import org.apache.nifi.util.TestRunner
@@ -63,9 +64,8 @@ class TestPostHTTPGroovy extends GroovyTestCase {
     private static final String TLSv1 = "TLSv1"
     private static final String TLSv1_1 = "TLSv1.1"
     private static final String TLSv1_2 = "TLSv1.2"
-    private static final List DEFAULT_PROTOCOLS = [TLSv1, TLSv1_1, TLSv1_2]
+    private static final List DEFAULT_PROTOCOLS = new ArrayList(TlsPlatform.defaultProtocols)
 
-    private static final String TLSv1_1_CIPHER_SUITE = "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA"
     private static final SSLContext SSL_CONTEXT = SSLContext.default
     private static final SSLEngine SSL_ENGINE = SSL_CONTEXT.createSSLEngine()
     private static
@@ -293,7 +293,7 @@ class TestPostHTTPGroovy extends GroovyTestCase {
     }
 
     @Test
-    void testDefaultShouldPreferTLSv1_2() {
+    void testDefaultShouldPreferHighestSupportedVersion() {
         // Arrange
         final String MSG = "This is a test message"
         final String url = "${HTTPS_URL}/ReverseHandler.groovy?string=${URLEncoder.encode(MSG, "UTF-8")}"
@@ -319,7 +319,7 @@ class TestPostHTTPGroovy extends GroovyTestCase {
         logger.info("Selected protocol: ${selectedProtocol}")
 
         // Assert
-        assert selectedProtocol == TLSv1_2
+        assert selectedProtocol == TlsPlatform.latestProtocol
     }
 
     private static void enableContextServiceProtocol(TestRunner runner, String protocol) {


### PR DESCRIPTION
#### Description of PR

NIFI-8019 Added TlsPlatform utility class and updated multiple unit tests to use the getDefaultProtocols() and getLatestProtocol() methods.  Fedora 33 introduced a default Java Security configuration that disabled TLSv1 and TLSv1.1, which results in build failures for tests that expected those TLS protocols.  This problem can be duplicated on other platforms by adding TLSv1 and TLSv1.1 to jdk.tls.disabledAlgorithms in the java.security configuration.  The TlsPlatform class uses the SSLContext.getDefaultSSLParameters().getProtocols() method to determine supported protocols at runtime.  This approach removes the need for checking Java versions in some tests.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
