### PR TITLE
NIFI-8024 Added null claim check to EncryptedFileSystemRepository.read()

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/crypto/EncryptedFileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/crypto/EncryptedFileSystemRepository.java
@@ -168,6 +168,10 @@ public class EncryptedFileSystemRepository extends FileSystemRepository {
     public InputStream read(final ContentClaim claim) throws IOException {
         InputStream inputStream = super.read(claim);
 
+        if (claim == null) {
+            return inputStream;
+        }
+
         try {
             String recordId = getRecordId(claim);
             logger.debug("Creating decrypted input stream to read flowfile content with record ID: " + recordId);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/repository/crypto/EncryptedFileSystemRepositoryTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/repository/crypto/EncryptedFileSystemRepositoryTest.groovy
@@ -159,6 +159,13 @@ class EncryptedFileSystemRepositoryTest {
         Cipher.getMaxAllowedKeyLength("AES") > 128
     }
 
+    @Test
+    void testReadNullContentClaimShouldReturnEmptyInputStream() {
+        final InputStream inputStream = repository.read(null)
+        final int read = inputStream.read()
+        assert read == -1
+    }
+
     /**
      * Simple test to write encrypted content to the repository, independently read the persisted file to ensure the content is encrypted, and then retrieve & decrypt via the repository.
      */


### PR DESCRIPTION
#### Description of PR

NIFI-8024 Added check for null ContentClaim in EncryptedFileSystemRepository.read() to avoid EOFException in following method implementation.  The standard FileSystemRepository.read() handles null ContentClaims, but the Encrypted implementation attempts to decrypt the contents.  This update brings the encrypted implementation in line with the standard implementation and adds a unit test for verification.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
