### PR TITLE
NIFI-8016: Support dynamic properties set on the DataSource in Hive connection pools

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-services-api/src/main/java/org/apache/nifi/dbcp/hive/HiveDBCPService.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-services-api/src/main/java/org/apache/nifi/dbcp/hive/HiveDBCPService.java
@@ -28,5 +28,7 @@ import org.apache.nifi.dbcp.DBCPService;
 @Tags({"hive", "dbcp", "jdbc", "database", "connection", "pooling", "store"})
 @CapabilityDescription("Provides Database Connection Pooling Service for Apache Hive. Connections can be asked from pool and returned after usage.")
 public interface HiveDBCPService extends DBCPService {
-    public String getConnectionURL();
+    /** Property Name Prefix for Sensitive Dynamic Properties */
+    String SENSITIVE_PROPERTY_PREFIX = "SENSITIVE.";
+    String getConnectionURL();
 }

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/dbcp/hive/Hive3ConnectionPool.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/dbcp/hive/Hive3ConnectionPool.java
@@ -21,6 +21,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.jdbc.HiveDriver;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -47,6 +48,7 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.security.krb.KerberosKeytabUser;
 import org.apache.nifi.security.krb.KerberosPasswordUser;
 import org.apache.nifi.security.krb.KerberosUser;
+import org.apache.nifi.util.StringUtils;
 import org.apache.nifi.util.hive.AuthenticationFailedException;
 import org.apache.nifi.util.hive.HiveConfigurator;
 import org.apache.nifi.util.hive.ValidationResources;
@@ -61,17 +63,21 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
- * Implementation for Database Connection Pooling Service used for Apache Hive
+ * Implementation for Database Connection Pooling Service used for Apache Hive 3
  * connections. Apache DBCP is used for connection pooling functionality.
  */
 @RequiresInstanceClassLoading
 @Tags({"hive", "dbcp", "jdbc", "database", "connection", "pooling", "store"})
 @CapabilityDescription("Provides Database Connection Pooling Service for Apache Hive 3.x. Connections can be asked from pool and returned after usage.")
+@DynamicProperty(name = "JDBC property name", value = "JDBC property value", expressionLanguageScope = ExpressionLanguageScope.VARIABLE_REGISTRY,
+        description = "Specifies a property name and value to be set on the JDBC connection(s). "
+                + "If Expression Language is used, evaluation will be performed upon the controller service being enabled. "
+                + "Note that no flow file input (attributes, e.g.) is available for use in Expression Language constructs for these properties.")
 public class Hive3ConnectionPool extends AbstractControllerService implements Hive3DBCPService {
     private static final String ALLOW_EXPLICIT_KEYTAB = "NIFI_ALLOW_EXPLICIT_KEYTAB";
     /**
@@ -298,6 +304,22 @@ public class Hive3ConnectionPool extends AbstractControllerService implements Hi
     }
 
     @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        final PropertyDescriptor.Builder builder = new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .required(false)
+                .addValidator(StandardValidators.ATTRIBUTE_KEY_PROPERTY_NAME_VALIDATOR)
+                .dynamic(true);
+
+        if (propertyDescriptorName.startsWith(SENSITIVE_PROPERTY_PREFIX)) {
+            builder.sensitive(true).expressionLanguageSupported(ExpressionLanguageScope.NONE);
+        } else {
+            builder.expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY);
+        }
+        return builder.build();
+    }
+
+    @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return properties;
     }
@@ -391,15 +413,7 @@ public class Hive3ConnectionPool extends AbstractControllerService implements Hi
         final Configuration hiveConfig = hiveConfigurator.getConfigurationFromFiles(configFiles);
         final String validationQuery = context.getProperty(VALIDATION_QUERY).evaluateAttributeExpressions().getValue();
 
-        // add any dynamic properties to the Hive configuration
-        for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
-            final PropertyDescriptor descriptor = entry.getKey();
-            if (descriptor.isDynamic()) {
-                hiveConfig.set(descriptor.getName(), context.getProperty(descriptor).evaluateAttributeExpressions().getValue());
-            }
-        }
-
-        final String drv = HiveDriver.class.getName();
+        final String drv = getDriverClassName();
         if (SecurityUtil.isSecurityEnabled(hiveConfig)) {
             final String explicitPrincipal = context.getProperty(kerberosProperties.getKerberosPrincipal()).evaluateAttributeExpressions().getValue();
             final String explicitKeytab = context.getProperty(kerberosProperties.getKerberosKeytab()).evaluateAttributeExpressions().getValue();
@@ -468,6 +482,22 @@ public class Hive3ConnectionPool extends AbstractControllerService implements Hi
         dataSource.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
         dataSource.setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis);
         dataSource.setSoftMinEvictableIdleTimeMillis(softMinEvictableIdleTimeMillis);
+        // Set any dynamic (user-defined) properties on the DataSource
+        final List<PropertyDescriptor> dynamicProperties = context.getProperties()
+                .keySet()
+                .stream()
+                .filter(PropertyDescriptor::isDynamic)
+                .collect(Collectors.toList());
+
+        dynamicProperties.forEach((descriptor) -> {
+            final PropertyValue propertyValue = context.getProperty(descriptor);
+            if (descriptor.isSensitive()) {
+                final String propertyName = StringUtils.substringAfter(descriptor.getName(), SENSITIVE_PROPERTY_PREFIX);
+                dataSource.addConnectionProperty(propertyName, propertyValue.getValue());
+            } else {
+                dataSource.addConnectionProperty(descriptor.getName(), propertyValue.evaluateAttributeExpressions().getValue());
+            }
+        });
     }
 
     private Long extractMillisWithInfinite(PropertyValue prop) {
@@ -545,5 +575,9 @@ public class Hive3ConnectionPool extends AbstractControllerService implements Hi
      */
     boolean isAllowExplicitKeytab() {
         return Boolean.parseBoolean(System.getenv(ALLOW_EXPLICIT_KEYTAB));
+    }
+
+    protected String getDriverClassName() {
+        return HiveDriver.class.getName();
     }
 }

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive_1_1-processors/src/test/java/org/apache/nifi/dbcp/hive/Hive_1_1ConnectionPoolTest.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive_1_1-processors/src/test/java/org/apache/nifi/dbcp/hive/Hive_1_1ConnectionPoolTest.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.dbcp.hive;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,8 +28,11 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.security.PrivilegedExceptionAction;
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,13 +42,19 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.kerberos.KerberosCredentialsService;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.registry.VariableDescriptor;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockConfigurationContext;
 import org.apache.nifi.util.MockControllerServiceLookup;
 import org.apache.nifi.util.MockVariableRegistry;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -53,7 +63,14 @@ public class Hive_1_1ConnectionPoolTest {
     private Hive_1_1ConnectionPool hiveConnectionPool;
     private BasicDataSource basicDataSource;
     private ComponentLog componentLog;
-    private File krb5conf = new File("src/test/resources/krb5.conf");
+    private final File krb5conf = new File("src/test/resources/krb5.conf");
+    private TestRunner runner;
+    private static final String DB_LOCATION = "target/db";
+
+    @BeforeClass
+    public static void setupBeforeClass() {
+        System.setProperty("derby.stream.error.file", "target/derby.log");
+    }
 
     @Before
     public void setup() throws Exception {
@@ -76,11 +93,13 @@ public class Hive_1_1ConnectionPoolTest {
             }
         });
 
+        runner = TestRunners.newTestRunner(MockProcessor.class);
         initPool();
+        runner.addControllerService("1", hiveConnectionPool);
     }
 
     private void initPool() throws Exception {
-        hiveConnectionPool = new Hive_1_1ConnectionPool();
+        hiveConnectionPool = new Hive_1_1ConnectionPoolOverride();
 
         Field ugiField = Hive_1_1ConnectionPool.class.getDeclaredField("ugi");
         ugiField.setAccessible(true);
@@ -116,7 +135,7 @@ public class Hive_1_1ConnectionPoolTest {
         final String MAX_CONN_LIFETIME = "1 sec";
         final String MAX_WAIT = "10 sec"; // 10000 milliseconds
         final String CONF = "/path/to/hive-site.xml";
-        hiveConnectionPool = new Hive_1_1ConnectionPool();
+        hiveConnectionPool = new Hive_1_1ConnectionPoolOverride();
 
         Map<PropertyDescriptor, String> props = new HashMap<PropertyDescriptor, String>() {{
             put(Hive_1_1ConnectionPool.DATABASE_URL, "${url}");
@@ -153,6 +172,43 @@ public class Hive_1_1ConnectionPoolTest {
         assertEquals(URL, hiveConnectionPool.getConnectionURL());
     }
 
+    @Test
+    public void testDynamicProperties() throws InitializationException, SQLException {
+        assertConnectionNotNullDynamicProperty("create", "true");
+    }
+
+    @Test
+    public void testExpressionLanguageDynamicProperties() throws InitializationException, SQLException {
+        assertConnectionNotNullDynamicProperty("create", "${literal(1):gt(0)}");
+    }
+
+    @Test
+    public void testSensitiveDynamicProperties() throws InitializationException, SQLException {
+        assertConnectionNotNullDynamicProperty("SENSITIVE.create", "true");
+    }
+
+    private void assertConnectionNotNullDynamicProperty(final String propertyName, final String propertyValue) throws InitializationException, SQLException {
+        // remove previous test database, if any
+        final File dbLocation = new File(DB_LOCATION);
+        dbLocation.delete();
+
+        final Hive_1_1ConnectionPool service = new Hive_1_1ConnectionPoolOverride();
+        runner.addControllerService(Hive_1_1ConnectionPool.class.getSimpleName(), service);
+
+        runner.setProperty(service, Hive_1_1ConnectionPool.DATABASE_URL, "jdbc:derby:" + DB_LOCATION);
+        runner.setProperty(service, Hive_1_1ConnectionPool.DB_USER, "tester");
+        runner.setProperty(service, Hive_1_1ConnectionPool.DB_PASSWORD, "testerp");
+        runner.setProperty(service, propertyName, propertyValue);
+
+        runner.enableControllerService(service);
+        runner.assertValid(service);
+
+        try (final Connection connection = service.getConnection()) {
+            assertNotNull(connection);
+        }
+    }
+
+
     @Ignore("Kerberos does not seem to be properly handled in Travis build, but, locally, this test should successfully run")
     @Test(expected = InitializationException.class)
     public void testKerberosAuthException() throws Exception {
@@ -180,5 +236,56 @@ public class Hive_1_1ConnectionPoolTest {
 
         MockConfigurationContext context = new MockConfigurationContext(props, mockControllerServiceLookup, registry);
         hiveConnectionPool.onConfigured(context);
+    }
+
+    @Test
+    public void testValidWithDynamicProperty() throws Exception {
+        // set embedded Derby database connection url
+        runner.setProperty(hiveConnectionPool, Hive_1_1ConnectionPool.DATABASE_URL, "jdbc:derby:" + DB_LOCATION);
+        runner.setProperty(hiveConnectionPool, Hive_1_1ConnectionPool.DB_USER, "tester");
+        runner.setProperty(hiveConnectionPool, Hive_1_1ConnectionPool.DB_PASSWORD, "testerp");
+        runner.setProperty(hiveConnectionPool, "create", "true");
+        runner.assertValid(hiveConnectionPool);
+
+        // remove previous test database, if any
+        final File dbLocation = new File(DB_LOCATION);
+        dbLocation.delete();
+
+        runner.enableControllerService(hiveConnectionPool);
+
+        Connection connection = hiveConnectionPool.getConnection();
+        assertNotNull(connection);
+        connection.close(); // will return connection to pool
+        connection = hiveConnectionPool.getConnection();
+        assertNotNull(connection);
+        connection.close(); // will return connection to pool
+    }
+
+    public static class MockProcessor extends AbstractProcessor {
+        static final PropertyDescriptor HIVE_CONNECTION_POOL = new PropertyDescriptor.Builder()
+                .name("Hive Connection Pool")
+                .required(true)
+                .identifiesControllerService(Hive_1_1ConnectionPool.class)
+                .build();
+
+        static final List<PropertyDescriptor> PROPS = Collections.singletonList(HIVE_CONNECTION_POOL);
+
+        @Override
+        public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+            return PROPS;
+        }
+
+        @Override
+        public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+
+        }
+    }
+
+    // Override the driver class name to use Derby
+    private static class Hive_1_1ConnectionPoolOverride extends Hive_1_1ConnectionPool {
+        @Override
+        protected String getDriverClassName() {
+            return "org.apache.derby.jdbc.EmbeddedDriver";
+        }
     }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Fix the use of dynamic properties in Hive connection pool controller services to be consistent with DBCPConnectionPool (i.e. set the properties on the DataSource rather than the Hive configuration)

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
