### PR TITLE
 NIFI-8035: added userGroupsFilterExpression to allow per user LDAP filters and LDAP nested groups

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -486,6 +486,7 @@ The LdapUserGroupProvider has the following properties:
 |`User Identity Attribute` | Attribute to use to extract user identity (i.e. `cn`). Optional. If not set, the entire DN is used.
 |`User Group Name Attribute` | Attribute to use to define group membership (i.e. `memberof`). Optional. If not set group membership will not be calculated through the users. Will rely on group membership being defined through `Group Member Attribute` if set. The value of this property is the name of the attribute in the user ldap entry that associates them with a group. The value of that user attribute could be a dn or group name for instance. What value is expected is configured in the `User Group Name Attribute - Referenced Group Attribute`.
 |`User Group Name Attribute - Referenced Group Attribute` | If blank, the value of the attribute defined in `User Group Name Attribute` is expected to be the full dn of the group. If not blank, this property will define the attribute of the group ldap entry that the value of the attribute defined in `User Group Name Attribute` is referencing (i.e. `name`). Use of this property requires that `Group Search Base` is also configured.
+|`User Groups Filter Expression` | Filter for searching for groups against the `Group Search Base` based on each user's DN (i.e. `(member={})`). `{}` will be replaced with the user's DN. This attribute allows the usage of special match operators such as LDAP_MATCHING_RULE_IN_CHAIN (e.g. `member:1.2.840.113556.1.4.1941:={}`) to recursively retrieve a user's groups. This attribute can't be used in conjunction with `User Group Name Attribute`.
 |`Group Search Base` | Base DN for searching for groups (i.e. `ou=groups,o=nifi`). Required to search groups.
 |`Group Object Class` | Object class for identifying groups (i.e. `groupOfNames`). Required if searching groups.
 |`Group Search Scope` | Search scope for searching groups (`ONE_LEVEL`, `OBJECT`, or `SUBTREE`). Required if searching groups.
@@ -736,6 +737,7 @@ member: cn=User 2,ou=users,o=nifi
         <property name="User Identity Attribute">cn</property>
         <property name="User Group Name Attribute"></property>
         <property name="User Group Name Attribute - Referenced Group Attribute"></property>
+        <property name="User Groups Filter Expression"></property>
 
         <property name="Group Search Base">ou=groups,o=nifi</property>
         <property name="Group Object Class">groupOfNames</property>
@@ -825,6 +827,7 @@ memberUid: user2
         <property name="User Identity Attribute">cn</property>
         <property name="User Group Name Attribute"></property>
         <property name="User Group Name Attribute - Referenced Group Attribute"></property>
+        <property name="User Groups Filter Expression"></property>
 
         <property name="Group Search Base">ou=Groups,dc=local</property>
         <property name="Group Object Class">posixGroup</property>
@@ -926,6 +929,7 @@ member: cn=User 2,ou=users,o=nifi
         <property name="User Identity Attribute">cn</property>
         <property name="User Group Name Attribute"></property>
         <property name="User Group Name Attribute - Referenced Group Attribute"></property>
+        <property name="User Groups Filter Expression"></property>
 
         <property name="Group Search Base">ou=groups,o=nifi</property>
         <property name="Group Object Class">groupOfNames</property>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
@@ -73,6 +73,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.LinkedList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -103,6 +104,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
     public static final String PROP_USER_IDENTITY_ATTRIBUTE = "User Identity Attribute";
     public static final String PROP_USER_GROUP_ATTRIBUTE = "User Group Name Attribute";
     public static final String PROP_USER_GROUP_REFERENCED_GROUP_ATTRIBUTE = "User Group Name Attribute - Referenced Group Attribute";
+    public static final String PROP_USER_GROUPS_FILTER_EXPRESSION = "User Groups Filter Expression" ;
 
     public static final String PROP_GROUP_SEARCH_BASE = "Group Search Base";
     public static final String PROP_GROUP_OBJECT_CLASS = "Group Object Class";
@@ -131,6 +133,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
     private String userGroupReferencedGroupAttribute;
     private boolean useDnForUserIdentity;
     private boolean performUserSearch;
+    private String userGroupsFilterExpression;
 
     private String groupSearchBase;
     private SearchScope groupSearchScope;
@@ -278,6 +281,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
         userIdentityAttribute = configurationContext.getProperty(PROP_USER_IDENTITY_ATTRIBUTE).getValue();
         userGroupNameAttribute = configurationContext.getProperty(PROP_USER_GROUP_ATTRIBUTE).getValue();
         userGroupReferencedGroupAttribute = configurationContext.getProperty(PROP_USER_GROUP_REFERENCED_GROUP_ATTRIBUTE).getValue();
+        userGroupsFilterExpression = configurationContext.getProperty(PROP_USER_GROUPS_FILTER_EXPRESSION).getValue();
 
         try {
             userSearchScope = SearchScope.valueOf(rawUserSearchScope.getValue());
@@ -322,8 +326,8 @@ public class LdapUserGroupProvider implements UserGroupProvider {
 
         // determine group behavior
         useDnForGroupName = StringUtils.isBlank(groupNameAttribute);
-        performGroupSearch = StringUtils.isNotBlank(groupSearchBase);
-
+        // if userGroupsFilterExpression is not blank, groups are searched for each user separately and there is no general group search.
+        performGroupSearch = StringUtils.isNotBlank(groupSearchBase)  & StringUtils.isBlank(userGroupsFilterExpression);
         // ensure we are either searching users or groups (at least one must be specified)
         if (!performUserSearch && !performGroupSearch) {
             throw new AuthorizerCreationException("LDAP user group provider 'User Search Base' or 'Group Search Base' must be specified.");
@@ -343,7 +347,14 @@ public class LdapUserGroupProvider implements UserGroupProvider {
         if (StringUtils.isNotBlank(userGroupReferencedGroupAttribute) && !performGroupSearch) {
             throw new AuthorizerCreationException("'Group Search Base' must be set when specifying 'User Group Name Attribute - Referenced Group Attribute'.");
         }
-
+        //ensure that groupSearchBase is set when userGroupsFilterExpression is specified.
+        if (StringUtils.isNotBlank(userGroupsFilterExpression) && StringUtils.isBlank(groupSearchBase)){
+         throw new AuthorizerCreationException("Group Search Base' must be set when specifying 'User Groups Filter Expression'.");
+             }
+         //ensure we are not simultaneously searching groups inside user entry through userGroupNameAttribute and using userGroupsFilterExpression.
+           if (StringUtils.isNotBlank(userGroupNameAttribute) && StringUtils.isNotBlank(userGroupsFilterExpression)){
+                       throw new AuthorizerCreationException("'User Group Name Attribute' and 'User Groups Filter Expression' are both set. Only one may be used.");
+           }
         // get the page size if configured
         final PropertyValue rawPageSize = configurationContext.getProperty(PROP_PAGE_SIZE);
         if (rawPageSize.isSet() && StringUtils.isNotBlank(rawPageSize.getValue())) {
@@ -512,38 +523,66 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                             // store the user for group member later
                             userLookup.put(getReferencedUserValue(ctx), user);
 
-                            if (StringUtils.isNotBlank(userGroupNameAttribute)) {
-                                final Attribute attributeGroups = ctx.getAttributes().get(userGroupNameAttribute);
 
+                            // we can compute group values from user in two ways :
+                            //  1 - either directly from user entry using userGroupNameAttribute
+                            //  2 - search for each user's groups using userGroupsFilterExpression
+                            //if either userGroupNameAttribute or userGroupsFilterExpression is not blank, we try to populate the groupValues list, otherwise no groups are inferred from users.
+                            List<String> groupValues = null;
+                            if (StringUtils.isNotBlank(userGroupNameAttribute)) {
+                                Attribute attributeGroups = attributeGroups = ctx.getAttributes().get(userGroupNameAttribute);
                                 if (attributeGroups == null) {
                                     logger.debug(String.format("User group name attribute [%s] does not exist for %s. This may be due to "
                                             + "misconfiguration or the user may just not belong to any groups. Ignoring group membership.", userGroupNameAttribute, identity));
                                 } else {
                                     try {
-                                        final NamingEnumeration<String> groupValues = (NamingEnumeration<String>) attributeGroups.getAll();
-                                        while (groupValues.hasMoreElements()) {
-                                            final String groupValue = groupValues.next();
-
-                                            // if we are performing a group search, then we need to normalize the group value so that each
-                                            // user associating with it can be matched. if we are not performing a group search then these
-                                            // values will be used to actually build the group itself. case sensitivity is for group
-                                            // membership, not group identification.
-                                            final String groupValueNormalized;
-                                            if (performGroupSearch) {
-                                                groupValueNormalized = groupMembershipEnforceCaseSensitivity ? groupValue : groupValue.toLowerCase();
-                                            } else {
-                                                groupValueNormalized = groupValue;
-                                            }
-
-                                            // store the group -> user identifier mapping... if case sensitivity is disabled, the group reference value will
-                                            // be lowercased when adding to groupToUserIdentifierMappings
-                                            groupToUserIdentifierMappings.computeIfAbsent(groupValueNormalized, g -> new HashSet<>()).add(user.getIdentifier());
-                                        }
+                                        NamingEnumeration<String> groupValuesFromAttribute = (NamingEnumeration<String>) attributeGroups.getAll();
+                                        groupValues = new LinkedList<String>();
+                                        while (groupValuesFromAttribute.hasMoreElements())
+                                            groupValues.add(groupValuesFromAttribute.next());
                                     } catch (NamingException e) {
                                         throw new AuthorizationAccessException("Error while retrieving user group name attribute [" + userIdentityAttribute + "].");
                                     }
                                 }
                             }
+                            if (StringUtils.isNotBlank(userGroupsFilterExpression)) {
+                                // for each user, we search for groups according to userGroupsFilterExpression. Nested Ldap filter such as LDAP_MATCHING_RULE_IN_CHAIN can be used.
+                                AndFilter filter = new AndFilter();
+                                if (StringUtils.isNotBlank(userGroupsFilterExpression)) {
+                                    String currentUserGroupsFilterExpression = userGroupsFilterExpression.replaceAll("\\{\\}", ctx.getDn().toString());
+                                    filter.and(new HardcodedFilter(currentUserGroupsFilterExpression));
+                                }
+                                groupValues = ldapTemplate.search(
+                                        groupSearchBase,
+                                        filter.encode(),
+                                        new AbstractContextMapper<String>() {
+                                            @Override
+                                            protected String doMapFromContext(DirContextOperations ctx) {
+                                                return ctx.getDn().toString();
+                                            }
+                                        });
+                            }
+
+                            if (groupValues != null) {
+                                // we have inferred groups from either the user entry or by querying according to  userGroupsFilterExpression
+                                for (String groupValue : groupValues) {
+                                    // if we are performing a group search, then we need to normalize the group value so that each
+                                    // user associating with it can be matched. if we are not performing a group search then these
+                                    // values will be used to actually build the group itself. case sensitivity is for group
+                                    // membership, not group identification.
+                                    final String groupValueNormalized;
+                                    if (performGroupSearch) {
+                                        groupValueNormalized = groupMembershipEnforceCaseSensitivity ? groupValue : groupValue.toLowerCase();
+                                    } else {
+                                        groupValueNormalized = groupValue;
+                                    }
+
+                                    // store the group -> user identifier mapping... if case sensitivity is disabled, the group reference value will
+                                    // be lowercased when adding to groupToUserIdentifierMappings
+                                    groupToUserIdentifierMappings.computeIfAbsent(groupValueNormalized, g -> new HashSet<>()).add(user.getIdentifier());
+                                }
+                            }
+
 
                             return user;
                         }

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/java/org/apache/nifi/ldap/tenants/LdapUserGroupProviderTest.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/java/org/apache/nifi/ldap/tenants/LdapUserGroupProviderTest.java
@@ -777,8 +777,15 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
     }
 
     @Test(expected = AuthorizerCreationException.class)
-    public void tesUserGroupsFilterExpressionAndUserGroupNameAttributeBothSpecified() throws Exception {
-        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, null);
+    public void testUserGroupsFilterExpressionSpecifiedButNoGroupSearchBase() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE,null);
+        when(configurationContext.getProperty(PROP_USER_GROUPS_FILTER_EXPRESSION)).thenReturn(new StandardPropertyValue("member={}", null, ParameterLookup.EMPTY));
+        ldapUserGroupProvider.onConfigured(configurationContext);
+    }
+
+    @Test(expected = AuthorizerCreationException.class)
+    public void testUserGroupsFilterExpressionAndUserGroupNameAttributeBothSpecified() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, GROUP_SEARCH_BASE);
         when(configurationContext.getProperty(PROP_USER_GROUPS_FILTER_EXPRESSION)).thenReturn(new StandardPropertyValue("member={}", null, ParameterLookup.EMPTY));
         when(configurationContext.getProperty(PROP_USER_GROUP_ATTRIBUTE)).thenReturn(new StandardPropertyValue("description", null, ParameterLookup.EMPTY));
         ldapUserGroupProvider.onConfigured(configurationContext);

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/java/org/apache/nifi/ldap/tenants/LdapUserGroupProviderTest.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/java/org/apache/nifi/ldap/tenants/LdapUserGroupProviderTest.java
@@ -65,6 +65,7 @@ import static org.apache.nifi.ldap.tenants.LdapUserGroupProvider.PROP_USER_OBJEC
 import static org.apache.nifi.ldap.tenants.LdapUserGroupProvider.PROP_USER_SEARCH_BASE;
 import static org.apache.nifi.ldap.tenants.LdapUserGroupProvider.PROP_USER_SEARCH_FILTER;
 import static org.apache.nifi.ldap.tenants.LdapUserGroupProvider.PROP_USER_SEARCH_SCOPE;
+import static org.apache.nifi.ldap.tenants.LdapUserGroupProvider.PROP_USER_GROUPS_FILTER_EXPRESSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -745,6 +746,44 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
                 user -> "user6".equals(user.getIdentity()) || "user7".equals(user.getIdentity()) || "user8".equals(user.getIdentity())).count());
     }
 
+    @Test
+    public void testSearchUsersAndGroupsMembershipThroughUserGroupsFilterExpression() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, GROUP_SEARCH_BASE);
+        when(configurationContext.getProperty(PROP_USER_IDENTITY_ATTRIBUTE)).thenReturn(new StandardPropertyValue("uid", null, ParameterLookup.EMPTY));
+        // using PROP_USER_GROUPS_FILTER_EXPRESSION to search for each user groups based on its DN. Allows special filters to retrieve nested groups.
+        when(configurationContext.getProperty(PROP_USER_GROUPS_FILTER_EXPRESSION)).thenReturn(new StandardPropertyValue("member={}", null, ParameterLookup.EMPTY));
+        when(configurationContext.getProperty(PROP_GROUP_NAME_ATTRIBUTE)).thenReturn(new StandardPropertyValue("cn", null, ParameterLookup.EMPTY));
+        when(configurationContext.getProperty(PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY)).thenReturn(new StandardPropertyValue("false", null, ParameterLookup.EMPTY));
+        ldapUserGroupProvider.onConfigured(configurationContext);
+
+        assertEquals(8, ldapUserGroupProvider.getUsers().size());
+
+        final Set<Group> groups = ldapUserGroupProvider.getGroups();
+        assertEquals(5, groups.size());
+
+        final Group team1 = groups.stream().filter(group -> "team1".equals(group.getName())).findFirst().orElse(null);
+        assertNotNull(team1);
+        assertEquals(1, team1.getUsers().size()); // team1 members are inferred from 'member' attribute. Only user1 is there.
+        assertEquals(1, team1.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user1".equals(user.getIdentity())).count());
+
+        final Group team4 = groups.stream().filter(group -> "team4".equals(group.getName())).findFirst().orElse(null);
+        assertNotNull(team4);
+        assertEquals(2, team4.getUsers().size()); // team4 members are inferred from 'member' attribute. Only user1 and user2 are there.
+        assertEquals(2, team4.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user1".equals(user.getIdentity()) || "user2".equals(user.getIdentity()) ).count());
+    }
+
+    @Test(expected = AuthorizerCreationException.class)
+    public void tesUserGroupsFilterExpressionAndUserGroupNameAttributeBothSpecified() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, null);
+        when(configurationContext.getProperty(PROP_USER_GROUPS_FILTER_EXPRESSION)).thenReturn(new StandardPropertyValue("member={}", null, ParameterLookup.EMPTY));
+        when(configurationContext.getProperty(PROP_USER_GROUP_ATTRIBUTE)).thenReturn(new StandardPropertyValue("description", null, ParameterLookup.EMPTY));
+        ldapUserGroupProvider.onConfigured(configurationContext);
+    }
+
     private AuthorizerConfigurationContext getBaseConfiguration(final String userSearchBase, final String groupSearchBase) {
         final AuthorizerConfigurationContext configurationContext = mock(AuthorizerConfigurationContext.class);
         when(configurationContext.getProperty(PROP_URL)).thenReturn(new StandardPropertyValue("ldap://127.0.0.1:" + getLdapServer().getPort(), null, ParameterLookup.EMPTY));
@@ -766,6 +805,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         when(configurationContext.getProperty(PROP_USER_IDENTITY_ATTRIBUTE)).thenReturn(new StandardPropertyValue(null, null, ParameterLookup.EMPTY));
         when(configurationContext.getProperty(PROP_USER_GROUP_ATTRIBUTE)).thenReturn(new StandardPropertyValue(null, null, ParameterLookup.EMPTY));
         when(configurationContext.getProperty(PROP_USER_GROUP_REFERENCED_GROUP_ATTRIBUTE)).thenReturn(new StandardPropertyValue(null, null, ParameterLookup.EMPTY));
+        when(configurationContext.getProperty(PROP_USER_GROUPS_FILTER_EXPRESSION)).thenReturn(new StandardPropertyValue(null, null, ParameterLookup.EMPTY));
 
         when(configurationContext.getProperty(PROP_GROUP_SEARCH_BASE)).thenReturn(new StandardPropertyValue(groupSearchBase, null, ParameterLookup.EMPTY));
         when(configurationContext.getProperty(PROP_GROUP_OBJECT_CLASS)).thenReturn(new StandardPropertyValue("groupOfNames", null, ParameterLookup.EMPTY));


### PR DESCRIPTION
Added a 'User Groups Filter Expression' property to the LdapUserGroupProvider's configuration in authorizers.xml. When set, this property retrieves each user's groups according to the filter expressed in it and by replacing '{}' with the user's DN.

This introduces the possibility of filters such as : "member:1.2.840.113556.1.4.1941:={}". For each user, a request will be made and will populate all his direct and indirect groups.
This property can also be used to map groups to users regardless of the presence of an attribute that links the user to the group or vice versa. As long as a group satisfies the filter, the user will be assigned to it. The presence of '{}' (which is replaced by a user's DN) is optionnal.

The 'Group Search Base' property is used as the search base for each request but the 'User Group Name Attribute' property is not allowed when the new property is defined as it conflicts with it since they both rely on a user entry for group inference.

As mentionned in the JIRA issue, this property will offer more flexibility and will allow handling of nested groups which are necessary in Microsoft's AGDLP and other organizational security requirements.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
