### PR TITLE
NIFI-7973: Add default precision and scale properties to remaining SQL-based components

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -43,9 +43,14 @@ import java.util.stream.Stream;
 
 public class ResultSetRecordSet implements RecordSet, Closeable {
     private static final Logger logger = LoggerFactory.getLogger(ResultSetRecordSet.class);
+    private static final int JDBC_DEFAULT_PRECISION_VALUE = 10;
+    private static final int JDBC_DEFAULT_SCALE_VALUE = 0;
     private final ResultSet rs;
     private final RecordSchema schema;
     private final Set<String> rsColumnNames;
+    private final int defaultPrecision;
+    private final int defaultScale;
+
     private boolean moreRows;
 
     private static final String STRING_CLASS_NAME = String.class.getName();
@@ -57,6 +62,12 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
     private static final String BIGDECIMAL_CLASS_NAME = BigDecimal.class.getName();
 
     public ResultSetRecordSet(final ResultSet rs, final RecordSchema readerSchema) throws SQLException {
+        this(rs, readerSchema, JDBC_DEFAULT_PRECISION_VALUE, JDBC_DEFAULT_SCALE_VALUE);
+    }
+
+    public ResultSetRecordSet(final ResultSet rs, final RecordSchema readerSchema, final int defaultPrecision, final int defaultScale) throws SQLException {
+        this.defaultPrecision = defaultPrecision;
+        this.defaultScale = defaultScale;
         this.rs = rs;
         this.rsColumnNames = new HashSet<>();
         RecordSchema tempSchema;
@@ -177,7 +188,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         return new SimpleRecordSchema(fields);
     }
 
-    private static DataType getDataType(final int sqlType, final ResultSet rs, final int columnIndex, final RecordSchema readerSchema) throws SQLException {
+    private DataType getDataType(final int sqlType, final ResultSet rs, final int columnIndex, final RecordSchema readerSchema) throws SQLException {
         switch (sqlType) {
             case Types.ARRAY:
                 // The JDBC API does not allow us to know what the base type of an array is through the metadata.
@@ -202,7 +213,26 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType());
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return RecordFieldType.DECIMAL.getDecimalDataType(rs.getMetaData().getPrecision(columnIndex), rs.getMetaData().getScale(columnIndex));
+                final int decimalPrecision;
+                final int decimalScale;
+                final int resultSetPrecision = rs.getMetaData().getPrecision(columnIndex);
+                final int resultSetScale = rs.getMetaData().getScale(columnIndex);
+                if (rs.getMetaData().getPrecision(columnIndex) > 0) {
+                    // When database returns a certain precision, we can rely on that.
+                    decimalPrecision = resultSetPrecision;
+                    //For the float data type Oracle return decimalScale < 0 which cause is not expected to org.apache.avro.LogicalTypes
+                    //Hence falling back to default scale if decimalScale < 0
+                    decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+                } else {
+                    // If not, use default precision.
+                    decimalPrecision = defaultPrecision;
+                    // Oracle returns precision=0, scale=-127 for variable scale value such as ROWNUM or function result.
+                    // Specifying 'oracle.jdbc.J2EE13Compliant' SystemProperty makes it to return scale=0 instead.
+                    // Queries for example, 'SELECT 1.23 as v from DUAL' can be problematic because it can't be mapped with decimal with scale=0.
+                    // Default scale is used to preserve decimals in such case.
+                    decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+                }
+                return RecordFieldType.DECIMAL.getDecimalDataType(decimalPrecision, decimalScale);
             case Types.OTHER: {
                 // If we have no records to inspect, we can't really know its schema so we simply use the default data type.
                 if (rs.isAfterLast()) {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -160,8 +160,9 @@ public class JdbcCommon {
         private final int maxRows;
         private final boolean convertNames;
         private final boolean useLogicalTypes;
-        public final int defaultPrecision;
-        public final int defaultScale;
+
+        private final int defaultPrecision;
+        private final int defaultScale;
         private final CodecFactory codec;
 
         private AvroConversionOptions(String recordName, int maxRows, boolean convertNames, boolean useLogicalTypes,
@@ -177,6 +178,14 @@ public class JdbcCommon {
 
         public static Builder builder() {
             return new Builder();
+        }
+
+        public int getDefaultPrecision() {
+            return defaultPrecision;
+        }
+
+        public int getDefaultScale() {
+            return defaultScale;
         }
 
         public static class Builder {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -160,8 +160,8 @@ public class JdbcCommon {
         private final int maxRows;
         private final boolean convertNames;
         private final boolean useLogicalTypes;
-        private final int defaultPrecision;
-        private final int defaultScale;
+        public final int defaultPrecision;
+        public final int defaultScale;
         private final CodecFactory codec;
 
         private AvroConversionOptions(String recordName, int maxRows, boolean convertNames, boolean useLogicalTypes,

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcProperties.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcProperties.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.processors.standard.util;
+package org.apache.nifi.util.db;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.util.db.JdbcCommon;
 
 public class JdbcProperties {
 
@@ -78,4 +77,15 @@ public class JdbcProperties {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(true)
             .build();
+
+    // Registry-only versions of Default Precision and Default Scale properties
+    public static final PropertyDescriptor REGISTRY_ONLY_DEFAULT_PRECISION =
+            new PropertyDescriptor.Builder().fromPropertyDescriptor(DEFAULT_PRECISION)
+                    .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+                    .build();
+
+    public static final PropertyDescriptor REGISTRY_ONLY_DEFAULT_SCALE =
+            new PropertyDescriptor.Builder().fromPropertyDescriptor(DEFAULT_SCALE)
+                    .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+                    .build();
 }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcProperties.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcProperties.java
@@ -79,12 +79,12 @@ public class JdbcProperties {
             .build();
 
     // Registry-only versions of Default Precision and Default Scale properties
-    public static final PropertyDescriptor REGISTRY_ONLY_DEFAULT_PRECISION =
+    public static final PropertyDescriptor VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION =
             new PropertyDescriptor.Builder().fromPropertyDescriptor(DEFAULT_PRECISION)
                     .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
                     .build();
 
-    public static final PropertyDescriptor REGISTRY_ONLY_DEFAULT_SCALE =
+    public static final PropertyDescriptor VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE =
             new PropertyDescriptor.Builder().fromPropertyDescriptor(DEFAULT_SCALE)
                     .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
                     .build();

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsEventReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsEventReportingTask.java
@@ -38,8 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE;
 
 @Tags({"reporting", "rules", "action", "action handler", "status", "connection", "processor", "jvm", "metrics", "history", "bulletin", "sql"})
 @CapabilityDescription("Triggers rules-driven actions based on metrics values ")
@@ -61,8 +61,8 @@ public class MetricsEventReportingTask  extends AbstractReportingTask {
         properties.add(QueryMetricsUtil.QUERY);
         properties.add(QueryMetricsUtil.RULES_ENGINE);
         properties.add(QueryMetricsUtil.ACTION_HANDLER);
-        properties.add(REGISTRY_ONLY_DEFAULT_PRECISION);
-        properties.add(REGISTRY_ONLY_DEFAULT_SCALE);
+        properties.add(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION);
+        properties.add(VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE);
         this.properties = Collections.unmodifiableList(properties);
     }
 
@@ -70,8 +70,8 @@ public class MetricsEventReportingTask  extends AbstractReportingTask {
     public void setup(final ConfigurationContext context) throws IOException {
         actionHandler = context.getProperty(QueryMetricsUtil.ACTION_HANDLER).asControllerService(PropertyContextActionHandler.class);
         rulesEngineService = context.getProperty(QueryMetricsUtil.RULES_ENGINE).asControllerService(RulesEngineService.class);
-        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
-        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
+        final Integer defaultPrecision = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
         metricsQueryService = new MetricsSqlQueryService(getLogger(), defaultPrecision, defaultScale);
     }
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsEventReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsEventReportingTask.java
@@ -38,6 +38,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+
 @Tags({"reporting", "rules", "action", "action handler", "status", "connection", "processor", "jvm", "metrics", "history", "bulletin", "sql"})
 @CapabilityDescription("Triggers rules-driven actions based on metrics values ")
 public class MetricsEventReportingTask  extends AbstractReportingTask {
@@ -54,11 +57,12 @@ public class MetricsEventReportingTask  extends AbstractReportingTask {
 
     @Override
     protected void init(final ReportingInitializationContext config) {
-        metricsQueryService = new MetricsSqlQueryService(getLogger());
         final List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(QueryMetricsUtil.QUERY);
         properties.add(QueryMetricsUtil.RULES_ENGINE);
         properties.add(QueryMetricsUtil.ACTION_HANDLER);
+        properties.add(REGISTRY_ONLY_DEFAULT_PRECISION);
+        properties.add(REGISTRY_ONLY_DEFAULT_SCALE);
         this.properties = Collections.unmodifiableList(properties);
     }
 
@@ -66,6 +70,9 @@ public class MetricsEventReportingTask  extends AbstractReportingTask {
     public void setup(final ConfigurationContext context) throws IOException {
         actionHandler = context.getProperty(QueryMetricsUtil.ACTION_HANDLER).asControllerService(PropertyContextActionHandler.class);
         rulesEngineService = context.getProperty(QueryMetricsUtil.RULES_ENGINE).asControllerService(RulesEngineService.class);
+        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
+        metricsQueryService = new MetricsSqlQueryService(getLogger(), defaultPrecision, defaultScale);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsSqlQueryService.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsSqlQueryService.java
@@ -52,14 +52,17 @@ import java.util.function.Supplier;
 public class MetricsSqlQueryService implements MetricsQueryService {
 
     private final ComponentLog logger;
+    private final int defaultPrecision;
+    private final int defaultScale;
 
     private final Cache<String, BlockingQueue<CachedStatement>> statementQueues = Caffeine.newBuilder()
             .maximumSize(25)
             .removalListener(this::onCacheEviction)
             .build();
 
-    public MetricsSqlQueryService(ComponentLog logger) {
-
+    public MetricsSqlQueryService(ComponentLog logger, final int defaultPrecision, final int defaultScale) {
+        this.defaultPrecision = defaultPrecision;
+        this.defaultScale = defaultScale;
         try {
             DriverManager.registerDriver(new org.apache.calcite.jdbc.Driver());
         } catch (final SQLException e) {
@@ -122,7 +125,7 @@ public class MetricsSqlQueryService implements MetricsQueryService {
         final RecordSchema writerSchema = AvroTypeUtil.createSchema(JdbcCommon.createSchema(rs));
 
         try {
-            recordSet = new ResultSetRecordSet(rs, writerSchema);
+            recordSet = new ResultSetRecordSet(rs, writerSchema, defaultPrecision, defaultScale);
         } catch (final SQLException e) {
             getLogger().error("Error creating record set from query results due to {}", new Object[]{e.getMessage()}, e);
         }

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/QueryNiFiReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/QueryNiFiReportingTask.java
@@ -38,8 +38,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE;
 
 @Tags({"status", "connection", "processor", "jvm", "metrics", "history", "bulletin", "prediction", "process", "group", "provenance", "record", "sql"})
 @CapabilityDescription("Publishes NiFi status information based on the results of a user-specified SQL query. The query may make use of the CONNECTION_STATUS, PROCESSOR_STATUS, "
@@ -60,8 +60,8 @@ public class QueryNiFiReportingTask extends AbstractReportingTask {
         properties.add(QueryMetricsUtil.QUERY);
         properties.add(QueryMetricsUtil.RECORD_SINK);
         properties.add(QueryMetricsUtil.INCLUDE_ZERO_RECORD_RESULTS);
-        properties.add(REGISTRY_ONLY_DEFAULT_PRECISION);
-        properties.add(REGISTRY_ONLY_DEFAULT_SCALE);
+        properties.add(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION);
+        properties.add(VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE);
         this.properties = Collections.unmodifiableList(properties);
     }
 
@@ -74,8 +74,8 @@ public class QueryNiFiReportingTask extends AbstractReportingTask {
     public void setup(final ConfigurationContext context) throws IOException {
         recordSinkService = context.getProperty(QueryMetricsUtil.RECORD_SINK).asControllerService(RecordSinkService.class);
         recordSinkService.reset();
-        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
-        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
+        final Integer defaultPrecision = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
         metricsQueryService = new MetricsSqlQueryService(getLogger(), defaultPrecision, defaultScale);
     }
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/QueryNiFiReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/QueryNiFiReportingTask.java
@@ -38,13 +38,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+
 @Tags({"status", "connection", "processor", "jvm", "metrics", "history", "bulletin", "prediction", "process", "group", "provenance", "record", "sql"})
 @CapabilityDescription("Publishes NiFi status information based on the results of a user-specified SQL query. The query may make use of the CONNECTION_STATUS, PROCESSOR_STATUS, "
         + "BULLETINS, PROCESS_GROUP_STATUS, JVM_METRICS, CONNECTION_STATUS_PREDICTIONS, or PROVENANCE tables, and can use any functions or capabilities provided by Apache Calcite. Note that the "
         + "CONNECTION_STATUS_PREDICTIONS table is not available for querying if analytics are not enabled (see the nifi.analytics.predict.enabled property in nifi.properties). Attempting a "
         + "query on the table when the capability is disabled will cause an error.")
 public class QueryNiFiReportingTask extends AbstractReportingTask {
-
 
     private List<PropertyDescriptor> properties;
 
@@ -54,11 +56,12 @@ public class QueryNiFiReportingTask extends AbstractReportingTask {
 
     @Override
     protected void init(final ReportingInitializationContext config) {
-        metricsQueryService = new MetricsSqlQueryService(getLogger());
         final List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(QueryMetricsUtil.QUERY);
         properties.add(QueryMetricsUtil.RECORD_SINK);
         properties.add(QueryMetricsUtil.INCLUDE_ZERO_RECORD_RESULTS);
+        properties.add(REGISTRY_ONLY_DEFAULT_PRECISION);
+        properties.add(REGISTRY_ONLY_DEFAULT_SCALE);
         this.properties = Collections.unmodifiableList(properties);
     }
 
@@ -71,6 +74,9 @@ public class QueryNiFiReportingTask extends AbstractReportingTask {
     public void setup(final ConfigurationContext context) throws IOException {
         recordSinkService = context.getProperty(QueryMetricsUtil.RECORD_SINK).asControllerService(RecordSinkService.class);
         recordSinkService.reset();
+        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
+        metricsQueryService = new MetricsSqlQueryService(getLogger(), defaultPrecision, defaultScale);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/util/QueryMetricsUtil.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/util/QueryMetricsUtil.java
@@ -27,6 +27,7 @@ import org.apache.nifi.record.sink.RecordSinkService;
 import org.apache.nifi.rules.PropertyContextActionHandler;
 import org.apache.nifi.rules.engine.RulesEngineService;
 
+
 public class QueryMetricsUtil {
 
     public static final PropertyDescriptor RECORD_SINK = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestMetricsEventReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestMetricsEventReportingTask.java
@@ -42,6 +42,7 @@ import org.apache.nifi.rules.engine.RulesEngineService;
 import org.apache.nifi.state.MockStateManager;
 import org.apache.nifi.util.MockPropertyValue;
 import org.apache.nifi.util.Tuple;
+import org.apache.nifi.util.db.JdbcProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -213,6 +214,8 @@ public class TestMetricsEventReportingTask {
         ConfigurationContext configContext = Mockito.mock(ConfigurationContext.class);
         Mockito.when(configContext.getProperty(QueryMetricsUtil.RULES_ENGINE)).thenReturn(resValue);
         Mockito.when(configContext.getProperty(QueryMetricsUtil.ACTION_HANDLER)).thenReturn(pValue);
+        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION)).thenReturn(new MockPropertyValue("10"));
+        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE)).thenReturn(new MockPropertyValue("0"));
         reportingTask.setup(configContext);
 
         return reportingTask;

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestMetricsEventReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestMetricsEventReportingTask.java
@@ -214,8 +214,8 @@ public class TestMetricsEventReportingTask {
         ConfigurationContext configContext = Mockito.mock(ConfigurationContext.class);
         Mockito.when(configContext.getProperty(QueryMetricsUtil.RULES_ENGINE)).thenReturn(resValue);
         Mockito.when(configContext.getProperty(QueryMetricsUtil.ACTION_HANDLER)).thenReturn(pValue);
-        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION)).thenReturn(new MockPropertyValue("10"));
-        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE)).thenReturn(new MockPropertyValue("0"));
+        Mockito.when(configContext.getProperty(JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION)).thenReturn(new MockPropertyValue("10"));
+        Mockito.when(configContext.getProperty(JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE)).thenReturn(new MockPropertyValue("0"));
         reportingTask.setup(configContext);
 
         return reportingTask;

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
@@ -42,6 +42,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessSession;
 import org.apache.nifi.util.MockPropertyValue;
 import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.db.JdbcProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -323,6 +324,9 @@ public class TestQueryNiFiReportingTask {
 
         ConfigurationContext configContext = mock(ConfigurationContext.class);
         Mockito.when(configContext.getProperty(QueryMetricsUtil.RECORD_SINK)).thenReturn(pValue);
+
+        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION)).thenReturn(new MockPropertyValue("10"));
+        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE)).thenReturn(new MockPropertyValue("0"));
         reportingTask.setup(configContext);
 
         MockProvenanceRepository provenanceRepository = new MockProvenanceRepository();

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
@@ -325,8 +325,8 @@ public class TestQueryNiFiReportingTask {
         ConfigurationContext configContext = mock(ConfigurationContext.class);
         Mockito.when(configContext.getProperty(QueryMetricsUtil.RECORD_SINK)).thenReturn(pValue);
 
-        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION)).thenReturn(new MockPropertyValue("10"));
-        Mockito.when(configContext.getProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE)).thenReturn(new MockPropertyValue("0"));
+        Mockito.when(configContext.getProperty(JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION)).thenReturn(new MockPropertyValue("10"));
+        Mockito.when(configContext.getProperty(JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE)).thenReturn(new MockPropertyValue("0"));
         reportingTask.setup(configContext);
 
         MockProvenanceRepository provenanceRepository = new MockProvenanceRepository();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQL.java
@@ -41,10 +41,10 @@ import org.apache.nifi.processors.standard.sql.DefaultAvroSqlWriter;
 import org.apache.nifi.processors.standard.sql.SqlWriter;
 import org.apache.nifi.util.db.JdbcCommon;
 
-import static org.apache.nifi.processors.standard.util.JdbcProperties.DEFAULT_PRECISION;
-import static org.apache.nifi.processors.standard.util.JdbcProperties.DEFAULT_SCALE;
-import static org.apache.nifi.processors.standard.util.JdbcProperties.NORMALIZE_NAMES_FOR_AVRO;
-import static org.apache.nifi.processors.standard.util.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
+import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.NORMALIZE_NAMES_FOR_AVRO;
+import static org.apache.nifi.util.db.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
 import static org.apache.nifi.util.db.AvroUtil.CodecType;
 
 @EventDriven

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQLRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQLRecord.java
@@ -41,7 +41,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.nifi.processors.standard.util.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
+import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
 
 
 @EventDriven
@@ -133,6 +135,8 @@ public class ExecuteSQLRecord extends AbstractExecuteSQL {
         pds.add(RECORD_WRITER_FACTORY);
         pds.add(NORMALIZE_NAMES);
         pds.add(USE_AVRO_LOGICAL_TYPES);
+        pds.add(DEFAULT_PRECISION);
+        pds.add(DEFAULT_SCALE);
         pds.add(MAX_ROWS_PER_FLOW_FILE);
         pds.add(OUTPUT_BATCH_SIZE);
         pds.add(FETCH_SIZE);
@@ -144,9 +148,13 @@ public class ExecuteSQLRecord extends AbstractExecuteSQL {
         final Integer maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions(fileToProcess).asInteger();
         final boolean convertNamesForAvro = context.getProperty(NORMALIZE_NAMES).asBoolean();
         final Boolean useAvroLogicalTypes = context.getProperty(USE_AVRO_LOGICAL_TYPES).asBoolean();
+        final Integer defaultPrecision = context.getProperty(DEFAULT_PRECISION).evaluateAttributeExpressions(fileToProcess).asInteger();
+        final Integer defaultScale = context.getProperty(DEFAULT_SCALE).evaluateAttributeExpressions(fileToProcess).asInteger();
         final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
                 .convertNames(convertNamesForAvro)
                 .useLogicalTypes(useAvroLogicalTypes)
+                .defaultPrecision(defaultPrecision)
+                .defaultScale(defaultScale)
                 .build();
         final RecordSetWriterFactory recordSetWriterFactory = context.getProperty(RECORD_WRITER_FACTORY).asControllerService(RecordSetWriterFactory.class);
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
@@ -44,8 +44,8 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.nifi.util.db.JdbcProperties.NORMALIZE_NAMES_FOR_AVRO;
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE;
 import static org.apache.nifi.util.db.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
 
 
@@ -111,8 +111,8 @@ public class QueryDatabaseTable extends AbstractQueryDatabaseTable {
         pds.add(NORMALIZE_NAMES_FOR_AVRO);
         pds.add(TRANS_ISOLATION_LEVEL);
         pds.add(USE_AVRO_LOGICAL_TYPES);
-        pds.add(REGISTRY_ONLY_DEFAULT_PRECISION);
-        pds.add(REGISTRY_ONLY_DEFAULT_SCALE);
+        pds.add(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION);
+        pds.add(VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE);
 
         propDescriptors = Collections.unmodifiableList(pds);
     }
@@ -123,8 +123,8 @@ public class QueryDatabaseTable extends AbstractQueryDatabaseTable {
         final boolean convertNamesForAvro = context.getProperty(NORMALIZE_NAMES_FOR_AVRO).asBoolean();
         final Boolean useAvroLogicalTypes = context.getProperty(USE_AVRO_LOGICAL_TYPES).asBoolean();
         final Integer maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions().asInteger();
-        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
-        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultPrecision = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
 
         final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
                 .recordName(tableName)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
@@ -43,10 +43,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.nifi.processors.standard.util.JdbcProperties.DEFAULT_PRECISION;
-import static org.apache.nifi.processors.standard.util.JdbcProperties.DEFAULT_SCALE;
-import static org.apache.nifi.processors.standard.util.JdbcProperties.NORMALIZE_NAMES_FOR_AVRO;
-import static org.apache.nifi.processors.standard.util.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
+import static org.apache.nifi.util.db.JdbcProperties.NORMALIZE_NAMES_FOR_AVRO;
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
 
 
 @TriggerSerially
@@ -111,8 +111,8 @@ public class QueryDatabaseTable extends AbstractQueryDatabaseTable {
         pds.add(NORMALIZE_NAMES_FOR_AVRO);
         pds.add(TRANS_ISOLATION_LEVEL);
         pds.add(USE_AVRO_LOGICAL_TYPES);
-        pds.add(DEFAULT_PRECISION);
-        pds.add(DEFAULT_SCALE);
+        pds.add(REGISTRY_ONLY_DEFAULT_PRECISION);
+        pds.add(REGISTRY_ONLY_DEFAULT_SCALE);
 
         propDescriptors = Collections.unmodifiableList(pds);
     }
@@ -123,8 +123,8 @@ public class QueryDatabaseTable extends AbstractQueryDatabaseTable {
         final boolean convertNamesForAvro = context.getProperty(NORMALIZE_NAMES_FOR_AVRO).asBoolean();
         final Boolean useAvroLogicalTypes = context.getProperty(USE_AVRO_LOGICAL_TYPES).asBoolean();
         final Integer maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions().asInteger();
-        final Integer defaultPrecision = context.getProperty(DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
-        final Integer defaultScale = context.getProperty(DEFAULT_SCALE).evaluateAttributeExpressions().asInteger();
+        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
 
         final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
                 .recordName(tableName)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecord.java
@@ -44,8 +44,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
-import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE;
 import static org.apache.nifi.util.db.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
 
 
@@ -132,8 +132,8 @@ public class QueryDatabaseTableRecord extends AbstractQueryDatabaseTable {
         pds.add(MAX_FRAGMENTS);
         pds.add(NORMALIZE_NAMES);
         pds.add(USE_AVRO_LOGICAL_TYPES);
-        pds.add(REGISTRY_ONLY_DEFAULT_PRECISION);
-        pds.add(REGISTRY_ONLY_DEFAULT_SCALE);
+        pds.add(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION);
+        pds.add(VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE);
 
         propDescriptors = Collections.unmodifiableList(pds);
     }
@@ -143,8 +143,8 @@ public class QueryDatabaseTableRecord extends AbstractQueryDatabaseTable {
         final Integer maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions().asInteger();
         final boolean convertNamesForAvro = context.getProperty(NORMALIZE_NAMES).asBoolean();
         final Boolean useAvroLogicalTypes = context.getProperty(USE_AVRO_LOGICAL_TYPES).asBoolean();
-        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
-        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultPrecision = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
 
         final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
                 .convertNames(convertNamesForAvro)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecord.java
@@ -44,7 +44,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.nifi.processors.standard.util.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION;
+import static org.apache.nifi.util.db.JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE;
+import static org.apache.nifi.util.db.JdbcProperties.USE_AVRO_LOGICAL_TYPES;
 
 
 @TriggerSerially
@@ -130,6 +132,8 @@ public class QueryDatabaseTableRecord extends AbstractQueryDatabaseTable {
         pds.add(MAX_FRAGMENTS);
         pds.add(NORMALIZE_NAMES);
         pds.add(USE_AVRO_LOGICAL_TYPES);
+        pds.add(REGISTRY_ONLY_DEFAULT_PRECISION);
+        pds.add(REGISTRY_ONLY_DEFAULT_SCALE);
 
         propDescriptors = Collections.unmodifiableList(pds);
     }
@@ -139,9 +143,14 @@ public class QueryDatabaseTableRecord extends AbstractQueryDatabaseTable {
         final Integer maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions().asInteger();
         final boolean convertNamesForAvro = context.getProperty(NORMALIZE_NAMES).asBoolean();
         final Boolean useAvroLogicalTypes = context.getProperty(USE_AVRO_LOGICAL_TYPES).asBoolean();
+        final Integer defaultPrecision = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+        final Integer defaultScale = context.getProperty(REGISTRY_ONLY_DEFAULT_PRECISION).evaluateAttributeExpressions().asInteger();
+
         final JdbcCommon.AvroConversionOptions options = JdbcCommon.AvroConversionOptions.builder()
                 .convertNames(convertNamesForAvro)
                 .useLogicalTypes(useAvroLogicalTypes)
+                .defaultPrecision(defaultPrecision)
+                .defaultScale(defaultScale)
                 .build();
         final RecordSetWriterFactory recordSetWriterFactory = context.getProperty(RECORD_WRITER_FACTORY).asControllerService(RecordSetWriterFactory.class);
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
@@ -70,7 +70,7 @@ public class RecordSqlWriter implements SqlWriter {
             if (fullRecordSet == null) {
                 final Schema avroSchema = JdbcCommon.createSchema(resultSet, options);
                 final RecordSchema recordAvroSchema = AvroTypeUtil.createSchema(avroSchema);
-                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.defaultPrecision, options.defaultScale);
+                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.getDefaultPrecision(), options.getDefaultScale());
                 writeSchema = recordSetWriterFactory.getSchema(originalAttributes, fullRecordSet.getSchema());
             }
             recordSet = (maxRowsPerFlowFile > 0) ? fullRecordSet.limit(maxRowsPerFlowFile) : fullRecordSet;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
@@ -70,7 +70,7 @@ public class RecordSqlWriter implements SqlWriter {
             if (fullRecordSet == null) {
                 final Schema avroSchema = JdbcCommon.createSchema(resultSet, options);
                 final RecordSchema recordAvroSchema = AvroTypeUtil.createSchema(avroSchema);
-                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback);
+                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.defaultPrecision, options.defaultScale);
                 writeSchema = recordSetWriterFactory.getSchema(originalAttributes, fullRecordSet.getSchema());
             }
             recordSet = (maxRowsPerFlowFile > 0) ? fullRecordSet.limit(maxRowsPerFlowFile) : fullRecordSet;
@@ -134,8 +134,9 @@ public class RecordSqlWriter implements SqlWriter {
 
         private final ResultSetRowCallback callback;
 
-        ResultSetRecordSetWithCallback(ResultSet rs, RecordSchema readerSchema, ResultSetRowCallback callback) throws SQLException {
-            super(rs, readerSchema);
+        ResultSetRecordSetWithCallback(ResultSet rs, RecordSchema readerSchema, ResultSetRowCallback callback,
+                                       final int defaultPrecision, final int defaultScale) throws SQLException {
+            super(rs, readerSchema, defaultPrecision, defaultScale);
             this.callback = callback;
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordTest.java
@@ -33,6 +33,7 @@ import org.apache.nifi.serialization.record.MockRecordWriter;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.apache.nifi.util.db.JdbcProperties;
 import org.apache.nifi.util.file.FileUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -122,6 +123,8 @@ public class QueryDatabaseTableRecordTest {
         MockRecordWriter recordWriter = new MockRecordWriter(null, true, -1);
         runner.addControllerService("writer", recordWriter);
         runner.setProperty(QueryDatabaseTableRecord.RECORD_WRITER_FACTORY, "writer");
+        runner.setProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION, "8");
+        runner.setProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE, "2");
         runner.enableControllerService(recordWriter);
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordTest.java
@@ -123,8 +123,8 @@ public class QueryDatabaseTableRecordTest {
         MockRecordWriter recordWriter = new MockRecordWriter(null, true, -1);
         runner.addControllerService("writer", recordWriter);
         runner.setProperty(QueryDatabaseTableRecord.RECORD_WRITER_FACTORY, "writer");
-        runner.setProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_PRECISION, "8");
-        runner.setProperty(JdbcProperties.REGISTRY_ONLY_DEFAULT_SCALE, "2");
+        runner.setProperty(JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_PRECISION, "8");
+        runner.setProperty(JdbcProperties.VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE, "2");
         runner.enableControllerService(recordWriter);
     }
 


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Some SQL-based components were missing Default Precision and Default Scale properties, causing at least the Avro writer to fail using Oracle as the ResultSet returns zero for precision. Using these properties ensures a default precision/scale will be used when invalid precision/scale values are returned in the ResultSet

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
