### PR TITLE
NIFI-7885 Added Environment Variable to deny LFS access using Hadoop

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
@@ -35,3 +35,7 @@ export NIFI_LOG_DIR="${NIFI_HOME}/logs"
 # a user with elevated permissions (i.e., users that have been granted the 'ACCESS_KEYTAB'
 # restriction).
 export NIFI_ALLOW_EXPLICIT_KEYTAB=true
+
+# Set to true to deny access to the Local File System from HDFS Processors
+# This flag forces HDFS Processors to evaluate the File System path during scheduling
+export NIFI_HDFS_DENY_LOCAL_FILE_SYSTEM_ACCESS=false

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/AbstractHadoopTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/AbstractHadoopTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.nifi.processors.hadoop;
 
+import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.hadoop.KerberosProperties;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.MockProcessContext;
+import org.apache.nifi.util.MockValidationContext;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -33,11 +35,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -177,11 +180,29 @@ public class AbstractHadoopTest {
     }
 
     @Test
-    public void testLocalFileSystemAccessDenied() {
+    public void testLocalFileSystemInvalid() {
         final SimpleHadoopProcessor processor = new SimpleHadoopProcessor(kerberosProperties, true, true);
         TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setProperty(AbstractHadoopProcessor.HADOOP_CONFIGURATION_RESOURCES, "src/test/resources/core-site.xml");
+
+        final MockProcessContext processContext = (MockProcessContext) runner.getProcessContext();
+        final ValidationContext validationContext = new MockValidationContext(processContext);
+        final Collection<ValidationResult> results = processor.customValidate(validationContext);
+        final Optional<ValidationResult> optionalResult = results.stream()
+                .filter(result -> result.getSubject().equals("Hadoop File System"))
+                .findFirst();
+        assertTrue("Hadoop File System Validation Result not found", optionalResult.isPresent());
+        final ValidationResult result = optionalResult.get();
+        assertFalse("Hadoop File System Valid", result.isValid());
+    }
+
+    @Test
+    public void testDistributedFileSystemValid() {
+        final SimpleHadoopProcessor processor = new SimpleHadoopProcessor(kerberosProperties, true, true);
+        TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setProperty(AbstractHadoopProcessor.HADOOP_CONFIGURATION_RESOURCES, "src/test/resources/core-site-security.xml");
+        runner.setProperty(kerberosProperties.getKerberosPrincipal(), "principal");
+        runner.setProperty(kerberosProperties.getKerberosKeytab(), temporaryFile.getAbsolutePath());
         runner.assertValid();
-        final ProcessContext context = runner.getProcessContext();
-        assertThrows(AccessDeniedException.class, () -> processor.abstractOnScheduled(context));
     }
 }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/AbstractHadoopTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/AbstractHadoopTest.java
@@ -33,9 +33,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.util.Collection;
 import java.util.HashSet;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -172,5 +174,14 @@ public class AbstractHadoopTest {
         runner.setProperty(kerberosProperties.getKerberosKeytab(), temporaryFile.getAbsolutePath());
         runner.assertNotValid();
 
+    }
+
+    @Test
+    public void testLocalFileSystemAccessDenied() {
+        final SimpleHadoopProcessor processor = new SimpleHadoopProcessor(kerberosProperties, true, true);
+        TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.assertValid();
+        final ProcessContext context = runner.getProcessContext();
+        assertThrows(AccessDeniedException.class, () -> processor.abstractOnScheduled(context));
     }
 }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/SimpleHadoopProcessor.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/SimpleHadoopProcessor.java
@@ -33,11 +33,6 @@ public class SimpleHadoopProcessor extends AbstractHadoopProcessor {
         this(kerberosProperties, true, true);
     }
 
-    public SimpleHadoopProcessor(KerberosProperties kerberosProperties, boolean allowExplicitKeytab) {
-        this.testKerberosProperties = kerberosProperties;
-        this.allowExplicitKeytab = allowExplicitKeytab;
-    }
-
     public SimpleHadoopProcessor(KerberosProperties kerberosProperties, boolean allowExplicitKeytab, boolean localFileSystemAccessDenied) {
         this.testKerberosProperties = kerberosProperties;
         this.allowExplicitKeytab = allowExplicitKeytab;

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/SimpleHadoopProcessor.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/SimpleHadoopProcessor.java
@@ -27,14 +27,21 @@ public class SimpleHadoopProcessor extends AbstractHadoopProcessor {
 
     private KerberosProperties testKerberosProperties;
     private boolean allowExplicitKeytab;
+    private boolean localFileSystemAccessDenied;
 
     public SimpleHadoopProcessor(KerberosProperties kerberosProperties) {
-        this(kerberosProperties, true);
+        this(kerberosProperties, true, true);
     }
 
     public SimpleHadoopProcessor(KerberosProperties kerberosProperties, boolean allowExplicitKeytab) {
         this.testKerberosProperties = kerberosProperties;
         this.allowExplicitKeytab = allowExplicitKeytab;
+    }
+
+    public SimpleHadoopProcessor(KerberosProperties kerberosProperties, boolean allowExplicitKeytab, boolean localFileSystemAccessDenied) {
+        this.testKerberosProperties = kerberosProperties;
+        this.allowExplicitKeytab = allowExplicitKeytab;
+        this.localFileSystemAccessDenied = localFileSystemAccessDenied;
     }
 
     @Override
@@ -49,5 +56,10 @@ public class SimpleHadoopProcessor extends AbstractHadoopProcessor {
     @Override
     boolean isAllowExplicitKeytab() {
         return allowExplicitKeytab;
+    }
+
+    @Override
+    boolean isLocalFileSystemAccessDenied() {
+        return localFileSystemAccessDenied;
     }
 }


### PR DESCRIPTION
#### Description of PR

NIFI-7885 Introduces a Boolean environment variable named NIFI_HDFS_DENY_LOCAL_FILE_SYSTEM_ACCESS that be set to _true_ in order to deny access from HDFS Processors to the Local File System.  This change impacts all Processors that extend AbstractHadoopProcessor.  The evaluation occurs during Processor scheduling when retrieving the initial FileSystem object based on the provided Hadoop Configuration.  Setting the environment variable to _true_ will caused an AccessDeniedException to be thrown if an operator attempts to configure access to the Local File System.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
