### PR TITLE
NIFI-8088 Removed deprecation warning log for PKCS12 trust stores

### DIFF
--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java
@@ -89,20 +89,6 @@ public class KeyStoreUtils {
     }
 
     /**
-     * Returns an empty KeyStore intended for use as a TrustStore backed by the appropriate provider
-     *
-     * @param trustStoreType the trustStoreType
-     * @return an empty KeyStore
-     * @throws KeyStoreException if a KeyStore of the given type cannot be instantiated
-     */
-    public static KeyStore getTrustStore(String trustStoreType) throws KeyStoreException {
-        if (KeystoreType.PKCS12.toString().equalsIgnoreCase(trustStoreType)) {
-            logger.warn(trustStoreType + " truststores are deprecated.  " + KeystoreType.JKS.toString() + " is preferred.");
-        }
-        return getKeyStore(trustStoreType);
-    }
-
-    /**
      * Returns a loaded {@link KeyStore} given the provided configuration values.
      *
      * @param keystorePath     the file path to the keystore
@@ -194,7 +180,7 @@ public class KeyStoreUtils {
     public static KeyStore loadTrustStore(String truststorePath, char[] truststorePassword, String truststoreType) throws TlsException {
         final KeyStore trustStore;
         try {
-            trustStore = KeyStoreUtils.getTrustStore(truststoreType);
+            trustStore = KeyStoreUtils.getKeyStore(truststoreType);
             try (final InputStream trustStoreStream = new FileInputStream(truststorePath)) {
                 trustStore.load(trustStoreStream, truststorePassword);
             }

--- a/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/KeyStoreUtilsTest.java
+++ b/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/KeyStoreUtilsTest.java
@@ -88,17 +88,17 @@ public class KeyStoreUtilsTest {
 
     @Test
     public void testJksTrustStoreRoundTrip() throws GeneralSecurityException, IOException {
-        testTrustStoreRoundTrip(() -> KeyStoreUtils.getTrustStore(KeystoreType.JKS.toString().toLowerCase()));
+        testTrustStoreRoundTrip(() -> KeyStoreUtils.getKeyStore(KeystoreType.JKS.toString().toLowerCase()));
     }
 
     @Test
     public void testPkcs12TrustStoreBcRoundTrip() throws GeneralSecurityException, IOException {
-        testTrustStoreRoundTrip(() -> KeyStoreUtils.getTrustStore(KeystoreType.PKCS12.toString().toLowerCase()));
+        testTrustStoreRoundTrip(() -> KeyStoreUtils.getKeyStore(KeystoreType.PKCS12.toString().toLowerCase()));
     }
 
     @Test
     public void testPkcs12TrustStoreRoundTripBcReload() throws GeneralSecurityException, IOException {
-        testTrustStoreRoundTrip(() -> KeyStore.getInstance(KeystoreType.PKCS12.toString().toLowerCase()), () -> KeyStoreUtils.getTrustStore(KeystoreType.PKCS12.toString().toLowerCase()));
+        testTrustStoreRoundTrip(() -> KeyStore.getInstance(KeystoreType.PKCS12.toString().toLowerCase()), () -> KeyStoreUtils.getKeyStore(KeystoreType.PKCS12.toString().toLowerCase()));
     }
 
     private void testTrustStoreRoundTrip(KeyStoreSupplier keyStoreSupplier) throws GeneralSecurityException, IOException {

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteToSiteClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteToSiteClient.java
@@ -902,13 +902,7 @@ public interface SiteToSiteClient extends Closeable {
             final TrustManagerFactory trustManagerFactory;
             if (truststoreFilename != null && truststorePass != null && truststoreType != null) {
                 try {
-                    // prepare the truststore
-                    final KeyStore trustStore = KeyStoreUtils.getTrustStore(getTruststoreType().name());
-                    try (final InputStream trustStoreStream = new FileInputStream(new File(getTruststoreFilename()))) {
-                        trustStore.load(trustStoreStream, truststorePass.toCharArray());
-                    }
-                    trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                    trustManagerFactory.init(trustStore);
+                    trustManagerFactory = KeyStoreUtils.loadTrustManagerFactory(truststoreFilename, truststorePass, getTruststoreType().name());
                 } catch (final Exception e) {
                     throw new IllegalStateException("Failed to load Truststore", e);
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
@@ -194,7 +194,7 @@ public class OcspCertificateValidator {
 
         // load the configured truststore
         try (final FileInputStream fis = new FileInputStream(truststorePath)) {
-            final KeyStore truststore = KeyStoreUtils.getTrustStore(KeyStore.getDefaultType());
+            final KeyStore truststore = KeyStoreUtils.getKeyStore(KeyStore.getDefaultType());
             truststore.load(fis, truststorePassword);
 
             TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetHTTP.java
@@ -332,7 +332,7 @@ public class GetHTTP extends AbstractSessionFactoryProcessor {
         final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
 
         if (StringUtils.isNotBlank(service.getTrustStoreFile())) {
-            final KeyStore truststore = KeyStoreUtils.getTrustStore(service.getTrustStoreType());
+            final KeyStore truststore = KeyStoreUtils.getKeyStore(service.getTrustStoreType());
             try (final InputStream in = new FileInputStream(new File(service.getTrustStoreFile()))) {
                 truststore.load(in, service.getTrustStorePassword().toCharArray());
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PostHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PostHTTP.java
@@ -514,7 +514,7 @@ public class PostHTTP extends AbstractProcessor {
         SSLContextBuilder builder = SSLContexts.custom();
         final String trustFilename = service.getTrustStoreFile();
         if (trustFilename != null) {
-            final KeyStore truststore = KeyStoreUtils.getTrustStore(service.getTrustStoreType());
+            final KeyStore truststore = KeyStoreUtils.getKeyStore(service.getTrustStoreType());
             try (final InputStream in = new FileInputStream(new File(service.getTrustStoreFile()))) {
                 truststore.load(in, service.getTrustStorePassword().toCharArray());
             }

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/TlsCertificateAuthorityTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/TlsCertificateAuthorityTest.java
@@ -251,7 +251,7 @@ public class TlsCertificateAuthorityTest {
         // Does the certificate contain the SAN we defined in the client config?
         assert(isSANPresent(certificateChain[0]));
 
-        KeyStore clientTrustStore = KeyStoreUtils.getTrustStore(KeystoreType.JKS.toString());
+        KeyStore clientTrustStore = KeyStoreUtils.getKeyStore(KeystoreType.JKS.toString());
         clientTrustStore.load(new ByteArrayInputStream(clientTrustStoreOutputStream.toByteArray()), clientConfig.getTrustStorePassword().toCharArray());
         assertEquals(caCertificate, clientTrustStore.getCertificate(TlsToolkitStandalone.NIFI_CERT));
     }

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/standalone/TlsToolkitStandaloneTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/standalone/TlsToolkitStandaloneTest.java
@@ -464,7 +464,7 @@ public class TlsToolkitStandaloneTest {
 
         String trustStoreType = nifiProperties.getProperty(NiFiProperties.SECURITY_TRUSTSTORE_TYPE);
         assertEquals(KeystoreType.JKS.toString().toLowerCase(), trustStoreType.toLowerCase());
-        KeyStore trustStore = KeyStoreUtils.getTrustStore(trustStoreType);
+        KeyStore trustStore = KeyStoreUtils.getKeyStore(trustStoreType);
         try (InputStream inputStream = new FileInputStream(new File(hostDir, "truststore." + trustStoreType))) {
             trustStore.load(inputStream, nifiProperties.getProperty(NiFiProperties.SECURITY_TRUSTSTORE_PASSWD).toCharArray());
         }


### PR DESCRIPTION
#### Description of PR

NIFI-8088 Removes KeyStoreUtils.getTrustStore() method which logged a deprecation warning for PKCS12 trust stores. JEP 229 changed the default key store type to PKCS12 starting in Java 9.  The getTrustStore() method checked the trust store type and delegated to the getKeyStore() method, so this PR refactors replaces references to getTrustStore() with getKeyStore() to provide the same functionality.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
