### PR TITLE
NIFI-8023 Added toLocalDate() and updated toDate() in DataTypeUtils

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -81,8 +81,6 @@ import java.util.regex.Pattern;
 public class DataTypeUtils {
     private static final Logger logger = LoggerFactory.getLogger(DataTypeUtils.class);
 
-    private static final Pattern TIME_ZONE_PATTERN = Pattern.compile("[zZX]");
-
     // Regexes for parsing Floating-Point numbers
     private static final String OptionalSign  = "[\\-\\+]?";
     private static final String Infinity = "(Infinity)";
@@ -1183,27 +1181,8 @@ public class DataTypeUtils {
 
     private static Date parseDate(final String string, final DateFormat dateFormat) throws ParseException {
         // DateFormat.parse() creates java.util.Date with System Default Time Zone
-        final java.util.Date parsed = dateFormat.parse(string);
-
-        Instant parsedInstant = parsed.toInstant();
-        if (isTimeZoneAdjustmentRequired(dateFormat)) {
-            // Adjust parsed date using System Default Time Zone offset milliseconds when time zone format not found
-            parsedInstant = parsedInstant.minus(TimeZone.getDefault().getRawOffset(), ChronoUnit.MILLIS);
-        }
-
-        return new Date(parsedInstant.toEpochMilli());
-    }
-
-    private static boolean isTimeZoneAdjustmentRequired(final DateFormat dateFormat) {
-        boolean adjustmentRequired = false;
-
-        if (dateFormat instanceof SimpleDateFormat) {
-            final SimpleDateFormat simpleDateFormat = (SimpleDateFormat) dateFormat;
-            final String pattern = simpleDateFormat.toPattern();
-            adjustmentRequired = !TIME_ZONE_PATTERN.matcher(pattern).find();
-        }
-
-        return adjustmentRequired;
+        final long epochMilliseconds = dateFormat.parse(string).getTime();
+        return new Date(epochMilliseconds);
     }
 
     public static boolean isDateTypeCompatible(final Object value, final String format) {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -81,7 +81,7 @@ import java.util.regex.Pattern;
 public class DataTypeUtils {
     private static final Logger logger = LoggerFactory.getLogger(DataTypeUtils.class);
 
-    private static final String TIME_ZONE_PATTERN = "Z";
+    private static final Pattern TIME_ZONE_PATTERN = Pattern.compile("[zZX]");
 
     // Regexes for parsing Floating-Point numbers
     private static final String OptionalSign  = "[\\-\\+]?";
@@ -1075,7 +1075,8 @@ public class DataTypeUtils {
             try {
                 localDate = parseLocalDate((String) value, formatter);
             } catch (final RuntimeException e) {
-                final String message = String.format("Failed Conversion of Field [%s] from String [%s] to LocalDate with Formatter [%s]", fieldName, value, formatter, e);
+                final String format = formatter == null ? "Formatter Not Provided" : formatter.get().toString();
+                final String message = String.format("Failed Conversion of Field [%s] from String [%s] to LocalDate with Formatter [%s]", fieldName, value, format, e);
                 throw new IllegalTypeConversionException(message);
             }
         } else {
@@ -1199,7 +1200,7 @@ public class DataTypeUtils {
         if (dateFormat instanceof SimpleDateFormat) {
             final SimpleDateFormat simpleDateFormat = (SimpleDateFormat) dateFormat;
             final String pattern = simpleDateFormat.toPattern();
-            adjustmentRequired = !pattern.contains(TIME_ZONE_PATTERN);
+            adjustmentRequired = !TIME_ZONE_PATTERN.matcher(pattern).find();
         }
 
         return adjustmentRequired;

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -29,11 +29,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.DateFormat;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -105,22 +101,6 @@ public class TestDataTypeUtils {
     }
 
     @Test
-    public void testLocalDateTimeStringToDate() {
-        final String localDateTime = "1970-01-01T00:00:00";
-        final java.sql.Date date = DataTypeUtils.toDate(localDateTime, () -> DataTypeUtils.getDateFormat("yyyy-MM-dd'T'HH:mm:ss"), FIELD_NAME);
-        final long expected = LocalDateTime.parse(localDateTime).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-        assertEquals(expected, date.getTime());
-    }
-
-    @Test
-    public void testInstantStringToDate() {
-        final String instant = "1970-01-01T00:00:00Z";
-        final java.sql.Date date = DataTypeUtils.toDate(instant, () -> DataTypeUtils.getDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"), FIELD_NAME);
-        final long expected = Instant.parse(instant).toEpochMilli();
-        assertEquals(expected, date.getTime());
-    }
-
-    @Test
     public void testEpochMillisNumberToLocalDate() {
         final LocalDate localDate = DataTypeUtils.toLocalDate(TWELVE_HOURS_EPOCH_MILLIS, null, FIELD_NAME);
         assertEquals(FIRST_EPOCH_DAY, localDate);
@@ -159,20 +139,6 @@ public class TestDataTypeUtils {
     @Test
     public void testListToLocalDateException() {
         assertThrows(IllegalTypeConversionException.class, () -> DataTypeUtils.toLocalDate(Collections.emptyList(), null, FIELD_NAME));
-    }
-
-    @Test
-    public void testFormattedStringToDateWithImplicitUniversalZoneId() {
-        final DateFormat format = DataTypeUtils.getDateFormat(YEAR_MONTH_DAY_PATTERN);
-        final java.sql.Date date = DataTypeUtils.toDate(FIRST_EPOCH_DAY_FORMATTED, () -> format, FIELD_NAME);
-        assertEquals(FIRST_EPOCH_DAY_FORMATTED, date.toString());
-    }
-
-    @Test
-    public void testFormattedStringToDateWithUniversalZoneId() {
-        final DateFormat format = DataTypeUtils.getDateFormat(YEAR_MONTH_DAY_PATTERN, ZoneOffset.UTC.getId());
-        final java.sql.Date date = DataTypeUtils.toDate(FIRST_EPOCH_DAY_FORMATTED, () -> format, FIELD_NAME);
-        assertEquals(FIRST_EPOCH_DAY_FORMATTED, date.toString());
     }
 
     @Test

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -162,8 +162,8 @@ public class TestDataTypeUtils {
     }
 
     @Test
-    public void testFormattedStringToDateWithSystemDefaultZoneId() {
-        final DateFormat format = DataTypeUtils.getDateFormat(YEAR_MONTH_DAY_PATTERN, ZoneOffset.systemDefault().getId());
+    public void testFormattedStringToDateWithImplicitUniversalZoneId() {
+        final DateFormat format = DataTypeUtils.getDateFormat(YEAR_MONTH_DAY_PATTERN);
         final java.sql.Date date = DataTypeUtils.toDate(FIRST_EPOCH_DAY_FORMATTED, () -> format, FIELD_NAME);
         assertEquals(FIRST_EPOCH_DAY_FORMATTED, date.toString());
     }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -989,7 +989,8 @@ public class AvroTypeUtil {
                 final String logicalName = logicalType.getName();
                 if (LOGICAL_TYPE_DATE.equals(logicalName)) {
                     // date logical name means that the value is number of days since Jan 1, 1970
-                    return new java.sql.Date(TimeUnit.DAYS.toMillis((int) value));
+                    final LocalDate localDate = LocalDate.ofEpochDay((int) value);
+                    return java.sql.Date.valueOf(localDate);
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalName)) {
                     // time-millis logical name means that the value is number of milliseconds since midnight.
                     return new java.sql.Time((int) value);

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -61,7 +61,8 @@ import java.sql.Blob;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
-import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -665,8 +666,9 @@ public class AvroTypeUtil {
 
                 if (LOGICAL_TYPE_DATE.equals(logicalType.getName())) {
                     final String format = AvroTypeUtil.determineDataType(fieldSchema).getFormat();
-                    final java.sql.Date date = DataTypeUtils.toDate(rawValue, () -> DataTypeUtils.getDateFormat(format), fieldName);
-                    return (int) ChronoUnit.DAYS.between(Instant.EPOCH, Instant.ofEpochMilli(date.getTime()));
+                    // Parse Local Date using System Default Time Zone since Local Date does not include Time Zone
+                    final LocalDate localDate = DataTypeUtils.toLocalDate(rawValue, () -> DataTypeUtils.getDateTimeFormatter(format, ZoneOffset.systemDefault()), fieldName);
+                    return (int) localDate.toEpochDay();
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalType.getName())) {
                     final String format = AvroTypeUtil.determineDataType(fieldSchema).getFormat();
                     final Time time = DataTypeUtils.toTime(rawValue, () -> DataTypeUtils.getDateFormat(format), fieldName);

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
@@ -47,10 +47,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -483,16 +481,12 @@ public class TestAvroTypeUtil {
 
     @Test
     public void testDateConversion() {
-        final Calendar c = Calendar.getInstance();
-        c.set(2019, Calendar.JANUARY, 1, 0, 0, 0);
-        final long epochMillis = c.getTimeInMillis();
+        assertConvertedDateEqualsEpochDays(Date.valueOf("1970-01-31"), 30);
+    }
 
-        final LogicalTypes.Date dateType = LogicalTypes.date();
-        final Schema fieldSchema = Schema.create(Type.INT);
-        dateType.addToSchema(fieldSchema);
-        final Object convertedValue = AvroTypeUtil.convertToAvroObject(new Date(epochMillis), fieldSchema);
-        assertTrue(convertedValue instanceof Integer);
-        assertEquals((int) convertedValue, LocalDate.of(2019, 1, 1).toEpochDay());
+    @Test
+    public void testDateStringConversion() {
+        assertConvertedDateEqualsEpochDays("1970-01-31", 30);
     }
 
     @Test
@@ -769,5 +763,14 @@ public class TestAvroTypeUtil {
         );
 
         return Schema.createRecord(avroFields);
+    }
+
+    private void assertConvertedDateEqualsEpochDays(final Object date, final int epochDays) {
+        final LogicalTypes.Date dateType = LogicalTypes.date();
+        final Schema fieldSchema = Schema.create(Type.INT);
+        dateType.addToSchema(fieldSchema);
+
+        final Object convertedValue = AvroTypeUtil.convertToAvroObject(date, fieldSchema);
+        assertEquals(convertedValue, epochDays);
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
@@ -43,6 +43,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,6 +60,14 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class TestQueryRecord {
+
+    private static final String YEAR_MONTH_DAY = "2018-02-04";
+
+    private static final Instant YEAR_MONTH_DAY_INSTANT = LocalDate.parse(YEAR_MONTH_DAY).atStartOfDay(ZoneOffset.systemDefault()).toInstant();
+
+    private static final long YEAR_MONTH_DAY_MILLIS = YEAR_MONTH_DAY_INSTANT.toEpochMilli();
+
+    private static final String TIMESTAMP_FORMATTED = String.format("%s 10:20:55.802", YEAR_MONTH_DAY);
 
     static {
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
@@ -126,7 +137,7 @@ public class TestQueryRecord {
         assertEquals(30, output.getValue("ageObj"));
         assertArrayEquals(new String[] { "red", "green"}, (Object[]) output.getValue("colors"));
         assertArrayEquals(new String[] { "John Doe", "Jane Doe"}, (Object[]) output.getValue("names"));
-        assertEquals("1517702400000", output.getAsString("joinTime"));
+        assertEquals(Long.toString(YEAR_MONTH_DAY_MILLIS), output.getAsString("joinTime"));
         assertEquals(Double.valueOf(180.8D), output.getAsDouble("weight"));
     }
 
@@ -683,7 +694,7 @@ public class TestQueryRecord {
         map.put("favoriteColors", new String[] { "red", "green" });
         map.put("dob", new Date(ts));
         map.put("dobTimestamp", ts);
-        map.put("joinTimestamp", "2018-02-04 10:20:55.802");
+        map.put("joinTimestamp", TIMESTAMP_FORMATTED);
         map.put("weight", 180.8D);
         map.put("height", 60.5);
         map.put("mother", mother);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestAvroReaderWithEmbeddedSchema.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestAvroReaderWithEmbeddedSchema.java
@@ -29,9 +29,11 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -75,9 +77,10 @@ public class TestAvroReaderWithEmbeddedSchema {
     private void testLogicalTypes(Schema schema) throws ParseException, IOException, MalformedRecordException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        final String expectedTime = "2017-04-04 14:20:33.000";
+        final String expectedDate = "2017-04-04";
+        final String expectedTime = String.format("%s 14:20:33.000", expectedDate);
         final DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-        df.setTimeZone(TimeZone.getTimeZone("gmt"));
+        df.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC));
         final long timeLong = df.parse(expectedTime).getTime();
 
         final long secondsSinceMidnight = 33 + (20 * 60) + (14 * 60 * 60);
@@ -120,9 +123,8 @@ public class TestAvroReaderWithEmbeddedSchema {
             assertEquals(new java.sql.Time(millisSinceMidnight), record.getValue("timeMicros"));
             assertEquals(new java.sql.Timestamp(timeLong), record.getValue("timestampMillis"));
             assertEquals(new java.sql.Timestamp(timeLong), record.getValue("timestampMicros"));
-            final DateFormat noTimeOfDayDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-            noTimeOfDayDateFormat.setTimeZone(TimeZone.getTimeZone("gmt"));
-            assertEquals(noTimeOfDayDateFormat.format(new java.sql.Date(timeLong)), noTimeOfDayDateFormat.format(record.getValue("date")));
+
+            assertEquals(Date.valueOf(expectedDate), record.getValue("date"));
             assertEquals(bigDecimal, record.getValue("decimal"));
         }
     }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestCSVRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestCSVRecordReader.java
@@ -45,7 +45,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.TimeZone;
@@ -98,25 +97,24 @@ public class TestCSVRecordReader {
 
     @Test
     public void testDate() throws IOException, MalformedRecordException {
-        final String text = "date\n11/30/1983";
+        final String localDate = "1983-11-30";
+        final String localDateFormat = "yyyy-MM-dd";
+        final String dateField = "date";
+
+        final String text = String.format("%s\n%s", dateField, localDate);
 
         final List<RecordField> fields = new ArrayList<>();
         fields.add(new RecordField("date", RecordFieldType.DATE.getDataType()));
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         for (final boolean coerceTypes : new boolean[] {true, false}) {
-            try (final InputStream bais = new ByteArrayInputStream(text.getBytes());
-                 final CSVRecordReader reader = new CSVRecordReader(bais, Mockito.mock(ComponentLog.class), schema, format, true, false,
-                     "MM/dd/yyyy", RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
+            try (final InputStream inputStream = new ByteArrayInputStream(text.getBytes());
+                 final CSVRecordReader reader = new CSVRecordReader(inputStream, Mockito.mock(ComponentLog.class), schema, format, true, false,
+                         localDateFormat, RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
 
                 final Record record = reader.nextRecord(coerceTypes, false);
-                final java.sql.Date date = (Date) record.getValue("date");
-                final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("gmt"));
-                calendar.setTimeInMillis(date.getTime());
-
-                assertEquals(1983, calendar.get(Calendar.YEAR));
-                assertEquals(10, calendar.get(Calendar.MONTH));
-                assertEquals(30, calendar.get(Calendar.DAY_OF_MONTH));
+                final Object date = record.getValue(dateField);
+                assertEquals(Date.valueOf(localDate), date);
             }
         }
     }
@@ -143,24 +141,23 @@ public class TestCSVRecordReader {
 
     @Test
     public void testDateNoCoersionExpectedFormat() throws IOException, MalformedRecordException {
-        final String text = "date\n11/30/1983";
+        final String localDate = "1983-11-30";
+        final String localDateFormat = "yyyy-MM-dd";
+        final String dateField = "date";
+
+        final String text = String.format("%s\n%s", dateField, localDate);
 
         final List<RecordField> fields = new ArrayList<>();
         fields.add(new RecordField("date", RecordFieldType.DATE.getDataType()));
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
-        try (final InputStream bais = new ByteArrayInputStream(text.getBytes());
-             final CSVRecordReader reader = new CSVRecordReader(bais, Mockito.mock(ComponentLog.class), schema, format, true, false,
-                     "MM/dd/yyyy", RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
+        try (final InputStream inputStream = new ByteArrayInputStream(text.getBytes());
+             final CSVRecordReader reader = new CSVRecordReader(inputStream, Mockito.mock(ComponentLog.class), schema, format, true, false,
+                     localDateFormat, RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
 
             final Record record = reader.nextRecord(false, false);
-            final java.sql.Date date = (Date) record.getValue("date");
-            final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("gmt"));
-            calendar.setTimeInMillis(date.getTime());
-
-            assertEquals(1983, calendar.get(Calendar.YEAR));
-            assertEquals(10, calendar.get(Calendar.MONTH));
-            assertEquals(30, calendar.get(Calendar.DAY_OF_MONTH));
+            final Object date = record.getValue(dateField);
+            assertEquals(Date.valueOf(localDate), date);
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestJacksonCSVRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestJacksonCSVRecordReader.java
@@ -38,9 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Date;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
-import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -85,24 +83,23 @@ public class TestJacksonCSVRecordReader {
 
     @Test
     public void testDate() throws IOException, MalformedRecordException {
-        final String text = "date\n11/30/1983";
+        final String localDate = "1983-11-30";
+        final String localDateFormat = "yyyy-MM-dd";
+        final String dateField = "date";
+
+        final String text = String.format("%s\n%s", dateField, localDate);
 
         final List<RecordField> fields = new ArrayList<>();
-        fields.add(new RecordField("date", RecordFieldType.DATE.getDataType()));
+        fields.add(new RecordField(dateField, RecordFieldType.DATE.getDataType()));
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
-        try (final InputStream bais = new ByteArrayInputStream(text.getBytes());
-             final JacksonCSVRecordReader reader = new JacksonCSVRecordReader(bais, Mockito.mock(ComponentLog.class), schema, format, true, false,
-                     "MM/dd/yyyy", RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
+        try (final InputStream inputStream = new ByteArrayInputStream(text.getBytes());
+             final JacksonCSVRecordReader reader = new JacksonCSVRecordReader(inputStream, Mockito.mock(ComponentLog.class), schema, format, true, false,
+                     localDateFormat, RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
 
             final Record record = reader.nextRecord();
-            final Date date = (Date) record.getValue("date");
-            final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("gmt"));
-            calendar.setTimeInMillis(date.getTime());
-
-            assertEquals(1983, calendar.get(Calendar.YEAR));
-            assertEquals(10, calendar.get(Calendar.MONTH));
-            assertEquals(30, calendar.get(Calendar.DAY_OF_MONTH));
+            final Object date = record.getValue(dateField);
+            assertEquals(Date.valueOf(localDate), date);
         }
     }
 


### PR DESCRIPTION
#### Description of PR

NIFI-8023 Added `DataTypeUtils.toLocalDate()` method for use in `AvroTypeUtil` to determine epoch days when logical date types enabled.

Updated `DataTypeUtils.toDate()` with new `parseDate()` method that evaluates the format pattern of `java.text.SimpleDateFormat` to determine whether a Time Zone field `Z` is present in the pattern.  This conditional adjustment is necessary because absence of the Time Zone Field in a `java.text.SimpleDateFormat` pattern definition produces different results depending on the system time zone configuration.

This approach resolves a latent issue when using the `DataTypeUtils.toDate()` method to parse a string that does not contain any time zone information.  Changes to `DataTypeUtils.toDate()` and updates to unit tests in referencing classes indicate the expected behavior.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
