### PR TITLE
NIFI-8096 Deprecated ClientAuth references in SSLContextService

### DIFF
--- a/nifi-bootstrap/src/test/java/org/apache/nifi/bootstrap/http/TestHttpNotificationServiceSSL.java
+++ b/nifi-bootstrap/src/test/java/org/apache/nifi/bootstrap/http/TestHttpNotificationServiceSSL.java
@@ -31,7 +31,6 @@ import javax.net.ssl.SSLContext;
 import javax.xml.parsers.ParserConfigurationException;
 import okhttp3.mockwebserver.MockWebServer;
 import org.apache.nifi.bootstrap.NotificationServiceManager;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -138,7 +137,7 @@ public class TestHttpNotificationServiceSSL extends TestHttpNotificationServiceC
 
         TlsConfiguration tlsConfiguration = new StandardTlsConfiguration("./src/test/resources/keystore.jks", "passwordpassword", null, "JKS",
                 "./src/test/resources/truststore.jks", "passwordpassword", "JKS", TlsConfiguration.getHighestCurrentSupportedTlsProtocolVersion());
-        final SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.REQUIRED);
+        final SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration);
         mockWebServer.useHttps(sslContext.getSocketFactory(), false);
 
         String configFileOutput = CONFIGURATION_FILE_TEXT.replace("${test.server}", String.valueOf(mockWebServer.url("/")));

--- a/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/SslContextFactoryTest.groovy
+++ b/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/SslContextFactoryTest.groovy
@@ -99,17 +99,11 @@ class SslContextFactoryTest extends GroovyTestCase {
         logger.info("Creating SSL Context from TLS Configuration: ${tlsConfiguration}")
 
         // Act
-        SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.NONE)
+        SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration)
         logger.info("Created SSL Context: ${KeyStoreUtils.sslContextToString(sslContext)}")
 
         // Assert
         assert sslContext.protocol == tlsConfiguration.protocol
-
-        def defaultSSLParameters = sslContext.defaultSSLParameters
-        logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
-        assert !defaultSSLParameters.needClientAuth
-        assert !defaultSSLParameters.wantClientAuth
 
         // Check a socket created from this context
         assertSocketProtocols(sslContext)
@@ -129,17 +123,11 @@ class SslContextFactoryTest extends GroovyTestCase {
         logger.info("Creating SSL Context from TLS Configuration: ${configWithoutKeyPassword}")
 
         // Act
-        SSLContext sslContext = SslContextFactory.createSslContext(configWithoutKeyPassword, ClientAuth.NONE)
+        SSLContext sslContext = SslContextFactory.createSslContext(configWithoutKeyPassword)
         logger.info("Created SSL Context: ${KeyStoreUtils.sslContextToString(sslContext)}")
 
         // Assert
         assert sslContext.protocol == configWithoutKeyPassword.protocol
-
-        def defaultSSLParameters = sslContext.defaultSSLParameters
-        logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
-        assert !defaultSSLParameters.needClientAuth
-        assert !defaultSSLParameters.wantClientAuth
 
         // Check a socket created from this context
         assertSocketProtocols(sslContext)
@@ -175,12 +163,12 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         // Act
         def noKeystorePathMsg = shouldFail(TlsException) {
-            SSLContext sslContext = SslContextFactory.createSslContext(configNoKeystorePath, ClientAuth.NONE)
+            SSLContext sslContext = SslContextFactory.createSslContext(configNoKeystorePath)
             logger.info("Created SSL Context missing keystore path: ${KeyStoreUtils.sslContextToString(sslContext)}")
         }
 
         def noTruststorePathMsg = shouldFail(TlsException) {
-            SSLContext sslContext = SslContextFactory.createSslContext(configNoTruststorePath, ClientAuth.NONE)
+            SSLContext sslContext = SslContextFactory.createSslContext(configNoTruststorePath)
             logger.info("Created SSL Context missing truststore path: ${KeyStoreUtils.sslContextToString(sslContext)}")
         }
 
@@ -206,17 +194,11 @@ class SslContextFactoryTest extends GroovyTestCase {
         logger.info("Creating SSL Context from TLS Configuration: ${configNoTruststorePassword}")
 
         // Act
-        SSLContext sslContext = SslContextFactory.createSslContext(configNoTruststorePassword, ClientAuth.NONE)
+        SSLContext sslContext = SslContextFactory.createSslContext(configNoTruststorePassword)
         logger.info("Created SSL Context: ${KeyStoreUtils.sslContextToString(sslContext)}")
 
         // Assert
         assert sslContext.protocol == configNoTruststorePassword.protocol
-
-        def defaultSSLParameters = sslContext.defaultSSLParameters
-        logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.protocols, TlsPlatform.supportedProtocols)
-        assert !defaultSSLParameters.needClientAuth
-        assert !defaultSSLParameters.wantClientAuth
 
         // Check a socket created from this context
         assertSocketProtocols(sslContext)
@@ -239,7 +221,7 @@ class SslContextFactoryTest extends GroovyTestCase {
 
         // Act
         def msg = shouldFail(TlsException) {
-            SSLContext sslContext = SslContextFactory.createSslContext(keystoreOnlyConfig, ClientAuth.NONE)
+            SSLContext sslContext = SslContextFactory.createSslContext(keystoreOnlyConfig)
             logger.info("Created SSL Context: ${KeyStoreUtils.sslContextToString(sslContext)}")
         }
         logger.expected(msg)
@@ -259,7 +241,7 @@ class SslContextFactoryTest extends GroovyTestCase {
         logger.info("Creating SSL Context from TLS Configuration: ${emptyConfig}")
 
         // Act
-        SSLContext sslContext = SslContextFactory.createSslContext(emptyConfig, ClientAuth.NONE)
+        SSLContext sslContext = SslContextFactory.createSslContext(emptyConfig)
 
         // Assert
         assert !sslContext

--- a/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/socket/ServerSocketConfiguration.java
+++ b/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/socket/ServerSocketConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.io.socket;
 
 import javax.net.ssl.SSLContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.TlsConfiguration;
 import org.apache.nifi.security.util.TlsException;
@@ -34,8 +33,7 @@ public final class ServerSocketConfiguration {
     }
 
     public SSLContext createSSLContext() throws TlsException {
-        // ClientAuth was hardcoded to REQUIRED in removed SSLContextFactory and overridden in SocketUtils when the socket is created
-        return SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.REQUIRED);
+        return SslContextFactory.createSslContext(tlsConfiguration);
     }
 
     public void setTlsConfiguration(final TlsConfiguration tlsConfiguration) {

--- a/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/socket/SocketConfiguration.java
+++ b/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/socket/SocketConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.io.socket;
 
 import javax.net.ssl.SSLContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.TlsConfiguration;
 import org.apache.nifi.security.util.TlsException;
@@ -35,8 +34,7 @@ public final class SocketConfiguration {
     private TlsConfiguration tlsConfiguration;
 
     public SSLContext createSSLContext() throws TlsException {
-        // This is only used for client sockets, so the client auth setting is ignored
-        return SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.NONE);
+        return SslContextFactory.createSslContext(tlsConfiguration);
     }
 
     public void setTlsConfiguration(final TlsConfiguration tlsConfiguration) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -298,7 +298,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
         final Boolean useCertAuthentication = context.getProperty(USE_CERT_AUTHENTICATION).asBoolean();
 
         if (sslService != null) {
-            final SSLContext sslContext = sslService.createSSLContext(ClientAuth.NONE);
+            final SSLContext sslContext = sslService.createContext();
             cf.useSslProtocol(sslContext);
 
             if (useCertAuthentication) {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSProcessor.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSProcessor.java
@@ -58,7 +58,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.aws.credentials.provider.factory.CredentialPropertyDescriptors;
 import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.proxy.ProxySpec;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 
 /**
@@ -227,7 +226,7 @@ public abstract class AbstractAWSProcessor<ClientType extends AmazonWebServiceCl
         if(this.getSupportedPropertyDescriptors().contains(SSL_CONTEXT_SERVICE)) {
             final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
             if (sslContextService != null) {
-                final SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.NONE);
+                final SSLContext sslContext = sslContextService.createContext();
                 // NIFI-3788: Changed hostnameVerifier from null to DHV (BrowserCompatibleHostnameVerifier is deprecated)
                 SdkTLSSocketFactory sdkTLSSocketFactory = new SdkTLSSocketFactory(sslContext, new DefaultHostnameVerifier());
                 config.getApacheHttpClientConfig().setSslSocketFactory(sdkTLSSocketFactory);

--- a/nifi-nar-bundles/nifi-beats-bundle/nifi-beats-processors/src/main/java/org/apache/nifi/processors/beats/ListenBeats.java
+++ b/nifi-nar-bundles/nifi-beats-bundle/nifi-beats-processors/src/main/java/org/apache/nifi/processors/beats/ListenBeats.java
@@ -157,7 +157,7 @@ public class ListenBeats extends AbstractListenEventBatchingProcessor<BeatsEvent
         final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
         if (sslContextService != null) {
             final String clientAuthValue = context.getProperty(CLIENT_AUTH).getValue();
-            sslContext = sslContextService.createSSLContext(ClientAuth.valueOf(clientAuthValue));
+            sslContext = sslContextService.createContext();
             clientAuth = ClientAuth.valueOf(clientAuthValue);
 
         }

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
@@ -252,24 +252,10 @@ public abstract class AbstractCassandraProcessor extends AbstractProcessor {
 
             // Set up the client for secure (SSL/TLS communications) if configured to do so
             final SSLContextService sslService = context.getProperty(PROP_SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-            final String rawClientAuth = context.getProperty(CLIENT_AUTH).getValue();
             final SSLContext sslContext;
 
             if (sslService != null) {
-                final ClientAuth clientAuth;
-
-                if (StringUtils.isBlank(rawClientAuth)) {
-                    clientAuth = ClientAuth.REQUIRED;
-                } else {
-                    try {
-                        clientAuth = ClientAuth.valueOf(rawClientAuth);
-                    } catch (final IllegalArgumentException iae) {
-                        throw new IllegalStateException(String.format("Unrecognized client auth '%s'. Possible values are [%s]",
-                                rawClientAuth, StringUtils.join(ClientAuth.values(), ", ")));
-                    }
-                }
-
-                sslContext = sslService.createSSLContext(clientAuth);
+                sslContext = sslService.createContext();
             } else {
                 sslContext = null;
             }

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessorTest.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessorTest.java
@@ -232,23 +232,6 @@ public class AbstractCassandraProcessorTest {
         assertNotNull(processor.getCluster());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testConnectToCassandraWithSSLBadClientAuth() throws Exception {
-        SSLContextService sslService = mock(SSLContextService.class);
-        when(sslService.getIdentifier()).thenReturn("ssl-context");
-        testRunner.addControllerService("ssl-context", sslService);
-        testRunner.enableControllerService(sslService);
-        testRunner.setProperty(AbstractCassandraProcessor.PROP_SSL_CONTEXT_SERVICE, "ssl-context");
-        testRunner.setProperty(AbstractCassandraProcessor.CONSISTENCY_LEVEL, "ONE");
-        testRunner.assertValid(sslService);
-        processor.connectToCassandra(testRunner.getProcessContext());
-        assertNotNull(processor.getCluster());
-        processor.setCluster(null);
-        // Try with a ClientAuth value
-        testRunner.setProperty(AbstractCassandraProcessor.CLIENT_AUTH, "BAD");
-        processor.connectToCassandra(testRunner.getProcessContext());
-    }
-
     @Test
     public void testConnectToCassandraUsernamePassword() throws Exception {
         testRunner.setProperty(AbstractCassandraProcessor.USERNAME, "user");

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-services/src/main/java/org/apache/nifi/service/CassandraSessionProvider.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-services/src/main/java/org/apache/nifi/service/CassandraSessionProvider.java
@@ -28,12 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.net.ssl.SSLContext;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
-import org.apache.nifi.authentication.exception.ProviderCreationException;
 import org.apache.nifi.cassandra.CassandraSessionProviderService;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
@@ -219,24 +217,12 @@ public class CassandraSessionProvider extends AbstractControllerService implemen
             // Set up the client for secure (SSL/TLS communications) if configured to do so
             final SSLContextService sslService =
                     context.getProperty(PROP_SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-            final String rawClientAuth = context.getProperty(CLIENT_AUTH).getValue();
             final SSLContext sslContext;
 
-            if (sslService != null) {
-                final ClientAuth clientAuth;
-                if (StringUtils.isBlank(rawClientAuth)) {
-                    clientAuth = ClientAuth.REQUIRED;
-                } else {
-                    try {
-                        clientAuth = ClientAuth.valueOf(rawClientAuth);
-                    } catch (final IllegalArgumentException iae) {
-                        throw new ProviderCreationException(String.format("Unrecognized client auth '%s'. Possible values are [%s]",
-                                rawClientAuth, StringUtils.join(ClientAuth.values(), ", ")));
-                    }
-                }
-                sslContext = sslService.createSSLContext(clientAuth);
-            } else {
+            if (sslService == null) {
                 sslContext = null;
+            } else {
+                sslContext = sslService.createContext();;
             }
 
             final String username, password;

--- a/nifi-nar-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
+++ b/nifi-nar-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
@@ -47,12 +47,9 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.schema.access.SchemaField;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.schemaregistry.services.SchemaRegistry;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.SchemaIdentifier;
 import org.apache.nifi.ssl.SSLContextService;
-
-
 
 @Tags({"schema", "registry", "confluent", "avro", "kafka"})
 @CapabilityDescription("Provides a Schema Registry that interacts with the Confluent Schema Registry so that those Schemas that are stored in the Confluent Schema "
@@ -136,7 +133,7 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
         if (sslContextService == null) {
             sslContext = null;
         } else {
-            sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            sslContext = sslContextService.createContext();
         }
 
         final SchemaRegistryClient restClient = new RestSchemaRegistryClient(baseUrls, timeoutMillis, sslContext, getLogger());

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -49,7 +49,6 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.StopWatch;
 import org.apache.nifi.util.StringUtils;
@@ -125,7 +124,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         final SSLContext sslContext;
         try {
             sslContext = (sslService != null && (sslService.isKeyStoreConfigured() || sslService.isTrustStoreConfigured()))
-                    ? sslService.createSSLContext(ClientAuth.NONE) : null;
+                    ? sslService.createContext() : null;
         } catch (Exception e) {
             getLogger().error("Error building up SSL Context from the supplied configuration.", e);
             throw new InitializationException(e);

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ListenSMTP.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ListenSMTP.java
@@ -249,16 +249,16 @@ public class ListenSMTP extends AbstractSessionFactoryProcessor {
             @Override
             public SSLSocket createSSLSocket(Socket socket) throws IOException {
                 InetSocketAddress remoteAddress = (InetSocketAddress) socket.getRemoteSocketAddress();
-                String clientAuth = context.getProperty(CLIENT_AUTH).getValue();
-                SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.valueOf(clientAuth));
-                SSLSocketFactory socketFactory = sslContext.getSocketFactory();
-                SSLSocket sslSocket = (SSLSocket) (socketFactory.createSocket(socket, remoteAddress.getHostName(), socket.getPort(), true));
+                final String clientAuth = context.getProperty(CLIENT_AUTH).getValue();
+                final SSLContext sslContext = sslContextService.createContext();
+                final SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+                final SSLSocket sslSocket = (SSLSocket) socketFactory.createSocket(socket, remoteAddress.getHostName(), socket.getPort(), true);
                 final TlsConfiguration tlsConfiguration = sslContextService.createTlsConfiguration();
                 sslSocket.setEnabledProtocols(tlsConfiguration.getEnabledProtocols());
 
                 sslSocket.setUseClientMode(false);
 
-                if (ClientAuth.REQUIRED.toString().equals(clientAuth)) {
+                if (ClientAuth.REQUIRED.getType().equals(clientAuth)) {
                     this.setRequireTLS(true);
                     sslSocket.setNeedClientAuth(true);
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServerTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/groovy/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServerTest.groovy
@@ -18,7 +18,6 @@ package org.apache.nifi.controller.queue.clustered.server
 
 import org.apache.nifi.events.EventReporter
 import org.apache.nifi.reporting.Severity
-import org.apache.nifi.security.util.ClientAuth
 import org.apache.nifi.security.util.KeyStoreUtils
 import org.apache.nifi.security.util.KeystoreType
 import org.apache.nifi.security.util.SslContextFactory
@@ -99,7 +98,7 @@ class ConnectionLoadBalanceServerTest extends GroovyTestCase {
     void testRequestPeerListShouldUseTLS() {
         // Arrange
         logger.info("Creating SSL Context from TLS Configuration: ${tlsConfiguration}")
-        SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.NONE)
+        SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration)
         logger.info("Created SSL Context: ${KeyStoreUtils.sslContextToString(sslContext)}")
 
         def mockLBP = [

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/LoadBalancedQueueIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/LoadBalancedQueueIT.java
@@ -92,7 +92,6 @@ import org.apache.nifi.controller.repository.claim.ResourceClaimManager;
 import org.apache.nifi.controller.repository.claim.StandardResourceClaimManager;
 import org.apache.nifi.events.EventReporter;
 import org.apache.nifi.provenance.ProvenanceRepository;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.KeystoreType;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
@@ -195,7 +194,7 @@ public class LoadBalancedQueueIT {
         final String truststorePass = "wAOR0nQJ2EXvOP0JZ2EaqA/n7W69ILS4sWAHghmIWCc";
         TlsConfiguration tlsConfiguration = new StandardTlsConfiguration(keystore, keystorePass, keyPass, KeystoreType.JKS,
                 truststore, truststorePass, KeystoreType.JKS, TlsConfiguration.getHighestCurrentSupportedTlsProtocolVersion());
-        sslContext = SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.REQUIRED);
+        sslContext = SslContextFactory.createSslContext(tlsConfiguration);
     }
 
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/SocketRemoteSiteListenerTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/groovy/org/apache/nifi/remote/SocketRemoteSiteListenerTest.groovy
@@ -16,14 +16,11 @@
  */
 package org.apache.nifi.remote
 
-
-import org.apache.nifi.security.util.ClientAuth
 import org.apache.nifi.security.util.KeyStoreUtils
 import org.apache.nifi.security.util.KeystoreType
 import org.apache.nifi.security.util.SslContextFactory
 import org.apache.nifi.security.util.StandardTlsConfiguration
 import org.apache.nifi.security.util.TlsConfiguration
-import org.apache.nifi.security.util.TlsPlatform
 import org.apache.nifi.util.NiFiProperties
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.After
@@ -115,7 +112,7 @@ class SocketRemoteSiteListenerTest extends GroovyTestCase {
     void testShouldCreateSecureServer() {
         // Arrange
         logger.info("Creating SSL Context from TLS Configuration: ${tlsConfiguration}")
-        SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.NONE)
+        SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration)
         logger.info("Created SSL Context: ${KeyStoreUtils.sslContextToString(sslContext)}")
 
         srsListener = new SocketRemoteSiteListener(PORT, sslContext, mockNiFiProperties)
@@ -130,11 +127,5 @@ class SocketRemoteSiteListenerTest extends GroovyTestCase {
         logger.info("Created SSL server socket: ${KeyStoreUtils.sslServerSocketToString(sslServerSocket)}" as String)
         assertProtocolVersions(sslServerSocket.enabledProtocols, TlsConfiguration.getCurrentSupportedTlsProtocolVersions())
         assert sslServerSocket.needClientAuth
-
-        // Assert that the default parameters (which can't be modified) still have legacy protocols and no client auth
-        def defaultSSLParameters = sslContext.defaultSSLParameters
-        logger.info("Default SSL Parameters: ${KeyStoreUtils.sslParametersToString(defaultSSLParameters)}" as String)
-        assertProtocolVersions(defaultSSLParameters.getProtocols(), TlsPlatform.supportedProtocols)
-        assert !defaultSSLParameters.needClientAuth
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/config/SslConfigurationUtil.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/config/SslConfigurationUtil.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.stateless.config;
 
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -36,7 +35,7 @@ public class SslConfigurationUtil {
         final TlsConfiguration tlsConfiguration = createTlsConfiguration(sslContextDefinition);
 
         try {
-            return SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.REQUIRED);
+            return SslContextFactory.createSslContext(tlsConfiguration);
         } catch (final Exception e) {
             throw new StatelessConfigurationException("Failed to create SSL Context", e);
         }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandler.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandler.java
@@ -31,7 +31,6 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 
 /**
@@ -173,7 +172,7 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
 
         SSLContextService sc = context.getProperty(JMS_SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
         if (sc != null) {
-            SSLContext ssl = sc.createSSLContext(ClientAuth.NONE);
+            SSLContext ssl = sc.createContext();
             setProperty("sSLSocketFactory", ssl.getSocketFactory());
         }
 

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/LdapProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/LdapProvider.java
@@ -32,7 +32,6 @@ import org.apache.nifi.authentication.exception.InvalidLoginCredentialsException
 import org.apache.nifi.authentication.exception.ProviderCreationException;
 import org.apache.nifi.authentication.exception.ProviderDestructionException;
 import org.apache.nifi.configuration.NonComponentConfigurationContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -253,14 +252,12 @@ public class LdapProvider implements LoginIdentityProvider {
         final String rawTruststore = configurationContext.getProperty("TLS - Truststore");
         final String rawTruststorePassword = configurationContext.getProperty("TLS - Truststore Password");
         final String rawTruststoreType = configurationContext.getProperty("TLS - Truststore Type");
-        final String rawClientAuth = configurationContext.getProperty("TLS - Client Auth");
         final String rawProtocol = configurationContext.getProperty("TLS - Protocol");
 
         try {
             TlsConfiguration tlsConfiguration = new StandardTlsConfiguration(rawKeystore, rawKeystorePassword, null, rawKeystoreType,
                     rawTruststore, rawTruststorePassword, rawTruststoreType, rawProtocol);
-            ClientAuth clientAuth = ClientAuth.isValidClientAuthType(rawClientAuth) ? ClientAuth.valueOf(rawClientAuth) : ClientAuth.NONE;
-            return SslContextFactory.createSslContext(tlsConfiguration, clientAuth);
+            return SslContextFactory.createSslContext(tlsConfiguration);
         } catch (TlsException e) {
             logger.error("Encountered an error configuring TLS for LDAP identity provider: {}", e.getLocalizedMessage());
             throw new ProviderCreationException("Error configuring TLS for LDAP identity provider", e);

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
@@ -34,7 +34,6 @@ import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.ldap.LdapAuthenticationStrategy;
 import org.apache.nifi.ldap.LdapsSocketFactory;
 import org.apache.nifi.ldap.ReferralStrategy;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -827,14 +826,12 @@ public class LdapUserGroupProvider implements UserGroupProvider {
         final String rawTruststore = configurationContext.getProperty("TLS - Truststore").getValue();
         final String rawTruststorePassword = configurationContext.getProperty("TLS - Truststore Password").getValue();
         final String rawTruststoreType = configurationContext.getProperty("TLS - Truststore Type").getValue();
-        final String rawClientAuth = configurationContext.getProperty("TLS - Client Auth").getValue();
         final String rawProtocol = configurationContext.getProperty("TLS - Protocol").getValue();
 
         try {
             TlsConfiguration tlsConfiguration = new StandardTlsConfiguration(rawKeystore, rawKeystorePassword, null, rawKeystoreType,
                     rawTruststore, rawTruststorePassword, rawTruststoreType, rawProtocol);
-            ClientAuth clientAuth = ClientAuth.isValidClientAuthType(rawClientAuth) ? ClientAuth.valueOf(rawClientAuth) : ClientAuth.NONE;
-            return SslContextFactory.createSslContext(tlsConfiguration, clientAuth);
+            return SslContextFactory.createSslContext(tlsConfiguration);
         } catch (TlsException e) {
             logger.error("Encountered an error configuring TLS for LDAP user group provider: {}", e.getLocalizedMessage());
             throw new ProviderCreationException("Error configuring TLS for LDAP user group provider", e);

--- a/nifi-nar-bundles/nifi-lumberjack-bundle/nifi-lumberjack-processors/src/main/java/org/apache/nifi/processors/lumberjack/ListenLumberjack.java
+++ b/nifi-nar-bundles/nifi-lumberjack-bundle/nifi-lumberjack-processors/src/main/java/org/apache/nifi/processors/lumberjack/ListenLumberjack.java
@@ -48,7 +48,6 @@ import org.apache.nifi.processors.lumberjack.frame.LumberjackEncoder;
 import org.apache.nifi.processors.lumberjack.handler.LumberjackSocketChannelHandlerFactory;
 import org.apache.nifi.processors.lumberjack.response.LumberjackChannelResponse;
 import org.apache.nifi.processors.lumberjack.response.LumberjackResponse;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.RestrictedSSLContextService;
 import org.apache.nifi.ssl.SSLContextService;
 
@@ -143,7 +142,7 @@ public class ListenLumberjack extends AbstractListenEventBatchingProcessor<Lumbe
         SSLContext sslContext = null;
         final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
         if (sslContextService != null) {
-            sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            sslContext = sslContextService.createContext();
         }
 
         // if we decide to support SSL then get the context and pass it in here

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
@@ -241,22 +241,10 @@ public abstract class AbstractMongoProcessor extends AbstractProcessor {
 
         // Set up the client for secure (SSL/TLS communications) if configured to do so
         final SSLContextService sslService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-        final String rawClientAuth = context.getProperty(CLIENT_AUTH).getValue();
         final SSLContext sslContext;
 
         if (sslService != null) {
-            final ClientAuth clientAuth;
-            if (StringUtils.isBlank(rawClientAuth)) {
-                clientAuth = ClientAuth.REQUIRED;
-            } else {
-                try {
-                    clientAuth = ClientAuth.valueOf(rawClientAuth);
-                } catch (final IllegalArgumentException iae) {
-                    throw new IllegalStateException(String.format("Unrecognized client auth '%s'. Possible values are [%s]",
-                            rawClientAuth, StringUtils.join(ClientAuth.values(), ", ")));
-                }
-            }
-            sslContext = sslService.createSSLContext(clientAuth);
+            sslContext = sslService.createContext();
         } else {
             sslContext = null;
         }

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessorTest.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessorTest.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.processors.mongodb;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +26,6 @@ import javax.net.ssl.SSLContext;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -46,11 +44,11 @@ public class AbstractMongoProcessorTest {
     }
 
     @Test
-    public void testcreateClientWithSSL() throws Exception {
+    public void testCreateClientWithSSL() throws Exception {
         SSLContextService sslService = mock(SSLContextService.class);
         SSLContext sslContext = mock(SSLContext.class);
         when(sslService.getIdentifier()).thenReturn("ssl-context");
-        when(sslService.createSSLContext(any(ClientAuth.class))).thenReturn(sslContext);
+        when(sslService.createContext()).thenReturn(sslContext);
         testRunner.addControllerService("ssl-context", sslService);
         testRunner.enableControllerService(sslService);
         testRunner.setProperty(AbstractMongoProcessor.URI, "mongodb://localhost:27017");
@@ -59,29 +57,9 @@ public class AbstractMongoProcessorTest {
         processor.createClient(testRunner.getProcessContext());
         assertNotNull(processor.mongoClient);
         processor.mongoClient = null;
-        testRunner.setProperty(AbstractMongoProcessor.CLIENT_AUTH, "WANT");
         processor.createClient(testRunner.getProcessContext());
         assertNotNull(processor.mongoClient);
     }
-
-    @Test(expected = IllegalStateException.class)
-    public void testcreateClientWithSSLBadClientAuth() throws Exception {
-        SSLContextService sslService = mock(SSLContextService.class);
-        SSLContext sslContext = mock(SSLContext.class);
-        when(sslService.getIdentifier()).thenReturn("ssl-context");
-        when(sslService.createSSLContext(any(ClientAuth.class))).thenReturn(sslContext);
-        testRunner.addControllerService("ssl-context", sslService);
-        testRunner.enableControllerService(sslService);
-        testRunner.setProperty(AbstractMongoProcessor.URI, "mongodb://localhost:27017");
-        testRunner.setProperty(AbstractMongoProcessor.SSL_CONTEXT_SERVICE, "ssl-context");
-        testRunner.assertValid(sslService);
-        processor.createClient(testRunner.getProcessContext());
-        assertNotNull(processor.mongoClient);
-        processor.mongoClient = null;
-        testRunner.setProperty(AbstractMongoProcessor.CLIENT_AUTH, "BAD");
-        processor.createClient(testRunner.getProcessContext());
-    }
-
 
     /**
      * Provides a stubbed processor instance for testing

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/s2s/SiteToSiteUtils.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/s2s/SiteToSiteUtils.java
@@ -33,7 +33,6 @@ import org.apache.nifi.remote.protocol.SiteToSiteTransportProtocol;
 import org.apache.nifi.remote.protocol.http.HttpProxy;
 import org.apache.nifi.remote.util.SiteToSiteRestApiClient;
 import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.RestrictedSSLContextService;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.StringUtils;
@@ -147,7 +146,7 @@ public class SiteToSiteUtils {
 
     public static SiteToSiteClient getClient(PropertyContext reportContext, ComponentLog logger, StateManager stateManager) {
         final SSLContextService sslContextService = reportContext.getProperty(SiteToSiteUtils.SSL_CONTEXT).asControllerService(SSLContextService.class);
-        final SSLContext sslContext = sslContextService == null ? null : sslContextService.createSSLContext(ClientAuth.REQUIRED);
+        final SSLContext sslContext = sslContextService == null ? null : sslContextService.createContext();
         final EventReporter eventReporter = (EventReporter) (severity, category, message) -> {
             switch (severity) {
                 case WARNING:

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/SolrUtils.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/main/java/org/apache/nifi/processors/solr/SolrUtils.java
@@ -55,7 +55,6 @@ import org.apache.nifi.kerberos.KerberosCredentialsService;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.ListRecordSet;
@@ -78,12 +77,8 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SolrUtils {
-
-    static final Logger LOGGER = LoggerFactory.getLogger(SolrUtils.class);
 
     public static final AllowableValue SOLR_TYPE_CLOUD = new AllowableValue(
             "Cloud", "Cloud", "A SolrCloud instance.");
@@ -251,7 +246,7 @@ public class SolrUtils {
         }
 
         if (sslContextService != null) {
-            final SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            final SSLContext sslContext = sslContextService.createContext();
             final SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
             HttpClientUtil.setSchemaRegistryProvider(new HttpClientUtil.SchemaRegistryProvider() {
                 @Override

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/MockSSLContextService.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/MockSSLContextService.java
@@ -35,6 +35,11 @@ public class MockSSLContextService extends AbstractControllerService implements 
     }
 
     @Override
+    public SSLContext createContext() {
+        return null;
+    }
+
+    @Override
     public SSLContext createSSLContext(org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException {
         return null;
     }

--- a/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-controller-service/src/main/java/org/apache/nifi/controller/livy/LivySessionController.java
+++ b/nifi-nar-bundles/nifi-spark-bundle/nifi-livy-controller-service/src/main/java/org/apache/nifi/controller/livy/LivySessionController.java
@@ -77,7 +77,6 @@ import org.apache.nifi.hadoop.KerberosKeytabSPNegoAuthSchemeProvider;
 import org.apache.nifi.kerberos.KerberosCredentialsService;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -225,7 +224,7 @@ public class LivySessionController extends AbstractControllerService implements 
         final String jars = context.getProperty(JARS).evaluateAttributeExpressions().getValue();
         final String files = context.getProperty(FILES).evaluateAttributeExpressions().getValue();
         sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-        sslContext = sslContextService == null ? null : sslContextService.createSSLContext(ClientAuth.NONE);
+        sslContext = sslContextService == null ? null : sslContextService.createContext();
         connectTimeout = Math.toIntExact(context.getProperty(CONNECT_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS));
         credentialsService = context.getProperty(KERBEROS_CREDENTIALS_SERVICE).asControllerService(KerberosCredentialsService.class);
 

--- a/nifi-nar-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunk.java
+++ b/nifi-nar-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunk.java
@@ -45,7 +45,6 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.put.AbstractPutEventProcessor;
 import org.apache.nifi.processor.util.put.sender.ChannelSender;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.stream.io.ByteCountingInputStream;
 import org.apache.nifi.stream.io.StreamUtils;
@@ -120,7 +119,7 @@ public class PutSplunk extends AbstractPutEventProcessor {
 
         SSLContext sslContext = null;
         if (sslContextService != null) {
-            sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            sslContext = sslContextService.createContext();
         }
 
         return createSender(protocol, host, port, timeout, maxSendBuffer, sslContext);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetHTTP.java
@@ -98,7 +98,6 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.standard.util.HTTPUtils;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.KeyStoreUtils;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.StopWatch;
@@ -439,7 +438,8 @@ public class GetHTTP extends AbstractSessionFactoryProcessor {
 
             // set the ssl context if necessary
             if (sslContextService != null) {
-                clientBuilder.setSslcontext(sslContextService.createSSLContext(ClientAuth.REQUIRED));
+                final SSLContext sslContext = sslContextService.createContext();
+                clientBuilder.setSSLContext(sslContext);
             }
 
             final String username = context.getProperty(USERNAME).getValue();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -193,7 +193,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             .description("Client Authentication policy for TLS connections. Required when SSL Context Service configured.")
             .required(false)
             .allowableValues(ClientAuth.values())
-            .defaultValue(ClientAuth.REQUIRED.name())
+            .defaultValue(ClientAuth.WANT.name())
             .dependsOn(SSL_CONTEXT_SERVICE)
             .build();
 
@@ -403,12 +403,19 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
     }
 
     private SslContextFactory createSslContextFactory(SSLContextService sslContextService, final ClientAuth clientAuth) {
-        final SslContextFactory contextFactory = new SslContextFactory.Server();
-        final SSLContext sslContext = sslContextService.createSSLContext(clientAuth);
+        final SslContextFactory.Server contextFactory = new SslContextFactory.Server();
+        final SSLContext sslContext = sslContextService.createContext();
         contextFactory.setSslContext(sslContext);
 
         final TlsConfiguration tlsConfiguration = sslContextService.createTlsConfiguration();
         contextFactory.setIncludeProtocols(tlsConfiguration.getEnabledProtocols());
+
+        if (ClientAuth.REQUIRED.equals(clientAuth)) {
+            contextFactory.setNeedClientAuth(true);
+        } else if (ClientAuth.WANT.equals(clientAuth)) {
+            contextFactory.setWantClientAuth(true);
+        }
+
         return contextFactory;
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -193,7 +193,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             .description("Client Authentication policy for TLS connections. Required when SSL Context Service configured.")
             .required(false)
             .allowableValues(ClientAuth.values())
-            .defaultValue(ClientAuth.WANT.name())
+            .defaultValue(ClientAuth.REQUIRED.name())
             .dependsOn(SSL_CONTEXT_SERVICE)
             .build();
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenRELP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenRELP.java
@@ -146,9 +146,8 @@ public class ListenRELP extends AbstractListenEventBatchingProcessor<RELPEvent> 
         final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
         if (sslContextService != null) {
             final String clientAuthValue = context.getProperty(CLIENT_AUTH).getValue();
-            sslContext = sslContextService.createSSLContext(ClientAuth.valueOf(clientAuthValue));
+            sslContext = sslContextService.createContext();
             clientAuth = ClientAuth.valueOf(clientAuthValue);
-
         }
 
         // if we decide to support SSL then get the context and pass it in here

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
@@ -347,7 +347,7 @@ public class ListenSyslog extends AbstractSyslogProcessor {
 
             if (sslContextService != null) {
                 final String clientAuthValue = context.getProperty(CLIENT_AUTH).getValue();
-                sslContext = sslContextService.createSSLContext(ClientAuth.valueOf(clientAuthValue));
+                sslContext = sslContextService.createContext();
                 clientAuth = ClientAuth.valueOf(clientAuthValue);
             }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCP.java
@@ -177,7 +177,7 @@ public class ListenTCP extends AbstractListenEventBatchingProcessor<StandardEven
         final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
         if (sslContextService != null) {
             final String clientAuthValue = context.getProperty(CLIENT_AUTH).getValue();
-            sslContext = sslContextService.createSSLContext(ClientAuth.valueOf(clientAuthValue));
+            sslContext = sslContextService.createContext();
             clientAuth = ClientAuth.valueOf(clientAuthValue);
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCPRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCPRecord.java
@@ -280,7 +280,7 @@ public class ListenTCPRecord extends AbstractProcessor {
         final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
         if (sslContextService != null) {
             final String clientAuthValue = context.getProperty(CLIENT_AUTH).getValue();
-            sslContext = sslContextService.createSSLContext(ClientAuth.valueOf(clientAuthValue));
+            sslContext = sslContextService.createContext();
             clientAuth = ClientAuth.valueOf(clientAuthValue);
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSyslog.java
@@ -54,7 +54,6 @@ import org.apache.nifi.processor.util.put.sender.ChannelSender;
 import org.apache.nifi.processor.util.put.sender.DatagramChannelSender;
 import org.apache.nifi.processor.util.put.sender.SSLSocketChannelSender;
 import org.apache.nifi.processor.util.put.sender.SocketChannelSender;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.syslog.parsers.SyslogParser;
 import org.apache.nifi.util.StopWatch;
@@ -249,7 +248,7 @@ public class PutSyslog extends AbstractSyslogProcessor {
         } else {
             // if an SSLContextService is provided then we make a secure sender
             if (sslContextService != null) {
-                final SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+                final SSLContext sslContext = sslContextService.createContext();
                 sender = new SSLSocketChannelSender(host, port, maxSendBufferSize, sslContext, getLogger());
             } else {
                 sender = new SocketChannelSender(host, port, maxSendBufferSize, getLogger());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutTCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutTCP.java
@@ -42,7 +42,6 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.put.AbstractPutEventProcessor;
 import org.apache.nifi.processor.util.put.sender.ChannelSender;
 import org.apache.nifi.processor.util.put.sender.SocketChannelSender;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.StopWatch;
 
@@ -115,7 +114,7 @@ public class PutTCP extends AbstractPutEventProcessor {
 
         SSLContext sslContext = null;
         if (sslContextService != null) {
-            sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            sslContext = sslContextService.createContext();
         }
 
         return createSender(protocol, hostname, port, timeout, bufferSize, sslContext);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestGetHTTPGroovy.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestGetHTTPGroovy.groovy
@@ -366,7 +366,7 @@ class TestGetHTTPGroovy extends GroovyTestCase {
         runner.setProperty(sslContextService, StandardSSLContextService.TRUSTSTORE_TYPE, KEYSTORE_TYPE)
         runner.setProperty(sslContextService, StandardSSLContextService.SSL_ALGORITHM, protocol)
         runner.enableControllerService(sslContextService)
-        def sslContext = sslContextService.createSSLContext(org.apache.nifi.security.util.ClientAuth.NONE)
+        def sslContext = sslContextService.createContext();
         logger.info("GetHTTP supported protocols: ${sslContext.protocol}")
         logger.info("GetHTTP supported cipher suites: ${sslContext.supportedSSLParameters.cipherSuites}")
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestPostHTTPGroovy.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/processors/standard/TestPostHTTPGroovy.groovy
@@ -330,7 +330,7 @@ class TestPostHTTPGroovy extends GroovyTestCase {
         runner.setProperty(sslContextService, StandardSSLContextService.TRUSTSTORE_TYPE, KEYSTORE_TYPE)
         runner.setProperty(sslContextService, StandardSSLContextService.SSL_ALGORITHM, protocol)
         runner.enableControllerService(sslContextService)
-        def sslContext = sslContextService.createSSLContext(org.apache.nifi.security.util.ClientAuth.NONE)
+        def sslContext = sslContextService.createContext();
         logger.info("PostHTTP supported protocols: ${sslContext.protocol}")
         logger.info("PostHTTP supported cipher suites: ${sslContext.supportedSSLParameters.cipherSuites}")
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ITestHandleHttpRequest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ITestHandleHttpRequest.java
@@ -59,7 +59,6 @@ import org.apache.nifi.http.HttpContextMap;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.standard.util.HTTPUtils;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -106,7 +105,7 @@ public class ITestHandleHttpRequest {
         return properties;
     }
 
-    private static SSLContext useSSLContextService(final TestRunner controller, final Map<String, String> sslProperties, ClientAuth clientAuth) {
+    private static SSLContext useSSLContextService(final TestRunner controller, final Map<String, String> sslProperties) {
         final SSLContextService service = new StandardRestrictedSSLContextService();
         try {
             controller.addControllerService("ssl-service", service, sslProperties);
@@ -117,7 +116,7 @@ public class ITestHandleHttpRequest {
         }
 
         controller.setProperty(HandleHttpRequest.SSL_CONTEXT, "ssl-service");
-        return service.createSSLContext(clientAuth);
+        return service.createContext();
     }
 
     @Before
@@ -582,7 +581,7 @@ public class ITestHandleHttpRequest {
         final Map<String, String> sslProperties = getServerKeystoreProperties();
         sslProperties.putAll(getTruststoreProperties());
         sslProperties.put(StandardSSLContextService.SSL_ALGORITHM.getName(), TlsConfiguration.getHighestCurrentSupportedTlsProtocolVersion());
-        useSSLContextService(runner, sslProperties, twoWaySsl ? ClientAuth.REQUIRED : ClientAuth.NONE);
+        useSSLContextService(runner, sslProperties);
 
         final Thread httpThread = new Thread(new Runnable() {
             @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenRELP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenRELP.java
@@ -38,7 +38,6 @@ import org.apache.nifi.processors.standard.relp.response.RELPResponse;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.ssl.StandardSSLContextService;
 import org.apache.nifi.util.MockFlowFile;
@@ -226,7 +225,7 @@ public class TestListenRELP {
 
             // create either a regular socket or ssl socket based on context being passed in
             if (sslContextService != null) {
-                final SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+                final SSLContext sslContext = sslContextService.createContext();
                 socket = sslContext.getSocketFactory().createSocket("localhost", realPort);
             } else {
                 socket = new Socket("localhost", realPort);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenTCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenTCP.java
@@ -140,7 +140,7 @@ public class TestListenTCP {
         messages.add("This is message 5\n");
 
         // Make an SSLContext with a key and trust store to send the test messages
-        final SSLContext clientSslContext = SslContextFactory.createSslContext(clientTlsConfiguration, ClientAuth.NONE);
+        final SSLContext clientSslContext = SslContextFactory.createSslContext(clientTlsConfiguration);
 
         runTCP(messages, messages.size(), clientSslContext);
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TCPTestServer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TCPTestServer.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -57,7 +56,7 @@ public class TCPTestServer implements Runnable {
             if(ssl){
                 TlsConfiguration tlsConfiguration = new StandardTlsConfiguration("src/test/resources/keystore.jks","passwordpassword", null, "JKS", "src/test/resources/truststore.jks",
                         "passwordpassword", "JKS", TlsConfiguration.getHighestCurrentSupportedTlsProtocolVersion());
-                final SSLContext sslCtx = SslContextFactory.createSslContext(tlsConfiguration, ClientAuth.REQUIRED);
+                final SSLContext sslCtx = SslContextFactory.createSslContext(tlsConfiguration);
 
                 ServerSocketFactory sslSocketFactory = sslCtx.getServerSocketFactory();
                 serverSocket = sslSocketFactory.createServerSocket(0, 0, ipAddress);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClientService.java
@@ -43,7 +43,6 @@ import org.apache.nifi.distributed.cache.protocol.exception.HandshakeException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.remote.StandardVersionNegotiator;
 import org.apache.nifi.remote.VersionNegotiator;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -408,7 +407,7 @@ public class DistributedMapCacheClientService extends AbstractControllerService 
         if (sslContextService == null) {
             commsSession = new StandardCommsSession(hostname, port, timeoutMillis);
         } else {
-            commsSession = new SSLCommsSession(sslContextService.createSSLContext(ClientAuth.REQUIRED), hostname, port, timeoutMillis);
+            commsSession = new SSLCommsSession(sslContextService.createContext(), hostname, port, timeoutMillis);
         }
 
         commsSession.setTimeout(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
@@ -39,7 +39,6 @@ import org.apache.nifi.distributed.cache.protocol.exception.HandshakeException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.remote.StandardVersionNegotiator;
 import org.apache.nifi.remote.VersionNegotiator;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,7 +114,7 @@ public class DistributedSetCacheClientService extends AbstractControllerService 
         if (sslContextService == null) {
             commsSession = new StandardCommsSession(hostname, port, timeoutMillis);
         } else {
-            commsSession = new SSLCommsSession(sslContextService.createSSLContext(ClientAuth.REQUIRED), hostname, port, timeoutMillis);
+            commsSession = new SSLCommsSession(sslContextService.createContext(), hostname, port, timeoutMillis);
         }
 
         commsSession.setTimeout(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/DistributedSetCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/DistributedSetCacheServer.java
@@ -21,7 +21,6 @@ import javax.net.ssl.SSLContext;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 
 @Tags({"distributed", "set", "distinct", "cache", "server"})
@@ -41,7 +40,7 @@ public class DistributedSetCacheServer extends DistributedCacheServer {
         if (sslContextService == null) {
             sslContext = null;
         } else {
-            sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            sslContext = sslContextService.createContext();
         }
 
         final EvictionPolicy evictionPolicy;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/DistributedMapCacheServer.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/DistributedMapCacheServer.java
@@ -26,7 +26,6 @@ import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.distributed.cache.server.CacheServer;
 import org.apache.nifi.distributed.cache.server.DistributedCacheServer;
 import org.apache.nifi.distributed.cache.server.EvictionPolicy;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 
 @Tags({"distributed", "cluster", "map", "cache", "server", "key/value"})
@@ -47,7 +46,7 @@ public class DistributedMapCacheServer extends DistributedCacheServer {
         if (sslContextService == null) {
             sslContext = null;
         } else {
-            sslContext = sslContextService.createSSLContext(ClientAuth.REQUIRED);
+            sslContext = sslContextService.createContext();
         }
 
         final EvictionPolicy evictionPolicy;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/OAuth2TokenProviderImpl.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/OAuth2TokenProviderImpl.java
@@ -34,7 +34,6 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.security.util.OkHttpClientUtils;
 import org.apache.nifi.security.util.TlsConfiguration;
 import org.apache.nifi.ssl.SSLContextService;
@@ -60,7 +59,7 @@ public class OAuth2TokenProviderImpl extends AbstractControllerService implement
 
         sslService = context.getProperty(SSL_CONTEXT).asControllerService(SSLContextService.class);
 
-        sslContext = sslService == null ? null : sslService.createSSLContext(ClientAuth.NONE);
+        sslContext = sslService == null ? null : sslService.createContext();
     }
 
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
@@ -267,6 +267,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
      * @param clientAuth the desired level of client authentication
      * @return the configured SSLContext
      * @throws ProcessException if there is a problem configuring the context
+     * @deprecated The {@link #createContext()} method should be used instead
      */
     @Deprecated
     @Override
@@ -282,6 +283,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
      * @param clientAuth the desired level of client authentication
      * @return the configured SSLContext
      * @throws ProcessException if there is a problem configuring the context
+     * @deprecated The {@link #createContext()} method should be used instead
      */
     @Deprecated
     @Override

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
@@ -238,41 +238,55 @@ public class StandardSSLContextService extends AbstractControllerService impleme
     }
 
     /**
-     * Returns a configured {@link SSLContext} from the populated configuration values. This method is preferred
-     * over the overloaded method which accepts the deprecated {@link ClientAuth} enum.
+     * Create and initialize {@link SSLContext} using configured properties. This method is preferred over deprecated
+     * methods due to not requiring a client authentication policy. Invokes createTlsConfiguration() to prepare
+     * properties for processing.
      *
-     * @param clientAuth the desired level of client authentication
-     * @return the configured SSLContext
-     * @throws ProcessException if there is a problem configuring the context
+     * @return {@link SSLContext} initialized using configured properties
      */
     @Override
-    public SSLContext createSSLContext(final org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException {
+    public SSLContext createContext() {
+        final TlsConfiguration tlsConfiguration = createTlsConfiguration();
+        if (!tlsConfiguration.isTruststorePopulated()) {
+            getLogger().warn("Trust Store properties not found: using platform default Certificate Authorities");
+        }
+
         try {
-            final TlsConfiguration tlsConfiguration = createTlsConfiguration();
-            if (!tlsConfiguration.isTruststorePopulated()) {
-                getLogger().warn("Trust Store properties not found: using platform default Certificate Authorities");
-            }
             final TrustManager[] trustManagers = SslContextFactory.getTrustManagers(tlsConfiguration);
-            return SslContextFactory.createSslContext(tlsConfiguration, trustManagers, clientAuth);
-        } catch (TlsException e) {
-            getLogger().error("Encountered an error creating the SSL context from the SSL context service: {}", new String[]{e.getLocalizedMessage()});
-            throw new ProcessException("Error creating SSL context", e);
+            return SslContextFactory.createSslContext(tlsConfiguration, trustManagers);
+        } catch (final TlsException e) {
+            getLogger().error("Unable to create SSLContext: {}", new String[]{e.getLocalizedMessage()});
+            throw new ProcessException("Unable to create SSLContext", e);
         }
     }
 
     /**
      * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
-     * due to the use of the deprecated {@link ClientAuth} enum and the overloaded method
-     * ({@link #createSSLContext(org.apache.nifi.security.util.ClientAuth)}) is preferred.
+     * due to the Client Authentication policy not being applicable when initializing the SSLContext
      *
      * @param clientAuth the desired level of client authentication
      * @return the configured SSLContext
      * @throws ProcessException if there is a problem configuring the context
      */
+    @Deprecated
+    @Override
+    public SSLContext createSSLContext(final org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException {
+        return createContext();
+    }
+
+    /**
+     * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
+     * due to the use of the deprecated {@link ClientAuth} enum
+     * {@link #createContext()} method is preferred.
+     *
+     * @param clientAuth the desired level of client authentication
+     * @return the configured SSLContext
+     * @throws ProcessException if there is a problem configuring the context
+     */
+    @Deprecated
     @Override
     public SSLContext createSSLContext(final ClientAuth clientAuth) throws ProcessException {
-        org.apache.nifi.security.util.ClientAuth resolvedClientAuth = org.apache.nifi.security.util.ClientAuth.valueOf(clientAuth.name());
-            return createSSLContext(resolvedClientAuth);
+        return createContext();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/test/groovy/org/apache/nifi/ssl/StandardSSLContextServiceTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/test/groovy/org/apache/nifi/ssl/StandardSSLContextServiceTest.groovy
@@ -176,7 +176,7 @@ class StandardSSLContextServiceTest {
         runner.assertValid(sslContextService)
 
         // Act
-        SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.NONE)
+        SSLContext sslContext = sslContextService.createContext();
 
         // Assert
         assert sslContext
@@ -198,7 +198,7 @@ class StandardSSLContextServiceTest {
         runner.assertValid(sslContextService)
 
         // Act
-        SSLContext sslContext = sslContextService.createSSLContext(ClientAuth.NONE)
+        SSLContext sslContext = sslContextService.createContext();
 
         // Assert
         assert sslContext

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/test/java/org/apache/nifi/ssl/SSLContextServiceTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/test/java/org/apache/nifi/ssl/SSLContextServiceTest.java
@@ -38,7 +38,6 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.MockValidationContext;
 import org.apache.nifi.util.TestRunner;
@@ -146,9 +145,7 @@ public class SSLContextServiceTest {
         service = (SSLContextService) runner.getProcessContext().getControllerServiceLookup().getControllerService("test-good1");
         Assert.assertNotNull(service);
         SSLContextService sslService = service;
-        sslService.createSSLContext(ClientAuth.REQUIRED);
-        sslService.createSSLContext(ClientAuth.WANT);
-        sslService.createSSLContext(ClientAuth.NONE);
+        sslService.createContext();
     }
 
     @Test
@@ -257,7 +254,7 @@ public class SSLContextServiceTest {
             runner.assertValid();
             Assert.assertNotNull(service);
             assertTrue(service instanceof StandardSSLContextService);
-            service.createSSLContext(ClientAuth.NONE);
+            service.createContext();
         } catch (InitializationException e) {
         }
     }
@@ -280,7 +277,7 @@ public class SSLContextServiceTest {
             Assert.assertNotNull(service);
             assertTrue(service instanceof StandardSSLContextService);
             SSLContextService sslService = service;
-            sslService.createSSLContext(ClientAuth.NONE);
+            sslService.createContext();
         } catch (Exception e) {
             System.out.println(e);
             Assert.fail("Should not have thrown a exception " + e.getMessage());
@@ -311,7 +308,7 @@ public class SSLContextServiceTest {
             runner.setProperty("SSL Context Svc ID", "test-diff-keys");
             runner.assertValid();
             Assert.assertNotNull(service);
-            service.createSSLContext(ClientAuth.NONE);
+            service.createContext();
         } catch (Exception e) {
             System.out.println(e);
             Assert.fail("Should not have thrown a exception " + e.getMessage());

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/src/main/java/org/apache/nifi/ssl/SSLContextService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/src/main/java/org/apache/nifi/ssl/SSLContextService.java
@@ -71,6 +71,7 @@ public interface SSLContextService extends ControllerService {
      * @param clientAuth the desired level of client authentication
      * @return the configured SSLContext
      * @throws ProcessException if there is a problem configuring the context
+     * @deprecated The {@link #createContext()} method should be used instead
      */
     @Deprecated
     SSLContext createSSLContext(org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException;
@@ -83,6 +84,7 @@ public interface SSLContextService extends ControllerService {
      * @param clientAuth the desired level of client authentication
      * @return the configured SSLContext
      * @throws ProcessException if there is a problem configuring the context
+     * @deprecated The {@link #createContext()} method should be used instead
      */
     @Deprecated
     SSLContext createSSLContext(ClientAuth clientAuth) throws ProcessException;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/src/main/java/org/apache/nifi/ssl/SSLContextService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/src/main/java/org/apache/nifi/ssl/SSLContextService.java
@@ -56,26 +56,36 @@ public interface SSLContextService extends ControllerService {
     }
 
     /**
-     * Returns a configured {@link SSLContext} from the populated configuration values. This method is preferred
-     * over the overloaded method which accepts the deprecated {@link ClientAuth} enum.
+     * Create and initialize {@link SSLContext} using configured properties. This method is preferred over deprecated
+     * create methods due to not requiring a client authentication policy.
      *
-     * @param clientAuth the desired level of client authentication
-     * @return the configured SSLContext
-     * @throws ProcessException if there is a problem configuring the context
+     * @return {@link SSLContext} initialized using configured properties
      */
-    SSLContext createSSLContext(final org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException;
+    SSLContext createContext();
 
     /**
      * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
-     * due to the use of the deprecated {@link ClientAuth} enum and the overloaded method
-     * ({@link #createSSLContext(org.apache.nifi.security.util.ClientAuth)}) is preferred.
+     * due to {@link org.apache.nifi.security.util.ClientAuth} not being applicable or used when initializing the
+     * {@link SSLContext}
      *
      * @param clientAuth the desired level of client authentication
      * @return the configured SSLContext
      * @throws ProcessException if there is a problem configuring the context
      */
     @Deprecated
-    SSLContext createSSLContext(final ClientAuth clientAuth) throws ProcessException;
+    SSLContext createSSLContext(org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException;
+
+    /**
+     * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
+     * due to the use of the deprecated {@link ClientAuth} enum and the
+     * ({@link #createContext()}) method is preferred.
+     *
+     * @param clientAuth the desired level of client authentication
+     * @return the configured SSLContext
+     * @throws ProcessException if there is a problem configuring the context
+     */
+    @Deprecated
+    SSLContext createSSLContext(ClientAuth clientAuth) throws ProcessException;
 
     String getTrustStoreFile();
 


### PR DESCRIPTION
#### Description of PR

NIFI-8096 Deprecates `createSSLContext()` methods in `SSLContextService` and adds a `createContext()` method that does not use the `ClientAuth` enumeration.  Updated extension components to use `SSLContextService.createContext()` in place of deprecated methods.

Removed references to `ClientAuth` from internal `SslContextFactory` class, and refactored framework classes to eliminate unnecessary usage of `ClientAuth`.  

Updated `ListenHTTP` to call `SslContextBuilder.Server.setNeedClientAuth(true)` when the `Client Authentication` property is `REQUIRED` and call `setWantClientAuth(true)` when the `Client Authentication` property is `WANT`.

These changes remove attempts in `SslContextFactory` to modify the default `SSLParameters` object, which is a read-only representation for the Java Virtual Machine configuration.  Deprecating methods on `SSLContextService` that use `ClientAuth` is necessary to clarify component behavior.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
