### PR TITLE
NIFI-8116 The old peers do not be deleted when the URIs of the remote…

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
@@ -111,7 +111,7 @@ public class PeerSelector {
 
                     // If the remote instance URIs have changed, clear the cache
                     if (!currentRemoteInstanceUris.equals(cachedRemoteInstanceUris)) {
-                        logger.warn("Discard stored peer statuses in {} because remote instance URIs has changed from {} to {}",
+                        logger.info("Discard stored peer statuses in {} because remote instance URIs has changed from {} to {}",
                                 peerPersistence.getClass().getSimpleName(), cachedRemoteInstanceUris, currentRemoteInstanceUris);
                         restoredPeerStatusCache = null;
                     }

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
@@ -106,6 +106,16 @@ public class PeerSelector {
                     final SiteToSiteTransportProtocol currentProtocol = peerStatusProvider.getTransportProtocol();
                     final SiteToSiteTransportProtocol cachedProtocol = restoredPeerStatusCache.getTransportProtocol();
 
+                    final String currentRemoteInstanceUris = peerStatusProvider.getRemoteInstanceUris();
+                    final String cachedRemoteInstanceUris = restoredPeerStatusCache.getRemoteInstanceUris();
+
+                    // If the remote instance URIs have changed, clear the cache
+                    if (!currentRemoteInstanceUris.equals(cachedRemoteInstanceUris)) {
+                        logger.warn("Discard stored peer statuses in {} because remote instance URIs has changed from {} to {}",
+                                peerPersistence.getClass().getSimpleName(), cachedRemoteInstanceUris, currentRemoteInstanceUris);
+                        restoredPeerStatusCache = null;
+                    }
+
                     // If the protocols have changed, clear the cache
                     if (!currentProtocol.equals(cachedProtocol)) {
                         logger.warn("Discard stored peer statuses in {} because transport protocol has changed from {} to {}",
@@ -554,7 +564,7 @@ public class PeerSelector {
             }
 
             // Persist the fetched peer statuses
-            PeerStatusCache peerStatusCache = new PeerStatusCache(statuses, System.currentTimeMillis(), peerStatusProvider.getTransportProtocol());
+            PeerStatusCache peerStatusCache = new PeerStatusCache(statuses, System.currentTimeMillis(), peerStatusProvider.getRemoteInstanceUris(), peerStatusProvider.getTransportProtocol());
             persistPeerStatuses(peerStatusCache);
             logger.info("Successfully refreshed peer status cache; remote group consists of {} peers", statuses.size());
         } catch (Exception e) {

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerStatusProvider.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerStatusProvider.java
@@ -59,6 +59,12 @@ public interface PeerStatusProvider {
     Set<PeerStatus> fetchRemotePeerStatuses(final PeerDescription peerDescription) throws IOException;
 
     /**
+     * Returns the remote instance URIs.
+     * @return the instance URIs
+     */
+    String getRemoteInstanceUris();
+
+    /**
      * Returns the transport protocol being used.
      * @return the transport protocol
      */

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
@@ -113,6 +113,11 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
         }
     }
 
+    @Override
+    public String getRemoteInstanceUris() {
+        return String.join(",", siteInfoProvider.getClusterUrls());
+    }
+
     private Set<PeerStatus> fetchRemotePeerStatuses(SiteToSiteRestApiClient apiClient) throws IOException {
         // Each node should have the same URL structure and network reachability with the proxy configuration
         final Collection<PeerDTO> peers = apiClient.getPeers();

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/EndpointConnectionPool.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/EndpointConnectionPool.java
@@ -424,6 +424,11 @@ public class EndpointConnectionPool implements PeerStatusProvider {
         return peerStatuses;
     }
 
+    @Override
+    public String getRemoteInstanceUris() {
+        return String.join(",", siteInfoProvider.getClusterUrls());
+    }
+
     private CommunicationsSession establishSiteToSiteConnection(final PeerStatus peerStatus) throws IOException {
         final PeerDescription description = peerStatus.getPeerDescription();
         return establishSiteToSiteConnection(description.getHostname(), description.getPort());

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/PeerStatusCache.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/PeerStatusCache.java
@@ -26,12 +26,15 @@ public class PeerStatusCache {
 
     private final Set<PeerStatus> statuses;
     private final long timestamp;
+    private final String remoteInstanceUris;
     private final SiteToSiteTransportProtocol transportProtocol;
 
     public PeerStatusCache(final Set<PeerStatus> statuses, final long timestamp,
+                           final String remoteInstanceUris,
                            final SiteToSiteTransportProtocol transportProtocol) {
         this.statuses = statuses;
         this.timestamp = timestamp;
+        this.remoteInstanceUris = remoteInstanceUris;
         this.transportProtocol = transportProtocol;
     }
 
@@ -41,6 +44,10 @@ public class PeerStatusCache {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public String  getRemoteInstanceUris() {
+        return remoteInstanceUris;
     }
 
     public SiteToSiteTransportProtocol getTransportProtocol() {
@@ -56,6 +63,7 @@ public class PeerStatusCache {
         final ToStringBuilder builder = new ToStringBuilder(this);
         ToStringBuilder.setDefaultStyle(ToStringStyle.SHORT_PREFIX_STYLE);
         builder.append("Timestamp", timestamp);
+        builder.append("Remote instance URIs", remoteInstanceUris);
         builder.append("Transport protocol", transportProtocol);
         builder.append("Peer status count", statuses != null ? statuses.size() : 0);
         builder.append("Peer statuses", statuses);

--- a/nifi-commons/nifi-site-to-site-client/src/test/groovy/org/apache/nifi/remote/client/PeerSelectorTest.groovy
+++ b/nifi-commons/nifi-site-to-site-client/src/test/groovy/org/apache/nifi/remote/client/PeerSelectorTest.groovy
@@ -41,6 +41,7 @@ class PeerSelectorTest extends GroovyTestCase {
 
     private static final BOOTSTRAP_PEER_DESCRIPTION = new PeerDescription("localhost", -1, false)
     private static final List<String> DEFAULT_NODES = ["node1.nifi", "node2.nifi", "node3.nifi"]
+    private static final String DEFAULT_REMOTE_INSTANCE_URIS = buildRemoteInstanceUris(DEFAULT_NODES)
     private static final Set<PeerStatus> DEFAULT_PEER_STATUSES = buildPeerStatuses(DEFAULT_NODES)
     private static final Set<PeerDescription> DEFAULT_PEER_DESCRIPTIONS = DEFAULT_PEER_STATUSES*.peerDescription
     private static final Map<PeerDescription, Set<PeerStatus>> DEFAULT_PEER_NODES = buildPeersMap(DEFAULT_PEER_STATUSES)
@@ -69,6 +70,11 @@ class PeerSelectorTest extends GroovyTestCase {
     @After
     void tearDown() {
 
+    }
+
+    private static String buildRemoteInstanceUris(List<String> nodes = DEFAULT_NODES) {
+        String remoteInstanceUris = new String("http://").concat(nodes.join(":8443/nifi-api,http://")).concat(":8443/nifi-api");
+        remoteInstanceUris
     }
 
     private static Set<PeerStatus> buildPeerStatuses(List<String> nodes = DEFAULT_NODES) {
@@ -176,10 +182,13 @@ class PeerSelectorTest extends GroovyTestCase {
         return meanElements.sum() / meanElements.size()
     }
 
-    private static PeerStatusProvider mockPeerStatusProvider(PeerDescription bootstrapPeerDescription = BOOTSTRAP_PEER_DESCRIPTION, Map<PeerDescription, Set<PeerStatus>> peersMap = DEFAULT_PEER_NODES) {
+    private static PeerStatusProvider mockPeerStatusProvider(PeerDescription bootstrapPeerDescription = BOOTSTRAP_PEER_DESCRIPTION, String remoteInstanceUris = DEFAULT_REMOTE_INSTANCE_URIS, Map<PeerDescription, Set<PeerStatus>> peersMap = DEFAULT_PEER_NODES) {
         [getTransportProtocol       : { ->
             SiteToSiteTransportProtocol.HTTP
         },
+         getRemoteInstanceUris: { ->
+             remoteInstanceUris
+         },
          getBootstrapPeerDescription: { ->
              bootstrapPeerDescription
          },
@@ -188,9 +197,9 @@ class PeerSelectorTest extends GroovyTestCase {
          }] as PeerStatusProvider
     }
 
-    private static PeerPersistence mockPeerPersistence(Set<PeerStatus> peerStatuses = DEFAULT_PEER_STATUSES) {
+    private static PeerPersistence mockPeerPersistence(String remoteInstanceUris = DEFAULT_REMOTE_INSTANCE_URIS, Set<PeerStatus> peerStatuses = DEFAULT_PEER_STATUSES) {
         [restore: { ->
-            new PeerStatusCache(peerStatuses, System.currentTimeMillis(), SiteToSiteTransportProtocol.HTTP)
+            new PeerStatusCache(peerStatuses, System.currentTimeMillis(), remoteInstanceUris, SiteToSiteTransportProtocol.HTTP)
         },
          save   : { PeerStatusCache psc ->
              logger.mock("Persisting PeerStatusCache: ${psc}")
@@ -203,8 +212,8 @@ class PeerSelectorTest extends GroovyTestCase {
         logger.info("Using cluster map (${scenarioName}): ${clusterMap.collectEntries { k, v -> [k.peerDescription.hostname, v] }}")
 
         // Build a peer selector with this cluster
-        PeerStatusProvider mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, buildPeersMap(clusterMap.keySet()))
-        PeerPersistence mockPP = mockPeerPersistence(clusterMap.keySet())
+        PeerStatusProvider mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, DEFAULT_REMOTE_INSTANCE_URIS, buildPeersMap(clusterMap.keySet()))
+        PeerPersistence mockPP = mockPeerPersistence(DEFAULT_REMOTE_INSTANCE_URIS, clusterMap.keySet())
 
         new PeerSelector(mockPSP, mockPP)
     }
@@ -214,8 +223,8 @@ class PeerSelectorTest extends GroovyTestCase {
         // Arrange
 
         // Mock collaborators with empty data
-        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, [:])
-        mockPP = mockPeerPersistence([] as Set)
+        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, "", [:])
+        mockPP = mockPeerPersistence("", [] as Set)
 
         PeerSelector ps = new PeerSelector(mockPSP, mockPP)
 
@@ -234,7 +243,7 @@ class PeerSelectorTest extends GroovyTestCase {
         Set<PeerStatus> restoredPeerStatuses = buildPeerStatuses()
 
         // Mock collaborators
-        mockPP = mockPeerPersistence(restoredPeerStatuses)
+        mockPP = mockPeerPersistence(DEFAULT_REMOTE_INSTANCE_URIS, restoredPeerStatuses)
 
         PeerSelector ps = new PeerSelector(mockPSP, mockPP)
 
@@ -375,8 +384,8 @@ class PeerSelectorTest extends GroovyTestCase {
         clusterMap = clusterMap.sort { e1, e2 -> e1.value <=> e2.value }
         logger.info("Using cluster map: ${clusterMap.collectEntries { k, v -> [k.peerDescription.hostname, v] }}")
 
-        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, buildPeersMap(clusterMap.keySet()))
-        mockPP = mockPeerPersistence(clusterMap.keySet())
+        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, DEFAULT_REMOTE_INSTANCE_URIS, buildPeersMap(clusterMap.keySet()))
+        mockPP = mockPeerPersistence(DEFAULT_REMOTE_INSTANCE_URIS, clusterMap.keySet())
 
         PeerSelector ps = new PeerSelector(mockPSP, mockPP)
         Set<PeerStatus> peerStatuses = ps.getPeerStatuses()
@@ -399,8 +408,8 @@ class PeerSelectorTest extends GroovyTestCase {
         clusterMap = clusterMap.sort { e1, e2 -> e2.value <=> e1.value }
         logger.info("Using cluster map: ${clusterMap.collectEntries { k, v -> [k.peerDescription.hostname, v] }}")
 
-        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, buildPeersMap(clusterMap.keySet()))
-        mockPP = mockPeerPersistence(clusterMap.keySet())
+        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, DEFAULT_REMOTE_INSTANCE_URIS, buildPeersMap(clusterMap.keySet()))
+        mockPP = mockPeerPersistence(DEFAULT_REMOTE_INSTANCE_URIS, clusterMap.keySet())
 
         PeerSelector ps = new PeerSelector(mockPSP, mockPP)
         Set<PeerStatus> peerStatuses = ps.getPeerStatuses()
@@ -778,7 +787,7 @@ class PeerSelectorTest extends GroovyTestCase {
         cacheFile.deleteOnExit()
 
         // Construct the cache contents and write to disk
-        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + peerStatuses.collect { PeerStatus ps ->
+        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + "${mockPSP.getRemoteInstanceUris()}\n" + peerStatuses.collect { PeerStatus ps ->
             [ps.peerDescription.hostname, ps.peerDescription.port, ps.peerDescription.isSecure(), ps.isQueryForPeers()].join(":")
         }.join("\n")
         cacheFile.text = CACHE_CONTENTS
@@ -808,16 +817,17 @@ class PeerSelectorTest extends GroovyTestCase {
         // Arrange
         def nodes = DEFAULT_NODES
         def peerStatuses = DEFAULT_PEER_STATUSES
+        def remoteInstanceUris = buildRemoteInstanceUris(nodes)
 
         // Create the peer status provider with no actual remote peers
-        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, [:])
+        mockPSP = mockPeerStatusProvider(BOOTSTRAP_PEER_DESCRIPTION, remoteInstanceUris, [:])
 
         // Point to the persisted cache on disk
         final File cacheFile = File.createTempFile("peers", "txt")
         cacheFile.deleteOnExit()
 
         // Construct the cache contents and write to disk
-        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + peerStatuses.collect { PeerStatus ps ->
+        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + "${mockPSP.getRemoteInstanceUris()}\n" + peerStatuses.collect { PeerStatus ps ->
             [ps.peerDescription.hostname, ps.peerDescription.port, ps.peerDescription.isSecure(), ps.isQueryForPeers()].join(":")
         }.join("\n")
         cacheFile.text = CACHE_CONTENTS
@@ -873,7 +883,7 @@ class PeerSelectorTest extends GroovyTestCase {
         // Arrange
         mockPP = [
                 restore: { ->
-                    new PeerStatusCache([] as Set<PeerStatus>, System.currentTimeMillis(), SiteToSiteTransportProtocol.HTTP)
+                    new PeerStatusCache([] as Set<PeerStatus>, System.currentTimeMillis(), DEFAULT_REMOTE_INSTANCE_URIS, SiteToSiteTransportProtocol.HTTP)
                 },
                 // Create the peer persistence to throw an exception on save
                 save   : { PeerStatusCache cache ->
@@ -955,10 +965,15 @@ class PeerSelectorTest extends GroovyTestCase {
         PeerStatus node2Status = peerStatuses.find { it.peerDescription.hostname == "node2.nifi" }
         PeerDescription node2Description = node2Status.peerDescription
 
+        String remoteInstanceUris = buildRemoteInstanceUris(nodes)
+
         // Mock the PSP
         mockPSP = [
                 getTransportProtocol       : { ->
                     SiteToSiteTransportProtocol.HTTP
+                },
+                getRemoteInstanceUris: { ->
+                    remoteInstanceUris
                 },
                 getBootstrapPeerDescription: { ->
                     bootstrapDescription
@@ -980,7 +995,7 @@ class PeerSelectorTest extends GroovyTestCase {
         ] as PeerStatusProvider
 
         // Mock the PP with only these statuses
-        mockPP = mockPeerPersistence(peerStatuses)
+        mockPP = mockPeerPersistence(remoteInstanceUris, peerStatuses)
 
         PeerSelector ps = new PeerSelector(mockPSP, mockPP)
         ps.refresh()

--- a/nifi-commons/nifi-site-to-site-client/src/test/groovy/org/apache/nifi/remote/client/PeerSelectorTest.groovy
+++ b/nifi-commons/nifi-site-to-site-client/src/test/groovy/org/apache/nifi/remote/client/PeerSelectorTest.groovy
@@ -73,7 +73,7 @@ class PeerSelectorTest extends GroovyTestCase {
     }
 
     private static String buildRemoteInstanceUris(List<String> nodes = DEFAULT_NODES) {
-        String remoteInstanceUris = new String("http://").concat(nodes.join(":8443/nifi-api,http://")).concat(":8443/nifi-api");
+        String remoteInstanceUris = "http://" + nodes.join(":8443/nifi-api,http://") + ":8443/nifi-api";
         remoteInstanceUris
     }
 
@@ -787,7 +787,7 @@ class PeerSelectorTest extends GroovyTestCase {
         cacheFile.deleteOnExit()
 
         // Construct the cache contents and write to disk
-        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + "${mockPSP.getRemoteInstanceUris()}\n" + peerStatuses.collect { PeerStatus ps ->
+        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + "${AbstractPeerPersistence.REMOTE_INSTANCE_URIS_PREFIX}${mockPSP.getRemoteInstanceUris()}\n" + peerStatuses.collect { PeerStatus ps ->
             [ps.peerDescription.hostname, ps.peerDescription.port, ps.peerDescription.isSecure(), ps.isQueryForPeers()].join(":")
         }.join("\n")
         cacheFile.text = CACHE_CONTENTS
@@ -827,7 +827,7 @@ class PeerSelectorTest extends GroovyTestCase {
         cacheFile.deleteOnExit()
 
         // Construct the cache contents and write to disk
-        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + "${mockPSP.getRemoteInstanceUris()}\n" + peerStatuses.collect { PeerStatus ps ->
+        final String CACHE_CONTENTS = "${mockPSP.getTransportProtocol()}\n" + "${AbstractPeerPersistence.REMOTE_INSTANCE_URIS_PREFIX}${mockPSP.getRemoteInstanceUris()}\n" + peerStatuses.collect { PeerStatus ps ->
             [ps.peerDescription.hostname, ps.peerDescription.port, ps.peerDescription.isSecure(), ps.isQueryForPeers()].join(":")
         }.join("\n")
         cacheFile.text = CACHE_CONTENTS

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -222,6 +222,19 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
         verifyCanUpdate();
 
         this.targetUris = targetUris;
+
+        backgroundThreadExecutor.submit(() -> {
+            try {
+                refreshFlowContents();
+            } catch (final Exception e) {
+                // If the root cause is a connection error, don't print the entire stacktrace
+                if (isConnectionTimeoutError(e)) {
+                    logger.warn("Unable to communicate with remote instance {}", this);
+                } else {
+                    logger.warn("Unable to communicate with remote instance {}", this, e);
+                }
+            }
+        });
         backgroundThreadExecutor.submit(new InitializationTask());
     }
 


### PR DESCRIPTION
… process group are changed


#### Description of PR

https://issues.apache.org/jira/browse/NIFI-8116

When we start transmitting for RPG, Peer Persistence will restore the peers retrieved from disk. It only checks whether the protocol has changed but it doesn't check the URIs.
If the user changes the URIs to another instance, RPG not only keeps the old instance but also add the new instance to the state. the RPG will have two different instances at the same time and show the errors when transmission.

For this PR, I stored additional information into persistence files, this is used to check if the current target instance is matches with state persistence file in the disk.


### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
