### PR TITLE
NIFI-8034: Fixed PropertyValue.isExpressionLanguagePresent always ret…

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPreparedQuery.java
@@ -69,7 +69,12 @@ public class StandardPreparedQuery implements PreparedQuery {
 
     @Override
     public boolean isExpressionLanguagePresent() {
-        return !(expressions.isEmpty() || (expressions.size() == 1 && expressions.get(0) instanceof StringLiteralExpression));
+        for (Expression expression : expressions) {
+            if (expression instanceof CompiledExpression) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPreparedQuery.java
@@ -69,7 +69,7 @@ public class StandardPreparedQuery implements PreparedQuery {
 
     @Override
     public boolean isExpressionLanguagePresent() {
-        return !expressions.isEmpty();
+        return !(expressions.isEmpty() || (expressions.size() == 1 && expressions.get(0) instanceof StringLiteralExpression));
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
@@ -319,6 +319,12 @@ public class TestStandardPreparedQuery {
         assertTrue(Query.prepare("${hostname():equals('localhost')}").isExpressionLanguagePresent());
         assertTrue(Query.prepare("prefix-${hostname()}").isExpressionLanguagePresent());
         assertTrue(Query.prepare("${hostname()}-suffix").isExpressionLanguagePresent());
+        assertTrue(Query.prepare("${variable1}${hostname()}${variable2}").isExpressionLanguagePresent());
+        assertTrue(Query.prepare("${${variable}}").isExpressionLanguagePresent());
+
+        assertFalse(Query.prepare("${}").isExpressionLanguagePresent());
+
+        assertTrue(Query.prepare("#{param}").isExpressionLanguagePresent());
     }
 
     private String evaluate(final String query, final Map<String, String> attrs) {

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
@@ -324,7 +324,7 @@ public class TestStandardPreparedQuery {
 
         assertFalse(Query.prepare("${}").isExpressionLanguagePresent());
 
-        assertTrue(Query.prepare("#{param}").isExpressionLanguagePresent());
+        assertFalse(Query.prepare("#{param}").isExpressionLanguagePresent());
     }
 
     private String evaluate(final String query, final Map<String, String> attrs) {

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
@@ -309,6 +309,18 @@ public class TestStandardPreparedQuery {
         assertTrue(Query.prepare("${anyMatchingAttribute('a.*'):equals('hello')}").getVariableImpact().isImpacted("attr"));
     }
 
+    @Test
+    public void testIsExpressionLanguagePresent() {
+        assertFalse(Query.prepare("value").isExpressionLanguagePresent());
+        assertFalse(Query.prepare("").isExpressionLanguagePresent());
+
+        assertTrue(Query.prepare("${variable}").isExpressionLanguagePresent());
+        assertTrue(Query.prepare("${hostname()}").isExpressionLanguagePresent());
+        assertTrue(Query.prepare("${hostname():equals('localhost')}").isExpressionLanguagePresent());
+        assertTrue(Query.prepare("prefix-${hostname()}").isExpressionLanguagePresent());
+        assertTrue(Query.prepare("${hostname()}-suffix").isExpressionLanguagePresent());
+    }
+
     private String evaluate(final String query, final Map<String, String> attrs) {
         final String evaluated = ((StandardPreparedQuery) Query.prepare(query)).evaluateExpressions(new StandardEvaluationContext(attrs), null);
         return evaluated;


### PR DESCRIPTION
…urns true for non-null values

Expression Language is NOT present if the 'expressions' list is empty or it contains a single StringLiteralExpression.
Otherwise EL is considered to be present.

https://issues.apache.org/jira/browse/NIFI-8034

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
