### PR TITLE
NIFI-8125 Moved JWT filter ahead of X509 filter

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.web;
 
-import java.util.Arrays;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationFilter;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationProvider;
@@ -49,6 +48,8 @@ import org.springframework.security.web.authentication.preauth.x509.X509Principa
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 /**
  * NiFi Web Api Spring security. Applies the various NiFiAuthenticationFilter servlet filters which will extract authentication
@@ -125,11 +126,11 @@ public class NiFiWebApiSecurityConfiguration extends WebSecurityConfigurerAdapte
                 .sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
-        // x509
-        http.addFilterBefore(x509FilterBean(), AnonymousAuthenticationFilter.class);
-
         // jwt
         http.addFilterBefore(jwtFilterBean(), AnonymousAuthenticationFilter.class);
+
+        // x509
+        http.addFilterBefore(x509FilterBean(), AnonymousAuthenticationFilter.class);
 
         // otp
         http.addFilterBefore(otpFilterBean(), AnonymousAuthenticationFilter.class);


### PR DESCRIPTION
Was originally planning to add some type of property to control whether x509 should come before JWT, but it seems as though we should be able to just move JWT in front of it. The only scenario that would change behavior is if you were previously submitting a request to the API with a client cert AND also sending the Authorization header. Previously the Authorization header would be ignored, so arguably should not have been sent anyway. 
