### PR TITLE
NIFI-8163: When counting number of components, we traverse into all P…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -443,7 +443,7 @@ public final class StandardProcessGroup implements ProcessGroup {
                 syncFailure += childCounts.getSyncFailureCount();
             }
 
-            for (final RemoteProcessGroup remoteGroup : findAllRemoteProcessGroups()) {
+            for (final RemoteProcessGroup remoteGroup : getRemoteProcessGroups()) {
                 // Count only input ports that have incoming connections
                 for (final Port port : remoteGroup.getInputPorts()) {
                     if (port.hasIncomingConnection()) {


### PR DESCRIPTION
…rocess Groups, but then call findAllRemoteProcessGroups, which is a recursive call, instead of calling getRemoteProcessGroups(). This results in counting the Process Groups many times. So fixed that.

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
