### PR TITLE
Add "Mailbox" property to ConsumeEWS

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
@@ -113,7 +113,7 @@ public class ConsumeEWS extends AbstractProcessor {
             .name("mailbox")
             .displayName("Mailbox")
             .description("Mailbox")
-            .required(true)
+            .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
@@ -389,13 +389,20 @@ public class ConsumeEWS extends AbstractProcessor {
 
     protected Folder getFolder(ExchangeService service, ProcessContext context) {
         Folder folder;
-	Mailbox mailbox = new Mailbox(context.getProperty(MAILBOX).getValue());
-        	FolderId InboxFolderId = new FolderId(WellKnownFolderName.Inbox, mailbox);
-
+        String MailboxProperty = context.getProperty(MAILBOX).getValue();
         if(folderName.equals("INBOX")){
             try {
-         //       folder = Folder.bind(service, WellKnownFolderName.Inbox, context.getProperty(MAILBOX).getValue());
-			folder = Folder.bind(service, InboxFolderId );
+                if (!StringUtils.isEmpty(MailboxProperty))
+                    {
+                        Mailbox mailbox = new Mailbox(MailboxProperty);
+                        FolderId InboxFolderId = new FolderId(WellKnownFolderName.Inbox, mailbox);
+                        folder = Folder.bind(service, InboxFolderId);
+                }
+        
+                else {
+                        folder = Folder.bind(service, WellKnownFolderName.Inbox);
+                }
+			
             } catch (Exception e) {
                 throw new ProcessException("Failed to bind Inbox Folder on EWS Server", e);
             }

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
@@ -115,7 +115,6 @@ public class ConsumeEWS extends AbstractProcessor {
             .description("Mailbox")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
     public static final PropertyDescriptor FOLDER = new PropertyDescriptor.Builder()
             .name("folder")

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeEWS.java
@@ -115,6 +115,7 @@ public class ConsumeEWS extends AbstractProcessor {
             .description("Mailbox")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+	    .addValidator(Validator.VALID)
             .build();
     public static final PropertyDescriptor FOLDER = new PropertyDescriptor.Builder()
             .name("folder")


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Sometimes I need to consume EWS mailbox by service account that has access to multiple mailboxes.
for example user "svc_ews_consumer@example.com" has access to two mailboxes MB1@example.com and MB2@example.com

Maybe my code is not so good but I build it and it works for me. 
