### PR TITLE
NIFI-8142 Add "on conflict do nothing" feature to PutDatabaseRecord

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -113,6 +113,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
     public static final String INSERT_TYPE = "INSERT";
     public static final String DELETE_TYPE = "DELETE";
     public static final String UPSERT_TYPE = "UPSERT";
+    public static final String INSERT_IGNORE_TYPE = "INSERT_IGNORE";
     public static final String SQL_TYPE = "SQL";   // Not an allowable value in the Statement Type property, must be set by attribute
     public static final String USE_ATTR_TYPE = "Use statement.type Attribute";
     public static final String USE_RECORD_PATH = "Use Record Path";
@@ -172,7 +173,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
                     + "FlowFile. The 'Use statement.type Attribute' option is the only one that allows the 'SQL' statement type. If 'SQL' is specified, the value of the field specified by the "
                     + "'Field Containing SQL' property is expected to be a valid SQL statement on the target database, and will be executed as-is.")
             .required(true)
-            .allowableValues(UPDATE_TYPE, INSERT_TYPE, UPSERT_TYPE, DELETE_TYPE, USE_ATTR_TYPE, USE_RECORD_PATH)
+            .allowableValues(UPDATE_TYPE, INSERT_TYPE, UPSERT_TYPE, INSERT_IGNORE_TYPE, DELETE_TYPE, USE_ATTR_TYPE, USE_RECORD_PATH)
             .build();
 
     static final PropertyDescriptor STATEMENT_TYPE_RECORD_PATH = new Builder()
@@ -430,8 +431,8 @@ public class PutDatabaseRecord extends AbstractProcessor {
 
         DatabaseAdapter databaseAdapter = dbAdapters.get(validationContext.getProperty(DB_TYPE).getValue());
         String statementType = validationContext.getProperty(STATEMENT_TYPE).getValue();
-
-        if (UPSERT_TYPE.equals(statementType) && !databaseAdapter.supportsUpsert()) {
+        if ((UPSERT_TYPE.equals(statementType) && !databaseAdapter.supportsUpsert()) ||
+                (INSERT_IGNORE_TYPE.equals(statementType) && !databaseAdapter.supportsInsertIgnore())) {
             validationResults.add(new ValidationResult.Builder()
                 .subject(STATEMENT_TYPE.getDisplayName())
                 .valid(false)
@@ -647,6 +648,8 @@ public class PutDatabaseRecord extends AbstractProcessor {
                             sqlHolder = generateDelete(recordSchema, fqTableName, tableSchema, settings);
                         } else if (UPSERT_TYPE.equalsIgnoreCase(statementType)) {
                             sqlHolder = generateUpsert(recordSchema, fqTableName, updateKeys, tableSchema, settings);
+                        } else if (INSERT_IGNORE_TYPE.equalsIgnoreCase(statementType)) {
+                            sqlHolder = generateInsertIgnore(recordSchema, fqTableName, updateKeys, tableSchema, settings);
                         } else {
                             throw new IllegalArgumentException(format("Statement Type %s is not valid, FlowFile %s", statementType, flowFile));
                         }
@@ -791,7 +794,8 @@ public class PutDatabaseRecord extends AbstractProcessor {
         }
 
         if (INSERT_TYPE.equalsIgnoreCase(statementType) || UPDATE_TYPE.equalsIgnoreCase(statementType) || DELETE_TYPE.equalsIgnoreCase(statementType)
-            || UPSERT_TYPE.equalsIgnoreCase(statementType) || SQL_TYPE.equalsIgnoreCase(statementType) || USE_RECORD_PATH.equalsIgnoreCase(statementType) ) {
+                || UPSERT_TYPE.equalsIgnoreCase(statementType) || SQL_TYPE.equalsIgnoreCase(statementType) || USE_RECORD_PATH.equalsIgnoreCase(statementType)
+                || INSERT_IGNORE_TYPE.equalsIgnoreCase(statementType)) {
 
             return statementType;
         }
@@ -951,6 +955,47 @@ public class PutDatabaseRecord extends AbstractProcessor {
         }
 
         String sql = databaseAdapter.getUpsertStatement(tableName, usedColumnNames, normalizedKeyColumnNames);
+
+        return new SqlAndIncludedColumns(sql, usedColumnIndices);
+    }
+
+    SqlAndIncludedColumns generateInsertIgnore(final RecordSchema recordSchema, final String tableName, final String updateKeys,
+                                               final TableSchema tableSchema, final DMLSettings settings)
+            throws IllegalArgumentException, SQLException, MalformedRecordException {
+
+        checkValuesForRequiredColumns(recordSchema, tableSchema, settings);
+
+        Set<String> keyColumnNames = getUpdateKeyColumnNames(tableName, updateKeys, tableSchema);
+        Set<String> normalizedKeyColumnNames = normalizeKeyColumnNamesAndCheckForValues(recordSchema, updateKeys, settings, keyColumnNames, tableSchema.getQuotedIdentifierString());
+
+        List<String> usedColumnNames = new ArrayList<>();
+        List<Integer> usedColumnIndices = new ArrayList<>();
+
+        List<String> fieldNames = recordSchema.getFieldNames();
+        if (fieldNames != null) {
+            int fieldCount = fieldNames.size();
+
+            for (int i = 0; i < fieldCount; i++) {
+                RecordField field = recordSchema.getField(i);
+                String fieldName = field.getFieldName();
+
+                final ColumnDescription desc = tableSchema.getColumns().get(normalizeColumnName(fieldName, settings.translateFieldNames));
+                if (desc == null && !settings.ignoreUnmappedFields) {
+                    throw new SQLDataException("Cannot map field '" + fieldName + "' to any column in the database");
+                }
+
+                if (desc != null) {
+                    if (settings.escapeColumnNames) {
+                        usedColumnNames.add(tableSchema.getQuotedIdentifierString() + desc.getColumnName() + tableSchema.getQuotedIdentifierString());
+                    } else {
+                        usedColumnNames.add(desc.getColumnName());
+                    }
+                    usedColumnIndices.add(i);
+                }
+            }
+        }
+
+        String sql = databaseAdapter.getInsertIgnoreStatement(tableName, usedColumnNames, normalizedKeyColumnNames);
 
         return new SqlAndIncludedColumns(sql, usedColumnIndices);
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
@@ -68,6 +68,15 @@ public interface DatabaseAdapter {
     }
 
     /**
+     * Tells whether this adapter supports INSERT_IGNORE.
+     *
+     * @return true if INSERT_IGNORE is supported, false otherwise
+     */
+    default boolean supportsInsertIgnore() {
+        return false;
+    }
+
+    /**
      * Tells How many times the column values need to be inserted into the prepared statement. Some DBs (such as MySQL) need the values specified twice in the statement,
      * some need only to specify them once.
      *
@@ -89,6 +98,21 @@ public interface DatabaseAdapter {
      *                                      The order and number of parameters are the same as that of the provided column list.
      */
     default String getUpsertStatement(String table, List<String> columnNames, Collection<String> uniqueKeyColumnNames) {
+        throw new UnsupportedOperationException("UPSERT is not supported for " + getName());
+    }
+
+    /**
+     * Returns an SQL INSERT_IGNORE statement - i.e. Ignore record or INSERT if id doesn't exist.
+     * <br /><br />
+     * There is no standard way of doing this so not all adapters support it - use together with {@link #supportsInsertIgnore()}!
+     *
+     * @param table                The name of the table in which to ignore/insert a record into.
+     * @param columnNames          The name of the columns in the table to add values to.
+     * @param uniqueKeyColumnNames The name of the columns that form a unique key.
+     * @return A String containing the parameterized jdbc SQL statement.
+     * The order and number of parameters are the same as that of the provided column list.
+     */
+    default String getInsertIgnoreStatement(String table, List<String> columnNames, Collection<String> uniqueKeyColumnNames) {
         throw new UnsupportedOperationException("UPSERT is not supported for " + getName());
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MySQLDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MySQLDatabaseAdapter.java
@@ -49,6 +49,11 @@ public class MySQLDatabaseAdapter extends GenericDatabaseAdapter {
         return true;
     }
 
+    @Override
+    public boolean supportsInsertIgnore() {
+        return true;
+    }
+
     /**
      * Tells How many times the column values need to be inserted into the prepared statement. Some DBs (such as MySQL) need the values specified twice in the statement,
      * some need only to specify them once.
@@ -86,7 +91,27 @@ public class MySQLDatabaseAdapter extends GenericDatabaseAdapter {
                 .append("(").append(parameterizedInsertValues).append(")")
                 .append(" ON DUPLICATE KEY UPDATE ")
                 .append(parameterizedUpdateValues);
+        return statementStringBuilder.toString();
+    }
 
+    @Override
+    public String getInsertIgnoreStatement(String table, List<String> columnNames, Collection<String> uniqueKeyColumnNames) {
+        Preconditions.checkArgument(!StringUtils.isEmpty(table), "Table name cannot be null or blank");
+        Preconditions.checkArgument(columnNames != null && !columnNames.isEmpty(), "Column names cannot be null or empty");
+        Preconditions.checkArgument(uniqueKeyColumnNames != null && !uniqueKeyColumnNames.isEmpty(), "Key column names cannot be null or empty");
+
+        String columns = columnNames.stream()
+                .collect(Collectors.joining(", "));
+
+        String parameterizedInsertValues = columnNames.stream()
+                .map(__ -> "?")
+                .collect(Collectors.joining(", "));
+
+        StringBuilder statementStringBuilder = new StringBuilder("INSERT IGNORE INTO ")
+                .append(table)
+                .append("(").append(columns).append(")")
+                .append(" VALUES ")
+                .append("(").append(parameterizedInsertValues).append(")");
         return statementStringBuilder.toString();
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PostgreSQLDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PostgreSQLDatabaseAdapter.java
@@ -40,6 +40,11 @@ public class PostgreSQLDatabaseAdapter extends GenericDatabaseAdapter {
     }
 
     @Override
+    public boolean supportsInsertIgnore() {
+        return true;
+    }
+
+    @Override
     public String getUpsertStatement(String table, List<String> columnNames, Collection<String> uniqueKeyColumnNames) {
         Preconditions.checkArgument(!StringUtils.isEmpty(table), "Table name cannot be null or blank");
         Preconditions.checkArgument(columnNames != null && !columnNames.isEmpty(), "Column names cannot be null or empty");
@@ -72,4 +77,32 @@ public class PostgreSQLDatabaseAdapter extends GenericDatabaseAdapter {
 
         return statementStringBuilder.toString();
     }
+
+    @Override
+    public String getInsertIgnoreStatement(String table, List<String> columnNames, Collection<String> uniqueKeyColumnNames) {
+        Preconditions.checkArgument(!StringUtils.isEmpty(table), "Table name cannot be null or blank");
+        Preconditions.checkArgument(columnNames != null && !columnNames.isEmpty(), "Column names cannot be null or empty");
+        Preconditions.checkArgument(uniqueKeyColumnNames != null && !uniqueKeyColumnNames.isEmpty(), "Key column names cannot be null or empty");
+
+        String columns = columnNames.stream()
+                .collect(Collectors.joining(", "));
+
+        String parameterizedInsertValues = columnNames.stream()
+                .map(__ -> "?")
+                .collect(Collectors.joining(", "));
+
+        String conflictClause = "(" + uniqueKeyColumnNames.stream().collect(Collectors.joining(", ")) + ")";
+
+        StringBuilder statementStringBuilder = new StringBuilder("INSERT INTO ")
+                .append(table)
+                .append("(").append(columns).append(")")
+                .append(" VALUES ")
+                .append("(").append(parameterizedInsertValues).append(")")
+                .append(" ON CONFLICT ")
+                .append(conflictClause)
+                .append(" DO NOTHING");
+        return statementStringBuilder.toString();
+    }
+
+
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestMySQLDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestMySQLDatabaseAdapter.java
@@ -89,6 +89,21 @@ public class TestMySQLDatabaseAdapter {
         testGetUpsertStatement(tableName, columnNames, uniqueKeyColumnNames, expected);
     }
 
+    @Test
+    public void testGetInsertIgnoreStatement() throws Exception {
+        // GIVEN
+        String tableName = "table";
+        List<String> columnNames = Arrays.asList("column1", "column2", "column3", "column4");
+        Collection<String> uniqueKeyColumnNames = Arrays.asList("column2", "column4");
+
+        String ignoreExpected = "INSERT IGNORE INTO" +
+                " table(column1, column2, column3, column4) VALUES (?, ?, ?, ?)";
+
+        // WHEN
+        // THEN
+        testGetInsertIgnoreStatement(tableName, columnNames, uniqueKeyColumnNames, ignoreExpected);
+    }
+
     private void testGetUpsertStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, IllegalArgumentException expected) {
         try {
             testGetUpsertStatement(tableName, columnNames, uniqueKeyColumnNames, (String) null);
@@ -101,6 +116,14 @@ public class TestMySQLDatabaseAdapter {
     private void testGetUpsertStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, String expected) {
         // WHEN
         String actual = testSubject.getUpsertStatement(tableName, columnNames, uniqueKeyColumnNames);
+
+        // THEN
+        assertEquals(expected, actual);
+    }
+
+    private void testGetInsertIgnoreStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, String expected) {
+        // WHEN
+        String actual = testSubject.getInsertIgnoreStatement(tableName, columnNames, uniqueKeyColumnNames);
 
         // THEN
         assertEquals(expected, actual);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestPostgreSQLDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestPostgreSQLDatabaseAdapter.java
@@ -89,6 +89,23 @@ public class TestPostgreSQLDatabaseAdapter {
         testGetUpsertStatement(tableName, columnNames, uniqueKeyColumnNames, expected);
     }
 
+    @Test
+    public void testGetInsertIgnoreStatement() throws Exception {
+        // GIVEN
+        String tableName = "table";
+        List<String> columnNames = Arrays.asList("column1","column2", "column3", "column4");
+        Collection<String> uniqueKeyColumnNames = Arrays.asList("column2","column4");
+
+        String expected = "INSERT INTO" +
+                " table(column1, column2, column3, column4) VALUES (?, ?, ?, ?)" +
+                " ON CONFLICT (column2, column4)" +
+                " DO NOTHING";
+
+        // WHEN
+        // THEN
+        testGetInsertIgnoreStatement(tableName, columnNames, uniqueKeyColumnNames, expected);
+    }
+
     private void testGetUpsertStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, IllegalArgumentException expected) {
         try {
             testGetUpsertStatement(tableName, columnNames, uniqueKeyColumnNames, (String)null);
@@ -101,6 +118,14 @@ public class TestPostgreSQLDatabaseAdapter {
     private void testGetUpsertStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, String expected) {
         // WHEN
         String actual = testSubject.getUpsertStatement(tableName, columnNames, uniqueKeyColumnNames);
+
+        // THEN
+        assertEquals(expected, actual);
+    }
+
+    private void testGetInsertIgnoreStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, String expected) {
+        // WHEN
+        String actual = testSubject.getInsertIgnoreStatement(tableName, columnNames, uniqueKeyColumnNames);
 
         // THEN
         assertEquals(expected, actual);


### PR DESCRIPTION
I believe PutDatabaseRecord processor need a feature that we can ignore the record when it already exists in database. 

In this implement I add a new Statement Type "INSERT_IGNORE", inspired by @markap14 .

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
