### PR TITLE
NIFI-8126 Include Total Queued Duration in ConnectionStatus metrics

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/ConnectionStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/ConnectionStatus.java
@@ -42,8 +42,8 @@ public class ConnectionStatus implements Cloneable {
     private long outputBytes;
     private int maxQueuedCount;
     private long maxQueuedBytes;
-    private long totalActiveQueuedDuration;
-    private long maxActiveQueuedDuration;
+    private long totalQueuedDuration;
+    private long maxQueuedDuration;
 
     public String getId() {
         return id;
@@ -198,20 +198,20 @@ public class ConnectionStatus implements Cloneable {
         this.backPressureBytesThreshold = backPressureBytesThreshold;
     }
 
-    public long getTotalActiveQueuedDuration() {
-        return totalActiveQueuedDuration;
+    public long getTotalQueuedDuration() {
+        return totalQueuedDuration;
     }
 
-    public void setTotalActiveQueuedDuration(long totalActiveQueuedDuration) {
-        this.totalActiveQueuedDuration = totalActiveQueuedDuration;
+    public void setTotalQueuedDuration(long totalQueuedDuration) {
+        this.totalQueuedDuration = totalQueuedDuration;
     }
 
-    public long getMaxActiveQueuedDuration() {
-        return maxActiveQueuedDuration;
+    public long getMaxQueuedDuration() {
+        return maxQueuedDuration;
     }
 
-    public void setMaxActiveQueuedDuration(long maxActiveQueuedDuration) {
-        this.maxActiveQueuedDuration = maxActiveQueuedDuration;
+    public void setMaxQueuedDuration(long maxQueuedDuration) {
+        this.maxQueuedDuration = maxQueuedDuration;
     }
 
     @Override
@@ -239,8 +239,8 @@ public class ConnectionStatus implements Cloneable {
         clonedObj.backPressureObjectThreshold = backPressureObjectThreshold;
         clonedObj.maxQueuedBytes = maxQueuedBytes;
         clonedObj.maxQueuedCount = maxQueuedCount;
-        clonedObj.totalActiveQueuedDuration = totalActiveQueuedDuration;
-        clonedObj.maxActiveQueuedDuration = maxActiveQueuedDuration;
+        clonedObj.totalQueuedDuration = totalQueuedDuration;
+        clonedObj.maxQueuedDuration = maxQueuedDuration;
         return clonedObj;
     }
 
@@ -282,9 +282,9 @@ public class ConnectionStatus implements Cloneable {
         builder.append(", maxQueueBytes=");
         builder.append(maxQueuedBytes);
         builder.append(", totalActiveQueuedDuration=");
-        builder.append(totalActiveQueuedDuration);
+        builder.append(totalQueuedDuration);
         builder.append(", maxActiveQueuedDuration=");
-        builder.append(maxActiveQueuedDuration);
+        builder.append(maxQueuedDuration);
         builder.append("]");
         return builder.toString();
     }

--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/ConnectionStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/ConnectionStatus.java
@@ -42,6 +42,8 @@ public class ConnectionStatus implements Cloneable {
     private long outputBytes;
     private int maxQueuedCount;
     private long maxQueuedBytes;
+    private long totalActiveQueuedDuration;
+    private long maxActiveQueuedDuration;
 
     public String getId() {
         return id;
@@ -196,6 +198,22 @@ public class ConnectionStatus implements Cloneable {
         this.backPressureBytesThreshold = backPressureBytesThreshold;
     }
 
+    public long getTotalActiveQueuedDuration() {
+        return totalActiveQueuedDuration;
+    }
+
+    public void setTotalActiveQueuedDuration(long totalActiveQueuedDuration) {
+        this.totalActiveQueuedDuration = totalActiveQueuedDuration;
+    }
+
+    public long getMaxActiveQueuedDuration() {
+        return maxActiveQueuedDuration;
+    }
+
+    public void setMaxActiveQueuedDuration(long maxActiveQueuedDuration) {
+        this.maxActiveQueuedDuration = maxActiveQueuedDuration;
+    }
+
     @Override
     public ConnectionStatus clone() {
         final ConnectionStatus clonedObj = new ConnectionStatus();
@@ -221,6 +239,8 @@ public class ConnectionStatus implements Cloneable {
         clonedObj.backPressureObjectThreshold = backPressureObjectThreshold;
         clonedObj.maxQueuedBytes = maxQueuedBytes;
         clonedObj.maxQueuedCount = maxQueuedCount;
+        clonedObj.totalActiveQueuedDuration = totalActiveQueuedDuration;
+        clonedObj.maxActiveQueuedDuration = maxActiveQueuedDuration;
         return clonedObj;
     }
 
@@ -261,6 +281,10 @@ public class ConnectionStatus implements Cloneable {
         builder.append(maxQueuedCount);
         builder.append(", maxQueueBytes=");
         builder.append(maxQueuedBytes);
+        builder.append(", totalActiveQueuedDuration=");
+        builder.append(totalActiveQueuedDuration);
+        builder.append(", maxActiveQueuedDuration=");
+        builder.append(maxActiveQueuedDuration);
         builder.append("]");
         return builder.toString();
     }

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/queue/FlowFileQueue.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/queue/FlowFileQueue.java
@@ -94,6 +94,18 @@ public interface FlowFileQueue {
     QueueSize size();
 
     /**
+     * @param fromTimestamp The timestamp in milliseconds from which to calculate durations. This will typically be the current timestamp.
+     * @return the sum in milliseconds of how long all FlowFiles within this queue have currently been in this queue.
+     */
+    long getTotalActiveQueuedDuration(long fromTimestamp);
+
+    /**
+     * @param fromTimestamp The timestamp in milliseconds from which to calculate durations. This will typically be the current timestamp.
+     * @return the maximum time in milliseconds that any FlowFile within this queue has been in this queue.
+     */
+    long getMaxActiveQueuedDuration(long fromTimestamp);
+
+    /**
      * @return true if no items queue; false otherwise
      */
     boolean isEmpty();

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/queue/FlowFileQueue.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/queue/FlowFileQueue.java
@@ -97,13 +97,12 @@ public interface FlowFileQueue {
      * @param fromTimestamp The timestamp in milliseconds from which to calculate durations. This will typically be the current timestamp.
      * @return the sum in milliseconds of how long all FlowFiles within this queue have currently been in this queue.
      */
-    long getTotalActiveQueuedDuration(long fromTimestamp);
+    long getTotalQueuedDuration(long fromTimestamp);
 
     /**
-     * @param fromTimestamp The timestamp in milliseconds from which to calculate durations. This will typically be the current timestamp.
-     * @return the maximum time in milliseconds that any FlowFile within this queue has been in this queue.
+     * @return The minimum lastQueueDate in milliseconds of all FlowFiles currently enqueued. If no FlowFile is enqueued, this returns 0.
      */
-    long getMaxActiveQueuedDuration(long fromTimestamp);
+    long getMinLastQueueDate();
 
     /**
      * @return true if no items queue; false otherwise

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/SwapSummary.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/SwapSummary.java
@@ -47,4 +47,14 @@ public interface SwapSummary {
      * @return a List of all ResourceClaims that are referenced by the FlowFiles in the swap file
      */
     List<ResourceClaim> getResourceClaims();
+
+    /**
+     * @return The minimum lastQueueDate of all FlowFiles that are currently stored in this queue.
+     */
+    Long getMinLastQueueDate();
+
+    /**
+     * @return The sum of all the lastQueueDates of all FlowFiles that are currently stored in this queue.
+     */
+    Long getTotalLastQueueDate();
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
@@ -246,7 +246,7 @@ public abstract class AbstractEventAccess implements EventAccess {
             connStatus.setBackPressureObjectThreshold(conn.getFlowFileQueue().getBackPressureObjectThreshold());
             connStatus.setTotalQueuedDuration(conn.getFlowFileQueue().getTotalQueuedDuration(now));
             long minLastQueueDate = conn.getFlowFileQueue().getMinLastQueueDate();
-            connStatus.setMaxQueuedDuration(now - minLastQueueDate != 0 ? minLastQueueDate : now);
+            connStatus.setMaxQueuedDuration(minLastQueueDate == 0 ? 0 : now - minLastQueueDate);
 
             final FlowFileEvent connectionStatusReport = statusReport.getReportEntry(conn.getIdentifier());
             if (connectionStatusReport != null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
@@ -227,6 +227,8 @@ public abstract class AbstractEventAccess implements EventAccess {
         final Collection<ConnectionStatus> connectionStatusCollection = new ArrayList<>();
         status.setConnectionStatus(connectionStatusCollection);
 
+        long now = System.currentTimeMillis();
+
         // get the connection and remote port status
         for (final Connection conn : group.getConnections()) {
             final boolean isConnectionAuthorized = isAuthorized.test(conn);
@@ -242,6 +244,8 @@ public abstract class AbstractEventAccess implements EventAccess {
             connStatus.setDestinationName(isDestinationAuthorized ? conn.getDestination().getName() : conn.getDestination().getIdentifier());
             connStatus.setBackPressureDataSizeThreshold(conn.getFlowFileQueue().getBackPressureDataSizeThreshold());
             connStatus.setBackPressureObjectThreshold(conn.getFlowFileQueue().getBackPressureObjectThreshold());
+            connStatus.setTotalActiveQueuedDuration(conn.getFlowFileQueue().getTotalActiveQueuedDuration(now));
+            connStatus.setMaxActiveQueuedDuration(conn.getFlowFileQueue().getMaxActiveQueuedDuration(now));
 
             final FlowFileEvent connectionStatusReport = statusReport.getReportEntry(conn.getIdentifier());
             if (connectionStatusReport != null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
@@ -244,8 +244,9 @@ public abstract class AbstractEventAccess implements EventAccess {
             connStatus.setDestinationName(isDestinationAuthorized ? conn.getDestination().getName() : conn.getDestination().getIdentifier());
             connStatus.setBackPressureDataSizeThreshold(conn.getFlowFileQueue().getBackPressureDataSizeThreshold());
             connStatus.setBackPressureObjectThreshold(conn.getFlowFileQueue().getBackPressureObjectThreshold());
-            connStatus.setTotalActiveQueuedDuration(conn.getFlowFileQueue().getTotalActiveQueuedDuration(now));
-            connStatus.setMaxActiveQueuedDuration(conn.getFlowFileQueue().getMaxActiveQueuedDuration(now));
+            connStatus.setTotalQueuedDuration(conn.getFlowFileQueue().getTotalQueuedDuration(now));
+            long minLastQueueDate = conn.getFlowFileQueue().getMinLastQueueDate();
+            connStatus.setMaxQueuedDuration(now - minLastQueueDate != 0 ? minLastQueueDate : now);
 
             final FlowFileEvent connectionStatusReport = statusReport.getReportEntry(conn.getIdentifier());
             if (connectionStatusReport != null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FileSystemSwapManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FileSystemSwapManager.java
@@ -167,7 +167,7 @@ public class FileSystemSwapManager implements FlowFileSwapManager {
             warn("Cannot swap in FlowFiles from location " + swapLocation + " because the FlowFile Repository does not know about this Swap Location. " +
                 "This file should be manually removed. This typically occurs when a Swap File is written but the FlowFile Repository is not updated yet to reflect this. " +
                 "This is generally not a cause for concern, but may be indicative of a failure to update the FlowFile Repository.");
-            final SwapSummary swapSummary = new StandardSwapSummary(new QueueSize(0, 0), 0L, Collections.emptyList());
+            final SwapSummary swapSummary = new StandardSwapSummary(new QueueSize(0, 0), 0L, Collections.emptyList(), 0L, 0L);
             return new StandardSwapContents(swapSummary, Collections.emptyList());
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/StandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/StandardFlowFileQueue.java
@@ -162,6 +162,16 @@ public class StandardFlowFileQueue extends AbstractFlowFileQueue implements Flow
     }
 
     @Override
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return queue.getTotalActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        return queue.getMaxActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
     public boolean isEmpty() {
         return queue.getFlowFileQueueSize().isEmpty();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/StandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/StandardFlowFileQueue.java
@@ -162,13 +162,13 @@ public class StandardFlowFileQueue extends AbstractFlowFileQueue implements Flow
     }
 
     @Override
-    public long getTotalActiveQueuedDuration(long fromTimestamp) {
-        return queue.getTotalActiveQueuedDuration(fromTimestamp);
+    public long getTotalQueuedDuration(long fromTimestamp) {
+        return queue.getTotalQueuedDuration(fromTimestamp);
     }
 
     @Override
-    public long getMaxActiveQueuedDuration(long fromTimestamp) {
-        return queue.getMaxActiveQueuedDuration(fromTimestamp);
+    public long getMinLastQueueDate() {
+        return queue.getMinLastQueueDate();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
@@ -920,7 +921,14 @@ public class SwappablePriorityQueue {
         return new StandardSwapSummary(new QueueSize(swapFlowFileCount, swapByteCount), maxId, resourceClaims);
     }
 
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        // We want the oldest timestamp, which will be the min
+        return fromTimestamp - activeQueue.parallelStream().map(FlowFile::getLastQueueDate).filter(Objects::nonNull).min(Long::compareTo).orElse(fromTimestamp);
+    }
 
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return activeQueue.parallelStream().filter(flowFileRecord -> (flowFileRecord.getLastQueueDate() != null)).mapToLong(flowFileRecord -> fromTimestamp - flowFileRecord.getLastQueueDate()).sum();
+    }
 
     protected void incrementActiveQueueSize(final int count, final long bytes) {
         boolean updated = false;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
@@ -919,7 +919,7 @@ public class SwappablePriorityQueue {
 
                     // Update class member metrics
                     minQueueDateInSwapLocation.put(swapLocation, summary.getMinLastQueueDate());
-                    totalQueueDateInSwapLocation.put(swapLocation, summary.getMinLastQueueDate());
+                    totalQueueDateInSwapLocation.put(swapLocation, summary.getTotalLastQueueDate());
 
                     // Update metrics for this method's return value
                     if(minSwappedQueueDate == null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
@@ -537,16 +537,11 @@ public class SocketLoadBalancedFlowFileQueue extends AbstractFlowFileQueue imple
 
     @Override
     public long getMinLastQueueDate() {
-        boolean seen = false;
         long min = 0;
         for (QueuePartition queuePartition : queuePartitions) {
-            long minLastQueueDate = queuePartition.getMinLastQueueDate();
-            if (!seen || minLastQueueDate < min) {
-                seen = true;
-                min = minLastQueueDate;
-            }
+            min = min == 0 ? queuePartition.getMinLastQueueDate() : Long.min(min, queuePartition.getMinLastQueueDate());
         }
-        return seen ? min : 0L;
+        return min;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -511,6 +512,16 @@ public class SocketLoadBalancedFlowFileQueue extends AbstractFlowFileQueue imple
     @Override
     public QueueSize size() {
         return totalSize.get();
+    }
+
+    @Override
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return Arrays.stream(queuePartitions).mapToLong(queuePartition -> queuePartition.getTotalActiveQueuedDuration(fromTimestamp)).sum();
+    }
+
+    @Override
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        return Arrays.stream(queuePartitions).mapToLong(queuePartition -> queuePartition.getMaxActiveQueuedDuration(fromTimestamp)).max().orElse(0L);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/QueuePartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/QueuePartition.java
@@ -99,4 +99,16 @@ public interface QueuePartition {
      * @return the current size of the partition's queue
      */
     QueueSize size();
+
+    /**
+     * @param fromTimestamp The timestamp in miliiseconds from which to calculate durations. This will typically be the current timestamp.
+     * @return the sum in milliseconds of how long all FlowFiles within this queue have currently been in this queue.
+     */
+    long getTotalActiveQueuedDuration(long fromTimestamp);
+
+    /**
+     * @param fromTimestamp The timestamp in milliseconds from which to calculate durations. This will typically be the current timestamp.
+     * @return the maximum time in milliseconds that any FlowFile within this queue has been in this queue. If no Flowfile is enqueued, this returns 0.
+     */
+    long getMaxActiveQueuedDuration(long fromTimestamp);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/QueuePartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/QueuePartition.java
@@ -107,8 +107,7 @@ public interface QueuePartition {
     long getTotalActiveQueuedDuration(long fromTimestamp);
 
     /**
-     * @param fromTimestamp The timestamp in milliseconds from which to calculate durations. This will typically be the current timestamp.
-     * @return the maximum time in milliseconds that any FlowFile within this queue has been in this queue. If no Flowfile is enqueued, this returns 0.
+     * @return The minimum lastQueueDate in milliseconds of all FlowFiles currently enqueued. If no FlowFile is enqueued, this returns 0.
      */
-    long getMaxActiveQueuedDuration(long fromTimestamp);
+    long getMinLastQueueDate();
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/RemoteQueuePartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/RemoteQueuePartition.java
@@ -100,12 +100,12 @@ public class RemoteQueuePartition implements QueuePartition {
 
     @Override
     public long getTotalActiveQueuedDuration(long fromTimestamp) {
-        return priorityQueue.getTotalActiveQueuedDuration(fromTimestamp);
+        return priorityQueue.getTotalQueuedDuration(fromTimestamp);
     }
 
     @Override
-    public long getMaxActiveQueuedDuration(long fromTimestamp) {
-        return priorityQueue.getMaxActiveQueuedDuration(fromTimestamp);
+    public long getMinLastQueueDate() {
+        return priorityQueue.getMinLastQueueDate();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/RemoteQueuePartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/RemoteQueuePartition.java
@@ -99,6 +99,16 @@ public class RemoteQueuePartition implements QueuePartition {
     }
 
     @Override
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return priorityQueue.getTotalActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        return priorityQueue.getMaxActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
     public String getSwapPartitionName() {
         return nodeIdentifier.getId();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/StandardRebalancingPartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/StandardRebalancingPartition.java
@@ -68,6 +68,16 @@ public class StandardRebalancingPartition implements RebalancingPartition {
     }
 
     @Override
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return queue.getTotalActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        return queue.getMaxActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
     public SwapSummary recoverSwappedFlowFiles() {
         return this.queue.recoverSwappedFlowFiles();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/StandardRebalancingPartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/StandardRebalancingPartition.java
@@ -69,12 +69,12 @@ public class StandardRebalancingPartition implements RebalancingPartition {
 
     @Override
     public long getTotalActiveQueuedDuration(long fromTimestamp) {
-        return queue.getTotalActiveQueuedDuration(fromTimestamp);
+        return queue.getTotalQueuedDuration(fromTimestamp);
     }
 
     @Override
-    public long getMaxActiveQueuedDuration(long fromTimestamp) {
-        return queue.getMaxActiveQueuedDuration(fromTimestamp);
+    public long getMinLastQueueDate() {
+        return queue.getMinLastQueueDate();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/SwappablePriorityQueueLocalPartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/SwappablePriorityQueueLocalPartition.java
@@ -67,6 +67,16 @@ public class SwappablePriorityQueueLocalPartition implements LocalQueuePartition
     }
 
     @Override
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return priorityQueue.getTotalActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        return priorityQueue.getMaxActiveQueuedDuration(fromTimestamp);
+    }
+
+    @Override
     public boolean isUnacknowledgedFlowFile() {
         return priorityQueue.isUnacknowledgedFlowFile();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/SwappablePriorityQueueLocalPartition.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/SwappablePriorityQueueLocalPartition.java
@@ -68,12 +68,12 @@ public class SwappablePriorityQueueLocalPartition implements LocalQueuePartition
 
     @Override
     public long getTotalActiveQueuedDuration(long fromTimestamp) {
-        return priorityQueue.getTotalActiveQueuedDuration(fromTimestamp);
+        return priorityQueue.getTotalQueuedDuration(fromTimestamp);
     }
 
     @Override
-    public long getMaxActiveQueuedDuration(long fromTimestamp) {
-        return priorityQueue.getMaxActiveQueuedDuration(fromTimestamp);
+    public long getMinLastQueueDate() {
+        return priorityQueue.getMinLastQueueDate();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/ConnectionStatusDescriptor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/ConnectionStatusDescriptor.java
@@ -61,7 +61,21 @@ public enum ConnectionStatusDescriptor {
         "Queued Count",
         "The number of FlowFiles queued in this Connection",
         Formatter.COUNT,
-        s -> Long.valueOf(s.getQueuedCount()));
+        s -> Long.valueOf(s.getQueuedCount())),
+
+    TOTAL_QUEUED_DURATION(
+            "totalQueuedDuration",
+            "Total Queued Duration (5 mins)",
+            "The cumulative queued duration, in milliseconds, of all FlowFiles that were transferred to this Connection in the past 5 minutes",
+            Formatter.COUNT,
+            s -> Long.valueOf(s.getTotalQueuedDuration())),
+
+    MAX_QUEUED_DURATION(
+            "maxQueuedDuration",
+            "Max Queued Duration (5 mins)",
+            "The max queued duration, in milliseconds, of any FlowFile that was transferred to this Connection in the past 5 minutes",
+            Formatter.COUNT,
+            s -> Long.valueOf(s.getMaxQueuedDuration()));
 
 
     private MetricDescriptor<ConnectionStatus> descriptor;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SimpleSwapDeserializer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SimpleSwapDeserializer.java
@@ -104,7 +104,7 @@ public class SimpleSwapDeserializer implements SwapDeserializer {
             }
         } catch (final EOFException eof) {
             final QueueSize queueSize = new QueueSize(numRecords, contentSize);
-            final SwapSummary summary = new StandardSwapSummary(queueSize, maxRecordId, Collections.emptyList());
+            final SwapSummary summary = new StandardSwapSummary(queueSize, maxRecordId, Collections.emptyList(), 0L, 0L);
             final SwapContents partialContents = new StandardSwapContents(summary, Collections.emptyList());
             throw new IncompleteSwapFileException(swapLocation, partialContents);
         }
@@ -247,13 +247,13 @@ public class SimpleSwapDeserializer implements SwapDeserializer {
 
                 flowFiles.add(record);
             } catch (final EOFException eof) {
-                final SwapSummary swapSummary = new StandardSwapSummary(queueSize, maxId, resourceClaims);
+                final SwapSummary swapSummary = new StandardSwapSummary(queueSize, maxId, resourceClaims, 0L, 0L);
                 final SwapContents partialContents = new StandardSwapContents(swapSummary, flowFiles);
                 throw new IncompleteSwapFileException(location, partialContents);
             }
         }
 
-        final SwapSummary swapSummary = new StandardSwapSummary(queueSize, maxId, resourceClaims);
+        final SwapSummary swapSummary = new StandardSwapSummary(queueSize, maxId, resourceClaims, 0L, 0L);
         return new StandardSwapContents(swapSummary, flowFiles);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/StandardSwapSummary.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/StandardSwapSummary.java
@@ -25,16 +25,20 @@ import org.apache.nifi.controller.repository.SwapSummary;
 import org.apache.nifi.controller.repository.claim.ResourceClaim;
 
 public class StandardSwapSummary implements SwapSummary {
-    public static final SwapSummary EMPTY_SUMMARY = new StandardSwapSummary(new QueueSize(0, 0L), null, Collections.<ResourceClaim> emptyList());
+    public static final SwapSummary EMPTY_SUMMARY = new StandardSwapSummary(new QueueSize(0, 0L), null, Collections.<ResourceClaim> emptyList(), 0L, 0L);
 
     private final QueueSize queueSize;
     private final Long maxFlowFileId;
     private final List<ResourceClaim> resourceClaims;
+    private final Long minLastQueueDate;
+    private final Long totalLastQueueDate;
 
-    public StandardSwapSummary(final QueueSize queueSize, final Long maxFlowFileId, final List<ResourceClaim> resourceClaims) {
+    public StandardSwapSummary(final QueueSize queueSize, final Long maxFlowFileId, final List<ResourceClaim> resourceClaims, final Long minLastQueueDate, final Long totalLastQueueDate) {
         this.queueSize = queueSize;
         this.maxFlowFileId = maxFlowFileId;
         this.resourceClaims = Collections.unmodifiableList(resourceClaims);
+        this.minLastQueueDate = minLastQueueDate;
+        this.totalLastQueueDate = totalLastQueueDate;
     }
 
     @Override
@@ -51,4 +55,16 @@ public class StandardSwapSummary implements SwapSummary {
     public List<ResourceClaim> getResourceClaims() {
         return resourceClaims;
     }
+
+    @Override
+    public Long getMinLastQueueDate() {
+        return minLastQueueDate;
+    }
+
+    @Override
+    public Long getTotalLastQueueDate() {
+        return totalLastQueueDate;
+    }
+
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SwapSchema.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SwapSchema.java
@@ -40,6 +40,9 @@ public class SwapSchema {
     public static final RecordSchema SWAP_CONTENTS_SCHEMA_V2;
     public static final RecordSchema FULL_SWAP_FILE_SCHEMA_V2;
 
+    public static final RecordSchema SWAP_SUMMARY_SCHEMA_V3;
+    public static final RecordSchema FULL_SWAP_FILE_SCHEMA_V3;
+
     public static final String RESOURCE_CLAIMS = "Resource Claims";
     public static final String RESOURCE_CLAIM = "Resource Claim";
     public static final String RESOURCE_CLAIM_COUNT = "Claim Count";
@@ -48,6 +51,8 @@ public class SwapSchema {
     public static final String FLOWFILE_COUNT = "FlowFile Count";
     public static final String FLOWFILE_SIZE = "FlowFile Size";
     public static final String MAX_RECORD_ID = "Max Record ID";
+    public static final String MIN_LAST_QUEUE_DATE = "Min Last Queue Date";
+    public static final String TOTAL_LAST_QUEUE_DATE = "Total Last Queue Date";
     public static final String SWAP_SUMMARY = "Swap Summary";
     public static final String FLOWFILE_CONTENTS = "FlowFiles";
 
@@ -105,5 +110,33 @@ public class SwapSchema {
         fullSchemaFields.add(new ComplexRecordField(SWAP_SUMMARY, Repetition.EXACTLY_ONE, summaryFields));
         fullSchemaFields.add(new ComplexRecordField(FLOWFILE_CONTENTS, Repetition.ZERO_OR_MORE, FlowFileSchema.FLOWFILE_SCHEMA_V2.getFields()));
         FULL_SWAP_FILE_SCHEMA_V2 = new RecordSchema(fullSchemaFields);
+    }
+
+    static {
+        final RecordField queueIdentifier = new SimpleRecordField(QUEUE_IDENTIFIER, FieldType.STRING, Repetition.EXACTLY_ONE);
+        final RecordField flowFileCount = new SimpleRecordField(FLOWFILE_COUNT, FieldType.INT, Repetition.EXACTLY_ONE);
+        final RecordField flowFileSize = new SimpleRecordField(FLOWFILE_SIZE, FieldType.LONG, Repetition.EXACTLY_ONE);
+        final RecordField maxRecordId = new SimpleRecordField(MAX_RECORD_ID, FieldType.LONG, Repetition.EXACTLY_ONE);
+        final RecordField minLastQueueDate = new SimpleRecordField(MIN_LAST_QUEUE_DATE, FieldType.LONG, Repetition.EXACTLY_ONE);
+        final RecordField totalLastQueueDate = new SimpleRecordField(TOTAL_LAST_QUEUE_DATE, FieldType.LONG, Repetition.EXACTLY_ONE);
+
+        final RecordField resourceClaimField = new ComplexRecordField(RESOURCE_CLAIM, Repetition.EXACTLY_ONE, ContentClaimSchema.RESOURCE_CLAIM_SCHEMA_V1.getFields());
+        final RecordField claimCountField = new SimpleRecordField(RESOURCE_CLAIM_COUNT, FieldType.INT, Repetition.EXACTLY_ONE);
+        final RecordField resourceClaims = new MapRecordField(RESOURCE_CLAIMS, resourceClaimField, claimCountField, Repetition.EXACTLY_ONE);
+
+        final List<RecordField> summaryFields = new ArrayList<>();
+        summaryFields.add(queueIdentifier);
+        summaryFields.add(flowFileCount);
+        summaryFields.add(flowFileSize);
+        summaryFields.add(maxRecordId);
+        summaryFields.add(minLastQueueDate);
+        summaryFields.add(totalLastQueueDate);
+        summaryFields.add(resourceClaims);
+        SWAP_SUMMARY_SCHEMA_V3 = new RecordSchema(summaryFields);
+
+        final List<RecordField> fullSchemaFields = new ArrayList<>();
+        fullSchemaFields.add(new ComplexRecordField(SWAP_SUMMARY, Repetition.EXACTLY_ONE, summaryFields));
+        fullSchemaFields.add(new ComplexRecordField(FLOWFILE_CONTENTS, Repetition.ZERO_OR_MORE, FlowFileSchema.FLOWFILE_SCHEMA_V2.getFields()));
+        FULL_SWAP_FILE_SCHEMA_V3 = new RecordSchema(fullSchemaFields);
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SwapSummaryFieldMap.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SwapSummaryFieldMap.java
@@ -77,6 +77,10 @@ public class SwapSummaryFieldMap implements Record {
                 return queueIdentifier;
             case SwapSchema.RESOURCE_CLAIMS:
                 return claimCounts;
+            case SwapSchema.MIN_LAST_QUEUE_DATE:
+                return swapSummary.getMinLastQueueDate();
+            case SwapSchema.TOTAL_LAST_QUEUE_DATE:
+                return swapSummary.getTotalLastQueueDate();
         }
 
         return null;
@@ -86,6 +90,8 @@ public class SwapSummaryFieldMap implements Record {
     public static SwapSummary getSwapSummary(final Record record, final ResourceClaimManager claimManager) {
         final int flowFileCount = (Integer) record.getFieldValue(SwapSchema.FLOWFILE_COUNT);
         final long flowFileSize = (Long) record.getFieldValue(SwapSchema.FLOWFILE_SIZE);
+        final long minLastQueueDate = (Long) record.getFieldValue(SwapSchema.MIN_LAST_QUEUE_DATE);
+        final long totalLastQueueDate = (Long) record.getFieldValue(SwapSchema.TOTAL_LAST_QUEUE_DATE);
         final QueueSize queueSize = new QueueSize(flowFileCount, flowFileSize);
 
         final long maxFlowFileId = (Long) record.getFieldValue(SwapSchema.MAX_RECORD_ID);
@@ -101,6 +107,6 @@ public class SwapSummaryFieldMap implements Record {
             }
         }
 
-        return new StandardSwapSummary(queueSize, maxFlowFileId, resourceClaims);
+        return new StandardSwapSummary(queueSize, maxFlowFileId, resourceClaims, minLastQueueDate, totalLastQueueDate);
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SwapSummaryFieldMap.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/swap/SwapSummaryFieldMap.java
@@ -90,10 +90,21 @@ public class SwapSummaryFieldMap implements Record {
     public static SwapSummary getSwapSummary(final Record record, final ResourceClaimManager claimManager) {
         final int flowFileCount = (Integer) record.getFieldValue(SwapSchema.FLOWFILE_COUNT);
         final long flowFileSize = (Long) record.getFieldValue(SwapSchema.FLOWFILE_SIZE);
-        final long minLastQueueDate = (Long) record.getFieldValue(SwapSchema.MIN_LAST_QUEUE_DATE);
-        final long totalLastQueueDate = (Long) record.getFieldValue(SwapSchema.TOTAL_LAST_QUEUE_DATE);
-        final QueueSize queueSize = new QueueSize(flowFileCount, flowFileSize);
 
+        // In the event that min and totalLastQueueDate are null, set them to neutral values based on
+        // the current time.
+        Long minLastQueueDate = (Long) record.getFieldValue(SwapSchema.MIN_LAST_QUEUE_DATE);
+        long now = System.currentTimeMillis();
+        if(minLastQueueDate == null) {
+            minLastQueueDate = now;
+        }
+
+        Long totalLastQueueDate = (Long) record.getFieldValue(SwapSchema.TOTAL_LAST_QUEUE_DATE);
+        if(totalLastQueueDate == null) {
+            totalLastQueueDate = now * flowFileCount;
+        }
+
+        final QueueSize queueSize = new QueueSize(flowFileCount, flowFileSize);
         final long maxFlowFileId = (Long) record.getFieldValue(SwapSchema.MAX_RECORD_ID);
 
         final Map<Record, Integer> resourceClaimRecords = (Map<Record, Integer>) record.getFieldValue(SwapSchema.RESOURCE_CLAIMS);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockFlowFileRecord.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockFlowFileRecord.java
@@ -35,7 +35,7 @@ public class MockFlowFileRecord implements FlowFileRecord {
     private final Map<String, String> attributes;
     private final long size;
     private final ContentClaim contentClaim;
-    private Long lastQueuedDate;
+    private long lastQueuedDate = System.currentTimeMillis() + 1;
 
     public MockFlowFileRecord() {
         this(1L);
@@ -133,7 +133,7 @@ public class MockFlowFileRecord implements FlowFileRecord {
         return lastQueuedDate;
     }
 
-    public void setLastQueuedDate(Long lastQueuedDate) {
+    public void setLastQueuedDate(long lastQueuedDate) {
         this.lastQueuedDate = lastQueuedDate;
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockFlowFileRecord.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockFlowFileRecord.java
@@ -35,6 +35,7 @@ public class MockFlowFileRecord implements FlowFileRecord {
     private final Map<String, String> attributes;
     private final long size;
     private final ContentClaim contentClaim;
+    private Long lastQueuedDate;
 
     public MockFlowFileRecord() {
         this(1L);
@@ -83,11 +84,6 @@ public class MockFlowFileRecord implements FlowFileRecord {
     }
 
     @Override
-    public Long getLastQueueDate() {
-        return null;
-    }
-
-    @Override
     public boolean isPenalized() {
         return false;
     }
@@ -133,7 +129,16 @@ public class MockFlowFileRecord implements FlowFileRecord {
     }
 
     @Override
+    public Long getLastQueueDate() {
+        return lastQueuedDate;
+    }
+
+    public void setLastQueuedDate(Long lastQueuedDate) {
+        this.lastQueuedDate = lastQueuedDate;
+    }
+
+    @Override
     public long getQueueDateIndex() {
-        return 0;
+        return lastQueuedDate;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockSwapManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockSwapManager.java
@@ -146,6 +146,8 @@ public class MockSwapManager implements FlowFileSwapManager {
         int count = 0;
         long size = 0L;
         Long max = null;
+        Long minLastQueueDate = null;
+        Long totalLastQueueDate = 0L;
         final List<ResourceClaim> resourceClaims = new ArrayList<>();
         for (final FlowFileRecord flowFile : flowFiles) {
             count++;
@@ -154,12 +156,16 @@ public class MockSwapManager implements FlowFileSwapManager {
                 max = flowFile.getId();
             }
 
+            minLastQueueDate = minLastQueueDate == null ? flowFile.getLastQueueDate() : Long.min(minLastQueueDate, flowFile.getLastQueueDate());
+
+            totalLastQueueDate += flowFile.getLastQueueDate();
+
             if (flowFile.getContentClaim() != null) {
                 resourceClaims.add(flowFile.getContentClaim().getResourceClaim());
             }
         }
 
-        return new StandardSwapSummary(new QueueSize(count, size), max, resourceClaims);
+        return new StandardSwapSummary(new QueueSize(count, size), max, resourceClaims, minLastQueueDate, totalLastQueueDate);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
@@ -81,7 +81,7 @@ public class TestFileSystemSwapManager {
         Mockito.doThrow(new IOException("Intentional IOException for unit test"))
             .when(flowFileRepo).updateRepository(anyCollection());
 
-        final FileSystemSwapManager swapManager = createSwapManager();
+        final FileSystemSwapManager swapManager = createSwapManager(flowFileRepo);
 
         final List<FlowFileRecord> flowFileRecords = new ArrayList<>();
         for (int i=0; i < 10000; i++) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -79,7 +80,7 @@ public class TestFileSystemSwapManager {
 
         final FlowFileRepository flowFileRepo = Mockito.mock(FlowFileRepository.class);
         Mockito.doThrow(new IOException("Intentional IOException for unit test"))
-            .when(flowFileRepo).updateRepository(anyCollection());
+            .when(flowFileRepo).swapFlowFilesOut(any(), any(), any());
 
         final FileSystemSwapManager swapManager = createSwapManager(flowFileRepo);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
@@ -45,7 +45,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestFileSystemSwapManager.java
@@ -26,7 +26,9 @@ import org.apache.nifi.controller.repository.claim.ResourceClaimManager;
 import org.apache.nifi.events.EventReporter;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import java.io.BufferedInputStream;
@@ -146,13 +148,16 @@ public class TestFileSystemSwapManager {
         assertEquals(10000, contents.getFlowFiles().size());
     }
 
-    private FileSystemSwapManager createSwapManager() {
+    private FileSystemSwapManager createSwapManager() throws IOException {
         final FlowFileRepository flowFileRepo = Mockito.mock(FlowFileRepository.class);
         return createSwapManager(flowFileRepo);
     }
 
-    private FileSystemSwapManager createSwapManager(final FlowFileRepository flowFileRepo) {
-        final FileSystemSwapManager swapManager = new FileSystemSwapManager();
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private FileSystemSwapManager createSwapManager(final FlowFileRepository flowFileRepo) throws IOException {
+        final FileSystemSwapManager swapManager = new FileSystemSwapManager(temporaryFolder.newFolder().toPath());
         final ResourceClaimManager resourceClaimManager = new NopResourceClaimManager();
         swapManager.initialize(new SwapManagerInitializationContext() {
             @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -604,6 +604,40 @@ public class TestStandardFlowFileQueue {
         assertTrue(swapManager.swappedOut.isEmpty());
     }
 
+    @Test
+    public void testGetTotalActiveQueuedDuration() {
+        long now = System.currentTimeMillis();
+        MockFlowFileRecord testFlowfile1 = new MockFlowFileRecord();
+        testFlowfile1.setLastQueuedDate(now - 500);
+        MockFlowFileRecord testFlowfile2 = new MockFlowFileRecord();
+        testFlowfile2.setLastQueuedDate(now - 1000);
+
+        queue.put(testFlowfile1);
+        queue.put(testFlowfile2);
+
+        assertEquals(1500, queue.getTotalActiveQueuedDuration(now));
+        queue.poll(1, Collections.emptySet());
+
+        assertEquals(1000, queue.getTotalActiveQueuedDuration(now));
+    }
+
+    @Test
+    public void testGetMaxActiveQueuedDuration() {
+        long now = System.currentTimeMillis();
+        MockFlowFileRecord testFlowfile1 = new MockFlowFileRecord();
+        testFlowfile1.setLastQueuedDate(now - 1000);
+        MockFlowFileRecord testFlowfile2 = new MockFlowFileRecord();
+        testFlowfile2.setLastQueuedDate(now - 500);
+
+        queue.put(testFlowfile1);
+        queue.put(testFlowfile2);
+
+        assertEquals(1000, queue.getMaxActiveQueuedDuration(now));
+        queue.poll(1, Collections.emptySet());
+
+        assertEquals(500, queue.getMaxActiveQueuedDuration(now));
+    }
+
 
     private static class FlowFileSizePrioritizer implements FlowFilePrioritizer {
         @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -615,14 +615,14 @@ public class TestStandardFlowFileQueue {
         queue.put(testFlowfile1);
         queue.put(testFlowfile2);
 
-        assertEquals(1500, queue.getTotalActiveQueuedDuration(now));
+        assertEquals(1500, queue.getTotalQueuedDuration(now));
         queue.poll(1, Collections.emptySet());
 
-        assertEquals(1000, queue.getTotalActiveQueuedDuration(now));
+        assertEquals(1000, queue.getTotalQueuedDuration(now));
     }
 
     @Test
-    public void testGetMaxActiveQueuedDuration() {
+    public void testGetMinLastQueueDate() {
         long now = System.currentTimeMillis();
         MockFlowFileRecord testFlowfile1 = new MockFlowFileRecord();
         testFlowfile1.setLastQueuedDate(now - 1000);
@@ -632,10 +632,10 @@ public class TestStandardFlowFileQueue {
         queue.put(testFlowfile1);
         queue.put(testFlowfile2);
 
-        assertEquals(1000, queue.getMaxActiveQueuedDuration(now));
+        assertEquals(1000, now - queue.getMinLastQueueDate());
         queue.poll(1, Collections.emptySet());
 
-        assertEquals(500, queue.getMaxActiveQueuedDuration(now));
+        assertEquals(500, now - queue.getMinLastQueueDate());
     }
 
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestRocksDBFlowFileRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestRocksDBFlowFileRepository.java
@@ -786,7 +786,7 @@ public class TestRocksDBFlowFileRepository {
                 }
             }
 
-            return new StandardSwapSummary(new QueueSize(records.size(), size), maxId, resourceClaims);
+            return new StandardSwapSummary(new QueueSize(records.size(), size), maxId, resourceClaims, 0L, 0L);
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestWriteAheadFlowFileRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestWriteAheadFlowFileRepository.java
@@ -173,6 +173,16 @@ public class TestWriteAheadFlowFileRepository {
             }
 
             @Override
+            public long getTotalActiveQueuedDuration(long fromTimestamp) {
+                return 0;
+            }
+
+            @Override
+            public long getMaxActiveQueuedDuration(long fromTimestamp) {
+                return 0;
+            }
+
+            @Override
             public boolean isEmpty() {
                 return false;
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestWriteAheadFlowFileRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestWriteAheadFlowFileRepository.java
@@ -173,12 +173,12 @@ public class TestWriteAheadFlowFileRepository {
             }
 
             @Override
-            public long getTotalActiveQueuedDuration(long fromTimestamp) {
+            public long getTotalQueuedDuration(long fromTimestamp) {
                 return 0;
             }
 
             @Override
-            public long getMaxActiveQueuedDuration(long fromTimestamp) {
+            public long getMinLastQueueDate() {
                 return 0;
             }
 
@@ -773,7 +773,7 @@ public class TestWriteAheadFlowFileRepository {
                 }
             }
 
-            return new StandardSwapSummary(new QueueSize(records.size(), size), maxId, resourceClaims);
+            return new StandardSwapSummary(new QueueSize(records.size(), size), maxId, resourceClaims, 0L, 0L);
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/swap/MockFlowFile.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/swap/MockFlowFile.java
@@ -34,7 +34,7 @@ public class MockFlowFile implements FlowFileRecord {
 
     private final long id;
     private final long entryDate = System.currentTimeMillis();
-    private final long lastQueueDate = System.currentTimeMillis();
+    private final long lastQueueDate = System.currentTimeMillis() + 1;
     private final Map<String, String> attributes;
     private final long size;
     private final ContentClaim contentClaim;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/swap/TestSchemaSwapSerializerDeserializer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/swap/TestSchemaSwapSerializerDeserializer.java
@@ -47,6 +47,7 @@ import org.apache.nifi.controller.repository.claim.ContentClaim;
 import org.apache.nifi.controller.repository.claim.ResourceClaim;
 import org.apache.nifi.controller.repository.claim.ResourceClaimManager;
 import org.apache.nifi.controller.repository.claim.StandardResourceClaimManager;
+import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.stream.io.NullOutputStream;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -108,6 +109,9 @@ public class TestSchemaSwapSerializerDeserializer {
 
         final Set<ResourceClaim> uniqueClaims = new HashSet<>(resourceClaims);
         assertEquals(9999, uniqueClaims.size());
+
+        assertEquals((Long)toSwap.stream().mapToLong(FlowFile::getLastQueueDate).sum(), swapSummary.getTotalLastQueueDate());
+        assertEquals((Long)toSwap.stream().mapToLong(FlowFile::getLastQueueDate).min().getAsLong(), swapSummary.getMinLastQueueDate());
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/queue/StatelessFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/queue/StatelessFlowFileQueue.java
@@ -99,6 +99,16 @@ public class StatelessFlowFileQueue implements DrainableFlowFileQueue {
     }
 
     @Override
+    public long getTotalActiveQueuedDuration(long fromTimestamp) {
+        return flowFiles.parallelStream().mapToLong(flowFileRecord -> fromTimestamp - flowFileRecord.getLastQueueDate()).sum();
+    }
+
+    @Override
+    public long getMaxActiveQueuedDuration(long fromTimestamp) {
+        return fromTimestamp - flowFiles.parallelStream().mapToLong(FlowFileRecord::getLastQueueDate).min().orElse(fromTimestamp);
+    }
+
+    @Override
     public boolean isEmpty() {
         return flowFiles.isEmpty() && unacknowledgedCount.get() == 0;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/queue/StatelessFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/queue/StatelessFlowFileQueue.java
@@ -110,16 +110,11 @@ public class StatelessFlowFileQueue implements DrainableFlowFileQueue {
 
     @Override
     public long getMinLastQueueDate() {
-        boolean seen = false;
         long min = 0;
         for (FlowFileRecord flowFile : flowFiles) {
-            long lastQueueDate = flowFile.getLastQueueDate();
-            if (!seen || lastQueueDate < min) {
-                seen = true;
-                min = lastQueueDate;
-            }
+            min = min == 0 ? flowFile.getLastQueueDate() : Long.min(min, flowFile.getLastQueueDate());
         }
-        return seen ? min : 0L;
+        return min;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/queue/StatelessFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/queue/StatelessFlowFileQueue.java
@@ -99,13 +99,27 @@ public class StatelessFlowFileQueue implements DrainableFlowFileQueue {
     }
 
     @Override
-    public long getTotalActiveQueuedDuration(long fromTimestamp) {
-        return flowFiles.parallelStream().mapToLong(flowFileRecord -> fromTimestamp - flowFileRecord.getLastQueueDate()).sum();
+    public long getTotalQueuedDuration(long fromTimestamp) {
+        long sum = 0L;
+        for (FlowFileRecord flowFileRecord : flowFiles) {
+            long l = fromTimestamp - flowFileRecord.getLastQueueDate();
+            sum += l;
+        }
+        return sum;
     }
 
     @Override
-    public long getMaxActiveQueuedDuration(long fromTimestamp) {
-        return fromTimestamp - flowFiles.parallelStream().mapToLong(FlowFileRecord::getLastQueueDate).min().orElse(fromTimestamp);
+    public long getMinLastQueueDate() {
+        boolean seen = false;
+        long min = 0;
+        for (FlowFileRecord flowFile : flowFiles) {
+            long lastQueueDate = flowFile.getLastQueueDate();
+            if (!seen || lastQueueDate < min) {
+                seen = true;
+                min = lastQueueDate;
+            }
+        }
+        return seen ? min : 0L;
     }
 
     @Override


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Adds total queued duration and max queued duration for ConnectionStatus objects based on the active portion of each FlowFileQueue per NIFI-8126. This allows these metrics to be exposed to ReportingTasks.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message? Yes, NIFI-8126

- [X ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? N/A
- [X] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`? N/A
- [X] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`? N/A
- [X] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties? N/A

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered? N/A

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
