### PR TITLE
NIFI-8198: ConsumeAMQP detects if Queue is deleted on server

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPConsumer.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPConsumer.java
@@ -68,6 +68,16 @@ final class AMQPConsumer extends AMQPWorker {
                     Thread.currentThread().interrupt();
                 }
             }
+
+            @Override
+            public void handleCancel(String consumerTag) throws IOException {
+                processorLog.error("Consumer has been cancelled by the broker, eg. due to deleted queue.");
+                try {
+                    close();
+                } catch (Exception e) {
+                    processorLog.error("Failed to close consumer.", e);
+                }
+            }
         };
 
         channel.basicConsume(queueName, autoAcknowledge, consumer);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -17,8 +17,10 @@
 package org.apache.nifi.amqp.processors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -58,6 +60,21 @@ public class AMQPConsumerTest {
         consumer.close();
 
         assertEquals(0, consumer.getResponseQueueSize());
+    }
+
+    @Test
+    public void testConsumerHandlesCancelling() throws IOException {
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1", "queue2"));
+        final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
+
+        final TestConnection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
+        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, processorLog);
+
+        assertFalse(consumer.closed);
+
+        consumer.getChannel().basicCancel("queue1");
+
+        assertTrue(consumer.closed);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/TestChannel.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/TestChannel.java
@@ -548,8 +548,10 @@ class TestChannel implements Channel {
 
     @Override
     public void basicCancel(String consumerTag) throws IOException {
-        throw new UnsupportedOperationException("This method is not currently supported as it is not used by current API in testing");
-
+        // consumerMap is indexed by queue name so the passed in consumerTag parameter needs to be the name of the test queue
+        for (Consumer consumer: consumerMap.get(consumerTag)) {
+            consumer.handleCancel(consumerTag);
+        }
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NIFI-8198

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
