### PR TITLE
NIFI-5535 NIFI-4713 - Change metric tagging in DataDogReportingTask

### DIFF
--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DDMetricRegistryBuilder.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DDMetricRegistryBuilder.java
@@ -34,18 +34,12 @@ public class DDMetricRegistryBuilder {
 
 
     private MetricRegistry metricRegistry = null;
-    private List<String> tags = Arrays.asList();
     private DatadogReporter datadogReporter;
     private String apiKey = "";
     private Transport transport;
 
     public DDMetricRegistryBuilder setMetricRegistry(MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
-        return this;
-    }
-
-    public DDMetricRegistryBuilder setTags(List<String> tags) {
-        this.tags = tags;
         return this;
     }
 
@@ -86,7 +80,6 @@ public class DDMetricRegistryBuilder {
                 DatadogReporter.forRegistry(metricRegistry)
                         .withHost(InetAddress.getLocalHost().getHostName())
                         .withTransport(transport)
-                        .withTags(tags)
                         .build();
         return reporter;
     }

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DDMetricRegistryBuilder.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DDMetricRegistryBuilder.java
@@ -24,8 +24,6 @@ import org.coursera.metrics.datadog.transport.UdpTransport;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Class configures MetricRegistry (passed outside or created from scratch) with Datadog support

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DataDogReportingTask.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DataDogReportingTask.java
@@ -18,7 +18,6 @@ package org.apache.nifi.reporting.datadog;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AtomicDouble;

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DataDogReportingTask.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/DataDogReportingTask.java
@@ -114,8 +114,7 @@ public class DataDogReportingTask extends AbstractReportingTask {
         metricsPrefix = METRICS_PREFIX.getDefaultValue();
         environment = ENVIRONMENT.getDefaultValue();
         virtualMachineMetrics = JmxJvmMetrics.getInstance();
-        ddMetricRegistryBuilder.setMetricRegistry(metricRegistry)
-                .setTags(metricsService.getAllTagsList());
+        ddMetricRegistryBuilder.setMetricRegistry(metricRegistry);
     }
 
     @Override
@@ -145,9 +144,9 @@ public class DataDogReportingTask extends AbstractReportingTask {
         ddMetricRegistryBuilder.getDatadogReporter().report();
     }
 
-    protected void updateMetrics(Map<String, Double> metrics, Optional<String> processorName, Map<String, String> tags) {
+    protected void updateMetrics(Map<String, Double> metrics, Map<String, String> tags) {
         for (Map.Entry<String, Double> entry : metrics.entrySet()) {
-            final String metricName = buildMetricName(processorName, entry.getKey());
+            final String metricName = buildMetricName(entry.getKey());
             logger.debug(metricName + ": " + entry.getValue());
             //if metric is not registered yet - register it
             if (!metricsMap.containsKey(metricName)) {
@@ -163,37 +162,31 @@ public class DataDogReportingTask extends AbstractReportingTask {
         final List<ProcessorStatus> processorStatuses = new ArrayList<>();
         populateProcessorStatuses(processGroupStatus, processorStatuses);
         for (final ProcessorStatus processorStatus : processorStatuses) {
-            updateMetrics(metricsService.getProcessorMetrics(processorStatus),
-                    Optional.of(processorStatus.getName()), defaultTags);
+            final Map<String, String> processorTags = new HashMap<>(defaultTags);
+            processorTags.putAll(metricsService.getProcessorTags(processorStatus));
+            updateMetrics(metricsService.getProcessorMetrics(processorStatus), processorTags);
         }
 
         final List<ConnectionStatus> connectionStatuses = new ArrayList<>();
         populateConnectionStatuses(processGroupStatus, connectionStatuses);
         for (ConnectionStatus connectionStatus: connectionStatuses) {
-            Map<String, String> connectionStatusTags = new HashMap<>(defaultTags);
-            connectionStatusTags.putAll(metricsService.getConnectionStatusTags(connectionStatus));
-            updateMetrics(metricsService.getConnectionStatusMetrics(connectionStatus), Optional.<String>absent(), connectionStatusTags);
+            updateMetrics(metricsService.getConnectionStatusMetrics(connectionStatus), defaultTags);
         }
 
         final List<PortStatus> inputPortStatuses = new ArrayList<>();
         populateInputPortStatuses(processGroupStatus, inputPortStatuses);
         for (PortStatus portStatus: inputPortStatuses) {
-            Map<String, String> portTags = new HashMap<>(defaultTags);
-            portTags.putAll(metricsService.getPortStatusTags(portStatus));
-            updateMetrics(metricsService.getPortStatusMetrics(portStatus), Optional.<String>absent(), portTags);
+            updateMetrics(metricsService.getPortStatusMetrics(portStatus), defaultTags);
         }
 
         final List<PortStatus> outputPortStatuses = new ArrayList<>();
         populateOutputPortStatuses(processGroupStatus, outputPortStatuses);
         for (PortStatus portStatus: outputPortStatuses) {
-            Map<String, String> portTags = new HashMap<>(defaultTags);
-            portTags.putAll(metricsService.getPortStatusTags(portStatus));
-            updateMetrics(metricsService.getPortStatusMetrics(portStatus), Optional.<String>absent(), portTags);
+            updateMetrics(metricsService.getPortStatusMetrics(portStatus), defaultTags);
         }
 
-        updateMetrics(metricsService.getJVMMetrics(virtualMachineMetrics),
-                Optional.<String>absent(), defaultTags);
-        updateMetrics(metricsService.getDataFlowMetrics(processGroupStatus), Optional.<String>absent(), defaultTags);
+        updateMetrics(metricsService.getJVMMetrics(virtualMachineMetrics), defaultTags);
+        updateMetrics(metricsService.getDataFlowMetrics(processGroupStatus), defaultTags);
     }
 
     private class MetricGauge implements Gauge, DynamicTagsCallback {
@@ -258,8 +251,8 @@ public class DataDogReportingTask extends AbstractReportingTask {
         }
     }
 
-    private String buildMetricName(Optional<String> processorName, String metricName) {
-        return metricsPrefix + "." + processorName.or("flow") + "." + metricName;
+    private String buildMetricName(String metricName) {
+        return metricsPrefix + "." + metricName;
     }
 
     protected MetricsService getMetricsService() {

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/metrics/MetricNames.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/metrics/MetricNames.java
@@ -57,18 +57,4 @@ public interface MetricNames {
     //Connection status metrics
     String QUEUED_COUNT = "QueuedCount";
     String QUEUED_BYTES = "QueuedBytes";
-
-    //Port status tags
-    String PORT_ID = "port-id";
-    String PORT_GROUP_ID = "port-group-id";
-    String PORT_NAME = "port-name";
-
-    //Connection status tags
-    String CONNECTION_ID = "connection-id";
-    String CONNECTION_GROUP_ID = "connection-group-id";
-    String CONNECTION_NAME = "connection-name";
-    String CONNECTION_SOURCE_ID = "connection-source-id";
-    String CONNECTION_SOURCE_NAME = "connection-source-name";
-    String CONNECTION_DESTINATION_ID = "connection-destination-id";
-    String CONNECTTION_DESTINATION_NAME = "connection-destination-name";
 }

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/metrics/MetricsService.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/metrics/MetricsService.java
@@ -46,6 +46,12 @@ public class MetricsService {
         return metrics;
     }
 
+    public Map<String, String> getProcessorTags(ProcessorStatus status) {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("processor", status.getName());
+        return tags;
+    }
+
     public Map<String, Double> getPortStatusMetrics(PortStatus status){
         final Map<String, Double> metrics = new HashMap<>();
         metrics.put(MetricNames.ACTIVE_THREADS, new Double(status.getActiveThreadCount()));
@@ -58,26 +64,6 @@ public class MetricsService {
         metrics.put(MetricNames.BYTES_RECEIVED, new Double(status.getBytesReceived()));
         metrics.put(MetricNames.BYTES_SENT, new Double(status.getBytesSent()));
         return metrics;
-    }
-
-    public Map<String,String> getPortStatusTags(PortStatus status) {
-        final Map<String, String> portTags = new HashMap<>();
-        portTags.put(MetricNames.PORT_ID, status.getId());
-        portTags.put(MetricNames.PORT_GROUP_ID, status.getGroupId());
-        portTags.put(MetricNames.PORT_NAME, status.getName());
-        return portTags;
-    }
-
-    public Map<String,String> getConnectionStatusTags(ConnectionStatus status) {
-        final Map<String, String> connectionTags = new HashMap<>();
-        connectionTags.put(MetricNames.CONNECTION_ID, status.getId());
-        connectionTags.put(MetricNames.CONNECTION_NAME, status.getName());
-        connectionTags.put(MetricNames.CONNECTION_GROUP_ID, status.getGroupId());
-        connectionTags.put(MetricNames.CONNECTION_DESTINATION_ID, status.getDestinationId());
-        connectionTags.put(MetricNames.CONNECTTION_DESTINATION_NAME, status.getDestinationName());
-        connectionTags.put(MetricNames.CONNECTION_SOURCE_ID, status.getSourceId());
-        connectionTags.put(MetricNames.CONNECTION_SOURCE_NAME, status.getSourceName());
-        return connectionTags;
     }
 
     public Map<String, Double> getConnectionStatusMetrics(ConnectionStatus status) {
@@ -107,23 +93,6 @@ public class MetricsService {
         metrics.put(MetricNames.TOTAL_TASK_DURATION, new Double(calculateProcessingNanos(status)));
         status.getOutputPortStatus();
         return metrics;
-    }
-
-    public List<String> getAllTagsList() {
-        List<String> tagsList = new ArrayList<>();
-        tagsList.add("env");
-        tagsList.add("dataflow_id");
-        tagsList.add(MetricNames.PORT_ID);
-        tagsList.add(MetricNames.PORT_NAME);
-        tagsList.add(MetricNames.PORT_GROUP_ID);
-        tagsList.add(MetricNames.CONNECTION_ID);
-        tagsList.add(MetricNames.CONNECTION_NAME);
-        tagsList.add(MetricNames.CONNECTION_GROUP_ID);
-        tagsList.add(MetricNames.CONNECTION_SOURCE_ID);
-        tagsList.add(MetricNames.CONNECTION_SOURCE_NAME);
-        tagsList.add(MetricNames.CONNECTION_DESTINATION_ID);
-        tagsList.add(MetricNames.CONNECTTION_DESTINATION_NAME);
-        return tagsList;
     }
 
     //virtual machine metrics

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/metrics/MetricsService.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/main/java/org/apache/nifi/reporting/datadog/metrics/MetricsService.java
@@ -23,9 +23,7 @@ import org.apache.nifi.controller.status.ProcessorStatus;
 import org.apache.nifi.metrics.jvm.JmxJvmMetrics;
 import org.apache.nifi.processor.DataUnit;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
@@ -119,13 +119,13 @@ public class TestDataDogReportingTask {
         DataDogReportingTask dataDogReportingTask = new TestableDataDogReportingTask();
         dataDogReportingTask.initialize(initContext);
         dataDogReportingTask.setup(configurationContext);
-        dataDogReportingTask.updateMetrics(processorMetrics, Optional.of("sampleProcessor"), tagsMap);
+        dataDogReportingTask.updateMetrics(processorMetrics, tagsMap);
 
-        verify(metricRegistry).register(eq("nifi.sampleProcessor.FlowFilesReceivedLast5Minutes"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.sampleProcessor.ActiveThreads"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.sampleProcessor.BytesWrittenLast5Minutes"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.sampleProcessor.BytesReadLast5Minutes"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.sampleProcessor.FlowFilesSentLast5Minutes"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.FlowFilesReceivedLast5Minutes"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.ActiveThreads"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.BytesWrittenLast5Minutes"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.BytesReadLast5Minutes"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.FlowFilesSentLast5Minutes"), Mockito.<Gauge>any());
     }
 
     //test updating JMV metrics
@@ -139,17 +139,17 @@ public class TestDataDogReportingTask {
         dataDogReportingTask.initialize(initContext);
         dataDogReportingTask.setup(configurationContext);
 
-        dataDogReportingTask.updateMetrics(processorMetrics, Optional.<String>absent(), tagsMap);
-        verify(metricRegistry).register(eq("nifi.flow.jvm.heap_usage"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.thread_count"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.thread_states.terminated"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.heap_used"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.thread_states.runnable"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.thread_states.timed_waiting"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.uptime"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.daemon_thread_count"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.file_descriptor_usage"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.flow.jvm.thread_states.blocked"), Mockito.<Gauge>any());
+        dataDogReportingTask.updateMetrics(processorMetrics, tagsMap);
+        verify(metricRegistry).register(eq("nifi.jvm.heap_usage"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_count"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.terminated"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.heap_used"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.runnable"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.timed_waiting"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.uptime"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.daemon_thread_count"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.file_descriptor_usage"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.blocked"), Mockito.<Gauge>any());
     }
 
 

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
@@ -18,7 +18,6 @@ package org.apache.nifi.reporting.datadog;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AtomicDouble;
 import org.apache.nifi.controller.ConfigurationContext;


### PR DESCRIPTION
#### Description of PR

This continues #4637, copying the description:

This resolves a few pain points related to the `DataDogReportingTask` that we've been hearing from customers, tracked in the following tickets:

* [NIFI-4713](https://issues.apache.org/jira/browse/NIFI-4713) - Processor name shouldn't be embedded into metric name
* [NIFI-5535](https://issues.apache.org/jira/browse/NIFI-5535) - Reporting task generates too many custom metrics (due to metric names and tags)

This PR contains the following changes (unchecked items still TODO):

* [x]  Remove all tags from metrics except from `env` (for all metrics) and `processor` (for processor metrics only).
* [x]  Drop the processor name from the name of metrics (eg `nifi.exampleProcessor.FlowFilesReceivedLast5Minutes` -> `nifi.FlowFilesReceivedLast5Minutes`, and `nifi.flow.ActiveThreads` -> `nifi.ActiveThreads`) and submit it as a tag

These changes are so that the `DataDogReporting` task plays better with Datadog, in particular:

* Allow users to use native functionality allowed by tagging, such as filtering, grouping, etc.
* Remove drastically the amount of `metric x tags` possible values, in order to reduce the number of custom metrics this reporting task generates. Now number of custom metrics is `23 + 6 * num_processors`, instead of potentially thousands or more.

**Note**: a natural follow-up to this PR would be to implement a configuration mechanism so that users have better control on what groups of metrics they'd like to collect. These groups would probably be: `processors`, `connection_statuses`, `input_port_statuses`, `output_port_statuses`, `jvm`, and `data_flow`. This has been requested in both NIFI-4713 and NIFI-5535, and would allow users to reduce even more the number of custom metrics so that only what they need is pushed to Datadog. This is completely orthogonal to what this PR focuses on: it won't require any changes to the metric names, values, or tags. So I'm keeping this for a follow-up PR.

### For all changes:
* [x]  Is there a JIRA ticket associated with this PR? Is it referenced
  in the commit message?
* [x]  Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character. (**Note**: this is related to two JIRA tickets so I've included both in the commit message and PR title.)
* [x]  Has your PR been rebased against the latest commit within the target branch (typically `main`)?
* [x]  Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
* [x]  Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
* [x]  Have you written or updated unit tests to verify your changes?
* [x]  Have you verified that the full build is successful on JDK 8?
* [x]  Have you verified that the full build is successful on JDK 11?
* [x]  ~If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?~ - Not applicable
* [x]  ~If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?~ - Not applicable
* [x]  ~If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?~ - Not applicable
* [x]  ~If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?~ - Not applicable

### For documentation related changes:
* [x]  ~Have you ensured that format looks appropriate for the output in which it is rendered?~ - Not applicable