### PR TITLE
NIFI-8304 Reduced test Jetty Server QueuedThreadPool to 8 threads

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-web-test-utils/src/main/java/org/apache/nifi/web/util/JettyServerUtils.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-web-test-utils/src/main/java/org/apache/nifi/web/util/JettyServerUtils.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import javax.net.ssl.SSLContext;
 
@@ -31,8 +32,11 @@ public class JettyServerUtils {
 
     private static final long SERVER_START_SLEEP = 100L;
 
+    private static final int MAXIMUM_THREADS = 8;
+
     public static Server createServer(final int port, final SSLContext sslContext, final ClientAuth clientAuth) {
-        final Server server = new Server();
+        final QueuedThreadPool threadPool = new QueuedThreadPool(MAXIMUM_THREADS);
+        final Server server = new Server(threadPool);
 
         final ServerConnector connector;
         if (sslContext == null) {


### PR DESCRIPTION
#### Description of PR

NIFI-8304 Introduces a configured QueuedThreadPool with a maximum of eight threads for running unit tests for InvokeHTTP.  Multiple executions of the GitHub CI runner on JDK 11 succeeded after this change, as opposed to a number of recent failures in the SSL versions of the InvokeHTTP unit tests.  The default minimum number of threads for Jetty is eight, so this change brings the maximum number in line with the minimum, reducing it from the default value of 200.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
