### PR TITLE
NIFI-8306: Support toLong standalone function in RecordPath expressions

### DIFF
--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/ToLong.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/ToLong.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.record.path.functions;
+
+
+import org.apache.nifi.record.path.FieldValue;
+import org.apache.nifi.record.path.RecordPathEvaluationContext;
+import org.apache.nifi.record.path.StandardFieldValue;
+import org.apache.nifi.record.path.paths.RecordPathSegment;
+import org.apache.nifi.record.path.util.RecordPathUtils;
+import org.apache.nifi.serialization.record.util.DataTypeUtils;
+
+import java.util.Date;
+import java.util.stream.Stream;
+
+public class ToLong extends RecordPathSegment {
+
+    private final RecordPathSegment recordPath;
+
+    public ToLong(final RecordPathSegment recordPath, final boolean absolute) {
+        super("toLong", null, absolute);
+        this.recordPath = recordPath;
+    }
+
+    @Override
+    public Stream<FieldValue> evaluate(RecordPathEvaluationContext context) {
+        final Stream<FieldValue> fieldValues = recordPath.evaluate(context);
+        return fieldValues.filter(fv -> fv.getValue() != null)
+                .map(fv -> {
+
+                    if (!(fv.getValue() instanceof String) && !(fv.getValue() instanceof Date) && !(fv.getValue() instanceof Number)) {
+                        return fv;
+                    }
+
+                    final Long longValue;
+                    try {
+                        longValue = DataTypeUtils.toLong(fv.getValue(), fv.getField().getFieldName());
+                    } catch (final Exception e) {
+                        return fv;
+                    }
+
+                    if (longValue == null) {
+                        return fv;
+                    }
+
+                    return new StandardFieldValue(longValue, fv.getField(), fv.getParent().orElse(null));
+                });
+    }
+
+}

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
@@ -56,6 +56,7 @@ import org.apache.nifi.record.path.functions.ToBytes;
 import org.apache.nifi.record.path.functions.ToDate;
 import org.apache.nifi.record.path.functions.ToLowerCase;
 import org.apache.nifi.record.path.functions.ToString;
+import org.apache.nifi.record.path.functions.ToLong;
 import org.apache.nifi.record.path.functions.ToUpperCase;
 import org.apache.nifi.record.path.functions.TrimString;
 import org.apache.nifi.record.path.functions.UUID5;
@@ -288,6 +289,10 @@ public class RecordPathCompiler {
                     case "toBytes": {
                         final RecordPathSegment[] args = getArgPaths(argumentListTree, 2, functionName, absolute);
                         return new ToBytes(args[0], args[1], absolute);
+                    }
+                    case "toLong": {
+                        final RecordPathSegment[] args = getArgPaths(argumentListTree, 1, functionName, absolute);
+                        return new ToLong(args[0], absolute);
                     }
                     case "format": {
                         final int numArgs = argumentListTree.getChildCount();

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -1577,6 +1577,37 @@ public class TestRecordPath {
     }
 
     @Test
+    public void testToLongFromString() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("s", RecordFieldType.STRING.getDataType()));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final Map<String, Object> values = new HashMap<>();
+        values.put("s", "214748364700");
+        final Record record = new MapRecord(schema, values);
+
+        assertEquals(Long.valueOf("214748364700"),
+                (Long) RecordPath.compile("toLong(/s)").evaluate(record).getSelectedFields().findFirst().get().getValue());
+    }
+
+    @Test
+    public void testToLongFromDate() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("d", RecordFieldType.DATE.getDataType()));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final Map<String, Object> values = new HashMap<>();
+        final long testDate = 1615371695278l;
+        values.put("d", new Date(testDate));
+        final Record record = new MapRecord(schema, values);
+
+        assertEquals(Long.valueOf(testDate),
+                (Long) RecordPath.compile("toLong(/d)").evaluate(record).getSelectedFields().findFirst().get().getValue());
+    }
+
+    @Test
     public void testBase64Encode() {
         final List<RecordField> fields = new ArrayList<>();
         fields.add(new RecordField("firstName", RecordFieldType.STRING.getDataType()));


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Support toLong standalone function in RecordPath expressions; fixes bug NIFI-8306._

for example for such a usecase:
format(toLong(concat(/timestampSeconds,"000")),"yyyyMMddHH")

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
