### PR TITLE
NIFI-8321  Add NoRouteToHostException

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.remote.client.http;
 
 import java.io.IOException;
+import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
@@ -187,7 +188,8 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
                 // Following exceptions will be thrown even if we tried other peers, so throw it.
                 if (e instanceof UnknownPortException
                         || e instanceof PortNotRunningException
-                        || e instanceof HandshakeException) {
+                        || e instanceof HandshakeException
+                        || e instanceof NoRouteToHostException) {
                     throw e;
                 }
 


### PR DESCRIPTION
#### Description of PR


- Although the HttpClient has thrown an "IOException" and the "StandardRemoteGroupPort", has caught the "IOException"
- but the HttpClient never throw "NoRouteToHostException", 
- therefore, "StandardRemoteGroupPort" will never catch the exception and still try to create lots of HTTP connections when "NoRouteToHostException"  happens

- "NoRouteToHostException" => when a host/instance suddenly shutdown or remove..., but the RemoteProcessGroup still enable or working.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
