### PR TITLE
NIFI-3711: Move replay button to the right of the connection ID.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/provenance/provenance-event-details-dialog.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/provenance/provenance-event-details-dialog.jsp
@@ -180,15 +180,18 @@
                 <div id="replay-details" class="content-details hidden">
                     <div class="event-header">Replay</div>
                     <div id="replay-content-connection" class="event-detail">
-                        <div class="content-detail-name">Connection Id</div>
-                        <div id="replay-connection-id" class="content-detail-value"></div>
-                        <div class="clear"></div>
+                        <div class="settings-left">
+                            <div class="content-detail-name">Connection Id</div>
+                            <div id="replay-connection-id" class="content-detail-value"></div>
+                        </div>
+                        <div class="spacer">&nbsp;</div>
+                        <div class="event-detail settings-right">
+                            <div id="replay-content" class="secondary-button fa fa-repeat button-icon"><span>Replay</span></div>
+                            <div class="clear"></div>
+                        </div>
                     </div>
+                    <div class="clear"></div>
                     <div id="replay-content-message" class="hidden"></div>
-                    <div class="event-detail">
-                        <div id="replay-content" class="secondary-button fa fa-repeat button-icon"><span>Replay</span></div>
-                        <div class="clear"></div>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### Description of PR

Fixes bug NIFI-3711. This moves the Replay button to the right of the connection ID. Event details are now in the two-column format that matches the section above.

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

