### PR TITLE
NIFI-8346 PutAzureBlobStorage doesn't route to failure despite the exception during upload

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.azure.storage.OperationContext;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -141,14 +142,14 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
                 }
 
                 try {
-                    blob.upload(in, -1, null, null, operationContext);
+                    uploadBlob(blob, operationContext, in);
                     BlobProperties properties = blob.getProperties();
                     attributes.put("azure.container", containerName);
                     attributes.put("azure.primaryUri", blob.getSnapshotQualifiedUri().toString());
                     attributes.put("azure.etag", properties.getEtag());
                     attributes.put("azure.length", String.valueOf(length));
                     attributes.put("azure.timestamp", String.valueOf(properties.getLastModified()));
-                } catch (StorageException | URISyntaxException e) {
+                } catch (StorageException | URISyntaxException | IOException e) {
                     storedException.set(e);
                     throw new IOException(e);
                 }
@@ -173,6 +174,11 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
             }
         }
 
+    }
+
+    @VisibleForTesting
+    void uploadBlob(CloudBlob blob, OperationContext operationContext, InputStream in) throws StorageException, IOException {
+        blob.upload(in, -1, null, null, operationContext);
     }
 
     // Used to help force Azure Blob SDK to write in blocks

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -151,7 +151,7 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
                     attributes.put("azure.timestamp", String.valueOf(properties.getLastModified()));
                 } catch (StorageException | URISyntaxException | IOException e) {
                     storedException.set(e);
-                    throw new IOException(e);
+                    throw e instanceof IOException ? (IOException) e : new IOException(e);
                 }
             });
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.azure.storage;
 
 import com.microsoft.azure.storage.blob.ListBlobItem;
 import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,6 +57,17 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.run();
 
         assertResult();
+    }
+
+    @Test
+    public void testInvalidCredentialsRoutesToFailure() {
+        runner.setProperty(AzureStorageUtils.ACCOUNT_NAME, "invalid");
+        runner.setProperty(AzureStorageUtils.ACCOUNT_KEY, "aW52YWxpZGludmFsaWQ=");
+        runner.assertValid();
+        runner.enqueue("test".getBytes());
+        runner.run();
+
+        runner.assertTransferCount(PutAzureBlobStorage.REL_FAILURE, 1);
     }
 
     private void assertResult() throws Exception {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestPutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestPutAzureBlobStorage.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+public class TestPutAzureBlobStorage {
+
+    @Test
+    public void testIOExceptionDuringUploadTransfersToFailure() throws Exception {
+        PutAzureBlobStorage processor = Mockito.spy(new PutAzureBlobStorage());
+        doThrow(IOException.class).when(processor).uploadBlob(any(), any(), any());
+
+        TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setProperty(PutAzureBlobStorage.BLOB, "test");
+        runner.setProperty(AzureStorageUtils.CONTAINER, "test");
+        runner.setProperty(AzureStorageUtils.ACCOUNT_NAME, "test");
+        runner.setProperty(AzureStorageUtils.ACCOUNT_KEY, "test");
+
+        runner.enqueue("test data");
+        runner.run();
+
+        runner.assertTransferCount(PutAzureBlobStorage.REL_FAILURE, 1);
+    }
+}


### PR DESCRIPTION
If uploading to an archived blob an IOException is thrown by the azure storage client library. If this happens the flowfile is not transferred to the failure relationship.


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
