### PR TITLE
NIFI-8347 Set ClassLoader for JettyWebSocketServer to resolve runtime exceptions

### DIFF
--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
@@ -58,6 +58,7 @@ import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
+import javax.servlet.ServletException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -211,6 +212,14 @@ public class JettyWebSocketServer extends AbstractJettyWebSocketService implemen
         @Override
         public void configure(WebSocketServletFactory webSocketServletFactory) {
             webSocketServletFactory.setCreator(this);
+        }
+
+        @Override
+        public void init() throws ServletException {
+            // Set Component ClassLoader as Thread Context ClassLoader so that jetty-server classes are available to WebSocketServletFactory.Loader
+            final ClassLoader componentClassLoader = getClass().getClassLoader();
+            Thread.currentThread().setContextClassLoader(componentClassLoader);
+            super.init();
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
@@ -58,7 +58,6 @@ import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
-import javax.servlet.ServletException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -215,14 +214,6 @@ public class JettyWebSocketServer extends AbstractJettyWebSocketService implemen
         }
 
         @Override
-        public void init() throws ServletException {
-            // Set Component ClassLoader as Thread Context ClassLoader so that jetty-server classes are available to WebSocketServletFactory.Loader
-            final ClassLoader componentClassLoader = getClass().getClassLoader();
-            Thread.currentThread().setContextClassLoader(componentClassLoader);
-            super.init();
-        }
-
-        @Override
         public Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest, ServletUpgradeResponse servletUpgradeResponse) {
             final URI requestURI = servletUpgradeRequest.getRequestURI();
             final int port = servletUpgradeRequest.getLocalPort();
@@ -272,6 +263,8 @@ public class JettyWebSocketServer extends AbstractJettyWebSocketService implemen
         final ContextHandlerCollection handlerCollection = new ContextHandlerCollection();
 
         final ServletContextHandler contextHandler = new ServletContextHandler();
+        // Set ClassLoader so that jetty-server classes are available to WebSocketServletFactory.Loader
+        contextHandler.setClassLoader(getClass().getClassLoader());
 
         // Add basic auth.
         if (context.getProperty(BASIC_AUTH).asBoolean()) {

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
@@ -16,49 +16,110 @@
  */
 package org.apache.nifi.websocket.jetty;
 
-import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.remote.io.socket.NetworkUtils;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collection;
+import java.net.URI;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class TestJettyWebSocketServer {
+    private static final long TIMEOUT_SECONDS = 5;
 
-    @Test
-    public void testValidationRequiredProperties() throws Exception {
-        final JettyWebSocketServer service = new JettyWebSocketServer();
-        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
-        service.initialize(context.getInitializationContext());
-        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
-        assertEquals(1, results.size());
-        final ValidationResult result = results.iterator().next();
-        assertEquals(JettyWebSocketServer.LISTEN_PORT.getDisplayName(), result.getSubject());
+    private static final String ROOT_ENDPOINT_ID = "/";
+
+    private static final String IDENTIFIER = JettyWebSocketServer.class.getSimpleName();
+
+    private static final int MAX_PORT = 65535;
+
+    private TestRunner runner;
+
+    @Before
+    public void setRunner() {
+        final Processor processor = mock(Processor.class);
+        runner = TestRunners.newTestRunner(processor);
+    }
+
+    @After
+    public void shutdown() {
+        runner.shutdown();
     }
 
     @Test
     public void testValidationHashLoginService() throws Exception {
-        final JettyWebSocketServer service = new JettyWebSocketServer();
-        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
-        context.setCustomValue(JettyWebSocketServer.LISTEN_PORT, "9001");
-        context.setCustomValue(JettyWebSocketServer.LOGIN_SERVICE, "hash");
-        context.setCustomValue(JettyWebSocketServer.BASIC_AUTH, "true");
-        service.initialize(context.getInitializationContext());
-        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
-        assertEquals(1, results.size());
-        final ValidationResult result = results.iterator().next();
-        assertEquals(JettyWebSocketServer.USERS_PROPERTIES_FILE.getDisplayName(), result.getSubject());
+        final JettyWebSocketServer server = new JettyWebSocketServer();
+        runner.addControllerService(IDENTIFIER, server);
+        runner.setProperty(server, JettyWebSocketServer.LISTEN_PORT, Integer.toString(MAX_PORT));
+        runner.setProperty(server, JettyWebSocketServer.LOGIN_SERVICE, JettyWebSocketServer.LOGIN_SERVICE_HASH.getValue());
+        runner.setProperty(server, JettyWebSocketServer.BASIC_AUTH, Boolean.TRUE.toString());
+        runner.assertNotValid();
     }
 
     @Test
     public void testValidationSuccess() throws Exception {
-        final JettyWebSocketServer service = new JettyWebSocketServer();
-        final ControllerServiceTestContext context = new ControllerServiceTestContext(service, "service-id");
-        context.setCustomValue(JettyWebSocketServer.LISTEN_PORT, "9001");
-        service.initialize(context.getInitializationContext());
-        final Collection<ValidationResult> results = service.validate(context.getValidationContext());
-        assertEquals(0, results.size());
+        final JettyWebSocketServer server = new JettyWebSocketServer();
+        runner.addControllerService(IDENTIFIER, server);
+        runner.setProperty(server, JettyWebSocketServer.LISTEN_PORT, Integer.toString(MAX_PORT));
+        runner.assertValid(server);
     }
 
+    @Test
+    public void testWebSocketConnect() throws Exception {
+        final int port = NetworkUtils.availablePort();
+
+        final String identifier = JettyWebSocketServer.class.getSimpleName();
+        final JettyWebSocketServer server = new JettyWebSocketServer();
+        runner.addControllerService(identifier, server);
+        runner.setProperty(server, JettyWebSocketServer.LISTEN_PORT, Integer.toString(port));
+        runner.enableControllerService(server);
+
+        server.registerProcessor(ROOT_ENDPOINT_ID, runner.getProcessor());
+
+        final String command = String.class.getName();
+        final AtomicBoolean connected = new AtomicBoolean();
+
+        final WebSocketClient client = new WebSocketClient();
+        final WebSocketAdapter adapter = new WebSocketAdapter() {
+            @Override
+            public void onWebSocketConnect(Session session) {
+                super.onWebSocketConnect(session);
+                connected.set(true);
+            }
+
+            @Override
+            public void onWebSocketText(final String message) {
+
+            }
+        };
+        try {
+            client.start();
+
+            final URI uri = getWebSocketUri(port);
+            final Future<Session> connectSession = client.connect(adapter, uri);
+            final Session session = connectSession.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            session.getRemote().sendString(command);
+            session.close();
+
+            assertTrue("Connection not found", connected.get());
+        } finally {
+            client.stop();
+            runner.disableControllerService(server);
+        }
+    }
+
+    private URI getWebSocketUri(final int port) {
+        return URI.create(String.format("ws://localhost:%d", port));
+    }
 }


### PR DESCRIPTION
#### Description of PR

NIFI-8347 Updates `JettyWebSocketServer` to set the the component's NAR ClassLoader for `JettyWebSocketServer`.  This change is necessary in order for the Jetty `WebSocketServerFactory.Loader` to have access to the `jetty-server` classes provided through the `nifi-jetty-bundle`.

The problem reported in the associated Jira issue can be reproduced using `ListenWebSocket` configured with `JettyWebSocketServer` and making a request to the configured listening port of the server.

Changes in this PR include an additional unit test method to test a successful connect to the Jetty WebSocket Server.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
