### PR TITLE
NIFI-8359 removing test that cannot be reliable.  Random data doesn't…

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/media/TestExtractMediaMetadata.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/media/TestExtractMediaMetadata.java
@@ -174,35 +174,6 @@ public class TestExtractMediaMetadata {
     }
 
     @Test
-    public void testJunkBytes() throws IOException {
-        final TestRunner runner = TestRunners.newTestRunner(new ExtractMediaMetadata());
-        runner.setProperty(ExtractMediaMetadata.METADATA_KEY_FILTER, "");
-        runner.setProperty(ExtractMediaMetadata.METADATA_KEY_PREFIX, "junk.");
-        runner.assertValid();
-
-        final Map<String, String> attrs = new HashMap<>();
-        attrs.put("filename", "junk");
-        Random random = new Random();
-        byte[] bytes = new byte[2048];
-        random.nextBytes(bytes);
-        runner.enqueue(bytes, attrs);
-        runner.run();
-
-        runner.assertAllFlowFilesTransferred(ExtractMediaMetadata.SUCCESS, 1);
-        runner.assertTransferCount(ExtractMediaMetadata.FAILURE, 0);
-
-        final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(ExtractMediaMetadata.SUCCESS);
-        MockFlowFile flowFile0 = successFiles.get(0);
-        flowFile0.assertAttributeExists("filename");
-        flowFile0.assertAttributeEquals("filename", "junk");
-        flowFile0.assertAttributeExists("junk.Content-Type");
-        assertTrue(flowFile0.getAttribute("junk.Content-Type").startsWith("application/octet-stream"));
-        flowFile0.assertAttributeExists("junk.X-Parsed-By");
-        assertTrue(flowFile0.getAttribute("junk.X-Parsed-By").contains("org.apache.tika.parser.EmptyParser"));
-        flowFile0.assertContentEquals(bytes);
-    }
-
-    @Test
     public void testMetadataKeyFilter() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractMediaMetadata());
         runner.setProperty(ExtractMediaMetadata.METADATA_KEY_FILTER, "(X-Parsed.*)");


### PR DESCRIPTION
… guarantee it will be detected as octet-stream and there is no obvious 'will never match' set of bytes so this test is not reliable or valuable

Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
