### PR TITLE
NIFI-8341 Support Multi Hosts in AMQP Processors

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -71,7 +71,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
             .required(false)
             .defaultValue("localhost")
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-            .addValidator(StandardValidators.ATTRIBUTE_EXPRESSION_LANGUAGE_VALIDATOR)
+            .addValidator(StandardValidators.NON_EMPTY_EL_VALIDATOR)
             .build();
     public static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
             .name("Port")
@@ -335,7 +335,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
                 Address[] hostsList = createHostsList(context);
                 connection = cf.newConnection(executor, hostsList);
             } else {
-                cf.setHost(context.getProperty(BROKERS).evaluateAttributeExpressions().getValue());
+                cf.setHost(context.getProperty(HOST).evaluateAttributeExpressions().getValue());
                 cf.setPort(Integer.parseInt(context.getProperty(PORT).evaluateAttributeExpressions().getValue()));
                 connection = cf.newConnection(executor);
             }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -16,10 +16,12 @@
  */
 package org.apache.nifi.amqp.processors;
 
+import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultSaslConfig;
 import com.rabbitmq.client.impl.DefaultExceptionHandler;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,18 +57,26 @@ import org.apache.nifi.ssl.SSLContextService;
  */
 abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProcessor {
 
+    public static final PropertyDescriptor BROKERS = new PropertyDescriptor.Builder()
+            .name("Brokers")
+            .description("A comma-separated list of known AMQP Brokers in the format <host>:<port> (e.g., localhost:5672). If this is " +
+                    "set, Host Name and Port are ignored. Only include hosts from the same AMQP cluster.")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .addValidator(StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR)
+            .build();
     public static final PropertyDescriptor HOST = new PropertyDescriptor.Builder()
             .name("Host Name")
-            .description("Network address of AMQP broker (e.g., localhost)")
-            .required(true)
+            .description("Network address of AMQP broker (e.g., localhost). If Brokers is set, then this property is ignored.")
+            .required(false)
             .defaultValue("localhost")
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-            .addValidator(StandardValidators.NON_EMPTY_EL_VALIDATOR)
+            .addValidator(StandardValidators.ATTRIBUTE_EXPRESSION_LANGUAGE_VALIDATOR)
             .build();
     public static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
             .name("Port")
-            .description("Numeric value identifying Port of AMQP broker (e.g., 5671)")
-            .required(true)
+            .description("Numeric value identifying Port of AMQP broker (e.g., 5671). If Brokers is set, then this property is ignored.")
+            .required(false)
             .defaultValue("5672")
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(StandardValidators.PORT_VALIDATOR)
@@ -128,6 +138,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
 
     static {
         final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(BROKERS);
         properties.add(HOST);
         properties.add(PORT);
         properties.add(V_HOST);
@@ -280,11 +291,13 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
         }
     }
 
+    private Address[] createHostsList(final ProcessContext context) {
+        String evaluatedUrls = context.getProperty(BROKERS).evaluateAttributeExpressions().getValue();
+        return Address.parseAddresses(evaluatedUrls);
+    }
 
     protected Connection createConnection(ProcessContext context, ExecutorService executor) {
         final ConnectionFactory cf = new ConnectionFactory();
-        cf.setHost(context.getProperty(HOST).evaluateAttributeExpressions().getValue());
-        cf.setPort(Integer.parseInt(context.getProperty(PORT).evaluateAttributeExpressions().getValue()));
         cf.setUsername(context.getProperty(USER).evaluateAttributeExpressions().getValue());
         cf.setPassword(context.getProperty(PASSWORD).getValue());
 
@@ -317,7 +330,16 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
         });
 
         try {
-            Connection connection = cf.newConnection(executor);
+            Connection connection;
+            if (context.getProperty(BROKERS).isSet()) {
+                Address[] hostsList = createHostsList(context);
+                connection = cf.newConnection(executor, hostsList);
+            } else {
+                cf.setHost(context.getProperty(BROKERS).evaluateAttributeExpressions().getValue());
+                cf.setPort(Integer.parseInt(context.getProperty(PORT).evaluateAttributeExpressions().getValue()));
+                connection = cf.newConnection(executor);
+            }
+
             return connection;
         } catch (Exception e) {
             throw new IllegalStateException("Failed to establish connection with AMQP Broker: " + cf.toString(), e);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
@@ -39,6 +39,7 @@ public class AbstractAMQPProcessorTest {
         testRunner = TestRunners.newTestRunner(ConsumeAMQP.class);
 
         testRunner.setProperty(ConsumeAMQP.QUEUE, "queue");
+        testRunner.setProperty(AbstractAMQPProcessor.BROKERS, "localhost:5672");
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -163,7 +163,7 @@ public class ConsumeAMQPTest {
 
     private TestRunner initTestRunner(ConsumeAMQP proc) {
         TestRunner runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(ConsumeAMQP.HOST, "injvm");
+        runner.setProperty(ConsumeAMQP.BROKERS, "injvm:5672");
         runner.setProperty(ConsumeAMQP.QUEUE, "queue1");
         runner.setProperty(ConsumeAMQP.USER, "user");
         runner.setProperty(ConsumeAMQP.PASSWORD, "password");

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -45,7 +45,7 @@ public class PublishAMQPTest {
     public void validateSuccessfulPublishAndTransferToSuccess() throws Exception {
         final PublishAMQP pubProc = new LocalPublishAMQP();
         final TestRunner runner = TestRunners.newTestRunner(pubProc);
-        runner.setProperty(PublishAMQP.HOST, "injvm");
+        runner.setProperty(PublishAMQP.BROKERS, "injvm:5672");
         runner.setProperty(PublishAMQP.EXCHANGE, "myExchange");
         runner.setProperty(PublishAMQP.ROUTING_KEY, "key1");
         runner.setProperty(PublishAMQP.USER, "user");
@@ -110,7 +110,7 @@ public class PublishAMQPTest {
     public void validateFailedPublishAndTransferToFailure() throws Exception {
         PublishAMQP pubProc = new LocalPublishAMQP();
         TestRunner runner = TestRunners.newTestRunner(pubProc);
-        runner.setProperty(PublishAMQP.HOST, "injvm");
+        runner.setProperty(PublishAMQP.BROKERS, "injvm:5672");
         runner.setProperty(PublishAMQP.EXCHANGE, "badToTheBone");
         runner.setProperty(PublishAMQP.ROUTING_KEY, "key1");
         runner.setProperty(PublishAMQP.USER, "user");


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

This provides an enhancement to the AMQP Processors to allow multiple hosts to be specified in a broker list. By specifying multiple hosts, a connection is made to one of the hosts, errors are only thrown if none of the hosts in the list are reachable. This property should only be used to specify amqp nodes in the same cluster. By specifying 2 nodes from 2 different clusters, only one cluster will be interacted with by NiFi.


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ Yes] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [Yes] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ Yes] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ Yes] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ Yes] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [Yes] Have you written or updated unit tests to verify your changes?
- [ Yes] Have you verified that the full build is successful on JDK 8?
- [ Yes] Have you verified that the full build is successful on JDK 11?
- [ N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ N/A] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ N/A] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ No, the other properties in the existing processor do not make use of a displayName ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ N/A] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
