### PR TITLE
NIFI-8370 Remove usages of deprecated FormatUtils#getTimeDuration

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPropertyValue.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/StandardPropertyValue.java
@@ -104,7 +104,7 @@ public class StandardPropertyValue implements PropertyValue {
 
     @Override
     public Long asTimePeriod(final TimeUnit timeUnit) {
-        return (rawValue == null) ? null : FormatUtils.getTimeDuration(rawValue.trim(), timeUnit);
+        return (rawValue == null) ? null : Math.round(FormatUtils.getPreciseTimeDuration(rawValue.trim(), timeUnit));
     }
 
     @Override

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -804,7 +804,7 @@ public class StandardValidators {
             final boolean validSyntax = pattern.matcher(lowerCase).matches();
             final ValidationResult.Builder builder = new ValidationResult.Builder();
             if (validSyntax) {
-                final long nanos = FormatUtils.getTimeDuration(lowerCase, TimeUnit.NANOSECONDS);
+                final long nanos =  Math.round(FormatUtils.getPreciseTimeDuration(lowerCase, TimeUnit.NANOSECONDS));
 
                 if (nanos < minNanos || nanos > maxNanos) {
                     builder.subject(subject).input(input).valid(false)

--- a/nifi-commons/nifi-utils/src/test/groovy/org/apache/nifi/util/TestFormatUtilsGroovy.groovy
+++ b/nifi-commons/nifi-utils/src/test/groovy/org/apache/nifi/util/TestFormatUtilsGroovy.groovy
@@ -52,22 +52,6 @@ class TestFormatUtilsGroovy extends GroovyTestCase {
     /**
      * New feature test
      */
-    @Test
-    void testGetTimeDurationShouldConvertWeeks() {
-        // Arrange
-        final List WEEKS = ["1 week", "1 wk", "1 w", "1 wks", "1 weeks"]
-        final long EXPECTED_DAYS = 7L
-
-        // Act
-        List days = WEEKS.collect { String week ->
-            FormatUtils.getTimeDuration(week, TimeUnit.DAYS)
-        }
-        logger.converted(days)
-
-        // Assert
-        assert days.every { it == EXPECTED_DAYS }
-    }
-
 
     @Test
     void testGetTimeDurationShouldHandleNegativeWeeks() {
@@ -77,7 +61,7 @@ class TestFormatUtilsGroovy extends GroovyTestCase {
         // Act
         List msgs = WEEKS.collect { String week ->
             shouldFail(IllegalArgumentException) {
-                FormatUtils.getTimeDuration(week, TimeUnit.DAYS)
+                FormatUtils.getPreciseTimeDuration(week, TimeUnit.DAYS)
             }
         }
 
@@ -96,7 +80,7 @@ class TestFormatUtilsGroovy extends GroovyTestCase {
         // Act
         List msgs = WEEKS.collect { String week ->
             shouldFail(IllegalArgumentException) {
-                FormatUtils.getTimeDuration(week, TimeUnit.DAYS)
+                FormatUtils.getPreciseTimeDuration(week, TimeUnit.DAYS)
             }
         }
 
@@ -116,38 +100,12 @@ class TestFormatUtilsGroovy extends GroovyTestCase {
 
         // Act
         List days = WEEKS.collect { String week ->
-            FormatUtils.getTimeDuration(week, TimeUnit.DAYS)
+            FormatUtils.getPreciseTimeDuration(week, TimeUnit.DAYS)
         }
         logger.converted(days)
 
         // Assert
         assert days.every { it == EXPECTED_DAYS }
-    }
-
-    /**
-     * New feature test
-     */
-    @Test
-    void testGetTimeDurationShouldHandleDecimalValues() {
-        // Arrange
-        final List WHOLE_NUMBERS = ["10 ms", "10 millis", "10 milliseconds"]
-        final List DECIMAL_NUMBERS = ["0.010 s", "0.010 seconds"]
-        final long EXPECTED_MILLIS = 10
-
-        // Act
-        List parsedWholeMillis = WHOLE_NUMBERS.collect { String whole ->
-            FormatUtils.getTimeDuration(whole, TimeUnit.MILLISECONDS)
-        }
-        logger.converted(parsedWholeMillis)
-
-        List parsedDecimalMillis = DECIMAL_NUMBERS.collect { String decimal ->
-            FormatUtils.getTimeDuration(decimal, TimeUnit.MILLISECONDS)
-        }
-        logger.converted(parsedDecimalMillis)
-
-        // Assert
-        assert parsedWholeMillis.every { it == EXPECTED_MILLIS }
-        assert parsedDecimalMillis.every { it == EXPECTED_MILLIS }
     }
 
     /**

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/processor/TestFormatUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/processor/TestFormatUtils.java
@@ -27,17 +27,6 @@ import static org.junit.Assert.assertEquals;
 public class TestFormatUtils {
 
     @Test
-    public void testParse() {
-        assertEquals(3, FormatUtils.getTimeDuration("3000 ms", TimeUnit.SECONDS));
-        assertEquals(3000, FormatUtils.getTimeDuration("3000 s", TimeUnit.SECONDS));
-        assertEquals(0, FormatUtils.getTimeDuration("999 millis", TimeUnit.SECONDS));
-        assertEquals(4L * 24L * 60L * 60L * 1000000000L, FormatUtils.getTimeDuration("4 days", TimeUnit.NANOSECONDS));
-        assertEquals(24, FormatUtils.getTimeDuration("1 DAY", TimeUnit.HOURS));
-        assertEquals(60, FormatUtils.getTimeDuration("1 hr", TimeUnit.MINUTES));
-        assertEquals(60, FormatUtils.getTimeDuration("1 Hrs", TimeUnit.MINUTES));
-    }
-
-    @Test
     public void testFormatTime() throws Exception {
         assertEquals("00:00:00.000", FormatUtils.formatHoursMinutesSeconds(0, TimeUnit.DAYS));
         assertEquals("01:00:00.000", FormatUtils.formatHoursMinutesSeconds(1, TimeUnit.HOURS));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/StandardClusterCoordinationProtocolSender.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/StandardClusterCoordinationProtocolSender.java
@@ -195,7 +195,7 @@ public class StandardClusterCoordinationProtocolSender implements ClusterCoordin
     }
 
     public void setHandshakeTimeout(final String handshakeTimeout) {
-        this.handshakeTimeoutSeconds = (int) FormatUtils.getTimeDuration(handshakeTimeout, TimeUnit.SECONDS);
+        this.handshakeTimeoutSeconds = (int) Math.round(FormatUtils.getPreciseTimeDuration(handshakeTimeout, TimeUnit.SECONDS));
     }
 
     private Socket createSocket(final NodeIdentifier nodeId, final boolean applyHandshakeTimeout) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/flow/PopularVoteFlowElectionFactoryBean.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/flow/PopularVoteFlowElectionFactoryBean.java
@@ -39,20 +39,20 @@ public class PopularVoteFlowElectionFactoryBean implements FactoryBean<PopularVo
     @Override
     public PopularVoteFlowElection getObject() {
         final String maxWaitTime = properties.getFlowElectionMaxWaitTime();
-        long maxWaitMillis;
+        double maxWaitMillis;
         try {
-            maxWaitMillis = FormatUtils.getTimeDuration(maxWaitTime, TimeUnit.MILLISECONDS);
+            maxWaitMillis = FormatUtils.getPreciseTimeDuration(maxWaitTime, TimeUnit.MILLISECONDS);
         } catch (final Exception e) {
             logger.warn("Failed to parse value of property '{}' as a valid time period. Value was '{}'. Ignoring this value and using the default value of '{}'",
                 NiFiProperties.FLOW_ELECTION_MAX_WAIT_TIME, maxWaitTime, NiFiProperties.DEFAULT_FLOW_ELECTION_MAX_WAIT_TIME);
-            maxWaitMillis = FormatUtils.getTimeDuration(NiFiProperties.DEFAULT_FLOW_ELECTION_MAX_WAIT_TIME, TimeUnit.MILLISECONDS);
+            maxWaitMillis = FormatUtils.getPreciseTimeDuration(NiFiProperties.DEFAULT_FLOW_ELECTION_MAX_WAIT_TIME, TimeUnit.MILLISECONDS);
         }
 
         final Integer maxNodes = properties.getFlowElectionMaxCandidates();
         final PropertyEncryptor encryptor = PropertyEncryptorFactory.getPropertyEncryptor(properties);
         final SensitiveValueEncoder sensitiveValueEncoder = new StandardSensitiveValueEncoder(properties);
         final FingerprintFactory fingerprintFactory = new FingerprintFactory(encryptor, extensionManager, sensitiveValueEncoder);
-        return new PopularVoteFlowElection(maxWaitMillis, TimeUnit.MILLISECONDS, maxNodes, fingerprintFactory);
+        return new PopularVoteFlowElection(Math.round(maxWaitMillis), TimeUnit.MILLISECONDS, maxNodes, fingerprintFactory);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
@@ -50,7 +50,7 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
         this.clusterCoordinator = clusterCoordinator;
         final String heartbeatInterval = nifiProperties.getProperty(NiFiProperties.CLUSTER_PROTOCOL_HEARTBEAT_INTERVAL,
                 NiFiProperties.DEFAULT_CLUSTER_PROTOCOL_HEARTBEAT_INTERVAL);
-        this.heartbeatIntervalMillis = (int) FormatUtils.getTimeDuration(heartbeatInterval, TimeUnit.MILLISECONDS);
+        this.heartbeatIntervalMillis = (int) Math.round(FormatUtils.getPreciseTimeDuration(heartbeatInterval, TimeUnit.MILLISECONDS));
 
         this.missableHeartbeatCount = nifiProperties.getIntegerProperty(NiFiProperties.CLUSTER_PROTOCOL_HEARTBEAT_MISSABLE_MAX,
                 NiFiProperties.DEFAULT_CLUSTER_PROTOCOL_HEARTBEAT_MISSABLE_MAX);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapper.java
@@ -102,12 +102,14 @@ public class StandardHttpResponseMapper implements HttpResponseMapper {
 
     public StandardHttpResponseMapper(final NiFiProperties nifiProperties) {
         final String snapshotFrequency = nifiProperties.getProperty(NiFiProperties.COMPONENT_STATUS_SNAPSHOT_FREQUENCY, NiFiProperties.DEFAULT_COMPONENT_STATUS_SNAPSHOT_FREQUENCY);
-        long snapshotMillis;
+        double snapshotMillis;
+        long snapshotMillisLong;
         try {
-            snapshotMillis = FormatUtils.getTimeDuration(snapshotFrequency, TimeUnit.MILLISECONDS);
+            snapshotMillis = FormatUtils.getPreciseTimeDuration(snapshotFrequency, TimeUnit.MILLISECONDS);
         } catch (final Exception e) {
-            snapshotMillis = FormatUtils.getTimeDuration(NiFiProperties.DEFAULT_COMPONENT_STATUS_SNAPSHOT_FREQUENCY, TimeUnit.MILLISECONDS);
+            snapshotMillis = FormatUtils.getPreciseTimeDuration(NiFiProperties.DEFAULT_COMPONENT_STATUS_SNAPSHOT_FREQUENCY, TimeUnit.MILLISECONDS);
         }
+        snapshotMillisLong = Math.round(snapshotMillis);
         endpointMergers.add(new ControllerStatusEndpointMerger());
         endpointMergers.add(new ControllerBulletinsEndpointMerger());
         endpointMergers.add(new GroupStatusEndpointMerger());
@@ -140,7 +142,7 @@ public class StandardHttpResponseMapper implements HttpResponseMapper {
         endpointMergers.add(new ListFlowFilesEndpointMerger());
         endpointMergers.add(new ComponentStateEndpointMerger());
         endpointMergers.add(new BulletinBoardEndpointMerger());
-        endpointMergers.add(new StatusHistoryEndpointMerger(snapshotMillis));
+        endpointMergers.add(new StatusHistoryEndpointMerger(snapshotMillisLong));
         endpointMergers.add(new SystemDiagnosticsEndpointMerger());
         endpointMergers.add(new CountersEndpointMerger());
         endpointMergers.add(new FlowMerger());
@@ -164,7 +166,7 @@ public class StandardHttpResponseMapper implements HttpResponseMapper {
         endpointMergers.add(new AccessPolicyEndpointMerger());
         endpointMergers.add(new SearchUsersEndpointMerger());
         endpointMergers.add(new VariableRegistryEndpointMerger());
-        endpointMergers.add(new ProcessorDiagnosticsEndpointMerger(snapshotMillis));
+        endpointMergers.add(new ProcessorDiagnosticsEndpointMerger(snapshotMillisLong));
         endpointMergers.add(new ParameterContextValidationMerger());
         endpointMergers.add(new ParameterContextsEndpointMerger());
         endpointMergers.add(new ParameterContextEndpointMerger());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -516,8 +516,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             break;
         case PRIMARY_NODE_ONLY:
         case TIMER_DRIVEN: {
-            final long schedulingNanos = FormatUtils.getTimeDuration(requireNonNull(schedulingPeriod),
-                    TimeUnit.NANOSECONDS);
+            final long schedulingNanos = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(schedulingPeriod),
+                    TimeUnit.NANOSECONDS));
             if (schedulingNanos < 0) {
                 throw new IllegalArgumentException("Scheduling Period must be positive");
             }
@@ -577,7 +577,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         if (isRunning()) {
             throw new IllegalStateException("Cannot modify Processor configuration while the Processor is running");
         }
-        final long yieldNanos = FormatUtils.getTimeDuration(requireNonNull(yieldPeriod), TimeUnit.NANOSECONDS);
+        final long yieldNanos = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(yieldPeriod),
+                TimeUnit.NANOSECONDS));
         if (yieldNanos < 0) {
             throw new IllegalArgumentException("Yield duration must be positive");
         }
@@ -623,7 +624,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
     @Override
     public long getPenalizationPeriod(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(getPenalizationPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(getPenalizationPeriod(),
+                timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit));
     }
 
     @Override
@@ -637,7 +639,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             throw new IllegalStateException("Cannot modify Processor configuration while the Processor is running");
         }
 
-        final long penalizationMillis = FormatUtils.getTimeDuration(requireNonNull(penalizationPeriod), TimeUnit.MILLISECONDS);
+        final long penalizationMillis = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(penalizationPeriod),
+                TimeUnit.MILLISECONDS));
         if (penalizationMillis < 0) {
             throw new IllegalArgumentException("Penalization duration must be positive");
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingTaskNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingTaskNode.java
@@ -139,7 +139,7 @@ public abstract class AbstractReportingTaskNode extends AbstractComponentNode im
 
     @Override
     public long getSchedulingPeriod(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(schedulingPeriod.get(), timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(schedulingPeriod.get(), timeUnit));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/StandardReportingInitializationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/StandardReportingInitializationContext.java
@@ -67,7 +67,7 @@ public class StandardReportingInitializationContext implements ReportingInitiali
     @Override
     public long getSchedulingPeriod(final TimeUnit timeUnit) {
         if (schedulingStrategy == SchedulingStrategy.TIMER_DRIVEN) {
-            return FormatUtils.getTimeDuration(schedulingPeriod, timeUnit);
+            return Math.round(FormatUtils.getPreciseTimeDuration(schedulingPeriod, timeUnit));
         }
         return -1L;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardConfigurationContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardConfigurationContext.java
@@ -52,7 +52,7 @@ public class StandardConfigurationContext implements ConfigurationContext {
             schedulingNanos = null;
         } else {
             if (FormatUtils.TIME_DURATION_PATTERN.matcher(schedulingPeriod).matches()) {
-                schedulingNanos = FormatUtils.getTimeDuration(schedulingPeriod, TimeUnit.NANOSECONDS);
+                schedulingNanos = Math.round(FormatUtils.getPreciseTimeDuration(schedulingPeriod, TimeUnit.NANOSECONDS));
             } else {
                 schedulingNanos = null;
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -371,7 +371,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
     public void setCommunicationsTimeout(final String timePeriod) throws IllegalArgumentException {
         // verify the timePeriod is legit
         try {
-            final long millis = FormatUtils.getTimeDuration(timePeriod, TimeUnit.MILLISECONDS);
+            final long millis = Math.round(FormatUtils.getPreciseTimeDuration(timePeriod, TimeUnit.MILLISECONDS));
             if (millis <= 0) {
                 throw new IllegalArgumentException("Time Period must be more than 0 milliseconds; Invalid Time Period: " + timePeriod);
             }
@@ -386,7 +386,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
 
     @Override
     public int getCommunicationsTimeout(final TimeUnit timeUnit) {
-        return (int) FormatUtils.getTimeDuration(communicationsTimeout, timeUnit);
+        return (int) Math.round(FormatUtils.getPreciseTimeDuration(communicationsTimeout, timeUnit));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractPort.java
@@ -455,7 +455,7 @@ public abstract class AbstractPort implements Port {
 
     @Override
     public void setYieldPeriod(final String yieldPeriod) {
-        final long yieldMillis = FormatUtils.getTimeDuration(requireNonNull(yieldPeriod), TimeUnit.MILLISECONDS);
+        final long yieldMillis = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(yieldPeriod), TimeUnit.MILLISECONDS));
         if (yieldMillis < 0) {
             throw new IllegalArgumentException("Yield duration must be positive");
         }
@@ -464,7 +464,7 @@ public abstract class AbstractPort implements Port {
 
     @Override
     public void setScheduldingPeriod(final String schedulingPeriod) {
-        final long schedulingNanos = FormatUtils.getTimeDuration(requireNonNull(schedulingPeriod), TimeUnit.NANOSECONDS);
+        final long schedulingNanos = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(schedulingPeriod), TimeUnit.NANOSECONDS));
         if (schedulingNanos < 0) {
             throw new IllegalArgumentException("Scheduling Period must be positive");
         }
@@ -475,7 +475,7 @@ public abstract class AbstractPort implements Port {
 
     @Override
     public long getPenalizationPeriod(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(getPenalizationPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(getPenalizationPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit));
     }
 
     @Override
@@ -522,7 +522,7 @@ public abstract class AbstractPort implements Port {
 
     @Override
     public long getYieldPeriod(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(getYieldPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(getYieldPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/StandardFunnel.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/StandardFunnel.java
@@ -433,7 +433,7 @@ public class StandardFunnel implements Funnel {
      */
     @Override
     public void setYieldPeriod(final String yieldPeriod) {
-        final long yieldMillis = FormatUtils.getTimeDuration(requireNonNull(yieldPeriod), TimeUnit.MILLISECONDS);
+        final long yieldMillis = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(yieldPeriod), TimeUnit.MILLISECONDS));
         if (yieldMillis < 0) {
             throw new IllegalArgumentException("Yield duration must be positive");
         }
@@ -442,7 +442,7 @@ public class StandardFunnel implements Funnel {
 
     @Override
     public void setScheduldingPeriod(final String schedulingPeriod) {
-        final long schedulingNanos = FormatUtils.getTimeDuration(requireNonNull(schedulingPeriod), TimeUnit.NANOSECONDS);
+        final long schedulingNanos = Math.round(FormatUtils.getPreciseTimeDuration(requireNonNull(schedulingPeriod), TimeUnit.NANOSECONDS));
         if (schedulingNanos < 0) {
             throw new IllegalArgumentException("Scheduling Period must be positive");
         }
@@ -453,7 +453,7 @@ public class StandardFunnel implements Funnel {
 
     @Override
     public long getPenalizationPeriod(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(getPenalizationPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(getPenalizationPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit));
     }
 
     @Override
@@ -501,7 +501,7 @@ public class StandardFunnel implements Funnel {
 
     @Override
     public long getYieldPeriod(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(getYieldPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(getYieldPeriod(), timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -573,7 +573,7 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
             throw new IllegalStateException("NiFi Configured to allow Secure Site-to-Site communications but the Keystore/Truststore properties are not configured");
         }
 
-        this.heartbeatDelaySeconds = (int) FormatUtils.getTimeDuration(nifiProperties.getNodeHeartbeatInterval(), TimeUnit.SECONDS);
+        this.heartbeatDelaySeconds = (int) Math.round(FormatUtils.getPreciseTimeDuration(nifiProperties.getNodeHeartbeatInterval(), TimeUnit.SECONDS));
 
         this.snippetManager = new SnippetManager();
         this.reloadComponent = new StandardReloadComponent(this);
@@ -614,9 +614,9 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
         final String snapshotFrequency = nifiProperties.getProperty(NiFiProperties.COMPONENT_STATUS_SNAPSHOT_FREQUENCY, NiFiProperties.DEFAULT_COMPONENT_STATUS_SNAPSHOT_FREQUENCY);
         long snapshotMillis;
         try {
-            snapshotMillis = FormatUtils.getTimeDuration(snapshotFrequency, TimeUnit.MILLISECONDS);
+            snapshotMillis = Math.round(FormatUtils.getPreciseTimeDuration(snapshotFrequency, TimeUnit.MILLISECONDS));
         } catch (final Exception e) {
-            snapshotMillis = FormatUtils.getTimeDuration(NiFiProperties.DEFAULT_COMPONENT_STATUS_SNAPSHOT_FREQUENCY, TimeUnit.MILLISECONDS);
+            snapshotMillis = Math.round(FormatUtils.getPreciseTimeDuration(NiFiProperties.DEFAULT_COMPONENT_STATUS_SNAPSHOT_FREQUENCY, TimeUnit.MILLISECONDS));
         }
 
         // Initialize the Embedded ZooKeeper server, if applicable
@@ -641,22 +641,22 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
             final String predictionInterval = nifiProperties.getProperty(NiFiProperties.ANALYTICS_PREDICTION_INTERVAL, NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_INTERVAL);
             long predictionIntervalMillis;
             try {
-                predictionIntervalMillis = FormatUtils.getTimeDuration(predictionInterval, TimeUnit.MILLISECONDS);
+                predictionIntervalMillis = Math.round(FormatUtils.getPreciseTimeDuration(predictionInterval, TimeUnit.MILLISECONDS));
             } catch (final Exception e) {
                 LOG.warn("Analytics is enabled however could not retrieve value for " + NiFiProperties.ANALYTICS_PREDICTION_INTERVAL + ". This property has been set to '"
                         + NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_INTERVAL + "'");
-                predictionIntervalMillis = FormatUtils.getTimeDuration(NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_INTERVAL, TimeUnit.MILLISECONDS);
+                predictionIntervalMillis = Math.round(FormatUtils.getPreciseTimeDuration(NiFiProperties.DEFAULT_ANALYTICS_PREDICTION_INTERVAL, TimeUnit.MILLISECONDS));
             }
 
             // Determine interval for querying past observations
             final String queryInterval = nifiProperties.getProperty(NiFiProperties.ANALYTICS_QUERY_INTERVAL, NiFiProperties.DEFAULT_ANALYTICS_QUERY_INTERVAL);
             long queryIntervalMillis;
             try {
-                queryIntervalMillis = FormatUtils.getTimeDuration(queryInterval, TimeUnit.MILLISECONDS);
+                queryIntervalMillis = Math.round(FormatUtils.getPreciseTimeDuration(queryInterval, TimeUnit.MILLISECONDS));
             } catch (final Exception e) {
                 LOG.warn("Analytics is enabled however could not retrieve value for " + NiFiProperties.ANALYTICS_QUERY_INTERVAL + ". This property has been set to '"
                         + NiFiProperties.DEFAULT_ANALYTICS_QUERY_INTERVAL + "'");
-                queryIntervalMillis = FormatUtils.getTimeDuration(NiFiProperties.DEFAULT_ANALYTICS_QUERY_INTERVAL, TimeUnit.MILLISECONDS);
+                queryIntervalMillis = Math.round(FormatUtils.getPreciseTimeDuration(NiFiProperties.DEFAULT_ANALYTICS_QUERY_INTERVAL, TimeUnit.MILLISECONDS));
             }
 
             // Determine score name to use for evaluating model performance
@@ -755,7 +755,7 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
 
             final int numThreads = nifiProperties.getIntegerProperty(NiFiProperties.LOAD_BALANCE_MAX_THREAD_COUNT, NiFiProperties.DEFAULT_LOAD_BALANCE_MAX_THREAD_COUNT);
             final String timeoutPeriod = nifiProperties.getProperty(NiFiProperties.LOAD_BALANCE_COMMS_TIMEOUT, NiFiProperties.DEFAULT_LOAD_BALANCE_COMMS_TIMEOUT);
-            final int timeoutMillis = (int) FormatUtils.getTimeDuration(timeoutPeriod, TimeUnit.MILLISECONDS);
+            final int timeoutMillis = (int) Math.round(FormatUtils.getPreciseTimeDuration(timeoutPeriod, TimeUnit.MILLISECONDS));
 
             loadBalanceServer = new ConnectionLoadBalanceServer(loadBalanceAddress.getHostName(), loadBalanceAddress.getPort(), sslContext,
                     numThreads, loadBalanceProtocol, eventReporter, timeoutMillis);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -193,8 +193,8 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
         this.nifiProperties = nifiProperties;
         this.controller = controller;
         flowXml = Paths.get(nifiProperties.getProperty(NiFiProperties.FLOW_CONFIGURATION_FILE));
-
-        gracefulShutdownSeconds = (int) FormatUtils.getTimeDuration(nifiProperties.getProperty(NiFiProperties.FLOW_CONTROLLER_GRACEFUL_SHUTDOWN_PERIOD), TimeUnit.SECONDS);
+        String shutDownPeriodConfiguredValue = nifiProperties.getProperty(NiFiProperties.FLOW_CONTROLLER_GRACEFUL_SHUTDOWN_PERIOD);
+        gracefulShutdownSeconds = (int) Math.round(FormatUtils.getPreciseTimeDuration(shutDownPeriodConfiguredValue, TimeUnit.SECONDS));
         autoResumeState = nifiProperties.getAutoResumeState();
 
         dao = new StandardXMLFlowConfigurationDAO(flowXml, encryptor, nifiProperties, controller.getExtensionManager());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/cluster/ZooKeeperClientConfig.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/cluster/ZooKeeperClientConfig.java
@@ -203,10 +203,10 @@ public class ZooKeeperClientConfig {
     private static int getTimePeriod(final NiFiProperties nifiProperties, final String propertyName, final String defaultValue) {
         final String timeout = nifiProperties.getProperty(propertyName, defaultValue);
         try {
-            return (int) FormatUtils.getTimeDuration(timeout, TimeUnit.MILLISECONDS);
+            return (int) Math.round(FormatUtils.getPreciseTimeDuration(timeout, TimeUnit.MILLISECONDS));
         } catch (final Exception e) {
             logger.warn("Value of '" + propertyName + "' property is set to '" + timeout + "', which is not a valid time period. Using default of " + defaultValue);
-            return (int) FormatUtils.getTimeDuration(defaultValue, TimeUnit.MILLISECONDS);
+            return (int) Math.round(FormatUtils.getPreciseTimeDuration(defaultValue, TimeUnit.MILLISECONDS));
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
@@ -200,7 +200,7 @@ public class StandardFlowManager extends AbstractFlowManager implements FlowMana
 
     public RemoteProcessGroup createRemoteProcessGroup(final String id, final String uris) {
         final String expirationPeriod = nifiProperties.getProperty(NiFiProperties.REMOTE_CONTENTS_CACHE_EXPIRATION, "30 secs");
-        final long remoteContentsCacheExpirationMillis = FormatUtils.getTimeDuration(expirationPeriod, TimeUnit.MILLISECONDS);
+        final long remoteContentsCacheExpirationMillis = Math.round(FormatUtils.getPreciseTimeDuration(expirationPeriod, TimeUnit.MILLISECONDS));
 
         return new StandardRemoteProcessGroup(requireNonNull(id), uris, null,
             processScheduler, bulletinRepository, sslContext,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/AbstractFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/AbstractFlowFileQueue.java
@@ -102,7 +102,7 @@ public abstract class AbstractFlowFileQueue implements FlowFileQueue {
 
     @Override
     public void setFlowFileExpiration(final String flowExpirationPeriod) {
-        final long millis = FormatUtils.getTimeDuration(flowExpirationPeriod, TimeUnit.MILLISECONDS);
+        final long millis = Math.round(FormatUtils.getPreciseTimeDuration(flowExpirationPeriod, TimeUnit.MILLISECONDS));
         if (millis < 0) {
             throw new IllegalArgumentException("FlowFile Expiration Period must be positive");
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -244,7 +244,8 @@ public class FileSystemRepository implements ContentRepository {
         if (maxArchiveRatio <= 0D) {
             maxArchiveMillis = 0L;
         } else {
-            maxArchiveMillis = StringUtils.isEmpty(maxArchiveRetentionPeriod) ? Long.MAX_VALUE : FormatUtils.getTimeDuration(maxArchiveRetentionPeriod, TimeUnit.MILLISECONDS);
+            maxArchiveMillis = StringUtils.isEmpty(maxArchiveRetentionPeriod) ? Long.MAX_VALUE :
+                    Math.round(FormatUtils.getPreciseTimeDuration(maxArchiveRetentionPeriod, TimeUnit.MILLISECONDS));
         }
 
         this.alwaysSync = Boolean.parseBoolean(nifiProperties.getProperty("nifi.content.repository.always.sync"));
@@ -1761,7 +1762,7 @@ public class FileSystemRepository implements ContentRepository {
         String archiveCleanupFrequency = properties.getProperty(NiFiProperties.CONTENT_ARCHIVE_CLEANUP_FREQUENCY);
         if (archiveCleanupFrequency != null) {
             try {
-                cleanupInterval = FormatUtils.getTimeDuration(archiveCleanupFrequency.trim(), TimeUnit.MILLISECONDS);
+                cleanupInterval = Math.round(FormatUtils.getPreciseTimeDuration(archiveCleanupFrequency.trim(), TimeUnit.MILLISECONDS));
             } catch (Exception e) {
                 throw new RuntimeException(
                         "Invalid value set for property " + NiFiProperties.CONTENT_ARCHIVE_CLEANUP_FREQUENCY);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/WriteAheadFlowFileRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/WriteAheadFlowFileRepository.java
@@ -194,7 +194,7 @@ public class WriteAheadFlowFileRepository implements FlowFileRepository, SyncLis
         }
 
 
-        checkpointDelayMillis = FormatUtils.getTimeDuration(nifiProperties.getFlowFileRepositoryCheckpointInterval(), TimeUnit.MILLISECONDS);
+        checkpointDelayMillis = Math.round(FormatUtils.getPreciseTimeDuration(nifiProperties.getFlowFileRepositoryCheckpointInterval(), TimeUnit.MILLISECONDS));
 
         checkpointExecutor = Executors.newSingleThreadScheduledExecutor();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/AbstractTimeBasedSchedulingAgent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/AbstractTimeBasedSchedulingAgent.java
@@ -88,7 +88,7 @@ public abstract class AbstractTimeBasedSchedulingAgent extends AbstractSchedulin
 
     @Override
     public long getAdministrativeYieldDuration(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(adminYieldDuration, timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(adminYieldDuration, timeUnit));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/EventDrivenSchedulingAgent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/EventDrivenSchedulingAgent.java
@@ -172,7 +172,7 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
 
     @Override
     public long getAdministrativeYieldDuration(final TimeUnit timeUnit) {
-        return FormatUtils.getTimeDuration(adminYieldDuration, timeUnit);
+        return Math.round(FormatUtils.getPreciseTimeDuration(adminYieldDuration, timeUnit));
     }
 
     private class EventDrivenTask implements Runnable {
@@ -332,7 +332,8 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
                     logger.warn("{} Administratively Pausing for {} due to processing failure: {}", worker, getAdministrativeYieldDuration(), t.toString());
                     logger.warn("", t);
                     try {
-                        Thread.sleep(FormatUtils.getTimeDuration(adminYieldDuration, TimeUnit.MILLISECONDS));
+                        long sleepMillis = Math.round(FormatUtils.getPreciseTimeDuration(adminYieldDuration, TimeUnit.MILLISECONDS));
+                        Thread.sleep(sleepMillis);
                     } catch (final InterruptedException e) {
                     }
 
@@ -374,8 +375,8 @@ public class EventDrivenSchedulingAgent extends AbstractSchedulingAgent {
                     procLog.warn("Processor Administratively Yielded for {} due to processing failure", new Object[]{adminYieldDuration});
                     logger.warn("Administratively Yielding {} due to uncaught Exception: ", worker.getProcessor());
                     logger.warn("", t);
-
-                    worker.yield(FormatUtils.getTimeDuration(adminYieldDuration, TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
+                    long yieldNanos = Math.round(FormatUtils.getPreciseTimeDuration(adminYieldDuration, TimeUnit.NANOSECONDS));
+                    worker.yield(yieldNanos, TimeUnit.NANOSECONDS);
                 }
             } finally {
                 // if the processor is no longer scheduled to run and this is the last thread,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -101,10 +101,10 @@ public final class StandardProcessScheduler implements ProcessScheduler {
         this.stateManagerProvider = stateManagerProvider;
 
         administrativeYieldDuration = nifiProperties.getAdministrativeYieldDuration();
-        administrativeYieldMillis = FormatUtils.getTimeDuration(administrativeYieldDuration, TimeUnit.MILLISECONDS);
+        administrativeYieldMillis = Math.round(FormatUtils.getPreciseTimeDuration(administrativeYieldDuration, TimeUnit.MILLISECONDS));
 
         final String timeoutString = nifiProperties.getProperty(NiFiProperties.PROCESSOR_SCHEDULING_TIMEOUT);
-        processorStartTimeoutMillis = timeoutString == null ? 60000 : FormatUtils.getTimeDuration(timeoutString.trim(), TimeUnit.MILLISECONDS);
+        processorStartTimeoutMillis = timeoutString == null ? 60000 : Math.round(FormatUtils.getPreciseTimeDuration(timeoutString.trim(), TimeUnit.MILLISECONDS));
 
         frameworkTaskExecutor = new FlowEngine(4, "Framework Task Thread");
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/TimerDrivenSchedulingAgent.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/TimerDrivenSchedulingAgent.java
@@ -42,7 +42,7 @@ public class TimerDrivenSchedulingAgent extends AbstractTimeBasedSchedulingAgent
 
         final String boredYieldDuration = nifiProperties.getBoredYieldDuration();
         try {
-            noWorkYieldNanos = FormatUtils.getTimeDuration(boredYieldDuration, TimeUnit.NANOSECONDS);
+            noWorkYieldNanos = Math.round(FormatUtils.getPreciseTimeDuration(boredYieldDuration, TimeUnit.NANOSECONDS));
         } catch (final IllegalArgumentException e) {
             throw new RuntimeException("Failed to create SchedulingAgent because the " + NiFiProperties.BORED_YIELD_DURATION + " property is set to an invalid time duration: " + boredYieldDuration);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ExpireFlowFiles.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ExpireFlowFiles.java
@@ -69,7 +69,7 @@ public class ExpireFlowFiles implements Runnable {
         // determine if the incoming connections for this Connectable have Expiration configured.
         boolean expirationConfigured = false;
         for (final Connection incomingConn : connectable.getIncomingConnections()) {
-            if (FormatUtils.getTimeDuration(incomingConn.getFlowFileQueue().getFlowFileExpiration(), TimeUnit.MILLISECONDS) > 0) {
+            if (FormatUtils.getPreciseTimeDuration(incomingConn.getFlowFileQueue().getFlowFileExpiration(), TimeUnit.MILLISECONDS) > 0) {
                 expirationConfigured = true;
                 break;
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/FlowConfigurationArchiveManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/FlowConfigurationArchiveManager.java
@@ -75,7 +75,7 @@ public class FlowConfigurationArchiveManager {
                     maxTime, maxStorage);
         }
 
-        this.maxTimeMillis = StringUtils.isBlank(maxTime) ? null : FormatUtils.getTimeDuration(maxTime, TimeUnit.MILLISECONDS);
+        this.maxTimeMillis = StringUtils.isBlank(maxTime) ? null : Math.round(FormatUtils.getPreciseTimeDuration(maxTime, TimeUnit.MILLISECONDS));
         this.maxStorageBytes = StringUtils.isBlank(maxStorage) ? null : DataUnit.parseDataSize(maxStorage, DataUnit.B).longValue();
 
         this.flowConfigFile = flowConfigFile;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/HttpRemoteSiteListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/HttpRemoteSiteListener.java
@@ -63,9 +63,9 @@ public class HttpRemoteSiteListener implements RemoteSiteListener {
         int txTtlSec;
         try {
             final String snapshotFrequency = nifiProperties.getProperty(SITE_TO_SITE_HTTP_TRANSACTION_TTL, DEFAULT_SITE_TO_SITE_HTTP_TRANSACTION_TTL);
-            txTtlSec = (int) FormatUtils.getTimeDuration(snapshotFrequency, TimeUnit.SECONDS);
+            txTtlSec = (int) Math.round(FormatUtils.getPreciseTimeDuration(snapshotFrequency, TimeUnit.SECONDS));
         } catch (final Exception e) {
-            txTtlSec = (int) FormatUtils.getTimeDuration(DEFAULT_SITE_TO_SITE_HTTP_TRANSACTION_TTL, TimeUnit.SECONDS);
+            txTtlSec = (int) Math.round(FormatUtils.getPreciseTimeDuration(DEFAULT_SITE_TO_SITE_HTTP_TRANSACTION_TTL, TimeUnit.SECONDS));
             logger.warn("Failed to parse {} due to {}, use default as {} secs.",
                     SITE_TO_SITE_HTTP_TRANSACTION_TTL, e.getMessage(), txTtlSec);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -158,7 +158,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
     public void onSchedulingStart() {
         super.onSchedulingStart();
 
-        final long penalizationMillis = FormatUtils.getTimeDuration(remoteGroup.getYieldDuration(), TimeUnit.MILLISECONDS);
+        final long penalizationMillis = Math.round(FormatUtils.getPreciseTimeDuration(remoteGroup.getYieldDuration(), TimeUnit.MILLISECONDS));
 
         final SiteToSiteClient.Builder clientBuilder = new SiteToSiteClient.Builder()
                 .urls(SiteToSiteRestApiClient.parseClusterUrls(remoteGroup.getTargetUris()))
@@ -185,7 +185,8 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
 
         final String batchDuration = getBatchDuration();
         if (batchDuration != null && batchDuration.length() > 0) {
-            clientBuilder.requestBatchDuration(FormatUtils.getTimeDuration(batchDuration.trim(), TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+            long batchDurationMillis = Math.round(FormatUtils.getPreciseTimeDuration(batchDuration.trim(), TimeUnit.MILLISECONDS));
+            clientBuilder.requestBatchDuration(batchDurationMillis, TimeUnit.MILLISECONDS);
         }
 
         clientRef.set(clientBuilder.build());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -898,7 +898,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         // we are able to avoid closing connections from users' browsers most of the time. This can make a significant difference
         // in HTTPS connections, as each HTTPS connection that is established must perform the SSL handshake.
         final String autoRefreshInterval = props.getAutoRefreshInterval();
-        final long autoRefreshMillis = autoRefreshInterval == null ? 30000L : FormatUtils.getTimeDuration(autoRefreshInterval, TimeUnit.MILLISECONDS);
+        final long autoRefreshMillis = autoRefreshInterval == null ? 30000L : Math.round(FormatUtils.getPreciseTimeDuration(autoRefreshInterval, TimeUnit.MILLISECONDS));
         final long idleTimeout = autoRefreshMillis * 2;
 
         // If the interfaces collection is empty or each element is empty

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AccessResource.java
@@ -1370,7 +1370,7 @@ public class AccessResource extends ApplicationResource {
                 }
 
                 final String expirationFromProperties = properties.getKerberosAuthenticationExpiration();
-                long expiration = FormatUtils.getTimeDuration(expirationFromProperties, TimeUnit.MILLISECONDS);
+                long expiration = Math.round(FormatUtils.getPreciseTimeDuration(expirationFromProperties, TimeUnit.MILLISECONDS));
                 final String rawIdentity = authentication.getName();
                 String mappedIdentity = IdentityMappingUtil.mapIdentity(rawIdentity, IdentityMappingUtil.getIdentityMappings(properties));
                 expiration = validateTokenExpiration(expiration, mappedIdentity);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -299,7 +299,7 @@ public final class DtoFactory {
         final FlowConfigurationDTO dto = new FlowConfigurationDTO();
 
         // get the refresh interval
-        final long refreshInterval = FormatUtils.getTimeDuration(autoRefreshInterval, TimeUnit.SECONDS);
+        final long refreshInterval =  Math.round(FormatUtils.getPreciseTimeDuration(autoRefreshInterval, TimeUnit.SECONDS));
         dto.setAutoRefreshIntervalSeconds(refreshInterval);
         dto.setSupportsManagedAuthorizer(AuthorizerCapabilityDetection.isManagedAuthorizer(authorizer));
         dto.setSupportsConfigurableUsersAndGroups(AuthorizerCapabilityDetection.isConfigurableUserGroupProvider(authorizer));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -817,7 +817,7 @@ public class ControllerFacade implements Authorizable {
      */
     public void save() throws NiFiCoreException {
         // save the flow controller
-        final long writeDelaySeconds = FormatUtils.getTimeDuration(properties.getFlowServiceWriteDelay(), TimeUnit.SECONDS);
+        final long writeDelaySeconds =  Math.round(FormatUtils.getPreciseTimeDuration(properties.getFlowServiceWriteDelay(), TimeUnit.SECONDS));
         flowService.saveFlowChanges(TimeUnit.SECONDS, writeDelaySeconds);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
@@ -124,7 +124,7 @@ public class OcspCertificateValidator {
                 }
 
                 // TODO - determine how long to cache the ocsp responses for
-                final long cacheDurationMillis = FormatUtils.getTimeDuration("12 hours", TimeUnit.MILLISECONDS);
+                final long cacheDurationMillis =  Math.round(FormatUtils.getPreciseTimeDuration("12 hours", TimeUnit.MILLISECONDS));
 
                 // build the ocsp cache
                 ocspCache = CacheBuilder.newBuilder().expireAfterWrite(cacheDurationMillis, TimeUnit.MILLISECONDS).build(new CacheLoader<OcspRequest, OcspStatus>() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/extensions/NexusExtensionClient.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/extensions/NexusExtensionClient.java
@@ -52,7 +52,7 @@ public class NexusExtensionClient implements ExtensionClient {
     public NexusExtensionClient(final String baseUrl, final SslContextDefinition sslContextDefinition, final String timeout) {
         this.baseUrl = baseUrl;
         this.sslContextDefinition = sslContextDefinition;
-        this.timeoutMillis = timeout == null ? DEFAULT_TIMEOUT_MILLIS : FormatUtils.getTimeDuration(timeout, TimeUnit.MILLISECONDS);
+        this.timeoutMillis = timeout == null ? DEFAULT_TIMEOUT_MILLIS : Math.round(FormatUtils.getPreciseTimeDuration(timeout, TimeUnit.MILLISECONDS));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-10-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-10-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
@@ -316,7 +316,8 @@ final class KafkaProcessorUtils {
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-11-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
@@ -318,7 +318,8 @@ final class KafkaProcessorUtils {
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-9-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-9-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
@@ -239,7 +239,8 @@ final class KafkaProcessorUtils {
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
@@ -318,7 +318,8 @@ public final class KafkaProcessorUtils {
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_1_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_1_0.java
@@ -328,7 +328,8 @@ public class KafkaRecordSink_1_0 extends AbstractControllerService implements Re
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (KafkaProcessorUtils.isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
@@ -411,7 +411,8 @@ public final class KafkaProcessorUtils {
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_2_0.java
@@ -328,7 +328,8 @@ public class KafkaRecordSink_2_0 extends AbstractControllerService implements Re
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (KafkaProcessorUtils.isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/KafkaProcessorUtils.java
@@ -411,7 +411,8 @@ public final class KafkaProcessorUtils {
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_2_6.java
@@ -328,7 +328,8 @@ public class KafkaRecordSink_2_6 extends AbstractControllerService implements Re
                 // If the property name ends in ".ms" then it is a time period. We want to accept either an integer as number of milliseconds
                 // or the standard NiFi time period such as "5 secs"
                 if (propertyName.endsWith(".ms") && !StringUtils.isNumeric(propertyValue.trim())) { // kafka standard time notation
-                    propertyValue = String.valueOf(FormatUtils.getTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    long millis = Math.round(FormatUtils.getPreciseTimeDuration(propertyValue.trim(), TimeUnit.MILLISECONDS));
+                    propertyValue = String.valueOf(millis);
                 }
 
                 if (KafkaProcessorUtils.isStaticStringFieldNamePresent(propertyName, kafkaConfigClass, CommonClientConfigs.class, SslConfigs.class, SaslConfigs.class)) {

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/LdapProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/LdapProvider.java
@@ -80,7 +80,7 @@ public class LdapProvider implements LoginIdentityProvider {
         }
 
         try {
-            expiration = FormatUtils.getTimeDuration(rawExpiration, TimeUnit.MILLISECONDS);
+            expiration = Math.round(FormatUtils.getPreciseTimeDuration(rawExpiration, TimeUnit.MILLISECONDS));
         } catch (final IllegalArgumentException iae) {
             throw new ProviderCreationException(String.format("The Expiration Duration '%s' is not a valid time duration", rawExpiration));
         }

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/main/java/org/apache/nifi/ldap/tenants/LdapUserGroupProvider.java
@@ -373,7 +373,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
         final long syncInterval;
         if (rawSyncInterval.isSet()) {
             try {
-                syncInterval = FormatUtils.getTimeDuration(rawSyncInterval.getValue(), TimeUnit.MILLISECONDS);
+                syncInterval = Math.round(FormatUtils.getPreciseTimeDuration(rawSyncInterval.getValue(), TimeUnit.MILLISECONDS));
             } catch (final IllegalArgumentException iae) {
                 throw new AuthorizerCreationException(String.format("The %s '%s' is not a valid time duration", PROP_SYNC_INTERVAL, rawSyncInterval.getValue()));
             }
@@ -811,7 +811,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
         final PropertyValue rawTimeout = configurationContext.getProperty(configurationProperty);
         if (rawTimeout.isSet()) {
             try {
-                final Long timeout = FormatUtils.getTimeDuration(rawTimeout.getValue(), TimeUnit.MILLISECONDS);
+                final Long timeout = Math.round(FormatUtils.getPreciseTimeDuration(rawTimeout.getValue(), TimeUnit.MILLISECONDS));
                 baseEnvironment.put(environmentKey, timeout.toString());
             } catch (final IllegalArgumentException iae) {
                 throw new AuthorizerCreationException(String.format("The %s '%s' is not a valid time duration", configurationProperty, rawTimeout));

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/RepositoryConfiguration.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/RepositoryConfiguration.java
@@ -444,9 +444,9 @@ public class RepositoryConfiguration {
         final int concurrentMergeThreads = nifiProperties.getIntegerProperty(CONCURRENT_MERGE_THREADS, 2);
         final String warmCacheFrequency = nifiProperties.getProperty(WARM_CACHE_FREQUENCY);
         final String maintenanceFrequency = nifiProperties.getProperty(MAINTENACE_FREQUENCY);
-        final long storageMillis = FormatUtils.getTimeDuration(storageTime, TimeUnit.MILLISECONDS);
+        final long storageMillis = Math.round(FormatUtils.getPreciseTimeDuration(storageTime, TimeUnit.MILLISECONDS));
         final long maxStorageBytes = DataUnit.parseDataSize(storageSize, DataUnit.B).longValue();
-        final long rolloverMillis = FormatUtils.getTimeDuration(rolloverTime, TimeUnit.MILLISECONDS);
+        final long rolloverMillis = Math.round(FormatUtils.getPreciseTimeDuration(rolloverTime, TimeUnit.MILLISECONDS));
         final long rolloverBytes = DataUnit.parseDataSize(rolloverSize, DataUnit.B).longValue();
 
         final boolean compressOnRollover = Boolean.parseBoolean(nifiProperties.getProperty(NiFiProperties.PROVENANCE_COMPRESS_ON_ROLLOVER));
@@ -497,13 +497,13 @@ public class RepositoryConfiguration {
         config.setConcurrentMergeThreads(concurrentMergeThreads);
 
         if (warmCacheFrequency != null && !warmCacheFrequency.trim().equals("")) {
-            config.setWarmCacheFrequencyMinutes((int) FormatUtils.getTimeDuration(warmCacheFrequency, TimeUnit.MINUTES));
+            config.setWarmCacheFrequencyMinutes((int)  Math.round(FormatUtils.getPreciseTimeDuration(warmCacheFrequency, TimeUnit.MINUTES)));
         }
         if (shardSize != null) {
             config.setDesiredIndexSize(DataUnit.parseDataSize(shardSize, DataUnit.B).longValue());
         }
         if (maintenanceFrequency != null && !maintenanceFrequency.trim().equals("")) {
-            final long millis = FormatUtils.getTimeDuration(maintenanceFrequency.trim(), TimeUnit.MILLISECONDS);
+            final long millis = Math.round(FormatUtils.getPreciseTimeDuration(maintenanceFrequency.trim(), TimeUnit.MILLISECONDS));
             config.setMaintenanceFrequency(millis, TimeUnit.MILLISECONDS);
         }
 

--- a/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/src/main/java/org/apache/nifi/spring/SpringContextProcessor.java
+++ b/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/src/main/java/org/apache/nifi/spring/SpringContextProcessor.java
@@ -222,10 +222,10 @@ public class SpringContextProcessor extends AbstractProcessor {
         this.applicationContextLibPath = processContext.getProperty(CTX_LIB_PATH).getValue();
 
         String stStr = processContext.getProperty(SEND_TIMEOUT).getValue();
-        this.sendTimeout = stStr == null ? 0 : FormatUtils.getTimeDuration(stStr, TimeUnit.MILLISECONDS);
+        this.sendTimeout = stStr == null ? 0 : Math.round(FormatUtils.getPreciseTimeDuration(stStr, TimeUnit.MILLISECONDS));
 
         String rtStr = processContext.getProperty(RECEIVE_TIMEOUT).getValue();
-        this.receiveTimeout = rtStr == null ? 0 : FormatUtils.getTimeDuration(rtStr, TimeUnit.MILLISECONDS);
+        this.receiveTimeout = rtStr == null ? 0 : Math.round(FormatUtils.getPreciseTimeDuration(rtStr, TimeUnit.MILLISECONDS));
 
         try {
             if (logger.isDebugEnabled()) {

--- a/nifi-toolkit/nifi-toolkit-s2s/src/main/java/org/apache/nifi/toolkit/s2s/SiteToSiteCliMain.java
+++ b/nifi-toolkit/nifi-toolkit-s2s/src/main/java/org/apache/nifi/toolkit/s2s/SiteToSiteCliMain.java
@@ -167,10 +167,12 @@ public class SiteToSiteCliMain {
             builder.portIdentifier(commandLine.getOptionValue(PORT_IDENTIFIER_OPTION));
         }
         if (commandLine.hasOption(TIMEOUT_OPTION)) {
-            builder.timeout(FormatUtils.getTimeDuration(commandLine.getOptionValue(TIMEOUT_OPTION), TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
+            long timeoutNanos = Math.round(FormatUtils.getPreciseTimeDuration(commandLine.getOptionValue(TIMEOUT_OPTION), TimeUnit.NANOSECONDS));
+            builder.timeout(timeoutNanos, TimeUnit.NANOSECONDS);
         }
         if (commandLine.hasOption(PENALIZATION_OPTION)) {
-            builder.nodePenalizationPeriod(FormatUtils.getTimeDuration(commandLine.getOptionValue(PENALIZATION_OPTION), TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
+            long penalizationNanos = Math.round(FormatUtils.getPreciseTimeDuration(commandLine.getOptionValue(PENALIZATION_OPTION), TimeUnit.NANOSECONDS));
+            builder.nodePenalizationPeriod(penalizationNanos, TimeUnit.NANOSECONDS);
         }
         if (commandLine.hasOption(KEYSTORE_OPTION)) {
             builder.keystoreFilename(commandLine.getOptionValue(KEYSTORE_OPTION));
@@ -207,7 +209,8 @@ public class SiteToSiteCliMain {
             builder.requestBatchSize(Long.parseLong(commandLine.getOptionValue(BATCH_SIZE_OPTION)));
         }
         if (commandLine.hasOption(BATCH_DURATION_OPTION)) {
-            builder.requestBatchDuration(FormatUtils.getTimeDuration(commandLine.getOptionValue(BATCH_DURATION_OPTION), TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
+            long batchDurationNanos = Math.round(FormatUtils.getPreciseTimeDuration(commandLine.getOptionValue(BATCH_DURATION_OPTION), TimeUnit.NANOSECONDS));
+            builder.requestBatchDuration(batchDurationNanos, TimeUnit.NANOSECONDS);
         }
         if (commandLine.hasOption(PROXY_HOST_OPTION)) {
             builder.httpProxy(new HttpProxy(commandLine.getOptionValue(PROXY_HOST_OPTION), Integer.parseInt(commandLine.getOptionValue(PROXY_PORT_OPTION, PROXY_PORT_OPTION_DEFAULT)),


### PR DESCRIPTION
#### Description of PR
#8370 Remove usages of deprecated org.apache.nifi.util.FormatUtils#getTimeDuration

Update usages in code of the deprecated method org.apache.nifi.util.FormatUtils#getTimeDuration
tests updated to use the 'new' version that replaces it

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
