### PR TITLE
NIFI-8374 class.newInstance has been deprecated, all references transformed

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NotificationServiceManager.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NotificationServiceManager.java
@@ -362,7 +362,7 @@ public class NotificationServiceManager {
 
         final Object serviceObject;
         try {
-            serviceObject = clazz.newInstance();
+            serviceObject = clazz.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             logger.error("Found configuration for Notification Service with ID '{}' and Class '{}' but could not instantiate Notification Service.", serviceId, className);
             logger.error("", e);

--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/crypto/CipherProviderFactory.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/crypto/CipherProviderFactory.java
@@ -46,7 +46,7 @@ public class CipherProviderFactory {
         if (registeredCipherProviders.containsKey(kdf)) {
             Class<? extends CipherProvider> clazz = registeredCipherProviders.get(kdf);
             try {
-                return clazz.newInstance();
+                return clazz.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                logger.error("Error instantiating new {} with default parameters for {}", clazz.getName(), kdf.getKdfName());
                 throw new ProcessException("Error instantiating cipher provider");

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunners.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunners.java
@@ -116,7 +116,7 @@ public class TestRunners {
      */
     public static TestRunner newTestRunner(final Class<? extends Processor> processorClass, String name) {
         try {
-            return newTestRunner(processorClass.newInstance(), name);
+            return newTestRunner(processorClass.getDeclaredConstructor().newInstance(), name);
         } catch (final Exception e) {
             System.err.println("Could not instantiate instance of class " + processorClass.getName() + " due to: " + e);
             throw new RuntimeException(e);
@@ -133,7 +133,7 @@ public class TestRunners {
      */
     public static TestRunner newTestRunner(final Class<? extends Processor> processorClass, String name, MockComponentLog logger) {
         try {
-            return newTestRunner(processorClass.newInstance(), name, logger);
+            return newTestRunner(processorClass.getDeclaredConstructor().newInstance(), name, logger);
         } catch (final Exception e) {
             System.err.println("Could not instantiate instance of class " + processorClass.getName() + " due to: " + e);
             throw new RuntimeException(e);

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -1272,7 +1272,7 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
                 if (clazz == null) {
                     throw new InitializationException("Can't load Database Driver " + drvName);
                 }
-                final Driver driver = (Driver) clazz.newInstance();
+                final Driver driver = (Driver) clazz.getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(new DriverShim(driver));
 
             } catch (final InitializationException e) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/state/manager/StandardStateManagerProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/state/manager/StandardStateManagerProvider.java
@@ -301,7 +301,8 @@ public class StandardStateManagerProvider implements StateManagerProvider {
         }
     }
 
-    private static StateProvider instantiateStateProvider(final ExtensionManager extensionManager, final String type) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    private static StateProvider instantiateStateProvider(final ExtensionManager extensionManager, final String type) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
         final ClassLoader ctxClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             final List<Bundle> bundles = extensionManager.getBundles(type);
@@ -318,7 +319,7 @@ public class StandardStateManagerProvider implements StateManagerProvider {
 
             Thread.currentThread().setContextClassLoader(detectedClassLoaderForType);
             final Class<? extends StateProvider> mgrClass = rawClass.asSubclass(StateProvider.class);
-            StateProvider provider = mgrClass.newInstance();
+            StateProvider provider = mgrClass.getDeclaredConstructor().newInstance();
             try {
                 performMethodInjection(provider, mgrClass);
             } catch (InvocationTargetException e) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/FlowManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/FlowManager.java
@@ -34,6 +34,7 @@ import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.parameter.ParameterContextManager;
 import org.apache.nifi.web.api.dto.FlowSnippetDTO;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
@@ -147,7 +148,7 @@ public interface FlowManager {
      * @param type the type of the prioritizer (fully qualified class name)
      * @return the newly created FlowFile Prioritizer
      */
-    FlowFilePrioritizer createPrioritizer(String type) throws InstantiationException, IllegalAccessException, ClassNotFoundException;
+    FlowFilePrioritizer createPrioritizer(String type) throws InstantiationException, IllegalAccessException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException;
 
     /**
      * Returns the ProcessGroup with the given ID, or null if no group exists with the given ID.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/logging/LogRepositoryFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/logging/LogRepositoryFactory.java
@@ -45,7 +45,7 @@ public class LogRepositoryFactory {
         LogRepository repository = repositoryMap.get(requireNonNull(componentId));
         if (repository == null) {
             try {
-                repository = logRepositoryClass.newInstance();
+                repository = logRepositoryClass.getDeclaredConstructor().newInstance();
             } catch (final Exception e) {
                 throw new RuntimeException(e);
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -59,6 +59,7 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.util.Collections;
@@ -353,7 +354,8 @@ public class ExtensionBuilder {
         }
     }
 
-    private ControllerServiceNode createControllerServiceNode() throws ClassNotFoundException, IllegalAccessException, InstantiationException, InitializationException {
+    private ControllerServiceNode createControllerServiceNode() throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, InitializationException,
+            NoSuchMethodException, ClassNotFoundException {
         final ClassLoader ctxClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             final Bundle bundle = extensionManager.getBundle(bundleCoordinate);
@@ -366,7 +368,7 @@ public class ExtensionBuilder {
             Thread.currentThread().setContextClassLoader(detectedClassLoader);
 
             final Class<? extends ControllerService> controllerServiceClass = rawClass.asSubclass(ControllerService.class);
-            final ControllerService serviceImpl = controllerServiceClass.newInstance();
+            final ControllerService serviceImpl = controllerServiceClass.getDeclaredConstructor().newInstance();
 
             final StandardControllerServiceInvocationHandler invocationHandler = new StandardControllerServiceInvocationHandler(extensionManager, serviceImpl);
 
@@ -527,7 +529,7 @@ public class ExtensionBuilder {
         }
     }
 
-    private <T extends ConfigurableComponent> LoggableComponent<T> createLoggableComponent(Class<T> nodeType) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    private <T extends ConfigurableComponent> LoggableComponent<T> createLoggableComponent(Class<T> nodeType) throws ReflectiveOperationException {
         final ClassLoader ctxClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             final Bundle bundle = extensionManager.getBundle(bundleCoordinate);
@@ -539,7 +541,7 @@ public class ExtensionBuilder {
             final Class<?> rawClass = Class.forName(type, true, detectedClassLoader);
             Thread.currentThread().setContextClassLoader(detectedClassLoader);
 
-            final Object extensionInstance = rawClass.newInstance();
+            final Object extensionInstance = rawClass.getDeclaredConstructor().newInstance();
 
             final ComponentLog componentLog = new SimpleProcessLogger(identifier, extensionInstance);
             final TerminationAwareLogger terminationAwareLogger = new TerminationAwareLogger(componentLog);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
@@ -70,6 +70,7 @@ import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupPortDTO;
 import org.apache.nifi.web.api.entity.ParameterContextReferenceEntity;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -585,7 +586,7 @@ public class StandardFlowSnippet implements FlowSnippet {
                 for (final String className : newPrioritizersClasses) {
                     try {
                         newPrioritizers.add(flowManager.createPrioritizer(className));
-                    } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                    } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                         throw new IllegalArgumentException("Unable to set prioritizer " + className + ": " + e);
                     }
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSynchronizer.java
@@ -115,6 +115,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -1101,7 +1102,7 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
                 for (final String className : newPrioritizersClasses) {
                     try {
                         newPrioritizers.add(flowManager.createPrioritizer(className));
-                    } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                    } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                         throw new IllegalArgumentException("Unable to set prioritizer " + className + ": " + e);
                     }
                 }
@@ -1666,7 +1667,7 @@ public class StandardFlowSynchronizer implements FlowSynchronizer {
                 for (final String className : newPrioritizersClasses) {
                     try {
                         newPrioritizers.add(flowManager.createPrioritizer(className));
-                    } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                    } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                         throw new IllegalArgumentException("Unable to set prioritizer " + className + ": " + e);
                     }
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
@@ -79,7 +79,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.sql.Ref;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -276,7 +278,7 @@ public class StandardFlowManager extends AbstractFlowManager implements FlowMana
         group.findAllRemoteProcessGroups().forEach(RemoteProcessGroup::initialize);
     }
 
-    public FlowFilePrioritizer createPrioritizer(final String type) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+    public FlowFilePrioritizer createPrioritizer(final String type) throws InstantiationException, IllegalAccessException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
         FlowFilePrioritizer prioritizer;
 
         final ClassLoader ctxClassLoader = Thread.currentThread().getContextClassLoader();
@@ -295,7 +297,7 @@ public class StandardFlowManager extends AbstractFlowManager implements FlowMana
 
             Thread.currentThread().setContextClassLoader(detectedClassLoaderForType);
             final Class<? extends FlowFilePrioritizer> prioritizerClass = rawClass.asSubclass(FlowFilePrioritizer.class);
-            final Object processorObj = prioritizerClass.newInstance();
+            final Object processorObj = prioritizerClass.getDeclaredConstructor().newInstance();
             prioritizer = prioritizerClass.cast(processorObj);
 
             return prioritizer;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
@@ -81,7 +81,6 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLContext;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
-import java.sql.Ref;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibFromNar.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibFromNar.java
@@ -79,7 +79,7 @@ public class TestLoadNativeLibFromNar extends AbstractTestNarLoader {
 
             Object actualJniMethodReturnValue = TestJNI
                     .getMethod("testJniMethod")
-                    .invoke(TestJNI.newInstance());
+                    .invoke(TestJNI.getDeclaredConstructor().newInstance());
 
             assertEquals("calledNativeTestJniMethod", actualJniMethodReturnValue);
         }
@@ -121,7 +121,7 @@ public class TestLoadNativeLibFromNar extends AbstractTestNarLoader {
 
             Object actualJniMethodReturnValue = TestJNI
                     .getMethod("testJniMethod")
-                    .invoke(TestJNI.newInstance());
+                    .invoke(TestJNI.getDeclaredConstructor().newInstance());
 
             assertThat(actualLibraryLocation, containsString(instanceClassLoader.getIdentifier()));
             assertEquals("calledNativeTestJniMethod", actualJniMethodReturnValue);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibViaSystemProperty.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibViaSystemProperty.java
@@ -94,7 +94,7 @@ public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
 
             Object actualJniMethodReturnValue = TestJNI
                     .getMethod("testJniMethod")
-                    .invoke(TestJNI.newInstance());
+                    .invoke(TestJNI.getDeclaredConstructor().newInstance());
 
             assertEquals("calledNativeTestJniMethod", actualJniMethodReturnValue);
         }
@@ -136,7 +136,7 @@ public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
 
             Object actualJniMethodReturnValue = TestJNI
                     .getMethod("testJniMethod")
-                    .invoke(TestJNI.newInstance());
+                    .invoke(TestJNI.getDeclaredConstructor().newInstance());
 
             assertThat(actualLibraryLocation, containsString(instanceClassLoader.getIdentifier()));
             assertEquals("calledNativeTestJniMethod", actualJniMethodReturnValue);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/NarThreadContextClassLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/NarThreadContextClassLoader.java
@@ -190,7 +190,7 @@ public class NarThreadContextClassLoader extends URLClassLoader {
      * @throws ClassNotFoundException if the class cannot be found
      */
     public static <T> T createInstance(final ExtensionManager extensionManager, final String implementationClassName, final Class<T> typeDefinition, final NiFiProperties nifiProperties)
-            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
         final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             final List<Bundle> bundles = extensionManager.getBundles(implementationClassName);
@@ -208,7 +208,7 @@ public class NarThreadContextClassLoader extends URLClassLoader {
             Thread.currentThread().setContextClassLoader(detectedClassLoaderForType);
             final Class<?> desiredClass = rawClass.asSubclass(typeDefinition);
             if(nifiProperties == null){
-                return typeDefinition.cast(desiredClass.newInstance());
+                return typeDefinition.cast(desiredClass.getDeclaredConstructor().newInstance());
             }
             Constructor<?> constructor = null;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/StandardExtensionDiscoveringManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/StandardExtensionDiscoveringManager.java
@@ -543,7 +543,7 @@ public class StandardExtensionDiscoveringManager implements ExtensionDiscovering
         final ClassLoader bundleClassLoader = bundle.getClassLoader();
         try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(bundleClassLoader)) {
             final Class<?> componentClass = Class.forName(classType, true, bundleClassLoader);
-            final ConfigurableComponent tempComponent = (ConfigurableComponent) componentClass.newInstance();
+            final ConfigurableComponent tempComponent = (ConfigurableComponent) componentClass.getDeclaredConstructor().newInstance();
             initializeTempComponent(tempComponent);
             tempComponentLookup.put(bundleKey, tempComponent);
             return tempComponent;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/RemoteResourceManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/RemoteResourceManager.java
@@ -134,7 +134,7 @@ public class RemoteResourceManager {
         }
 
         try {
-            return codecClass.newInstance();
+            return codecClass.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new RuntimeException("Unable to instantiate class " + codecClass.getName(), e);
         }
@@ -193,7 +193,7 @@ public class RemoteResourceManager {
         }
 
         try {
-            return desiredClass.newInstance();
+            return desiredClass.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new RuntimeException("Unable to instantiate class " + desiredClass.getName(), e);
         }
@@ -219,7 +219,7 @@ public class RemoteResourceManager {
         }
 
         try {
-            return desiredClass.newInstance();
+            return desiredClass.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new RuntimeException("Unable to instantiate class " + desiredClass.getName(), e);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -162,7 +163,7 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
             for (final String className : newPrioritizersClasses) {
                 try {
                     newPrioritizers.add(flowController.getFlowManager().createPrioritizer(className));
-                } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                     throw new IllegalArgumentException("Unable to set prioritizer " + className + ": " + e);
                 }
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/ComponentBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/ComponentBuilder.java
@@ -64,6 +64,7 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.util.Collections;
@@ -193,7 +194,7 @@ public class ComponentBuilder {
             Thread.currentThread().setContextClassLoader(detectedClassLoader);
 
             final Class<? extends ControllerService> controllerServiceClass = rawClass.asSubclass(ControllerService.class);
-            final ControllerService serviceImpl = controllerServiceClass.newInstance();
+            final ControllerService serviceImpl = controllerServiceClass.getDeclaredConstructor().newInstance();
             final StandardControllerServiceInvocationHandler invocationHandler = new StandardControllerServiceInvocationHandler(extensionManager, serviceImpl);
 
             // extract all interfaces... controllerServiceClass is non null so getAllInterfaces is non null
@@ -249,7 +250,8 @@ public class ComponentBuilder {
         }
     }
 
-    private <T extends ConfigurableComponent> LoggableComponent<T> createLoggableComponent(Class<T> nodeType) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    private <T extends ConfigurableComponent> LoggableComponent<T> createLoggableComponent(Class<T> nodeType) throws ClassNotFoundException, IllegalAccessException, InstantiationException,
+            NoSuchMethodException, InvocationTargetException {
         final ClassLoader ctxClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             final ExtensionManager extensionManager = statelessEngine.getExtensionManager();
@@ -271,7 +273,7 @@ public class ComponentBuilder {
             final Class<?> rawClass = Class.forName(type, true, detectedClassLoader);
             Thread.currentThread().setContextClassLoader(detectedClassLoader);
 
-            final Object extensionInstance = rawClass.newInstance();
+            final Object extensionInstance = rawClass.getDeclaredConstructor().newInstance();
             final ComponentLog componentLog = new SimpleProcessLogger(identifier, extensionInstance);
             final TerminationAwareLogger terminationAwareLogger = new TerminationAwareLogger(componentLog);
 

--- a/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -338,7 +338,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
             compiled = (Class<Script>) script.getClass();
         }
         if (script == null) {
-            script = compiled.newInstance();
+            script = compiled.getDeclaredConstructor().newInstance();
         }
         Thread.currentThread().setContextClassLoader(shell.getClassLoader());
         return script;

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
@@ -864,7 +864,7 @@ public class TestGetHDFSFileInfo {
                 String clzName = f.getName().substring("list_exception_".length(), f.getName().length());
                 IOException exception = null;
                 try {
-                     exception = (IOException)Class.forName(clzName).newInstance();
+                     exception = (IOException)Class.forName(clzName).getDeclaredConstructor().newInstance();
                 } catch (Throwable t) {
                     throw new RuntimeException(t);
                 }
@@ -903,7 +903,7 @@ public class TestGetHDFSFileInfo {
                 String clzName = f.getName().substring("exception_".length(), f.getName().length());
                 IOException exception = null;
                 try {
-                     exception = (IOException)Class.forName(clzName).newInstance();
+                     exception = (IOException)Class.forName(clzName).getDeclaredConstructor().newInstance();
                 } catch (Throwable t) {
                     throw new RuntimeException(t);
                 }

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcFlowFileWriter.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcFlowFileWriter.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -311,13 +312,17 @@ public class OrcFlowFileWriter implements Writer, MemoryManager.Callback {
                     Class<? extends CompressionCodec> lzo =
                             (Class<? extends CompressionCodec>)
                                     JavaUtils.loadClass("org.apache.hadoop.hive.ql.io.orc.LzoCodec");
-                    return lzo.newInstance();
+                    return lzo.getDeclaredConstructor().newInstance();
                 } catch (ClassNotFoundException e) {
                     throw new IllegalArgumentException("LZO is not available.", e);
                 } catch (InstantiationException e) {
                     throw new IllegalArgumentException("Problem initializing LZO", e);
                 } catch (IllegalAccessException e) {
                     throw new IllegalArgumentException("Insufficient access to LZO", e);
+                } catch (NoSuchMethodException e) {
+                    throw new IllegalArgumentException("LZO is not available.", e);
+                } catch (InvocationTargetException e) {
+                    throw new IllegalArgumentException("Problem initializing LZO", e);
                 }
             default:
                 throw new IllegalArgumentException("Unknown compression codec: " +

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/Utils.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/Utils.java
@@ -40,7 +40,7 @@ public final class Utils {
     static <T> T newDefaultInstance(String className) {
         try {
             Class<T> clazz = (Class<T>) Class.forName(className, false, Thread.currentThread().getContextClassLoader());
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new IllegalStateException("Failed to load and/or instantiate class '" + className + "'", e);
         }

--- a/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/main/java/org/apache/nifi/processors/jolt/record/util/TransformFactory.java
+++ b/nifi-nar-bundles/nifi-jolt-record-bundle/nifi-jolt-record-processors/src/main/java/org/apache/nifi/processors/jolt/record/util/TransformFactory.java
@@ -68,7 +68,7 @@ public class TransformFactory {
             return (JoltTransform)constructor.newInstance(specJson);
 
         }else{
-            return (JoltTransform)clazz.newInstance();
+            return (JoltTransform)clazz.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-8-processors/src/main/java/org/apache/nifi/processors/kafka/KafkaPublisher.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-0-8-processors/src/main/java/org/apache/nifi/processors/kafka/KafkaPublisher.java
@@ -75,7 +75,7 @@ class KafkaPublisher implements Closeable {
         this.ackCheckSize = ackCheckSize;
         try {
             if (kafkaProperties.containsKey("partitioner.class")) {
-                this.partitioner = (Partitioner) Class.forName(kafkaProperties.getProperty("partitioner.class")).newInstance();
+                this.partitioner = (Partitioner) Class.forName(kafkaProperties.getProperty("partitioner.class")).getDeclaredConstructor().newInstance();
             } else {
                 this.partitioner = null;
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-utils/src/main/java/org/apache/nifi/processors/standard/util/jolt/TransformFactory.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-utils/src/main/java/org/apache/nifi/processors/standard/util/jolt/TransformFactory.java
@@ -68,7 +68,7 @@ public class TransformFactory {
             return (JoltTransform)constructor.newInstance(specJson);
 
         }else{
-            return (JoltTransform)clazz.newInstance();
+            return (JoltTransform)clazz.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
@@ -484,7 +484,7 @@ public class DBCPConnectionPool extends AbstractControllerService implements DBC
                 if (clazz == null) {
                     throw new InitializationException("Can't load Database Driver " + drvName);
                 }
-                final Driver driver = (Driver) clazz.newInstance();
+                final Driver driver = (Driver) clazz.getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(new DriverShim(driver));
 
                 return classLoader;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/src/main/java/com/hortonworks/registries/schemaregistry/client/SchemaRegistryClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/src/main/java/com/hortonworks/registries/schemaregistry/client/SchemaRegistryClient.java
@@ -214,7 +214,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                 HostnameVerifier hostNameVerifier = null;
                 String hostNameVerifierClassName = sslConfigurations.get(HOSTNAME_VERIFIER_CLASS_KEY);
                 try {
-                    hostNameVerifier = (HostnameVerifier) Class.forName(hostNameVerifierClassName).newInstance();
+                    hostNameVerifier = (HostnameVerifier) Class.forName(hostNameVerifierClassName).getDeclaredConstructor().newInstance();
                 } catch (Exception e) {
                     throw new RuntimeException("Failed to instantiate hostNameVerifierClass : " + hostNameVerifierClassName, e);
                 }
@@ -1084,8 +1084,8 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
         for (SchemaProviderInfo schemaProvider : supportedSchemaProviders) {
             if (schemaProvider.getType().equals(type)) {
                 try {
-                    return (T) Class.forName(schemaProvider.getDefaultSerializerClassName()).newInstance();
-                } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+                    return (T) Class.forName(schemaProvider.getDefaultSerializerClassName()).getDeclaredConstructor().newInstance();
+                } catch (ReflectiveOperationException e) {
                     throw new SerDesException(e);
                 }
             }
@@ -1100,8 +1100,8 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
         for (SchemaProviderInfo schemaProvider : supportedSchemaProviders) {
             if (schemaProvider.getType().equals(type)) {
                 try {
-                    return (T) Class.forName(schemaProvider.getDefaultDeserializerClassName()).newInstance();
-                } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+                    return (T) Class.forName(schemaProvider.getDefaultDeserializerClassName()).getDeclaredConstructor().newInstance();
+                } catch (ReflectiveOperationException e) {
                     throw new SerDesException(e);
                 }
             }
@@ -1153,7 +1153,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                     isSerializer ? serDesPair.getSerializerClassName() : serDesPair.getDeserializerClassName();
 
             Class<T> clazz = (Class<T>) Class.forName(className, true, classLoader);
-            t = clazz.newInstance();
+            t = clazz.getDeclaredConstructor().newInstance();
             List<Class<?>> classes = new ArrayList<>();
             for (Class<?> interfaceClass : interfaceClasses) {
                 if (interfaceClass.isAssignableFrom(clazz)) {
@@ -1169,7 +1169,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
             Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
                     classes.toArray(new Class[classes.size()]),
                     new ClassLoaderAwareInvocationHandler(classLoader, t));
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new SerDesException(e);
         }
 

--- a/nifi-toolkit/nifi-toolkit-admin/src/main/groovy/org/apache/nifi/toolkit/admin/configmigrator/ConfigMigrator.groovy
+++ b/nifi-toolkit/nifi-toolkit-admin/src/main/groovy/org/apache/nifi/toolkit/admin/configmigrator/ConfigMigrator.groovy
@@ -68,13 +68,13 @@ public class ConfigMigrator {
 
     Boolean supportedVersion(final File script, final String currentVersion) {
         final Class ruleClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(script)
-        final GroovyObject ruleObject = (GroovyObject) ruleClass.newInstance()
+        final GroovyObject ruleObject = (GroovyObject) ruleClass.getDeclaredConstructor().newInstance()
         ruleObject.invokeMethod('supportedVersion', [currentVersion])
     }
 
     byte[] migrateContent(final File script, final byte[] content, final byte[] upgradeContent) {
         final Class ruleClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(script)
-        final GroovyObject ruleObject = (GroovyObject) ruleClass.newInstance()
+        final GroovyObject ruleObject = (GroovyObject) ruleClass.getDeclaredConstructor().newInstance()
         ruleObject.invokeMethod('migrate', [content, upgradeContent])
     }
 


### PR DESCRIPTION
#### Description of PR

#8374  The java method class.newIstance has been deprecated, according to java official documentation:
The call
 clazz.newInstance() can be replaced by  clazz.getDeclaredConstructor().newInstance()
exceptions have been added to the method signature when appropriate

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?