### PR TITLE
NIFI-8435 Added Kudu Client Worker Count property

### DIFF
--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/pom.xml
@@ -90,12 +90,6 @@
             <version>1.14.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-security-kerberos</artifactId>
-            <version>1.14.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.kudu</groupId>
             <artifactId>kudu-test-utils</artifactId>
             <version>${kudu.version}</version>

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -60,7 +60,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -121,6 +127,16 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
             .defaultValue(String.valueOf(AsyncKuduClient.DEFAULT_KEEP_ALIVE_PERIOD_MS) + "ms")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .build();
+
+    private static final int DEFAULT_WORKER_COUNT = 2 * Runtime.getRuntime().availableProcessors();
+    static final PropertyDescriptor WORKER_COUNT = new Builder()
+            .name("worker-count")
+            .displayName("Kudu Client Worker Count")
+            .description("The maximum number of worker threads handling Kudu client read and write operations. Defaults to the number of available processors multiplied by 2.")
+            .required(true)
+            .defaultValue(Integer.toString(DEFAULT_WORKER_COUNT))
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
     private volatile KuduClient kuduClient;
@@ -184,10 +200,25 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
         final String masters = context.getProperty(KUDU_MASTERS).evaluateAttributeExpressions().getValue();
         final int operationTimeout = context.getProperty(KUDU_OPERATION_TIMEOUT_MS).evaluateAttributeExpressions().asTimePeriod(TimeUnit.MILLISECONDS).intValue();
         final int adminOperationTimeout = context.getProperty(KUDU_KEEP_ALIVE_PERIOD_TIMEOUT_MS).evaluateAttributeExpressions().asTimePeriod(TimeUnit.MILLISECONDS).intValue();
+        final int workerCount = context.getProperty(WORKER_COUNT).asInteger();
+
+        // Create Executor following approach of Executors.newCachedThreadPool() using worker count as maximum pool size
+        final int corePoolSize = 0;
+        final long threadKeepAliveTime = 60;
+        final Executor nioExecutor = new ThreadPoolExecutor(
+                corePoolSize,
+                workerCount,
+                threadKeepAliveTime,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                new ClientThreadFactory(getIdentifier())
+        );
 
         return new KuduClient.KuduClientBuilder(masters)
                 .defaultOperationTimeoutMs(operationTimeout)
-                .defaultSocketReadTimeoutMs(adminOperationTimeout)
+                .defaultAdminOperationTimeoutMs(adminOperationTimeout)
+                .workerCount(workerCount)
+                .nioExecutor(nioExecutor)
                 .build();
     }
 
@@ -292,7 +323,7 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
     }
 
     @VisibleForTesting
-    protected void buildPartialRow(Schema schema, PartialRow row, Record record, List<String> fieldNames, Boolean ignoreNull, Boolean lowercaseFields) {
+    protected void buildPartialRow(Schema schema, PartialRow row, Record record, List<String> fieldNames, boolean ignoreNull, boolean lowercaseFields) {
         for (String recordFieldName : fieldNames) {
             String colName = recordFieldName;
             if (lowercaseFields) {
@@ -430,5 +461,35 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
                 .build());
 
         return alterTable;
+    }
+
+    private static class ClientThreadFactory implements ThreadFactory {
+        private final ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
+
+        private final AtomicInteger threadCount = new AtomicInteger();
+
+        private final String identifier;
+
+        private ClientThreadFactory(final String identifier) {
+            this.identifier = identifier;
+        }
+
+        /**
+         * Create new daemon Thread with custom name
+         *
+         * @param runnable Runnable
+         * @return Created Thread
+         */
+        @Override
+        public Thread newThread(final Runnable runnable) {
+            final Thread thread = defaultThreadFactory.newThread(runnable);
+            thread.setDaemon(true);
+            thread.setName(getName());
+            return thread;
+        }
+
+        private String getName() {
+            return String.format("PutKudu[%s]-client-%d", identifier, threadCount.getAndIncrement());
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -216,7 +216,7 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
 
         return new KuduClient.KuduClientBuilder(masters)
                 .defaultOperationTimeoutMs(operationTimeout)
-                .defaultAdminOperationTimeoutMs(adminOperationTimeout)
+                .defaultSocketReadTimeoutMs(adminOperationTimeout)
                 .workerCount(workerCount)
                 .nioExecutor(nioExecutor)
                 .build();

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
@@ -367,7 +367,7 @@ public class PutKudu extends AbstractKuduProcessor {
 
         final KuduSession kuduSession = createKuduSession(kuduClient);
         try {
-            processFlowFiles(flowFiles,
+            processRecords(flowFiles,
                     processedRecords,
                     flowFileFailures,
                     operationFlowFileMap,
@@ -393,7 +393,7 @@ public class PutKudu extends AbstractKuduProcessor {
         }
     }
 
-    private void processFlowFiles(final List<FlowFile> flowFiles,
+    private void processRecords(final List<FlowFile> flowFiles,
                                  final Map<FlowFile, Integer> processedRecords,
                                  final Map<FlowFile, Object> flowFileFailures,
                                  final Map<Operation, FlowFile> operationFlowFileMap,

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
@@ -30,6 +30,8 @@ import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.SystemResource;
+import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -78,6 +80,7 @@ import static org.apache.nifi.expression.ExpressionLanguageScope.FLOWFILE_ATTRIB
 import static org.apache.nifi.expression.ExpressionLanguageScope.NONE;
 import static org.apache.nifi.expression.ExpressionLanguageScope.VARIABLE_REGISTRY;
 
+@SystemResourceConsideration(resource = SystemResource.MEMORY)
 @EventDriven
 @SupportsBatching
 @RequiresInstanceClassLoading // Because of calls to UserGroupInformation.setConfiguration
@@ -296,6 +299,7 @@ public class PutKudu extends AbstractKuduProcessor {
         properties.add(IGNORE_NULL);
         properties.add(KUDU_OPERATION_TIMEOUT_MS);
         properties.add(KUDU_KEEP_ALIVE_PERIOD_TIMEOUT_MS);
+        properties.add(WORKER_COUNT);
         return properties;
     }
 
@@ -342,12 +346,12 @@ public class PutKudu extends AbstractKuduProcessor {
 
         final KerberosUser user = getKerberosUser();
         if (user == null) {
-            executeOnKuduClient(kuduClient -> trigger(context, session, flowFiles, kuduClient));
+            executeOnKuduClient(kuduClient -> processFlowFiles(context, session, flowFiles, kuduClient));
             return;
         }
 
         final PrivilegedExceptionAction<Void> privilegedAction = () -> {
-            executeOnKuduClient(kuduClient -> trigger(context, session, flowFiles, kuduClient));
+            executeOnKuduClient(kuduClient -> processFlowFiles(context, session, flowFiles, kuduClient));
             return null;
         };
 
@@ -355,25 +359,60 @@ public class PutKudu extends AbstractKuduProcessor {
         action.execute();
     }
 
-    private void trigger(final ProcessContext context, final ProcessSession session, final List<FlowFile> flowFiles, KuduClient kuduClient) throws ProcessException {
-        final RecordReaderFactory recordReaderFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
-
-        final KuduSession kuduSession = createKuduSession(kuduClient);
-
-        final Map<FlowFile, Integer> numRecords = new HashMap<>();
+    private void processFlowFiles(final ProcessContext context, final ProcessSession session, final List<FlowFile> flowFiles, final KuduClient kuduClient) {
+        final Map<FlowFile, Integer> processedRecords = new HashMap<>();
         final Map<FlowFile, Object> flowFileFailures = new HashMap<>();
         final Map<Operation, FlowFile> operationFlowFileMap = new HashMap<>();
-
-        int numBuffered = 0;
-        OperationType prevOperationType = OperationType.INSERT;
         final List<RowError> pendingRowErrors = new ArrayList<>();
+
+        final KuduSession kuduSession = createKuduSession(kuduClient);
+        try {
+            processFlowFiles(flowFiles,
+                    processedRecords,
+                    flowFileFailures,
+                    operationFlowFileMap,
+                    pendingRowErrors,
+                    session,
+                    context,
+                    kuduClient,
+                    kuduSession);
+        } finally {
+            try {
+                flushKuduSession(kuduSession, true, pendingRowErrors);
+            } catch (final KuduException|RuntimeException e) {
+                getLogger().error("KuduSession.close() Failed", e);
+            }
+        }
+
+        if (isRollbackOnFailure() && (!pendingRowErrors.isEmpty() || !flowFileFailures.isEmpty())) {
+            logFailures(pendingRowErrors, operationFlowFileMap);
+            session.rollback();
+            context.yield();
+        } else {
+            transferFlowFiles(flowFiles, processedRecords, flowFileFailures, operationFlowFileMap, pendingRowErrors, session);
+        }
+    }
+
+    private void processFlowFiles(final List<FlowFile> flowFiles,
+                                 final Map<FlowFile, Integer> processedRecords,
+                                 final Map<FlowFile, Object> flowFileFailures,
+                                 final Map<Operation, FlowFile> operationFlowFileMap,
+                                 final List<RowError> pendingRowErrors,
+                                 final ProcessSession session,
+                                 final ProcessContext context,
+                                 final KuduClient kuduClient,
+                                 final KuduSession kuduSession) {
+        final RecordReaderFactory recordReaderFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
+
+        int bufferedRecords = 0;
+        OperationType prevOperationType = OperationType.INSERT;
         for (FlowFile flowFile : flowFiles) {
             try (final InputStream in = session.read(flowFile);
-                final RecordReader recordReader = recordReaderFactory.createRecordReader(flowFile, in, getLogger())) {
+                 final RecordReader recordReader = recordReaderFactory.createRecordReader(flowFile, in, getLogger())) {
 
                 final String tableName = getEvaluatedProperty(TABLE_NAME, context, flowFile);
-                final Boolean ignoreNull = Boolean.valueOf(getEvaluatedProperty(IGNORE_NULL, context, flowFile));
-                final Boolean lowercaseFields = Boolean.valueOf(getEvaluatedProperty(LOWERCASE_FIELD_NAMES, context, flowFile));
+                final boolean ignoreNull = Boolean.parseBoolean(getEvaluatedProperty(IGNORE_NULL, context, flowFile));
+                final boolean lowercaseFields = Boolean.parseBoolean(getEvaluatedProperty(LOWERCASE_FIELD_NAMES, context, flowFile));
                 final boolean handleSchemaDrift = Boolean.parseBoolean(getEvaluatedProperty(HANDLE_SCHEMA_DRIFT, context, flowFile));
 
                 final Function<Record, OperationType> operationTypeFunction;
@@ -391,11 +430,11 @@ public class PutKudu extends AbstractKuduProcessor {
                 if (handleSchemaDrift) {
                     final Schema schema = kuduTable.getSchema();
                     final List<RecordField> missing = recordReader.getSchema().getFields().stream()
-                        .filter(field -> !schema.hasColumn(lowercaseFields ? field.getFieldName().toLowerCase() : field.getFieldName()))
-                        .collect(Collectors.toList());
+                            .filter(field -> !schema.hasColumn(lowercaseFields ? field.getFieldName().toLowerCase() : field.getFieldName()))
+                            .collect(Collectors.toList());
 
                     if (!missing.isEmpty()) {
-                        getLogger().info("adding {} columns to table '{}' to handle schema drift", new Object[]{missing.size(), tableName});
+                        getLogger().info("adding {} columns to table '{}' to handle schema drift", missing.size(), tableName);
 
                         // Add each column one at a time to avoid failing if some of the missing columns
                         // we created by a concurrent thread or application attempting to handle schema drift.
@@ -407,7 +446,7 @@ public class PutKudu extends AbstractKuduProcessor {
                                 // Ignore the exception if the column already exists due to concurrent
                                 // threads or applications attempting to handle schema drift.
                                 if (e.getStatus().isAlreadyPresent()) {
-                                    getLogger().info("Column already exists in table '{}' while handling schema drift", new Object[]{tableName});
+                                    getLogger().info("Column already exists in table '{}' while handling schema drift", tableName);
                                 } else {
                                     throw new ProcessException(e);
                                 }
@@ -437,7 +476,7 @@ public class PutKudu extends AbstractKuduProcessor {
                             final RecordFieldType fieldType = fieldValue.getField().getDataType().getFieldType();
                             if (fieldType != RecordFieldType.RECORD) {
                                 throw new ProcessException("RecordPath " + dataRecordPath.getPath() + " evaluated against Record expected to return one or more Records but encountered field of type" +
-                                    " " + fieldType);
+                                        " " + fieldType);
                             }
                         }
 
@@ -455,7 +494,7 @@ public class PutKudu extends AbstractKuduProcessor {
                         // This should be removed when the lowest supported version of Kudu supports
                         // ignore operations.
                         if (!supportsInsertIgnoreOp && prevOperationType != operationType
-                            && (prevOperationType == OperationType.INSERT_IGNORE || operationType == OperationType.INSERT_IGNORE)) {
+                                && (prevOperationType == OperationType.INSERT_IGNORE || operationType == OperationType.INSERT_IGNORE)) {
                             flushKuduSession(kuduSession, false, pendingRowErrors);
                             kuduSession.setIgnoreAllDuplicateRows(operationType == OperationType.INSERT_IGNORE);
                         }
@@ -470,8 +509,8 @@ public class PutKudu extends AbstractKuduProcessor {
                         // Flush mutation buffer of KuduSession to avoid "MANUAL_FLUSH is enabled
                         // but the buffer is too big" error. This can happen when flush mode is
                         // MANUAL_FLUSH and a FlowFile has more than one records.
-                        if (numBuffered == batchSize && flushMode == SessionConfiguration.FlushMode.MANUAL_FLUSH) {
-                            numBuffered = 0;
+                        if (bufferedRecords == batchSize && flushMode == SessionConfiguration.FlushMode.MANUAL_FLUSH) {
+                            bufferedRecords = 0;
                             flushKuduSession(kuduSession, false, pendingRowErrors);
                         }
 
@@ -484,8 +523,8 @@ public class PutKudu extends AbstractKuduProcessor {
                             break recordReaderLoop;
                         }
 
-                        numBuffered++;
-                        numRecords.merge(flowFile, 1, Integer::sum);
+                        bufferedRecords++;
+                        processedRecords.merge(flowFile, 1, Integer::sum);
                     }
 
                     record = recordSet.next();
@@ -495,58 +534,37 @@ public class PutKudu extends AbstractKuduProcessor {
                 flowFileFailures.put(flowFile, ex);
             }
         }
+    }
 
-        // If configured to rollback on failure, and there's at least one error, rollback the session and return.
-        if (isRollbackOnFailure() && (!pendingRowErrors.isEmpty() || !flowFileFailures.isEmpty())) {
-            logFailures(pendingRowErrors, operationFlowFileMap);
-            session.rollback();
-            context.yield();
-            return;
-        }
-
-        // If any data is buffered, flush it.
-        if (numBuffered > 0) {
-            try {
-                flushKuduSession(kuduSession, true, pendingRowErrors);
-            } catch (final Exception e) {
-                getLogger().error("Failed to flush/close Kudu Session", e);
-                for (final FlowFile flowFile : flowFiles) {
-                    session.transfer(flowFile, REL_FAILURE);
-                }
-
-                return;
-            }
-        }
-
-        // It's possible that there were no row errors when this was checked above, but flushing the Kudu session may have introduced
-        // one or more Row Errors. So we need to check again.
-        if (isRollbackOnFailure() && !pendingRowErrors.isEmpty()) {
-            logFailures(pendingRowErrors, operationFlowFileMap);
-            session.rollback();
-            context.yield();
-            return;
-        }
-
+    private void transferFlowFiles(final List<FlowFile> flowFiles,
+                                   final Map<FlowFile, Integer> processedRecords,
+                                   final Map<FlowFile, Object> flowFileFailures,
+                                   final Map<Operation, FlowFile> operationFlowFileMap,
+                                   final List<RowError> pendingRowErrors,
+                                   final ProcessSession session) {
         // Find RowErrors for each FlowFile
-        final Map<FlowFile, List<RowError>> flowFileRowErrors = pendingRowErrors.stream().collect(
-            Collectors.groupingBy(e -> operationFlowFileMap.get(e.getOperation())));
+        final Map<FlowFile, List<RowError>> flowFileRowErrors = pendingRowErrors.stream()
+                .filter(e -> operationFlowFileMap.get(e.getOperation()) != null)
+                .collect(
+                    Collectors.groupingBy(e -> operationFlowFileMap.get(e.getOperation()))
+                );
 
         long totalCount = 0L;
-        for (final FlowFile flowFile : flowFiles) {
-            final int count = numRecords.getOrDefault(flowFile, 0);
+        for (FlowFile flowFile : flowFiles) {
+            final int count = processedRecords.getOrDefault(flowFile, 0);
             totalCount += count;
             final List<RowError> rowErrors = flowFileRowErrors.get(flowFile);
 
             if (rowErrors != null) {
-                rowErrors.forEach(rowError -> getLogger().error("Failed to write due to {}", new Object[] {rowError.toString()}));
-                session.putAttribute(flowFile, RECORD_COUNT_ATTR, String.valueOf(count - rowErrors.size()));
+                rowErrors.forEach(rowError -> getLogger().error("Failed to write due to {}", rowError.toString()));
+                flowFile = session.putAttribute(flowFile, RECORD_COUNT_ATTR, Integer.toString(count - rowErrors.size()));
                 totalCount -= rowErrors.size(); // Don't include error rows in the the counter.
                 session.transfer(flowFile, REL_FAILURE);
             } else {
-                session.putAttribute(flowFile, RECORD_COUNT_ATTR, String.valueOf(count));
+                flowFile = session.putAttribute(flowFile, RECORD_COUNT_ATTR, String.valueOf(count));
 
                 if (flowFileFailures.containsKey(flowFile)) {
-                    getLogger().error("Failed to write due to {}", new Object[]{flowFileFailures.get(flowFile)});
+                    getLogger().error("Failed to write due to {}", flowFileFailures.get(flowFile));
                     session.transfer(flowFile, REL_FAILURE);
                 } else {
                     session.transfer(flowFile, REL_SUCCESS);
@@ -566,7 +584,7 @@ public class PutKudu extends AbstractKuduProcessor {
             final FlowFile flowFile = entry.getKey();
             final List<RowError> errors = entry.getValue();
 
-            getLogger().error("Could not write {} to Kudu due to: {}", new Object[] {flowFile, errors});
+            getLogger().error("Could not write {} to Kudu due to: {}", flowFile, errors);
         }
     }
 
@@ -586,8 +604,8 @@ public class PutKudu extends AbstractKuduProcessor {
     }
 
     protected Operation createKuduOperation(OperationType operationType, Record record,
-                                          List<String> fieldNames, Boolean ignoreNull,
-                                          Boolean lowercaseFields, KuduTable kuduTable) {
+                                          List<String> fieldNames, boolean ignoreNull,
+                                          boolean lowercaseFields, KuduTable kuduTable) {
         Operation operation;
         switch (operationType) {
             case INSERT:

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/test/java/org/apache/nifi/processors/kudu/MockPutKudu.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/test/java/org/apache/nifi/processors/kudu/MockPutKudu.java
@@ -72,8 +72,8 @@ public class MockPutKudu extends PutKudu {
 
     @Override
     protected Operation createKuduOperation(OperationType operationType, Record record,
-                                            List<String> fieldNames, Boolean ignoreNull,
-                                            Boolean lowercaseFields, KuduTable kuduTable) {
+                                            List<String> fieldNames, boolean ignoreNull,
+                                            boolean lowercaseFields, KuduTable kuduTable) {
         Operation operation = opQueue.poll();
         if (operation == null) {
             switch (operationType) {


### PR DESCRIPTION
#### Description of PR

NIFI-8435 Adds the `Kudu Client Worker Count` property to `PutKudu` with a default value that matches the value used in `KuduClient`.  The property sets both the worker count property for `KuduClient` as well the maximum pool size for the `ThreadPoolExecutor` that `KuduClient` uses to configure the internal Netty `NioEventLoopGroup`.  This maximum pool size ensures that the thread pool cannot continue to grow unbounded in certain edge case scenarios.  The custom `ThreadFactory` also names client threads using the Processor Identifier to assist with runtime troubleshooting.

Updates also include refactoring processing methods to ensure that the `KuduSession` is always closed after each `onTrigger` invocation.  Under the previous implementation, the Processor called `KuduSession.close()` when remaining buffered records were found.  `PutKudu` is also annotated with `SystemResource.MEMORY` to indicate that multiple instances increase memory usage based on pooled byte buffering present in Netty version 4.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [X] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
