### PR TITLE
NIFI-8463: Support custom SASL protocol name in PutKudu

### DIFF
--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
@@ -300,6 +300,7 @@ public class PutKudu extends AbstractKuduProcessor {
         properties.add(KUDU_OPERATION_TIMEOUT_MS);
         properties.add(KUDU_KEEP_ALIVE_PERIOD_TIMEOUT_MS);
         properties.add(WORKER_COUNT);
+        properties.add(KUDU_SASL_PROTOCOL_NAME);
         return properties;
     }
 

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/test/java/org/apache/nifi/processors/kudu/ITPutKudu.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/test/java/org/apache/nifi/processors/kudu/ITPutKudu.java
@@ -68,6 +68,8 @@ public class ITPutKudu {
             new MiniKuduCluster.MiniKuduClusterBuilder()
                 .addMasterServerFlag("--use_hybrid_clock=false")
                 .addTabletServerFlag("--use_hybrid_clock=false")
+                .enableKerberos()
+                .principal("oryx")
     );
 
     private TestRunner testRunner;
@@ -99,6 +101,9 @@ public class ITPutKudu {
         testRunner.setProperty(PutKudu.LOWERCASE_FIELD_NAMES, "false");
         testRunner.setProperty(PutKudu.RECORD_READER, "mock-reader-factory");
         testRunner.setProperty(PutKudu.INSERT_OPERATION, OperationType.INSERT_IGNORE.toString());
+        testRunner.setProperty(PutKudu.KERBEROS_PRINCIPAL, "test-user");
+        testRunner.setProperty(PutKudu.KERBEROS_PASSWORD, "test-user");
+        testRunner.setProperty(PutKudu.KUDU_SASL_PROTOCOL_NAME, "oryx");
     }
 
     private void createKuduTable() throws KuduException {

--- a/nifi-nar-bundles/nifi-kudu-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kudu-bundle/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <exclude.tests>None</exclude.tests>
-        <kudu.version>1.14.0</kudu.version>
+        <kudu.version>1.15.0</kudu.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
#### Description of PR

As of KUDU-1884, Kudu supports custom Kerberos principals on server-side
and custom SASL protocol (service) names on client-side which must match
the SPN base, i.e. if the SPN is kudu/_HOST, SASL protocol name *must*
be "kudu" in the client to be able to connect to the cluster.

This patch adds the ability to configure this in the PutKudu processor.

- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?
