### PR TITLE
NIFI-8502 Upgrade Spring Framework to 5.3.6

### DIFF
--- a/minifi/minifi-assembly/NOTICE
+++ b/minifi/minifi-assembly/NOTICE
@@ -107,8 +107,8 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4.1.4.RELEASE
-      Copyright (c) 2002-2015 Pivotal, Inc.
+      Spring Framework 5
+      Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Xalan
      This product includes software developed by

--- a/minifi/minifi-c2/minifi-c2-assembly/NOTICE
+++ b/minifi/minifi-c2/minifi-c2-assembly/NOTICE
@@ -157,12 +157,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
     (ASLv2) Quartz

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/src/main/resources/META-INF/NOTICE
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/src/main/resources/META-INF/NOTICE
@@ -88,12 +88,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Swagger Core

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/pom.xml
@@ -52,44 +52,6 @@
             <artifactId>nifi-expression-language</artifactId>
             <scope>compile</scope>
         </dependency>
-        <!--
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-framework-nar-loading-utils</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-nar-utils</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-properties</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-framework-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.8</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>5.0.9.RELEASE</version>
-            <scope>test</scope>
-        </dependency>-->
     </dependencies>
 </project>
 

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/src/main/resources/META-INF/NOTICE
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/src/main/resources/META-INF/NOTICE
@@ -95,12 +95,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Swagger Core

--- a/minifi/minifi-toolkit/minifi-toolkit-assembly/NOTICE
+++ b/minifi/minifi-toolkit/minifi-toolkit-assembly/NOTICE
@@ -106,12 +106,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
     (ASLv2) Quartz

--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -91,8 +91,8 @@ limitations under the License.
     <properties>
         <inceptionYear>2016</inceptionYear>
         <jersey.version>2.29</jersey.version>
-        <spring.version>4.3.30.RELEASE</spring.version>
-        <spring.security.version>4.2.20.RELEASE</spring.security.version>
+        <spring.version>5.3.6</spring.version>
+        <spring.security.version>5.4.6</spring.security.version>
         <system.rules.version>1.16.1</system.rules.version>
         <aws.sdk.version>1.11.172</aws.sdk.version>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>

--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -345,12 +345,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4 and 5
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Apache Flume

--- a/nifi-external/nifi-kafka-connect/nifi-kafka-connector-assembly/NOTICE
+++ b/nifi-external/nifi-kafka-connect/nifi-kafka-connector-assembly/NOTICE
@@ -100,7 +100,7 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) ASM Based Accessors Helper Used By JSON Smart (net.minidev:accessors-smart:jar:1.2 - http://www.minidev.net/)

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-nar/src/main/resources/META-INF/NOTICE
@@ -447,7 +447,7 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4.3.10.RELEASE
+      Spring Framework 5
       Copyright (c) 2002-2015 Pivotal, Inc.
 
   (ASLv2) Snappy Java

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <atlas.version>2.1.0</atlas.version>
+        <spring.version>5.3.6</spring.version>
     </properties>
 
     <modules>
@@ -67,6 +68,16 @@
                         <artifactId>log4j</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/pom.xml
+++ b/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/pom.xml
@@ -23,6 +23,9 @@
 
     <artifactId>nifi-easyrules-service</artifactId>
     <packaging>jar</packaging>
+    <properties>
+        <easy.rules.version>4.1.0</easy.rules.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -42,22 +45,22 @@
         <dependency>
             <groupId>org.jeasy</groupId>
             <artifactId>easy-rules-core</artifactId>
-            <version>3.4.0</version>
+            <version>${easy.rules.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jeasy</groupId>
             <artifactId>easy-rules-mvel</artifactId>
-            <version>3.4.0</version>
+            <version>${easy.rules.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-rules-spel</artifactId>
+            <version>${easy.rules.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl3</artifactId>
             <version>3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jeasy</groupId>
-            <artifactId>easy-rules-spel</artifactId>
-            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/src/main/java/org/apache/nifi/rules/RulesFactory.java
+++ b/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/src/main/java/org/apache/nifi/rules/RulesFactory.java
@@ -18,10 +18,10 @@ package org.apache.nifi.rules;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jeasy.rules.support.JsonRuleDefinitionReader;
+import org.jeasy.rules.support.reader.JsonRuleDefinitionReader;
 import org.jeasy.rules.support.RuleDefinition;
-import org.jeasy.rules.support.RuleDefinitionReader;
-import org.jeasy.rules.support.YamlRuleDefinitionReader;
+import org.jeasy.rules.support.reader.RuleDefinitionReader;
+import org.jeasy.rules.support.reader.YamlRuleDefinitionReader;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 

--- a/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/src/main/java/org/apache/nifi/rules/engine/EasyRulesEngine.java
+++ b/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/src/main/java/org/apache/nifi/rules/engine/EasyRulesEngine.java
@@ -21,6 +21,7 @@ import org.apache.nifi.rules.Rule;
 import org.apache.nifi.rules.RulesMVELCondition;
 import org.apache.nifi.rules.RulesSPELCondition;
 import org.jeasy.rules.api.Condition;
+import org.jeasy.rules.api.Fact;
 import org.jeasy.rules.api.Facts;
 import org.jeasy.rules.api.RuleListener;
 import org.jeasy.rules.api.Rules;
@@ -149,13 +150,13 @@ public class EasyRulesEngine implements RulesEngine {
 
             if (nifiRule.getFacts() != null) {
 
-                List<Map.Entry<String, Object>> filteredFacts = StreamSupport.stream(facts.spliterator(), false)
-                        .filter(fact -> nifiRule.getFacts().contains(fact.getKey())).collect(Collectors.toList());
+                List<Fact<?>> filteredFacts = StreamSupport.stream(facts.spliterator(), false)
+                        .filter(fact -> nifiRule.getFacts().contains(fact.getName())).collect(Collectors.toList());
 
                 if (filteredFacts.size() > 0) {
                     evaluateFacts = new Facts();
                     filteredFacts.forEach(filteredFact -> {
-                        evaluateFacts.put(filteredFact.getKey(), filteredFact.getValue());
+                        evaluateFacts.put(filteredFact.getName(), filteredFact.getValue());
                     });
                 } else {
                     evaluateFacts = facts;

--- a/nifi-nar-bundles/nifi-easyrules-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-easyrules-bundle/pom.xml
@@ -23,6 +23,9 @@
 
     <artifactId>nifi-easyrules-bundle</artifactId>
     <packaging>pom</packaging>
+    <properties>
+        <spring.version>5.3.6</spring.version>
+    </properties>
     <modules>
         <module>nifi-easyrules-service</module>
         <module>nifi-easyrules-nar</module>
@@ -34,6 +37,12 @@
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-easyrules-service</artifactId>
                 <version>1.14.0-SNAPSHOT</version>
+            </dependency>
+            <!-- Set Spring Expression version for easy-rules-spel -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -24,6 +24,9 @@
 
     <artifactId>nifi-email-processors</artifactId>
     <packaging>jar</packaging>
+    <properties>
+        <spring.integration.version>5.4.6</spring.integration.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -88,7 +91,7 @@
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-mail</artifactId>
-            <version>4.3.24.RELEASE</version>
+            <version>${spring.integration.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.retry</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-nar/src/main/resources/META-INF/NOTICE
@@ -108,12 +108,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Swagger Core

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/spring/ThreadPoolRequestReplicatorFactoryBean.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/spring/ThreadPoolRequestReplicatorFactoryBean.java
@@ -24,11 +24,12 @@ import org.apache.nifi.cluster.coordination.http.replication.okhttp.OkHttpReplic
 import org.apache.nifi.events.EventReporter;
 import org.apache.nifi.util.NiFiProperties;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-public class ThreadPoolRequestReplicatorFactoryBean implements FactoryBean<ThreadPoolRequestReplicator>, ApplicationContextAware {
+public class ThreadPoolRequestReplicatorFactoryBean implements FactoryBean<ThreadPoolRequestReplicator>, DisposableBean, ApplicationContextAware {
     private ApplicationContext applicationContext;
     private NiFiProperties nifiProperties;
 
@@ -73,4 +74,10 @@ public class ThreadPoolRequestReplicatorFactoryBean implements FactoryBean<Threa
         this.nifiProperties = properties;
     }
 
+    @Override
+    public void destroy() {
+        if (replicator != null) {
+            replicator.shutdown();
+        }
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-headless-server/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-headless-server/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.0.9.RELEASE</version>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.0.9.RELEASE</version>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -408,7 +408,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>4.3.26.RELEASE</version>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.0.6.RELEASE</version>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-headless-server-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-headless-server-nar/src/main/resources/META-INF/NOTICE
@@ -95,12 +95,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Swagger Core

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-server-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-server-nar/src/main/resources/META-INF/NOTICE
@@ -95,12 +95,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Swagger Core

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-stateless-bundle/nifi-stateless-nar/src/main/resources/META-INF/NOTICE
@@ -100,7 +100,7 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) ASM Based Accessors Helper Used By JSON Smart (net.minidev:accessors-smart:jar:1.2 - http://www.minidev.net/)

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -23,8 +23,8 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
-        <spring.security.version>4.2.20.RELEASE</spring.security.version>
+        <spring.version>5.3.6</spring.version>
+        <spring.security.version>5.4.6</spring.security.version>
     </properties>
     <modules>
         <module>nifi-framework</module>

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-nar/src/main/resources/META-INF/NOTICE
@@ -50,8 +50,8 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4.2.4.RELEASE
-      Copyright (c) 2002-2016 Pivotal, Inc.
+      Spring Framework 5
+      Copyright (c) 2002-2021 Pivotal, Inc.
 
 *****************
 Public Domain

--- a/nifi-nar-bundles/nifi-ignite-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ignite-bundle/pom.xml
@@ -30,7 +30,7 @@
         <module>nifi-ignite-nar</module>
     </modules>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.version>5.3.6</spring.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>nifi-jms-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.version>5.3.6</spring.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.processors.ConsumeJMS/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.processors.ConsumeJMS/additionalDetails.html
@@ -27,7 +27,7 @@
 </p>
 <p>
     This processor does two things. It constructs FlowFile by extracting information from the consumed JMS message including body, standard 
-    <a href="http://docs.spring.io/spring-integration/docs/4.2.0.RELEASE/api/org/springframework/integration/jms/JmsHeaders.html">JMS Headers</a> and Properties.
+    JMS Headers and Properties.
     The message body is written to a FlowFile while standard JMS Headers and Properties are set as FlowFile attributes.
 </p>
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.processors.PublishJMS/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.processors.PublishJMS/additionalDetails.html
@@ -28,7 +28,7 @@
 <p>
     This processor does two things. It constructs JMS Message by extracting FlowFile contents (both body and attributes). 
     Once message is constructed it is sent to a pre-configured JMS Destination.
-    Standard <a href="http://docs.spring.io/spring-integration/docs/4.2.0.RELEASE/api/org/springframework/integration/jms/JmsHeaders.html">JMS Headers</a>
+    Standard JMS Headers
     will be extracted from the FlowFile and set on <i>javax.jms.Message</i> as JMS headers while other 
     FlowFile attributes will be set as properties of <i>javax.jms.Message</i>. Upon success the incoming FlowFile is transferred
     to the <i>success</i> Relationship and upon failure FlowFile is

--- a/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers-nar/src/main/resources/META-INF/NOTICE
@@ -12,12 +12,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Apache Commons Lang

--- a/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers/pom.xml
+++ b/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers/pom.xml
@@ -22,9 +22,6 @@
     </parent>
     <artifactId>nifi-kerberos-iaa-providers</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <spring.security.version>4.2.20.RELEASE</spring.security.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -44,6 +41,12 @@
             <artifactId>spring-security-kerberos-core</artifactId>
             <version>1.0.1.RELEASE</version>
         </dependency>
+        <!-- Include spring-security-crypto to support spring-security-kerberos-core -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${spring.security.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
@@ -59,7 +62,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.12.0</version>
         </dependency>
     </dependencies>
     <name>nifi-kerberos-iaa-providers</name>

--- a/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/pom.xml
@@ -27,7 +27,8 @@
         <module>nifi-kerberos-iaa-providers-nar</module>
     </modules>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.version>5.3.6</spring.version>
+        <spring.security.version>5.4.6</spring.security.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -37,6 +38,11 @@
                 <version>${spring.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>${spring.security.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers-nar/src/main/resources/META-INF/NOTICE
@@ -12,12 +12,12 @@ The following binary components are provided under the Apache Software License v
 
   (ASLv2) Spring Framework
     The following NOTICE information applies:
-      Spring Framework 4
+      Spring Framework 5
       Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Spring Security
     The following NOTICE information applies:
-          Spring Security 4
+          Spring Security 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
   (ASLv2) Apache Commons Lang

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/pom.xml
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-ldap-iaa-providers</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.security.version>4.2.20.RELEASE</spring.security.version>
+        <spring.security.version>5.4.6</spring.security.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-ldap-iaa-providers-nar</module>
     </modules>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.version>5.3.6</spring.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
@@ -45,9 +45,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.9.0</version>
+            <version>${jedis.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- End Provided deps from nifi-redis-service-api -->

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
@@ -17,8 +17,8 @@ The following binary components are provided under the Apache Software License v
 
     (ASLv2) Spring Framework
         The following NOTICE information applies:
-          Spring Framework 5.1.0.RELEASE
-          Copyright (c) 2002-2018 Pivotal, Inc.
+          Spring Framework 5
+          Copyright (c) 2002-2021 Pivotal, Inc.
 
 
 ************************

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.9.0</version>
+            <version>${jedis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/pom.xml
@@ -27,7 +27,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>2.1.16.RELEASE</spring.data.redis.version>
+        <spring.data.redis.version>2.5.0</spring.data.redis.version>
+        <spring.version>5.3.6</spring.version>
+        <jedis.version>3.6.0</jedis.version>
     </properties>
 
     <modules>

--- a/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/pom.xml
+++ b/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>nifi-rules-action-handler-service</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.version>5.3.6</spring.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/pom.xml
@@ -18,8 +18,8 @@
     <artifactId>nifi-spring-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.version>4.3.30.RELEASE</spring.version>
-        <spring.integration.version>4.3.23.RELEASE</spring.integration.version>
+        <spring.version>5.3.6</spring.version>
+        <spring.integration.version>5.4.6</spring.integration.version>
     </properties>
     <dependencies>
 
@@ -28,6 +28,11 @@
             <artifactId>spring-messaging</artifactId>
             <version>${spring.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/src/main/resources/docs/org.apache.nifi.spring.SpringContextProcessor/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/src/main/resources/docs/org.apache.nifi.spring.SpringContextProcessor/additionalDetails.html
@@ -68,13 +68,13 @@
          ├── SI_DEMO-0.0.1-SNAPSHOT.jar
          ├── aopalliance-1.0.jar
          ├── commons-logging-1.2.jar
-         ├── spring-aop-4.3.19.RELEASE.jar
-         ├── spring-beans-4.3.19.RELEASE.jar
-         ├── spring-context-4.3.19.RELEASE.jar
-         ├── spring-core-4.3.19.RELEASE.jar
-         ├── spring-expression-4.3.19.RELEASE.jar
-         ├── spring-integration-core-4.3.17.RELEASE.jar
-         ├── spring-messaging-4.3.19.RELEASE.jar
+         ├── spring-aop-VERSION.jar
+         ├── spring-beans-VERSION.jar
+         ├── spring-context-VERSION.jar
+         ├── spring-core-VERSION.jar
+         ├── spring-expression-VERSION.jar
+         ├── spring-integration-core-VERSION.jar
+         ├── spring-messaging-VERSION.jar
         </pre>
         </p>
         <p>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml
@@ -27,9 +27,6 @@ limitations under the License.
 
     <artifactId>nifi-hwx-schema-registry-service</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <hwx.registry.version>0.8.1</hwx.registry.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -95,6 +92,11 @@ limitations under the License.
                     <artifactId>jsr305</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${spring.security.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/src/main/java/com/hortonworks/registries/schemaregistry/client/SchemaRegistryClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/src/main/java/com/hortonworks/registries/schemaregistry/client/SchemaRegistryClient.java
@@ -1257,6 +1257,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         String.class,
                         "URL of schema registry to which this client connects to. For ex: http://localhost:9090/api/v1",
                         "http://localhost:9090/api/v1",
+                        ConfigEntry.StringConverter.get(),
                         ConfigEntry.NonEmptyStringValidator.get());
 
         /**
@@ -1272,6 +1273,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         String.class,
                         "URL of schema registry to which this client connects to. For ex: http://localhost:9090/api/v1",
                         DEFAULT_LOCAL_JARS_PATH,
+                        ConfigEntry.StringConverter.get(),
                         ConfigEntry.NonEmptyStringValidator.get());
 
         /**
@@ -1293,6 +1295,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Maximum size of classloader cache",
                         DEFAULT_CLASSLOADER_CACHE_SIZE,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1304,6 +1307,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Expiry interval(in seconds) of an entry in classloader cache",
                         DEFAULT_CLASSLOADER_CACHE_EXPIRY_INTERVAL_SECS,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         public static final long DEFAULT_SCHEMA_CACHE_SIZE = 1024;
@@ -1317,6 +1321,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Maximum size of schema version cache",
                         DEFAULT_SCHEMA_CACHE_SIZE,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1327,6 +1332,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Expiry interval(in seconds) of an entry in schema version cache",
                         DEFAULT_SCHEMA_CACHE_EXPIRY_INTERVAL_SECS,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1337,6 +1343,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Maximum size of schema metadata cache",
                         DEFAULT_SCHEMA_CACHE_SIZE,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1347,6 +1354,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Expiry interval(in seconds) of an entry in schema metadata cache",
                         DEFAULT_SCHEMA_CACHE_EXPIRY_INTERVAL_SECS,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1358,6 +1366,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Maximum size of schema text cache",
                         DEFAULT_SCHEMA_CACHE_SIZE,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1368,6 +1377,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         Integer.class,
                         "Expiry interval(in seconds) of an entry in schema text cache.",
                         DEFAULT_SCHEMA_CACHE_EXPIRY_INTERVAL_SECS,
+                        ConfigEntry.IntegerConverter.get(),
                         ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1378,6 +1388,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         String.class,
                         "Schema Registry URL selector class.",
                         FailoverUrlSelector.class.getName(),
+                        ConfigEntry.StringConverter.get(),
                         ConfigEntry.NonEmptyStringValidator.get());
 
         /**
@@ -1388,6 +1399,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         String.class,
                         "Schema Registry Dynamic JAAS config for SASL connection.",
                         null,
+                        ConfigEntry.StringConverter.get(),
                         ConfigEntry.NonEmptyStringValidator.get());
 
         // connection properties

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/pom.xml
@@ -23,9 +23,55 @@
     <artifactId>nifi-hwx-schema-registry-bundle</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <hwx.registry.version>0.9.1</hwx.registry.version>
+        <!-- Override Spring Framework version from com.hortonworks.registries:common-auth -->
+        <spring.version>5.3.6</spring.version>
+        <spring.security.version>5.4.6</spring.security.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-jcl</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>nifi-hwx-schema-registry-service</module>
         <module>nifi-hwx-schema-registry-nar</module>
     </modules>
-    
+
 </project>


### PR DESCRIPTION
#### Description of PR

NIFI-8502 Upgrades Spring Framework and Spring Security dependencies across framework and extension components from version 4 to version 5.  Spring Framework 4 is no longer supported as of December 2020.

Spring Security version 4, as well as 5.4.3 and below, are vulnerable to [CVE-2021-22112](https://tanzu.vmware.com/security/cve-2021-22112).  Although NiFi does not use HttpSession and does not perform multiple modifications to the Spring Security Context, Spring Security should be upgraded to the current version.

Upgrading to Spring Framework 5 required a small refactor to the framework `ApplicationStartupContextListener` to avoid calling `ApplicationContext.getBean()` for objects that can be null when running in a standalone configuration.  Spring Framework 5 does not return `null` for `getBean()` and instead returns a `NullBean`, which did not meet the expectations of the listener.  Refactoring the `ThreadPoolRequestReplicatorFactoryBean` to implement `DisposableBean` allowed the Factory Bean to handle its own lifecycle, and removing the expected class parameter for `loginIdentityProvider` and `authorizer` also avoided unnecessary exceptions.

Other framework and extension updates include the following:

- Upgraded Spring Framework references from version 4.3.30 to 5.3.6
- Upgraded Spring Security from version 4.2.20 to 5.4.6
- Upgraded Spring Data Redis from 2.1.16 to 2.5.0
- Upgraded Jedis from 2.9.0 to 3.6.0 to match Spring Data Redis 2.5.0
- Upgraded Easy Rules from 3.4.0 to 4.1.0 to support Spring 5
- Upgraded Hortonworks Schema Registry Client from 0.8.1 to 0.9.1 to support Spring 5
- Included spring-security-crypto dependency with references to spring-security-kerberos-core to maintain capability with Spring Security 5

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [X] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [X] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
