### PR TITLE
NIFI-8614 Updated FileBasedClusterNodeFirewallFactoryBean for Spring 5

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/firewall/impl/FileBasedClusterNodeFirewallFactoryBeanTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/firewall/impl/FileBasedClusterNodeFirewallFactoryBeanTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cluster.firewall.impl;
+
+import org.apache.nifi.cluster.firewall.ClusterNodeFirewall;
+import org.apache.nifi.cluster.spring.FileBasedClusterNodeFirewallFactoryBean;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.util.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class FileBasedClusterNodeFirewallFactoryBeanTest {
+    private static final String PROPERTIES_SUFFIX = ".firewall.properties";
+
+    private FileBasedClusterNodeFirewallFactoryBean factoryBean;
+
+    private NiFiProperties properties;
+
+    @Before
+    public void setFactoryBean() {
+        properties = NiFiProperties.createBasicNiFiProperties(StringUtils.EMPTY);
+        factoryBean = new FileBasedClusterNodeFirewallFactoryBean();
+        factoryBean.setProperties(properties);
+    }
+
+    @Test
+    public void testGetObjectType() {
+        final Class<ClusterNodeFirewall> objectType = factoryBean.getObjectType();
+        assertEquals(ClusterNodeFirewall.class, objectType);
+    }
+
+    @Test
+    public void testGetObjectClusterNodeFirewallFileNotConfigured() throws Exception {
+        final ClusterNodeFirewall clusterNodeFirewall = factoryBean.getObject();
+        assertNotNull(clusterNodeFirewall);
+    }
+
+    @Test
+    public void testGetObjectClusterNodeFirewallFileConfigured() throws Exception {
+        final File firewallProperties = File.createTempFile(FileBasedClusterNodeFirewallFactoryBeanTest.class.getName(), PROPERTIES_SUFFIX);
+        firewallProperties.deleteOnExit();
+
+        final Map<String, String> beanProperties = new HashMap<>();
+        beanProperties.put(NiFiProperties.CLUSTER_FIREWALL_FILE, firewallProperties.getAbsolutePath());
+        properties = NiFiProperties.createBasicNiFiProperties(StringUtils.EMPTY, beanProperties);
+        factoryBean.setProperties(properties);
+
+        final ClusterNodeFirewall clusterNodeFirewall = factoryBean.getObject();
+        assertNotNull(clusterNodeFirewall);
+        assertEquals(FileBasedClusterNodeFirewall.class, clusterNodeFirewall.getClass());
+    }
+}


### PR DESCRIPTION
#### Description of PR

NIFI-8614 Updates the `FileBasedClusterNodeFirewallFactoryBean` to return an internal `PermitAllClusterNodeFirewall` implementation instead of `null` when the Cluster Node Firewall configuration file is not provided.  Spring Framework 4 allowed `ApplicationContext.getBean()` to return null, but Spring Framework 5 returns `NullBean` instead, which breaks the expected class in `NodeClusterCoordinatorFactoryBean`.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
