### PR TITLE
NIFI-8614 Corrected Cluster Node Firewall for Spring 5

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/spring/FileBasedClusterNodeFirewallFactoryBean.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/spring/FileBasedClusterNodeFirewallFactoryBean.java
@@ -32,14 +32,18 @@ public class FileBasedClusterNodeFirewallFactoryBean implements FactoryBean<Clus
 
     private NiFiProperties properties;
 
+    /**
+     * Get Cluster Node Firewall should return null when firewall file is not configured
+     *
+     * @return Cluster Node Firewall or null when file not configured
+     * @throws Exception Thrown on new FileBasedClusterNodeFirewall()
+     */
     @Override
     public ClusterNodeFirewall getObject() throws Exception {
         if (firewall == null) {
             final File config = properties.getClusterNodeFirewallFile();
             final File restoreDirectory = properties.getRestoreDirectory();
-            if (config == null) {
-                firewall = new PermitAllClusterNodeFirewall();
-            } else {
+            if (config != null) {
                 firewall = new FileBasedClusterNodeFirewall(config, restoreDirectory);
             }
         }
@@ -58,13 +62,5 @@ public class FileBasedClusterNodeFirewallFactoryBean implements FactoryBean<Clus
 
     public void setProperties(NiFiProperties properties) {
         this.properties = properties;
-    }
-
-    private static class PermitAllClusterNodeFirewall implements ClusterNodeFirewall {
-
-        @Override
-        public boolean isPermissible(final String hostOrIp) {
-            return true;
-        }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/spring/NodeClusterCoordinatorFactoryBean.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/spring/NodeClusterCoordinatorFactoryBean.java
@@ -45,7 +45,8 @@ public class NodeClusterCoordinatorFactoryBean implements FactoryBean<NodeCluste
             final ClusterCoordinationProtocolSenderListener protocolSenderListener =
                     applicationContext.getBean("clusterCoordinationProtocolSenderListener", ClusterCoordinationProtocolSenderListener.class);
             final EventReporter eventReporter = applicationContext.getBean("eventReporter", EventReporter.class);
-            final ClusterNodeFirewall clusterFirewall = applicationContext.getBean("clusterFirewall", ClusterNodeFirewall.class);
+            final Object clusterFirewallBean = applicationContext.getBean("clusterFirewall");
+            final ClusterNodeFirewall clusterFirewall = clusterFirewallBean instanceof ClusterNodeFirewall ? (ClusterNodeFirewall) clusterFirewallBean : null;
             final RevisionManager revisionManager = applicationContext.getBean("revisionManager", RevisionManager.class);
             final LeaderElectionManager electionManager = applicationContext.getBean("leaderElectionManager", LeaderElectionManager.class);
             final FlowElection flowElection = applicationContext.getBean("flowElection", FlowElection.class);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/firewall/impl/FileBasedClusterNodeFirewallFactoryBeanTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/firewall/impl/FileBasedClusterNodeFirewallFactoryBeanTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class FileBasedClusterNodeFirewallFactoryBeanTest {
     private static final String PROPERTIES_SUFFIX = ".firewall.properties";
@@ -53,7 +54,7 @@ public class FileBasedClusterNodeFirewallFactoryBeanTest {
     @Test
     public void testGetObjectClusterNodeFirewallFileNotConfigured() throws Exception {
         final ClusterNodeFirewall clusterNodeFirewall = factoryBean.getObject();
-        assertNotNull(clusterNodeFirewall);
+        assertNull(clusterNodeFirewall);
     }
 
     @Test


### PR DESCRIPTION
#### Description of PR

NIFI-8614 Updates `NodeClusterCoordinatorFactoryBean` to support a `null` instance of `ClusterNodeFirewall` as expected prior to upgrading from Spring Framework 4 to Spring Framework 5.  Changes include adjusting `FileBasedClusterNodeFirewallFactoryBean` to return `null` when the firewall configuration file is not found.  These changes are necessary to support existing system integration tests and clusters running without TLS configured.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
