### PR TITLE
NIFI-8632: Using available port in StandardOidcIdentityProviderGroovy…

### DIFF
--- a/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-processors/pom.xml
@@ -81,11 +81,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-minicluster</artifactId>
             <version>${accumulo.version}</version>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-distributedmapcache-service/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-distributedmapcache-service/pom.xml
@@ -68,11 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <version>1.14.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
@@ -51,10 +51,5 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/groovy/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProviderGroovyIT.groovy
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/groovy/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProviderGroovyIT.groovy
@@ -21,7 +21,11 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.PlainJWT
 import com.nimbusds.oauth2.sdk.AuthorizationCode
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant
-import com.nimbusds.oauth2.sdk.auth.*
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic
+import com.nimbusds.oauth2.sdk.auth.ClientSecretPost
+import com.nimbusds.oauth2.sdk.auth.Secret
 import com.nimbusds.oauth2.sdk.http.HTTPRequest
 import com.nimbusds.oauth2.sdk.http.HTTPResponse
 import com.nimbusds.oauth2.sdk.id.ClientID

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/groovy/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProviderGroovyIT.groovy
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/groovy/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProviderGroovyIT.groovy
@@ -58,17 +58,29 @@ import org.junit.runners.JUnit4
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import java.nio.channels.SocketChannel
+
 @RunWith(JUnit4.class)
-class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
-    private static final Logger logger = LoggerFactory.getLogger(StandardOidcIdentityProviderGroovyTest.class)
+class StandardOidcIdentityProviderGroovyIT extends GroovyTestCase {
+    private static final Logger logger = LoggerFactory.getLogger(StandardOidcIdentityProviderGroovyIT.class)
 
     private static final Key SIGNING_KEY = new Key(id: 1, identity: "signingKey", key: "mock-signing-key-value")
+
+    private static int getAvailablePort() throws IOException {
+        SocketChannel socket = SocketChannel.open()
+        socket.setOption(StandardSocketOptions.SO_REUSEADDR, true)
+        socket.bind(new InetSocketAddress("localhost", 0))
+        return socket.socket().getLocalPort()
+    }
+
+    private static final String HOST = "https://localhost:" + getAvailablePort()
+    private static final String OIDC_URL = HOST + "/oidc"
 
     /*
     Unlike NiFiProperties, NiFiRegistryProperties extends java.util.Properties, which ultimately implements java.util.Map<>, so map coercion cannot be used here. Setting the raw properties does allow for the same outcomes.
      */
     private static final Map<String, String> DEFAULT_NIFI_PROPERTIES = [
-            (NiFiRegistryProperties.SECURITY_USER_OIDC_DISCOVERY_URL)         : "https://localhost/oidc",
+            (NiFiRegistryProperties.SECURITY_USER_OIDC_DISCOVERY_URL)         : OIDC_URL,
             (NiFiRegistryProperties.SECURITY_IDENTITY_PROVIDER)               : "", // Makes isLoginIdentityProviderEnabled => false
             (NiFiRegistryProperties.SECURITY_USER_OIDC_CONNECT_TIMEOUT)       : "1000",
             (NiFiRegistryProperties.SECURITY_USER_OIDC_READ_TIMEOUT)          : "1000",
@@ -162,8 +174,8 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         // Arrange
         StandardOidcIdentityProvider soip = new StandardOidcIdentityProvider(mockJwtService, mockNiFiRegistryProperties)
 
-        Issuer mockIssuer = new Issuer("https://localhost/oidc")
-        URI mockURI = new URI("https://localhost/oidc")
+        Issuer mockIssuer = new Issuer(OIDC_URL)
+        URI mockURI = new URI(OIDC_URL)
         OIDCProviderMetadata metadata = new OIDCProviderMetadata(mockIssuer, [SubjectType.PUBLIC], mockURI)
 
         soip.oidcProviderMetadata = metadata
@@ -199,8 +211,8 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         // Mock collaborators
         StandardOidcIdentityProvider soip = new StandardOidcIdentityProvider(mockJwtService, mockNiFiRegistryProperties)
 
-        Issuer mockIssuer = new Issuer("https://localhost/oidc")
-        URI mockURI = new URI("https://localhost/oidc")
+        Issuer mockIssuer = new Issuer(OIDC_URL)
+        URI mockURI = new URI(OIDC_URL)
         OIDCProviderMetadata metadata = new OIDCProviderMetadata(mockIssuer, [SubjectType.PUBLIC], mockURI)
         soip.oidcProviderMetadata = metadata
 
@@ -236,8 +248,8 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         StandardOidcIdentityProvider soip = new StandardOidcIdentityProvider(mockJwtService, mockNiFiRegistryProperties)
 
         // Mock AuthorizationGrant
-        Issuer mockIssuer = new Issuer("https://localhost/oidc")
-        URI mockURI = new URI("https://localhost/oidc")
+        Issuer mockIssuer = new Issuer(OIDC_URL)
+        URI mockURI = new URI(OIDC_URL)
         AuthorizationCode mockCode = new AuthorizationCode("ABCDE")
         def mockAuthGrant = new AuthorizationCodeGrant(mockCode, mockURI)
 
@@ -252,7 +264,7 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         soip.clientId = CLIENT_ID
         soip.clientSecret = CLIENT_SECRET
         soip.oidcProviderMetadata["tokenEndpointAuthMethods"] = [ClientAuthenticationMethod.CLIENT_SECRET_BASIC]
-        soip.oidcProviderMetadata["tokenEndpointURI"] = new URI("https://localhost/token")
+        soip.oidcProviderMetadata["tokenEndpointURI"] = new URI(HOST + "/token")
 
         // Mock ClientAuthentication
         def clientAuthentication = soip.createClientAuthentication()
@@ -265,7 +277,7 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         // Assert
         assert httpRequest.getMethod().name() == "POST"
         assert httpRequest.query =~ "code=${mockCode.value}"
-        String encodedUri = URLEncoder.encode("https://localhost/oidc", "UTF-8")
+        String encodedUri = URLEncoder.encode(OIDC_URL, "UTF-8")
         assert httpRequest.query =~ "redirect_uri=${encodedUri}&grant_type=authorization_code"
     }
 
@@ -274,8 +286,8 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         // Arrange
         StandardOidcIdentityProvider soip = new StandardOidcIdentityProvider(mockJwtService, mockNiFiRegistryProperties)
 
-        Issuer mockIssuer = new Issuer("https://localhost/oidc")
-        URI mockURI = new URI("https://localhost/oidc")
+        Issuer mockIssuer = new Issuer(OIDC_URL)
+        URI mockURI = new URI(OIDC_URL)
 
         OIDCProviderMetadata metadata = new OIDCProviderMetadata(mockIssuer, [SubjectType.PUBLIC], mockURI)
         soip.oidcProviderMetadata = metadata
@@ -298,8 +310,8 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         // Arrange
         StandardOidcIdentityProvider soip = new StandardOidcIdentityProvider(mockJwtService, mockNiFiRegistryProperties)
 
-        Issuer mockIssuer = new Issuer("https://localhost/oidc")
-        URI mockURI = new URI("https://localhost/oidc")
+        Issuer mockIssuer = new Issuer(OIDC_URL)
+        URI mockURI = new URI(OIDC_URL)
 
         OIDCProviderMetadata metadata = new OIDCProviderMetadata(mockIssuer, [SubjectType.PUBLIC], mockURI)
         soip.oidcProviderMetadata = metadata
@@ -323,15 +335,15 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         // Arrange
         StandardOidcIdentityProvider soip = new StandardOidcIdentityProvider(mockJwtService, mockNiFiRegistryProperties)
 
-        Issuer mockIssuer = new Issuer("https://localhost/oidc")
-        URI mockURI = new URI("https://localhost/oidc")
+        Issuer mockIssuer = new Issuer(OIDC_URL)
+        URI mockURI = new URI(OIDC_URL)
 
         OIDCProviderMetadata metadata = new OIDCProviderMetadata(mockIssuer, [SubjectType.PUBLIC], mockURI)
         soip.oidcProviderMetadata = metadata
 
         def errorBody = [error            : "Failure to authenticate",
                          error_description: "The provided username and password were not correct",
-                         error_uri        : "https://localhost/oidc/error"]
+                         error_uri        : OIDC_URL + "/error"]
         HTTPRequest mockUserInfoRequest = mockHttpRequest(errorBody, 500, "HTTP ERROR")
 
         // Act
@@ -431,7 +443,7 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         }
 
         // Assert
-        assert msg =~ "Connection refused"
+        assert msg =~ "Connection refused" || msg =~ "Operation timed out"
     }
 
     @Test
@@ -484,7 +496,7 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
 
         // Mock OIDC provider metadata
         Issuer mockIssuer = new Issuer("mockIssuer")
-        URI mockURI = new URI("https://localhost/oidc")
+        URI mockURI = new URI(OIDC_URL)
         OIDCProviderMetadata metadata = new OIDCProviderMetadata(mockIssuer, [SubjectType.PUBLIC], mockURI)
         soip.oidcProviderMetadata = metadata
 
@@ -496,8 +508,8 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
         soip.clientId = CLIENT_ID
         soip.clientSecret = CLIENT_SECRET
         soip.oidcProviderMetadata["tokenEndpointAuthMethods"] = [ClientAuthenticationMethod.CLIENT_SECRET_BASIC]
-        soip.oidcProviderMetadata["tokenEndpointURI"] = new URI("https://localhost/oidc/token")
-        soip.oidcProviderMetadata["userInfoEndpointURI"] = new URI("https://localhost/oidc/userInfo")
+        soip.oidcProviderMetadata["tokenEndpointURI"] = new URI(OIDC_URL + "/token")
+        soip.oidcProviderMetadata["userInfoEndpointURI"] = new URI(OIDC_URL + "/userInfo")
 
         // Mock token validator
         IDTokenValidator mockTokenValidator = new IDTokenValidator(mockIssuer, CLIENT_ID) {
@@ -558,7 +570,7 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
                                                String status = "HTTP Response",
                                                Map<String, String> headers = [:],
                                                HTTPRequest.Method method = HTTPRequest.Method.GET,
-                                               URL url = new URL("https://localhost/oidc")) {
+                                               URL url = new URL(OIDC_URL)) {
         new HTTPRequest(method, url) {
             HTTPResponse send() {
                 HTTPResponse mockResponse = new HTTPResponse(statusCode)
@@ -574,7 +586,7 @@ class StandardOidcIdentityProviderGroovyTest extends GroovyTestCase {
     class MockOIDCProviderMetadata extends OIDCProviderMetadata {
 
         MockOIDCProviderMetadata() {
-            super([:] as Issuer, [SubjectType.PUBLIC] as List<SubjectType>, new URI("https://localhost"))
+            super([:] as Issuer, [SubjectType.PUBLIC] as List<SubjectType>, new URI(HOST))
         }
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/groovy/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProviderGroovyIT.groovy
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/groovy/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProviderGroovyIT.groovy
@@ -21,11 +21,7 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.PlainJWT
 import com.nimbusds.oauth2.sdk.AuthorizationCode
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant
-import com.nimbusds.oauth2.sdk.auth.ClientAuthentication
-import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
-import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic
-import com.nimbusds.oauth2.sdk.auth.ClientSecretPost
-import com.nimbusds.oauth2.sdk.auth.Secret
+import com.nimbusds.oauth2.sdk.auth.*
 import com.nimbusds.oauth2.sdk.http.HTTPRequest
 import com.nimbusds.oauth2.sdk.http.HTTPResponse
 import com.nimbusds.oauth2.sdk.id.ClientID
@@ -67,10 +63,15 @@ class StandardOidcIdentityProviderGroovyIT extends GroovyTestCase {
     private static final Key SIGNING_KEY = new Key(id: 1, identity: "signingKey", key: "mock-signing-key-value")
 
     private static int getAvailablePort() throws IOException {
-        SocketChannel socket = SocketChannel.open()
-        socket.setOption(StandardSocketOptions.SO_REUSEADDR, true)
-        socket.bind(new InetSocketAddress("localhost", 0))
-        return socket.socket().getLocalPort()
+        SocketChannel socket;
+        try {
+            socket = SocketChannel.open()
+            socket.setOption(StandardSocketOptions.SO_REUSEADDR, true)
+            socket.bind(new InetSocketAddress("localhost", 0))
+            return socket.socket().getLocalPort()
+        } finally {
+            socket.close()
+        }
     }
 
     private static final String HOST = "https://localhost:" + getAvailablePort()
@@ -443,7 +444,7 @@ class StandardOidcIdentityProviderGroovyIT extends GroovyTestCase {
         }
 
         // Assert
-        assert msg =~ "Connection refused" || msg =~ "Operation timed out"
+        assert msg =~ "Connection refused"
     }
 
     @Test

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -363,12 +363,6 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <version>4.13.2</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
…IT.groovy

<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Converts StandardOidcIdentityProviderGroovyTest to StandardOidcIdentityProviderGroovyIT since the test attempts to connect to a mock HTTP server using an actual port.  Additionally, uses an available port instead of assuming port 443 is available, when running it as an IT.

This specific test has the possibility of receiving a Connection Timeout instead of Connection Refused.  In order to support this, an upgrade to junit 4.3.12 was needed, since this version addressed some unit test timeout issues.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
