### PR TITLE
NIFI-8644: Introduced a notion of ParameterProviderDefinition. Refact…

### DIFF
--- a/nifi-external/nifi-kafka-connect/nifi-kafka-connector/src/main/java/org/apache/nifi/kafka/connect/StatelessKafkaConnectorUtil.java
+++ b/nifi-external/nifi-kafka-connect/nifi-kafka-connector/src/main/java/org/apache/nifi/kafka/connect/StatelessKafkaConnectorUtil.java
@@ -21,13 +21,9 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.nifi.kafka.connect.validators.ConnectDirectoryExistsValidator;
 import org.apache.nifi.kafka.connect.validators.ConnectHttpUrlValidator;
 import org.apache.nifi.kafka.connect.validators.FlowSnapshotValidator;
-import org.apache.nifi.stateless.bootstrap.CompositeParameterProvider;
-import org.apache.nifi.stateless.bootstrap.EnvironmentVariableParameterProvider;
-import org.apache.nifi.stateless.bootstrap.ParameterOverrideProvider;
 import org.apache.nifi.stateless.bootstrap.StatelessBootstrap;
 import org.apache.nifi.stateless.config.ExtensionClientDefinition;
 import org.apache.nifi.stateless.config.ParameterOverride;
-import org.apache.nifi.stateless.config.ParameterProvider;
 import org.apache.nifi.stateless.config.SslContextDefinition;
 import org.apache.nifi.stateless.engine.StatelessEngineConfiguration;
 import org.apache.nifi.stateless.flow.DataflowDefinition;
@@ -187,13 +183,8 @@ public class StatelessKafkaConnectorUtil {
                 unpackNarLock.unlock();
             }
 
-            dataflowDefinition = bootstrap.parseDataflowDefinition(dataflowDefinitionProperties);
-
-            final ParameterProvider configurationParameterProvider = new ParameterOverrideProvider(parameterOverrides);
-            final ParameterProvider environmentVariableProvider = new EnvironmentVariableParameterProvider();
-            final ParameterProvider compositeParameterProvider = new CompositeParameterProvider(Arrays.asList(configurationParameterProvider, environmentVariableProvider));
-
-            return bootstrap.createDataflow(dataflowDefinition, compositeParameterProvider);
+            dataflowDefinition = bootstrap.parseDataflowDefinition(dataflowDefinitionProperties, parameterOverrides);
+            return bootstrap.createDataflow(dataflowDefinition);
         } catch (final Exception e) {
             throw new RuntimeException("Failed to bootstrap Stateless NiFi Engine", e);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardPropertyContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardPropertyContext.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.controller.service;
+
+import org.apache.nifi.attribute.expression.language.PreparedQuery;
+import org.apache.nifi.attribute.expression.language.Query;
+import org.apache.nifi.attribute.expression.language.StandardPropertyValue;
+import org.apache.nifi.components.ConfigurableComponent;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.resource.ResourceContext;
+import org.apache.nifi.components.resource.StandardResourceContext;
+import org.apache.nifi.components.resource.StandardResourceReferenceFactory;
+import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.parameter.ParameterLookup;
+import org.apache.nifi.registry.VariableRegistry;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class StandardPropertyContext implements PropertyContext {
+    private final Map<PropertyDescriptor, PreparedQuery> preparedQueries;
+    private final Map<PropertyDescriptor, String> properties;
+    private final ConfigurableComponent component;
+
+    public StandardPropertyContext(final Map<PropertyDescriptor, String> effectivePropertyValues, final ConfigurableComponent component) {
+        this.properties = effectivePropertyValues;
+        this.preparedQueries = new HashMap<>();
+        this.component = component;
+
+        for (final Map.Entry<PropertyDescriptor, String> entry : properties.entrySet()) {
+            final PropertyDescriptor desc = entry.getKey();
+            String value = entry.getValue();
+            if (value == null) {
+                value = desc.getDefaultValue();
+            }
+
+            final PreparedQuery pq = Query.prepareWithParametersPreEvaluated(value);
+            preparedQueries.put(desc, pq);
+        }
+    }
+
+    @Override
+    public PropertyValue getProperty(final PropertyDescriptor property) {
+        final String configuredValue = properties.get(property);
+
+        // We need to get the 'canonical representation' of the property descriptor from the component itself,
+        // since the supplied PropertyDescriptor may not have the proper default value.
+        final PropertyDescriptor resolvedDescriptor = component.getPropertyDescriptor(property.getName());
+        final String resolvedValue = (configuredValue == null) ? resolvedDescriptor.getDefaultValue() : configuredValue;
+
+        final ResourceContext resourceContext = new StandardResourceContext(new StandardResourceReferenceFactory(), property);
+        return new StandardPropertyValue(resourceContext, resolvedValue, null, ParameterLookup.EMPTY, preparedQueries.get(property), VariableRegistry.EMPTY_REGISTRY);
+    }
+
+    @Override
+    public Map<String, String> getAllProperties() {
+        final Map<String,String> propValueMap = new LinkedHashMap<>();
+        for (final Map.Entry<PropertyDescriptor, String> entry : properties.entrySet()) {
+            propValueMap.put(entry.getKey().getName(), entry.getValue());
+        }
+        return propValueMap;
+    }
+
+}

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/ConfigurableExtensionDefinition.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/ConfigurableExtensionDefinition.java
@@ -15,27 +15,35 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.flow;
+package org.apache.nifi.stateless.config;
 
-import org.apache.nifi.stateless.config.ParameterContextDefinition;
-import org.apache.nifi.stateless.config.ParameterProviderDefinition;
-import org.apache.nifi.stateless.config.ReportingTaskDefinition;
+public class ConfigurableExtensionDefinition {
+    private String name;
+    private String type;
+    private String bundleCoordinates;
 
-import java.util.List;
-import java.util.Set;
+    public String getType() {
+        return type;
+    }
 
-public interface DataflowDefinition<T> {
-    T getFlowSnapshot();
+    public void setType(final String type) {
+        this.type = type;
+    }
 
-    String getFlowName();
+    public String getBundleCoordinates() {
+        return bundleCoordinates;
+    }
 
-    Set<String> getFailurePortNames();
+    public void setBundleCoordinates(final String bundleCoordinates) {
+        this.bundleCoordinates = bundleCoordinates;
+    }
 
-    List<ParameterContextDefinition> getParameterContexts();
+    public String getName() {
+        return name;
+    }
 
-    List<ReportingTaskDefinition> getReportingTaskDefinitions();
+    public void setName(final String name) {
+        this.name = name;
+    }
 
-    List<ParameterProviderDefinition> getParameterProviderDefinitions();
-
-    TransactionThresholds getTransactionThresholds();
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/ParameterProviderDefinition.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/ParameterProviderDefinition.java
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.bootstrap;
+package org.apache.nifi.stateless.config;
 
-import org.apache.nifi.stateless.config.ParameterProvider;
+import java.util.HashMap;
+import java.util.Map;
 
-public class EmptyParameterProvider implements ParameterProvider {
-    @Override
-    public String getParameterValue(final String contextName, final String parameterName) {
-        return null;
+public class ParameterProviderDefinition extends ConfigurableExtensionDefinition {
+    private Map<String, String> propertyValues = new HashMap<>();
+
+    public Map<String, String> getPropertyValues() {
+        return propertyValues;
     }
 
-    @Override
-    public boolean isParameterDefined(final String contextName, final String parameterName) {
-        return false;
+    public void setPropertyValues(final Map<String, String> propertyValues) {
+        this.propertyValues = propertyValues;
     }
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/ReportingTaskDefinition.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/ReportingTaskDefinition.java
@@ -20,36 +20,9 @@ package org.apache.nifi.stateless.config;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ReportingTaskDefinition {
-    private String name;
-    private String type;
-    private String bundleCoordinates;
+public class ReportingTaskDefinition extends ConfigurableExtensionDefinition {
     private String schedulingFrequency;
     private Map<String, String> propertyValues = new HashMap<>();
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(final String name) {
-        this.name = name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(final String type) {
-        this.type = type;
-    }
-
-    public String getBundleCoordinates() {
-        return bundleCoordinates;
-    }
-
-    public void setBundleCoordinates(final String bundleCoordinates) {
-        this.bundleCoordinates = bundleCoordinates;
-    }
 
     public String getSchedulingFrequency() {
         return schedulingFrequency;

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/DataflowDefinitionParser.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/DataflowDefinitionParser.java
@@ -17,15 +17,19 @@
 
 package org.apache.nifi.stateless.flow;
 
+import org.apache.nifi.stateless.config.ParameterOverride;
 import org.apache.nifi.stateless.config.StatelessConfigurationException;
 import org.apache.nifi.stateless.engine.StatelessEngineConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public interface DataflowDefinitionParser {
-    DataflowDefinition<?> parseFlowDefinition(File configurationFile, StatelessEngineConfiguration engineConfiguration) throws StatelessConfigurationException, IOException;
+    DataflowDefinition<?> parseFlowDefinition(File configurationFile, StatelessEngineConfiguration engineConfiguration, List<ParameterOverride> parameterOverrides)
+        throws StatelessConfigurationException, IOException;
 
-    DataflowDefinition<?> parseFlowDefinition(Map<String, String> configurationProperties, StatelessEngineConfiguration engineConfiguration) throws StatelessConfigurationException, IOException;
+    DataflowDefinition<?> parseFlowDefinition(Map<String, String> configurationProperties, StatelessEngineConfiguration engineConfiguration, List<ParameterOverride> parameterOverrides)
+        throws StatelessConfigurationException, IOException;
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/StatelessDataflowFactory.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/StatelessDataflowFactory.java
@@ -17,13 +17,11 @@
 
 package org.apache.nifi.stateless.flow;
 
-import org.apache.nifi.stateless.config.ParameterProvider;
 import org.apache.nifi.stateless.config.StatelessConfigurationException;
 import org.apache.nifi.stateless.engine.StatelessEngineConfiguration;
 
 import java.io.IOException;
 
 public interface StatelessDataflowFactory<T> {
-    StatelessDataflow createDataflow(StatelessEngineConfiguration statelessEngineConfiguration, DataflowDefinition<T> dataflowDefinition,
-                                     ParameterProvider parameterProvider) throws IOException, StatelessConfigurationException;
+    StatelessDataflow createDataflow(StatelessEngineConfiguration statelessEngineConfiguration, DataflowDefinition<T> dataflowDefinition) throws IOException, StatelessConfigurationException;
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/AbstractParameterProvider.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/AbstractParameterProvider.java
@@ -31,7 +31,7 @@ public abstract class AbstractParameterProvider extends AbstractConfigurableComp
 
     @Override
     public final String getIdentifier() {
-        return context.getIdentifier();
+        return context == null ? "<Unknown ID>" : context.getIdentifier();
     }
 
     /**
@@ -45,7 +45,7 @@ public abstract class AbstractParameterProvider extends AbstractConfigurableComp
      * An empty method that is intended for subclasses to optionally override in order to provide initialization
      * @param context the initialization context
      */
-    protected void init(ParameterProviderInitializationContext context){
+    protected void init(ParameterProviderInitializationContext context) {
 
     }
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/AbstractParameterProvider.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/AbstractParameterProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.stateless.parameter;
+
+import org.apache.nifi.components.AbstractConfigurableComponent;
+import org.apache.nifi.context.PropertyContext;
+
+public abstract class AbstractParameterProvider extends AbstractConfigurableComponent implements ParameterProvider {
+    private ParameterProviderInitializationContext context;
+
+    @Override
+    public final void initialize(final ParameterProviderInitializationContext context) {
+        this.context = context;
+        init(context);
+    }
+
+    @Override
+    public final String getIdentifier() {
+        return context.getIdentifier();
+    }
+
+    /**
+     * Provides PropertyContext to subclasses
+     */
+    protected final PropertyContext getPropertyContext() {
+        return context;
+    }
+
+    /**
+     * An empty method that is intended for subclasses to optionally override in order to provide initialization
+     * @param context the initialization context
+     */
+    protected void init(ParameterProviderInitializationContext context){
+
+    }
+}

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/ParameterProvider.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/ParameterProvider.java
@@ -15,27 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.flow;
+package org.apache.nifi.stateless.parameter;
 
-import org.apache.nifi.stateless.config.ParameterContextDefinition;
-import org.apache.nifi.stateless.config.ParameterProviderDefinition;
-import org.apache.nifi.stateless.config.ReportingTaskDefinition;
+import org.apache.nifi.components.ConfigurableComponent;
 
-import java.util.List;
-import java.util.Set;
+public interface ParameterProvider extends ConfigurableComponent {
 
-public interface DataflowDefinition<T> {
-    T getFlowSnapshot();
+    void initialize(ParameterProviderInitializationContext context);
 
-    String getFlowName();
+    /**
+     * Given a Parameter Context Name and a Parameter Name, returns the value of the parameter
+     * @param contextName the name of the Parameter Context
+     * @param parameterName the name of the Parameter
+     * @return the value for the Parameter, or <code>null</code> if no value has been specified
+     */
+    String getParameterValue(String contextName, String parameterName);
 
-    Set<String> getFailurePortNames();
-
-    List<ParameterContextDefinition> getParameterContexts();
-
-    List<ReportingTaskDefinition> getReportingTaskDefinitions();
-
-    List<ParameterProviderDefinition> getParameterProviderDefinitions();
-
-    TransactionThresholds getTransactionThresholds();
+    boolean isParameterDefined(String contextName, String parameterName);
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/ParameterProviderInitializationContext.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/parameter/ParameterProviderInitializationContext.java
@@ -15,27 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.bootstrap;
+package org.apache.nifi.stateless.parameter;
 
-import org.apache.nifi.stateless.config.ParameterProvider;
+import org.apache.nifi.context.PropertyContext;
 
-import java.util.Map;
-
-public class EnvironmentVariableParameterProvider implements ParameterProvider {
-    private final Map<String, String> environmentVariables = System.getenv();
-
-    @Override
-    public String getParameterValue(final String contextName, final String parameterName) {
-        String envValue = environmentVariables.get(contextName + ":" + parameterName);
-        if (envValue != null) {
-            return envValue;
-        }
-
-        return environmentVariables.get(parameterName);
-    }
-
-    @Override
-    public boolean isParameterDefined(final String contextName, final String parameterName) {
-        return getParameterValue(contextName, parameterName) != null;
-    }
+public interface ParameterProviderInitializationContext extends PropertyContext {
+    String getIdentifier();
 }

--- a/nifi-stateless/nifi-stateless-assembly/README.md
+++ b/nifi-stateless/nifi-stateless-assembly/README.md
@@ -463,7 +463,7 @@ If a given Parameter is referenced and is not defined using the `-p` syntax, an 
 allowed to contain only letters, numbers, and underscores in their names. As a result, it is important that the Parameters' names also adhere to that same rule, or the environment variable
 will not be addressable.
 
-At times, none of the builtin capabilities for resolving Parameters are ideal, though. In these situations, we can use a custom Parameter Provider in order to source Parameter values from elsewhere.
+At times, none of the built-in capabilities for resolving Parameters are ideal, though. In these situations, we can use a custom Parameter Provider in order to source Parameter values from elsewhere.
 To configure a custom Parameter Provider, we must configure it similarly to Reporting Tasks, using a common key to indicate which Parameter Provider the property belongs to.
 The following properties are supported:
 

--- a/nifi-stateless/nifi-stateless-assembly/README.md
+++ b/nifi-stateless/nifi-stateless-assembly/README.md
@@ -427,28 +427,29 @@ Additionally, there may be sensitive parameters that users prefer not to include
 Environment Variables, for example.
 
 These parameters may be passed when running NiFi via the `bin/nifi.sh` script by passing a `-p` argument.
-When used, the `-p` argument must be followed by an argument in the format `<context name>:<parameter name>:<parameter value>`
+When used, the `-p` argument must be followed by an argument in the format `[<context name>:]<parameter name>=<parameter value>`
 For example:
 
 ```
-bin/nifi.sh stateless -c -p "Kafka Parameter Context:Kafka Topic:Sensor Data" /var/lib/nifi/stateless/config/stateless.properties /var/lib/nifi/stateless/flows/jms-to-kafka.properties
+bin/nifi.sh stateless -c -p "Kafka Parameter Context:Kafka Topic=Sensor Data" /var/lib/nifi/stateless/config/stateless.properties /var/lib/nifi/stateless/flows/jms-to-kafka.properties
 ```
 
 Note that because of the spaces in the Parameter/Context name and the Parameter value, the argument is quoted.
 Multiple Parameters may be passed using this syntax:
 
 ```
-bin/nifi.sh stateless -c -p "Kafka Parameter Context:Kafka Brokers:kafka-01:9092,kafka-02:9092,kafka-03:9092" -p "Kafka Parameter Context:Kafka Topic:Sensor Data" /var/lib/nifi/stateless/config /stateless.properties
+bin/nifi.sh stateless -c -p "Kafka Parameter Context:Kafka Brokers=kafka-01:9092,kafka-02:9092,kafka-03:9092" -p "Kafka Parameter Context:Kafka Topic=Sensor Data" /var/lib/nifi/stateless/config /stateless.properties
 ```
 
-Note also that the Parameter Context Name and the Parameter Name may not include a colon character.
-The Parameter Value can include colon characters, as in the example here.
+If the name of the Parameter Context contains a colon, it must be escaped using a backslash.
+The name of the Parameter Context and the name of the Parameter may not include an equals sign (=).
+The Parameter Value can include colon characters, as well as equals, as in the example here.
 
 Often times, though, the Parameter Context name is not particularly important, and we just want to provide a Parameter name.
 This can be done by simply leaving off the name of the Parameter Context. For example:
 
 ```
-bin/nifi.sh stateless -c -p "Kafka Brokers:kafka-01:9092,kafka-02:9092,kafka-03:9092" -p "Kafka Topic:Sensor Data" /var/lib/nifi/stateless/config /stateless.properties
+bin/nifi.sh stateless -c -p "Kafka Brokers=kafka-01:9092,kafka-02:9092,kafka-03:9092" -p "Kafka Topic=Sensor Data" /var/lib/nifi/stateless/config /stateless.properties
 ```
 
 In this case, any Parameter Context that has a name of "Kafka Brokers" will have the parameter resolved to `kafka-01:9092,kafka-02:9092,kafka-03:9092`, regardless of the name

--- a/nifi-stateless/nifi-stateless-bootstrap/src/main/java/org/apache/nifi/stateless/bootstrap/StatelessBootstrap.java
+++ b/nifi-stateless/nifi-stateless-bootstrap/src/main/java/org/apache/nifi/stateless/bootstrap/StatelessBootstrap.java
@@ -22,7 +22,7 @@ import org.apache.nifi.bundle.BundleCoordinate;
 import org.apache.nifi.nar.NarClassLoaders;
 import org.apache.nifi.nar.NarUnpacker;
 import org.apache.nifi.nar.SystemBundle;
-import org.apache.nifi.stateless.config.ParameterProvider;
+import org.apache.nifi.stateless.config.ParameterOverride;
 import org.apache.nifi.stateless.config.StatelessConfigurationException;
 import org.apache.nifi.stateless.engine.NarUnpackLock;
 import org.apache.nifi.stateless.engine.StatelessEngineConfiguration;
@@ -60,22 +60,24 @@ public class StatelessBootstrap {
         this.engineConfiguration = engineConfiguration;
     }
 
-    public <T> StatelessDataflow createDataflow(final DataflowDefinition<T> dataflowDefinition, final ParameterProvider parameterProvider)
+    public <T> StatelessDataflow createDataflow(final DataflowDefinition<T> dataflowDefinition)
                 throws IOException, StatelessConfigurationException {
         final StatelessDataflowFactory<T> dataflowFactory = getSingleInstance(statelessClassLoader, StatelessDataflowFactory.class);
-        final StatelessDataflow dataflow = dataflowFactory.createDataflow(engineConfiguration, dataflowDefinition, parameterProvider);
+        final StatelessDataflow dataflow = dataflowFactory.createDataflow(engineConfiguration, dataflowDefinition);
         return dataflow;
     }
 
-    public DataflowDefinition<?> parseDataflowDefinition(final File flowDefinitionFile) throws StatelessConfigurationException, IOException {
+    public DataflowDefinition<?> parseDataflowDefinition(final File flowDefinitionFile, final List<ParameterOverride> parameterOverrides)
+                throws StatelessConfigurationException, IOException {
         final DataflowDefinitionParser dataflowDefinitionParser = getSingleInstance(statelessClassLoader, DataflowDefinitionParser.class);
-        final DataflowDefinition<?> dataflowDefinition = dataflowDefinitionParser.parseFlowDefinition(flowDefinitionFile, engineConfiguration);
+        final DataflowDefinition<?> dataflowDefinition = dataflowDefinitionParser.parseFlowDefinition(flowDefinitionFile, engineConfiguration, parameterOverrides);
         return dataflowDefinition;
     }
 
-    public DataflowDefinition<?> parseDataflowDefinition(final Map<String, String> flowDefinitionProperties) throws StatelessConfigurationException, IOException {
+    public DataflowDefinition<?> parseDataflowDefinition(final Map<String, String> flowDefinitionProperties, final List<ParameterOverride> parameterOverrides)
+                throws StatelessConfigurationException, IOException {
         final DataflowDefinitionParser dataflowDefinitionParser = getSingleInstance(statelessClassLoader, DataflowDefinitionParser.class);
-        final DataflowDefinition<?> dataflowDefinition = dataflowDefinitionParser.parseFlowDefinition(flowDefinitionProperties, engineConfiguration);
+        final DataflowDefinition<?> dataflowDefinition = dataflowDefinitionParser.parseFlowDefinition(flowDefinitionProperties, engineConfiguration, parameterOverrides);
         return dataflowDefinition;
     }
 

--- a/nifi-stateless/nifi-stateless-bootstrap/src/test/java/org/apache/nifi/stateless/bootstrap/TestBootstrapConfiguration.java
+++ b/nifi-stateless/nifi-stateless-bootstrap/src/test/java/org/apache/nifi/stateless/bootstrap/TestBootstrapConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.stateless.bootstrap;
+
+import org.apache.nifi.stateless.config.ParameterOverride;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class TestBootstrapConfiguration {
+
+    private final String engineConfigPropertiesFilename = "src/test/resources/nifi-stateless.properties";
+
+    @Test
+    public void testParseParameterOverride() {
+        final BootstrapConfiguration configuration = BootstrapConfiguration.fromCommandLineArgs(new String[] {"-e", engineConfigPropertiesFilename, "-f", engineConfigPropertiesFilename});
+
+        testOverride(configuration, "a:b=c", "a", "b", "c"); // simple case, context name, param name, param value, no special chars
+        testOverride(configuration, "a=b", null, "a", "b"); // test no context name
+        testOverride(configuration, "a\\:b:c=d", "a:b", "c", "d"); // test escaped colon in context name
+        testOverride(configuration, "a:b:c=d", "a", "b:c", "d"); // test colon in param name
+        testOverride(configuration, "a=b:c", null, "a", "b:c"); // test colon in param value
+        testOverride(configuration, "a=b=c", null, "a", "b=c"); // test equals in param value
+        testOverride(configuration, "a b:c d=e f g", "a b", "c d", "e f g"); // test spaces
+
+        // Any input that doesn't contain an equals should fail
+        testParseFailure(configuration, "a");
+        testParseFailure(configuration, "a:b");
+        testParseFailure(configuration, "a:b:c");
+
+        testParseFailure(configuration, "=c");
+    }
+
+    private void testOverride(final BootstrapConfiguration configuration, final String argument, final String contextName, final String parameterName, final String parameterValue) {
+        final ParameterOverride override = configuration.parseOverride(argument);
+        assertEquals(contextName, override.getContextName());
+        assertEquals(parameterName, override.getParameterName());
+        assertEquals(parameterValue, override.getParameterValue());
+    }
+
+    private void testParseFailure(final BootstrapConfiguration configuration, final String argument) {
+        try {
+            configuration.parseOverride(argument);
+            Assert.fail("Expected an IllegalArgumentException");
+        } catch (final IllegalArgumentException expected) {
+        }
+    }
+}

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/bootstrap/ExtensionDiscovery.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/bootstrap/ExtensionDiscovery.java
@@ -20,11 +20,13 @@ import org.apache.nifi.bundle.Bundle;
 import org.apache.nifi.nar.ExtensionDiscoveringManager;
 import org.apache.nifi.nar.NarClassLoaders;
 import org.apache.nifi.nar.StandardExtensionDiscoveringManager;
+import org.apache.nifi.stateless.parameter.ParameterProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -43,7 +45,7 @@ public class ExtensionDiscovery {
         final Set<Bundle> narBundles = narClassLoaders.getBundles();
 
         final long discoveryStart = System.nanoTime();
-        final StandardExtensionDiscoveringManager extensionManager = new StandardExtensionDiscoveringManager();
+        final StandardExtensionDiscoveringManager extensionManager = new StandardExtensionDiscoveringManager(Collections.singleton(ParameterProvider.class));
         extensionManager.discoverExtensions(narBundles);
 
         final long discoveryMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - discoveryStart);

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/config/PropertiesFileFlowDefinitionParser.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/config/PropertiesFileFlowDefinitionParser.java
@@ -185,6 +185,9 @@ public class PropertiesFileFlowDefinitionParser implements DataflowDefinitionPar
     private List<ParameterProviderDefinition> getParameterProviders(final Map<String, String> properties, final List<ParameterOverride> parameterOverrides) {
         final Map<String, ParameterProviderDefinition> parameterProviderDefinitions = new LinkedHashMap<>();
 
+        parameterProviderDefinitions.put("Default Parameter Override Provider", createParameterOverrideProvider(parameterOverrides));
+        parameterProviderDefinitions.put("Default Environment Variable Provider", createEnvironmentVariableProvider());
+
         for (final String propertyName : properties.keySet()) {
             final Matcher matcher = PARAMETER_PROVIDER_PATTERN.matcher(propertyName);
             if (!matcher.matches()) {
@@ -241,9 +244,6 @@ public class PropertiesFileFlowDefinitionParser implements DataflowDefinitionPar
                     PARAMETER_PROVIDER_PREFIX + providerKey + ".type");
             }
         }
-
-        parameterProviderDefinitions.put("Default Parameter Override Provider", createParameterOverrideProvider(parameterOverrides));
-        parameterProviderDefinitions.put("Default Environment Variable Provider", createEnvironmentVariableProvider());
 
         return new ArrayList<>(parameterProviderDefinitions.values());
     }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StandardParameterProviderInitializationContext.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StandardParameterProviderInitializationContext.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.stateless.engine;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.controller.service.StandardPropertyContext;
+import org.apache.nifi.stateless.parameter.ParameterProvider;
+import org.apache.nifi.stateless.parameter.ParameterProviderInitializationContext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class StandardParameterProviderInitializationContext extends StandardPropertyContext implements ParameterProviderInitializationContext {
+    private final String identifier;
+
+    public StandardParameterProviderInitializationContext(final ParameterProvider parameterProvider, final Map<String, String> propertyValues, final String identifier) {
+        super(createPropertyMap(parameterProvider, propertyValues), parameterProvider);
+        this.identifier = identifier;
+    }
+
+    private static Map<PropertyDescriptor, String> createPropertyMap(final ParameterProvider provider, final Map<String, String> propertyValues) {
+        final Map<PropertyDescriptor, String> propertyMap = new LinkedHashMap<>();
+        for (final Map.Entry<String, String> entry : propertyValues.entrySet()) {
+            final PropertyDescriptor descriptor = provider.getPropertyDescriptor(entry.getKey());
+            propertyMap.put(descriptor, entry.getValue());
+        }
+        return propertyMap;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+}

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StatelessEngine.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StatelessEngine.java
@@ -32,7 +32,6 @@ import org.apache.nifi.provenance.ProvenanceRepository;
 import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.registry.flow.FlowRegistryClient;
 import org.apache.nifi.reporting.BulletinRepository;
-import org.apache.nifi.stateless.config.ParameterProvider;
 import org.apache.nifi.stateless.flow.DataflowDefinition;
 import org.apache.nifi.stateless.flow.StatelessDataflow;
 
@@ -40,7 +39,7 @@ public interface StatelessEngine<T> {
 
     void initialize(StatelessEngineInitializationContext initializationContext);
 
-    StatelessDataflow createFlow(DataflowDefinition<T> dataflowDefinition, ParameterProvider parameterProvider);
+    StatelessDataflow createFlow(DataflowDefinition<T> dataflowDefinition);
 
     ExtensionManager getExtensionManager();
 

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardDataflowDefinition.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardDataflowDefinition.java
@@ -23,6 +23,7 @@ import org.apache.nifi.registry.flow.VersionedFlowSnapshot;
 import org.apache.nifi.registry.flow.VersionedProcessGroup;
 import org.apache.nifi.registry.flow.VersionedProcessor;
 import org.apache.nifi.stateless.config.ParameterContextDefinition;
+import org.apache.nifi.stateless.config.ParameterProviderDefinition;
 import org.apache.nifi.stateless.config.ReportingTaskDefinition;
 
 import java.util.Collections;
@@ -37,6 +38,7 @@ public class StandardDataflowDefinition implements DataflowDefinition<VersionedF
     private final Set<String> failurePortNames;
     private final List<ParameterContextDefinition> parameterContexts;
     private final List<ReportingTaskDefinition> reportingTaskDefinitions;
+    private final List<ParameterProviderDefinition> parameterProviderDefinitions;
     private final TransactionThresholds transactionThresholds;
     private final String flowName;
 
@@ -46,6 +48,7 @@ public class StandardDataflowDefinition implements DataflowDefinition<VersionedF
         parameterContexts = builder.parameterContexts == null ? Collections.emptyList() : builder.parameterContexts;
         reportingTaskDefinitions = builder.reportingTaskDefinitions == null ? Collections.emptyList() : builder.reportingTaskDefinitions;
         transactionThresholds = builder.transactionThresholds == null ? TransactionThresholds.SINGLE_FLOWFILE : builder.transactionThresholds;
+        parameterProviderDefinitions = builder.parameterProviderDefinitions == null ? Collections.emptyList() : builder.parameterProviderDefinitions;
         flowName = builder.flowName;
     }
 
@@ -72,6 +75,11 @@ public class StandardDataflowDefinition implements DataflowDefinition<VersionedF
     @Override
     public List<ReportingTaskDefinition> getReportingTaskDefinitions() {
         return reportingTaskDefinitions;
+    }
+
+    @Override
+    public List<ParameterProviderDefinition> getParameterProviderDefinitions() {
+        return parameterProviderDefinitions;
     }
 
     @Override
@@ -105,6 +113,7 @@ public class StandardDataflowDefinition implements DataflowDefinition<VersionedF
         private Set<String> failurePortNames;
         private List<ParameterContextDefinition> parameterContexts;
         private List<ReportingTaskDefinition> reportingTaskDefinitions;
+        private List<ParameterProviderDefinition> parameterProviderDefinitions;
         private TransactionThresholds transactionThresholds;
         private String flowName;
 
@@ -130,6 +139,11 @@ public class StandardDataflowDefinition implements DataflowDefinition<VersionedF
 
         public Builder reportingTasks(final List<ReportingTaskDefinition> reportingTasks) {
             this.reportingTaskDefinitions = reportingTasks;
+            return this;
+        }
+
+        public Builder parameterProviders(final List<ParameterProviderDefinition> parameterProviders) {
+            this.parameterProviderDefinitions = parameterProviders;
             return this;
         }
 

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
@@ -54,7 +54,6 @@ import org.apache.nifi.reporting.BulletinRepository;
 import org.apache.nifi.security.util.EncryptionMethod;
 import org.apache.nifi.stateless.bootstrap.ExtensionDiscovery;
 import org.apache.nifi.stateless.config.ExtensionClientDefinition;
-import org.apache.nifi.stateless.config.ParameterProvider;
 import org.apache.nifi.stateless.config.SslConfigurationUtil;
 import org.apache.nifi.stateless.config.SslContextDefinition;
 import org.apache.nifi.stateless.config.StatelessConfigurationException;
@@ -92,8 +91,8 @@ public class StandardStatelessDataflowFactory implements StatelessDataflowFactor
     private static final EncryptionMethod ENCRYPTION_METHOD = EncryptionMethod.MD5_256AES;
 
     @Override
-    public StatelessDataflow createDataflow(final StatelessEngineConfiguration engineConfiguration, final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition,
-                                            final ParameterProvider parameterProvider) throws IOException, StatelessConfigurationException {
+    public StatelessDataflow createDataflow(final StatelessEngineConfiguration engineConfiguration, final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition)
+                    throws IOException, StatelessConfigurationException {
         final long start = System.currentTimeMillis();
 
         final VersionedFlowSnapshot flowSnapshot = dataflowDefinition.getFlowSnapshot();
@@ -221,7 +220,7 @@ public class StandardStatelessDataflowFactory implements StatelessDataflowFactor
             rootGroup.setName("root");
             flowManager.setRootGroup(rootGroup);
 
-            final StatelessDataflow dataflow = statelessEngine.createFlow(dataflowDefinition, parameterProvider);
+            final StatelessDataflow dataflow = statelessEngine.createFlow(dataflowDefinition);
             final long millis = System.currentTimeMillis() - start;
             logger.info("NiFi Stateless Engine and Dataflow created and initialized in {} millis", millis);
 

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
@@ -218,7 +218,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
 
             // Create executor for dataflow
             final String flowName = dataflowDefinition.getFlowName();
-            final String threadName = (flowName == null) ? "Run Dataflow" : "Run Dataflow " + flowName;
+            final String threadName = (flowName == null || flowName.trim().isEmpty()) ? "Run Dataflow" : "Run Dataflow " + flowName;
             runDataflowExecutor = Executors.newFixedThreadPool(1, createNamedThreadFactory(threadName, false));
 
             // Periodically log component statuses
@@ -354,7 +354,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
                 future.get(COMPONENT_ENABLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             } catch (final Exception e) {
                 throw new IllegalStateException("Controller Service " + serviceNode + " has not fully enabled. Current Validation Status is "
-                    + serviceNode.getValidationStatus() + " with validation Errors: " + serviceNode.getValidationErrors());
+                    + serviceNode.getValidationStatus() + " with validation Errors: " + serviceNode.getValidationErrors(), e);
             }
         }
 

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/CompositeParameterProvider.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/CompositeParameterProvider.java
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.bootstrap;
-
-import org.apache.nifi.stateless.config.ParameterProvider;
+package org.apache.nifi.stateless.parameter;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class CompositeParameterProvider implements ParameterProvider {
+public class CompositeParameterProvider extends AbstractParameterProvider implements ParameterProvider {
     private final List<ParameterProvider> parameterProviders;
 
     public CompositeParameterProvider(final List<ParameterProvider> providers) {

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/EnvironmentVariableParameterProvider.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/EnvironmentVariableParameterProvider.java
@@ -15,17 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.config;
+package org.apache.nifi.stateless.parameter;
 
-public interface ParameterProvider {
+import java.util.Map;
 
-    /**
-     * Given a Parameter Context Name and a Parameter Name, returns the value of the parameter
-     * @param contextName the name of the Parameter Context
-     * @param parameterName the name of the Parameter
-     * @return the value for the Parameter, or <code>null</code> if no value has been specified
-     */
-    String getParameterValue(String contextName, String parameterName);
+public class EnvironmentVariableParameterProvider extends AbstractParameterProvider implements ParameterProvider {
+    private final Map<String, String> environmentVariables = System.getenv();
 
-    boolean isParameterDefined(String contextName, String parameterName);
+    @Override
+    public String getParameterValue(final String contextName, final String parameterName) {
+        String envValue = environmentVariables.get(contextName + ":" + parameterName);
+        if (envValue != null) {
+            return envValue;
+        }
+
+        return environmentVariables.get(parameterName);
+    }
+
+    @Override
+    public boolean isParameterDefined(final String contextName, final String parameterName) {
+        return getParameterValue(contextName, parameterName) != null;
+    }
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/ParameterOverrideProvider.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/ParameterOverrideProvider.java
@@ -17,6 +17,8 @@
 
 package org.apache.nifi.stateless.parameter;
 
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.stateless.config.ParameterOverride;
 
 import java.util.ArrayList;
@@ -31,6 +33,14 @@ public class ParameterOverrideProvider extends AbstractParameterProvider impleme
     @Override
     public void init(final ParameterProviderInitializationContext context) {
         parameterOverrides = parseConfiguration(context);
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+            .name(propertyDescriptorName)
+            .addValidator(Validator.VALID)
+            .build();
     }
 
     private List<ParameterOverride> parseConfiguration(final ParameterProviderInitializationContext context) {

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/ParameterOverrideProvider.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/parameter/ParameterOverrideProvider.java
@@ -15,19 +15,46 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.bootstrap;
+package org.apache.nifi.stateless.parameter;
 
 import org.apache.nifi.stateless.config.ParameterOverride;
-import org.apache.nifi.stateless.config.ParameterProvider;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
-public class ParameterOverrideProvider implements ParameterProvider {
-    private final List<ParameterOverride> parameterOverrides;
+public class ParameterOverrideProvider extends AbstractParameterProvider implements ParameterProvider {
+    // Effectively final
+    private List<ParameterOverride> parameterOverrides;
 
-    public ParameterOverrideProvider(final List<ParameterOverride> overrides) {
-        this.parameterOverrides = overrides;
+    @Override
+    public void init(final ParameterProviderInitializationContext context) {
+        parameterOverrides = parseConfiguration(context);
+    }
+
+    private List<ParameterOverride> parseConfiguration(final ParameterProviderInitializationContext context) {
+        final List<ParameterOverride> overrides = new ArrayList<>();
+
+        final Map<String, String> properties = context.getAllProperties();
+        for (final Map.Entry<String, String> entry : properties.entrySet()) {
+            final String propertyName = entry.getKey();
+            final String propertyValue = entry.getValue();
+
+            final ParameterOverride override;
+            if (propertyName.contains(":")) {
+                final String[] splits = propertyName.split(":", 2);
+                final String contextName = splits[0];
+                final String parameterName = splits[1];
+                override = new ParameterOverride(contextName, parameterName, propertyValue);
+            } else {
+                override = new ParameterOverride(propertyName, propertyValue);
+            }
+
+            overrides.add(override);
+        }
+
+        return overrides;
     }
 
     @Override

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/resources/META-INF/services/org.apache.nifi.stateless.parameter.ParameterProvider
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/resources/META-INF/services/org.apache.nifi.stateless.parameter.ParameterProvider
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.stateless.parameter.EnvironmentVariableParameterProvider
+org.apache.nifi.stateless.parameter.ParameterOverrideProvider

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/test/java/org/apache/nifi/stateless/config/TestPropertiesFileFlowDefinitionParser.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/test/java/org/apache/nifi/stateless/config/TestPropertiesFileFlowDefinitionParser.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -40,7 +41,9 @@ public class TestPropertiesFileFlowDefinitionParser {
     public void testParse() throws IOException, StatelessConfigurationException {
         final PropertiesFileFlowDefinitionParser parser = new PropertiesFileFlowDefinitionParser();
 
-        final DataflowDefinition dataflowDefinition = parser.parseFlowDefinition(new File("src/test/resources/flow-configuration.properties"), createStatelessEngineConfiguration());
+        final List<ParameterOverride> parameterOverrides = new ArrayList<>();
+        final StatelessEngineConfiguration engineConfig = createStatelessEngineConfiguration();
+        final DataflowDefinition<?> dataflowDefinition = parser.parseFlowDefinition(new File("src/test/resources/flow-configuration.properties"), engineConfig, parameterOverrides);
         assertEquals(new HashSet<>(Arrays.asList("foo", "bar", "baz")), dataflowDefinition.getFailurePortNames());
 
         final List<ParameterContextDefinition> contextDefinitions = dataflowDefinition.getParameterContexts();

--- a/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/StatelessSystemIT.java
+++ b/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/StatelessSystemIT.java
@@ -20,10 +20,10 @@ package org.apache.nifi.stateless;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.nifi.registry.flow.Bundle;
 import org.apache.nifi.registry.flow.VersionedFlowSnapshot;
-import org.apache.nifi.stateless.bootstrap.EmptyParameterProvider;
 import org.apache.nifi.stateless.bootstrap.StatelessBootstrap;
 import org.apache.nifi.stateless.config.ExtensionClientDefinition;
 import org.apache.nifi.stateless.config.ParameterContextDefinition;
+import org.apache.nifi.stateless.config.ParameterProviderDefinition;
 import org.apache.nifi.stateless.config.ReportingTaskDefinition;
 import org.apache.nifi.stateless.config.SslContextDefinition;
 import org.apache.nifi.stateless.config.StatelessConfigurationException;
@@ -138,7 +138,7 @@ public class StatelessSystemIT {
     protected StatelessDataflow loadDataflow(final VersionedFlowSnapshot versionedFlowSnapshot, final List<ParameterContextDefinition> parameterContexts, final Set<String> failurePortNames,
                                              final TransactionThresholds transactionThresholds) throws IOException, StatelessConfigurationException {
 
-            final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition = new DataflowDefinition<VersionedFlowSnapshot>() {
+        final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition = new DataflowDefinition<VersionedFlowSnapshot>() {
             @Override
             public VersionedFlowSnapshot getFlowSnapshot() {
                 return versionedFlowSnapshot;
@@ -161,6 +161,11 @@ public class StatelessSystemIT {
 
             @Override
             public List<ReportingTaskDefinition> getReportingTaskDefinitions() {
+            return Collections.emptyList();
+        }
+
+            @Override
+            public List<ParameterProviderDefinition> getParameterProviderDefinitions() {
                 return Collections.emptyList();
             }
 
@@ -171,7 +176,7 @@ public class StatelessSystemIT {
         };
 
         final StatelessBootstrap bootstrap = StatelessBootstrap.bootstrap(getEngineConfiguration());
-        final StatelessDataflow dataflow = bootstrap.createDataflow(dataflowDefinition, new EmptyParameterProvider());
+        final StatelessDataflow dataflow = bootstrap.createDataflow(dataflowDefinition);
         dataflow.initialize();
 
         createdFlows.add(dataflow);

--- a/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/StatelessSystemIT.java
+++ b/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/StatelessSystemIT.java
@@ -137,6 +137,12 @@ public class StatelessSystemIT {
 
     protected StatelessDataflow loadDataflow(final VersionedFlowSnapshot versionedFlowSnapshot, final List<ParameterContextDefinition> parameterContexts, final Set<String> failurePortNames,
                                              final TransactionThresholds transactionThresholds) throws IOException, StatelessConfigurationException {
+        return loadDataflow(versionedFlowSnapshot, parameterContexts, Collections.emptyList(), failurePortNames, transactionThresholds);
+    }
+
+    protected StatelessDataflow loadDataflow(final VersionedFlowSnapshot versionedFlowSnapshot, final List<ParameterContextDefinition> parameterContexts,
+                                             final List<ParameterProviderDefinition> parameterProviderDefinitions, final Set<String> failurePortNames,
+                                             final TransactionThresholds transactionThresholds) throws IOException, StatelessConfigurationException {
 
         final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition = new DataflowDefinition<VersionedFlowSnapshot>() {
             @Override
@@ -166,7 +172,7 @@ public class StatelessSystemIT {
 
             @Override
             public List<ParameterProviderDefinition> getParameterProviderDefinitions() {
-                return Collections.emptyList();
+                return parameterProviderDefinitions;
             }
 
             @Override

--- a/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/parameters/ParameterContextIT.java
+++ b/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/parameters/ParameterContextIT.java
@@ -84,7 +84,7 @@ public class ParameterContextIT extends StatelessSystemIT {
 
 
     @Test
-    public void testInvalidParameterProvider() throws IOException, StatelessConfigurationException {
+    public void testInvalidParameterProvider() {
         final VersionedFlowBuilder flowBuilder = new VersionedFlowBuilder();
         final VersionedPort outPort = flowBuilder.createOutputPort("Out");
         final VersionedProcessor generate = flowBuilder.createSimpleProcessor("GenerateFlowFile");
@@ -105,11 +105,9 @@ public class ParameterContextIT extends StatelessSystemIT {
         parameterContext.getParameters().add(createVersionedParameter("three", "-1"));  // Set value to -1. This should be overridden by the Numeric Parameter Context.
         flowBuilder.getRootGroup().setParameterContextName("Context 1");
 
-        try {
+        Assert.assertThrows(IllegalStateException.class, () -> {
             loadDataflow(flowSnapshot, Collections.emptyList(), parameterProviders, Collections.emptySet(), TransactionThresholds.SINGLE_FLOWFILE);
-            Assert.fail("Expected to fail on startup because parameter provider is not valid");
-        } catch (final IllegalStateException expected) {
-        }
+        });
     }
 
 
@@ -135,11 +133,9 @@ public class ParameterContextIT extends StatelessSystemIT {
         parameterContext.getParameters().add(createVersionedParameter("three", "1"));  // Set value to -1. This should be overridden by the Numeric Parameter Context.
         flowBuilder.getRootGroup().setParameterContextName("Context 1");
 
-        try {
+        Assert.assertThrows(IllegalStateException.class, () -> {
             loadDataflow(flowSnapshot, Collections.emptyList(), parameterProviders, Collections.emptySet(), TransactionThresholds.SINGLE_FLOWFILE);
-            Assert.fail("Expected to fail on startup because parameter provider is not valid");
-        } catch (final IllegalStateException expected) {
-        }
+        });
     }
 
     @Test

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/pom.xml
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-stateless-api</artifactId>
+            <version>1.14.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
             <version>1.14.0-SNAPSHOT</version>
         </dependency>

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/stateless/parameters/InvalidParameterProvider.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/stateless/parameters/InvalidParameterProvider.java
@@ -15,43 +15,34 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.parameter;
+package org.apache.nifi.stateless.parameters;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.stateless.parameter.AbstractParameterProvider;
 
-public class CompositeParameterProvider extends AbstractParameterProvider implements ParameterProvider {
-    private final List<ParameterProvider> parameterProviders;
+import java.util.Collection;
+import java.util.Collections;
 
-    public CompositeParameterProvider(final List<ParameterProvider> providers) {
-        this.parameterProviders = new ArrayList<>(providers);
+public class InvalidParameterProvider extends AbstractParameterProvider {
+
+    @Override
+    protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
+        final ValidationResult validationResult = new ValidationResult.Builder()
+            .valid(false)
+            .explanation("This Parameter Provider is never valid")
+            .build();
+
+        return Collections.singleton(validationResult);
     }
 
     @Override
     public String getParameterValue(final String contextName, final String parameterName) {
-        for (final ParameterProvider provider : parameterProviders) {
-            if (!provider.isParameterDefined(contextName, parameterName)) {
-                continue;
-            }
-
-            final String value = provider.getParameterValue(contextName, parameterName);
-            if (value != null) {
-                return value;
-            }
-        }
-
         return null;
     }
 
     @Override
     public boolean isParameterDefined(final String contextName, final String parameterName) {
-        for (final ParameterProvider provider : parameterProviders) {
-            final boolean defined = provider.isParameterDefined(contextName, parameterName);
-            if (defined) {
-                return true;
-            }
-        }
-
         return false;
     }
 }

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/stateless/parameters/NumericParameterProvider.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/stateless/parameters/NumericParameterProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.stateless.parameters;
+
+import org.apache.nifi.stateless.parameter.AbstractParameterProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NumericParameterProvider extends AbstractParameterProvider {
+    private final Map<String, String> parameterValues = new HashMap<>();
+
+    {
+        parameterValues.put("zero", "0");
+        parameterValues.put("one", "1");
+        parameterValues.put("two", "2");
+        parameterValues.put("three", "3");
+        parameterValues.put("four", "4");
+        parameterValues.put("five", "5");
+        parameterValues.put("six", "6");
+        parameterValues.put("seven", "7");
+        parameterValues.put("eight", "8");
+        parameterValues.put("nine", "9");
+    }
+
+    @Override
+    public String getParameterValue(final String contextName, final String parameterName) {
+        return parameterValues.get(parameterName);
+    }
+
+    @Override
+    public boolean isParameterDefined(final String contextName, final String parameterName) {
+        return parameterValues.containsKey(parameterName);
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/stateless/parameters/ParameterProviderWithProperties.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/stateless/parameters/ParameterProviderWithProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.stateless.parameters;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.stateless.parameter.AbstractParameterProvider;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.nifi.expression.ExpressionLanguageScope.NONE;
+import static org.apache.nifi.processor.util.StandardValidators.NON_EMPTY_VALIDATOR;
+
+public class ParameterProviderWithProperties extends AbstractParameterProvider {
+
+    static final PropertyDescriptor REQUIRED_PARAMETER = new PropertyDescriptor.Builder()
+        .name("Required")
+        .displayName("Required")
+        .description("A required parameter")
+        .required(true)
+        .addValidator(NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(NONE)
+        .build();
+
+    static final PropertyDescriptor OPTIONAL_PARAMETER = new PropertyDescriptor.Builder()
+        .name("Optional")
+        .displayName("Optional")
+        .description("An optional parameter")
+        .required(false)
+        .addValidator(NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(NONE)
+        .build();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Arrays.asList(REQUIRED_PARAMETER, OPTIONAL_PARAMETER);
+    }
+
+    @Override
+    public String getParameterValue(final String contextName, final String parameterName) {
+        return getPropertyContext().getAllProperties().get(parameterName);
+    }
+
+    @Override
+    public boolean isParameterDefined(final String contextName, final String parameterName) {
+        return getPropertyContext().getAllProperties().containsKey(parameterName);
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.stateless.parameter.ParameterProvider
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.stateless.parameter.ParameterProvider
@@ -15,3 +15,4 @@
 
 org.apache.nifi.stateless.parameters.InvalidParameterProvider
 org.apache.nifi.stateless.parameters.NumericParameterProvider
+org.apache.nifi.stateless.parameters.ParameterProviderWithProperties

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.stateless.parameter.ParameterProvider
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.stateless.parameter.ParameterProvider
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.stateless.parameters.InvalidParameterProvider
+org.apache.nifi.stateless.parameters.NumericParameterProvider


### PR DESCRIPTION
…ored stateless to use this when creating a dataflow so that Parameter Provider implementations can be externalized into NARs. Also updated ExtensionDiscoveringManager such that callers are able to provide a new type of class to be discovered (e.g., ParameterProvider) so that the extensions will be automatically discovered.

<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
