### PR TITLE
NIFI-8654 Changed SNMP TestAgent to use getAvailableUdpPort()

### DIFF
--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/testagents/TestAgent.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/testagents/TestAgent.java
@@ -44,19 +44,19 @@ public abstract class TestAgent extends BaseAgent {
 
     protected static final String BOOT_COUNTER_NAME_TEMPLATE = "target/bootCounter%s_%s.agent";
     protected static final String CONFIG_NAME_TEMPLATE = "target/conf%s_%s.agent";
-    protected final String host;
+    protected final String address;
     protected final int port;
 
     public TestAgent(final File bootCounterFile, final File configFile, final CommandProcessor commandProcessor, final String host) {
         super(bootCounterFile, configFile, commandProcessor);
-        port = NetworkUtils.availablePort();
-        this.host = host + "/" + port;
+        port = NetworkUtils.getAvailableUdpPort();
+        this.address = String.format("udp:%s/%d", host, port);
     }
 
     @Override
     protected void initTransportMappings() {
         transportMappings = new TransportMapping[1];
-        final Address transportAddress = GenericAddress.parse(host);
+        final Address transportAddress = GenericAddress.parse(address);
         final TransportMapping<? extends Address> transportMapping = TransportMappings.getInstance().createTransportMapping(transportAddress);
         transportMappings[0] = transportMapping;
     }


### PR DESCRIPTION
#### Description of PR

NIFI-8654 Updates the SNMP `TestAgent` to use `NetworkUtils.getAvailableUdpPort()` instead of `NetworkUtils.availablePort()` in order to find an available UDP port instead of TCP.  The TestAgent address also includes the explicit `udp` prefix in the address instead of relying on the default behavior of `GenericAddress.parse()` to select UDP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
