### PR TITLE
NIFI-8611: GCP BigQuery processors support using designate project resource for ingestion

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
@@ -60,6 +60,15 @@ public abstract class AbstractBigQueryProcessor extends AbstractGCPProcessor<Big
     public static final Set<Relationship> relationships = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
 
+    public static final PropertyDescriptor DESIGNATE_PROJECT_ID = new PropertyDescriptor.Builder()
+            .name(BigQueryAttributes.DESIGNATE_PROJECT_ID_ATTR)
+            .displayName("Designate Project ID")
+            .description(BigQueryAttributes.DESIGNATE_PROJECT_ID_DESC)
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_EL_VALIDATOR)
+            .build();
+
     public static final PropertyDescriptor DATASET = new PropertyDescriptor.Builder()
             .name(BigQueryAttributes.DATASET_ATTR)
             .displayName("Dataset")
@@ -99,6 +108,7 @@ public abstract class AbstractBigQueryProcessor extends AbstractGCPProcessor<Big
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return ImmutableList.<PropertyDescriptor> builder()
                 .addAll(super.getSupportedPropertyDescriptors())
+                .add(DESIGNATE_PROJECT_ID)
                 .add(DATASET)
                 .add(TABLE_NAME)
                 .add(IGNORE_UNKNOWN)

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/BigQueryAttributes.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/BigQueryAttributes.java
@@ -51,6 +51,10 @@ public class BigQueryAttributes {
             + "the job. If the number of bad records exceeds this value, an invalid error is returned in the job result. By default "
             + "no bad record is ignored.";
 
+    public static final String DESIGNATE_PROJECT_ID_ATTR = "bq.designate.project.id";
+    public static final String DESIGNATE_PROJECT_ID_DESC = "Sets the designate project id that BigqQuery can use current project resource to "
+            + "manipulate the designate proejct.";
+
     public static final String DATASET_ATTR = "bq.dataset";
     public static final String DATASET_DESC = "BigQuery dataset name (Note - The dataset must exist in GCP)";
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/BigQueryAttributes.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/BigQueryAttributes.java
@@ -52,8 +52,8 @@ public class BigQueryAttributes {
             + "no bad record is ignored.";
 
     public static final String DESIGNATE_PROJECT_ID_ATTR = "bq.designate.project.id";
-    public static final String DESIGNATE_PROJECT_ID_DESC = "Sets the designate project id that BigqQuery can use current project resource to "
-            + "manipulate the designate proejct.";
+    public static final String DESIGNATE_PROJECT_ID_DESC = "Sets the designate project id that BigQuery can use current project resource to "
+            + "manipulate the designate project.";
 
     public static final String DATASET_ATTR = "bq.dataset";
     public static final String DATASET_DESC = "BigQuery dataset name (Note - The dataset must exist in GCP)";

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryBatch.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryBatch.java
@@ -257,16 +257,18 @@ public class PutBigQueryBatch extends AbstractBigQueryProcessor {
         }
 
         final String projectId = context.getProperty(PROJECT_ID).evaluateAttributeExpressions().getValue();
+        final String designateProjectId = context.getProperty(DESIGNATE_PROJECT_ID).evaluateAttributeExpressions().getValue();
         final String dataset = context.getProperty(DATASET).evaluateAttributeExpressions(flowFile).getValue();
         final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(flowFile).getValue();
         final String type = context.getProperty(SOURCE_TYPE).evaluateAttributeExpressions(flowFile).getValue();
 
         final TableId tableId;
-        if (StringUtils.isEmpty(projectId)) {
-            tableId = TableId.of(dataset, tableName);
-        } else {
-            tableId = TableId.of(projectId, dataset, tableName);
+        String targetProjectId = projectId;
+        if (!StringUtils.isEmpty(designateProjectId)) {
+            targetProjectId = designateProjectId;
         }
+
+        tableId = targetProjectId != null ? TableId.of(targetProjectId, dataset, tableName) : TableId.of(dataset, tableName);
 
         try {
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryBatch.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryBatch.java
@@ -257,7 +257,7 @@ public class PutBigQueryBatch extends AbstractBigQueryProcessor {
         }
 
         final String projectId = context.getProperty(PROJECT_ID).evaluateAttributeExpressions().getValue();
-        final String designateProjectId = context.getProperty(DESIGNATE_PROJECT_ID).evaluateAttributeExpressions().getValue();
+        final String designateProjectId = context.getProperty(DESIGNATE_PROJECT_ID).evaluateAttributeExpressions(flowFile).getValue();
         final String dataset = context.getProperty(DATASET).evaluateAttributeExpressions(flowFile).getValue();
         final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(flowFile).getValue();
         final String type = context.getProperty(SOURCE_TYPE).evaluateAttributeExpressions(flowFile).getValue();

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryStreaming.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryStreaming.java
@@ -116,15 +116,17 @@ public class PutBigQueryStreaming extends AbstractBigQueryProcessor {
         }
 
         final String projectId = context.getProperty(PROJECT_ID).evaluateAttributeExpressions().getValue();
+        final String designateProjectId = context.getProperty(DESIGNATE_PROJECT_ID).evaluateAttributeExpressions().getValue();
         final String dataset = context.getProperty(DATASET).evaluateAttributeExpressions(flowFile).getValue();
         final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(flowFile).getValue();
 
         final TableId tableId;
-        if (StringUtils.isEmpty(projectId)) {
-            tableId = TableId.of(dataset, tableName);
-        } else {
-            tableId = TableId.of(projectId, dataset, tableName);
+        String targetProjectId = projectId;
+        if (!StringUtils.isEmpty(designateProjectId)) {
+            targetProjectId = designateProjectId;
         }
+
+        tableId = targetProjectId != null ? TableId.of(targetProjectId, dataset, tableName) : TableId.of(dataset, tableName);
 
         try {
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Please refer to JIRA ticket for details: 
https://issues.apache.org/jira/browse/NIFI-8611
This change is already used in our production environment which can properly support using different source project and ingestion project in the property of GCP processors. 

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
