### PR TITLE
NIFI-8674: Update Apache Calcite version to 1.27.0

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -349,7 +349,7 @@
             <dependency>
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
-                <version>1.26.0</version>
+                <version>1.27.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Update Apache Calcite to latest version 1.27.0, which includes Apache Avatica 1.18.0.
This update will issues NIFI-7601 which is resolved by CALCITE-4181 in Calcite 1.27.0.
