### PR TITLE
NIFI-8727 & NIFI-8728 - claimantCount will never decrement to zero bug fix

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -1947,7 +1947,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         if (claim != null) {
             context.getContentRepository().incrementClaimaintCount(claim);
         }
-        final StandardRepositoryRecord record = new StandardRepositoryRecord(null);
+        final StandardRepositoryRecord record = new StandardRepositoryRecord(null, currRec);
         record.setWorking(clone, clone.getAttributes(), false);
         records.put(clone.getId(), record);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -487,11 +487,11 @@ public class FileSystemRepository implements ContentRepository {
 
         final ResourceClaim resourceClaim = resourceClaimManager.newResourceClaim(containerName, sectionName, id, false, false);
         if (resourceClaimManager.getClaimantCount(resourceClaim) == 0) {
-            removeIncompleteContent(fileToRemove);
+            removeIncompleteContent(fileToRemove, containerName);
         }
     }
 
-    private void removeIncompleteContent(final Path fileToRemove) {
+    private void removeIncompleteContent(final Path fileToRemove, String containerName) {
         String fileDescription = null;
         try {
             fileDescription = fileToRemove.toFile().getAbsolutePath() + " (" + Files.size(fileToRemove) + " bytes)";
@@ -502,8 +502,8 @@ public class FileSystemRepository implements ContentRepository {
         LOG.info("Found unknown file {} in File System Repository; {} file", fileDescription, archiveData ? "archiving" : "removing");
 
         try {
-            if (archiveData) {
-                archive(fileToRemove);
+            if (archiveData && archive(fileToRemove)) {
+                containerStateMap.get(containerName).incrementArchiveCount();
             } else {
                 Files.delete(fileToRemove);
             }


### PR DESCRIPTION
The issue is https://issues.apache.org/jira/browse/NIFI-8727 
The sub issue is https://issues.apache.org/jira/browse/NIFI-8728

#### Description of PR

  //originalFlowFile has content , so ClaimantCount=1
  FlowFile multiFlowFile = session.clone(originalFlowFile); // claim count +1，so ClaimantCount=2
  multiFlowFile = session.write(multiFlowFile, new OutputStreamCallback() {
                  @Override
                  public void process(OutputStream out) throws IOException {
                      IOUtils.write(tvMultiAlbumJson, out, Charset.forName("UTF-8"));
                  }
  });//the new content will resuse the same resource claim , so ClaimantCount=3
  //At this point we have two flowfile and two contentClaim ，and ClaimCount=3.
  //When this two flowfiles dropped，the claimantCount should decrement to 0，however the result is ClaimantCount=1！
  //If we use "sh nifi.sh diagnostics --verbose dump.log" to get a dump log，we will find some info like this “default/465/1623853427574-10705, Claimant Count = 1, In Use = true, Awaiting Destruction = false, References (0) = []” 
  //And the file “default/465/1623853427574-10705” will never be archived，and will never be destroyed，and the content_repository will use more storage than it configs.

The above is a sort of phenomenon. The reason is the code below：

    //session.clone
    public FlowFile clone(FlowFile example, final long offset, final long size) {
        .....................................
        final StandardRepositoryRecord record = new StandardRepositoryRecord(null);    //here the originalFlowFileRecord of record is null
        .....................................
        return clone;
    }
    //session.commit
    private void updateClaimCounts(final RepositoryRecord record) {
        ..........................................................
        if (record.isContentModified()) {
            decrementClaimCount(originalClaim);  //here the originalClaim is null
        }
    }

Perhaps we should not use session.clone like that，but without official note it will sometimes happen to be used.
So i change "final StandardRepositoryRecord record = new StandardRepositoryRecord(null)" to "final StandardRepositoryRecord record = new StandardRepositoryRecord(null, currRec);"

--------------------------------------------------------

When I found the issue “claimantCount will never decrement to zero”，I restart the nifi instance and a new issue happened；

Here is the log：

2021-06-23 10:33:02,788 INFO [main] o.a.n.c.repository.FileSystemRepository Found unknown file /data/nifi/nifi-1.13.2/content_repository/1/1624415033830-1 (286096 bytes) in File System Repository; archiving file
2021-06-23 10:33:57,786 DEBUG [Cleanup Archive for default] o.a.n.c.repository.FileSystemRepository Deleted archived ContentClaim with ID 1624415033830-1 from Container default because the archival size was exceeding the max configured size, archiveCount -1

If i config "nifi.content.repository.archive.max.usage.percentage=50%",When the archiveCount is “-1” and disk storage is over 50% ,  all processors with content modified  will blocked in the method "isWaitRequired()" ! 

