### PR TITLE
NIFI-8736 Adding capability to override HDFS location for NAR autoloading

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -4085,6 +4085,7 @@ The value of the `nifi.nar.library.provider.<providerName>.implementation` must 
 | Name                       |  Description
 | resources                  |  List of HDFS resources, separated by comma.
 | source.directory           |  The source directory of NAR files within HDFS. Note: the provider does not check for files recursively.
+| storage.location           |  Optional. If set the storage location defined in the core-site.xml will be overwritten by this value.
 | kerberos.principal         |  Optional. Kerberos principal to authenticate as.
 | kerberos.keytab            |  Optional. Kerberos keytab associated with the principal.
 | kerberos.password          |  Optional. Kerberos password associated with the principal.

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/nar/hadoop/HDFSNarProvider.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/nar/hadoop/HDFSNarProvider.java
@@ -56,6 +56,7 @@ public class HDFSNarProvider implements NarProvider {
 
     private static final String RESOURCES_PARAMETER = "resources";
     private static final String SOURCE_DIRECTORY_PARAMETER = "source.directory";
+    private static final String STORAGE_LOCATION = "storage.location";
     private static final String KERBEROS_PRINCIPAL_PARAMETER = "kerberos.principal";
     private static final String KERBEROS_KEYTAB_PARAMETER = "kerberos.keytab";
     private static final String KERBEROS_PASSWORD_PARAMETER = "kerberos.password";
@@ -64,9 +65,11 @@ public class HDFSNarProvider implements NarProvider {
     private static final String DELIMITER = "/";
     private static final int BUFFER_SIZE_DEFAULT = 4096;
     private static final Object RESOURCES_LOCK = new Object();
+    private static final String STORAGE_LOCATION_PROPERTY = "fs.defaultFS";
 
     private volatile List<String> resources = null;
     private volatile Path sourceDirectory = null;
+    private volatile String storageLocation = null;
 
     private volatile NarProviderInitializationContext context;
 
@@ -87,6 +90,7 @@ public class HDFSNarProvider implements NarProvider {
         }
 
         this.sourceDirectory = new Path(sourceDirectory);
+        this.storageLocation = context.getProperties().get(STORAGE_LOCATION);
 
         this.context = context;
         this.initialized = true;
@@ -99,7 +103,6 @@ public class HDFSNarProvider implements NarProvider {
         }
 
         final HdfsResources hdfsResources = getHdfsResources();
-
 
         try {
             final FileStatus[] fileStatuses = hdfsResources.getUserGroupInformation()
@@ -160,6 +163,11 @@ public class HDFSNarProvider implements NarProvider {
 
         for (final String resource : resources) {
             config.addResource(new Path(resource));
+        }
+
+        // If storage location property is set, the original location will be overwritten
+        if (storageLocation != null) {
+            config.set(STORAGE_LOCATION_PROPERTY, storageLocation);
         }
 
         // first check for timeout on HDFS connection, because FileSystem has a hard coded 15 minute timeout


### PR DESCRIPTION
[NIFI-8736](https://issues.apache.org/jira/browse/NIFI-8736)

This is a small proposal for extending the HDFS based NAR autoloading feature with a convenience feature: the addition makes it possible to use the same core-site.xml for multiple providers but overwriting the endpoint for every and each actual provider. This eases the administrational overhead of this feature.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
