### PR TITLE
NIFI-8748 Corrected PutKudu String to java.sql.Date parsing

### DIFF
--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -63,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
@@ -117,7 +118,7 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
             .displayName("Kudu Operation Timeout")
             .description("Default timeout used for user operations (using sessions and scanners)")
             .required(false)
-            .defaultValue(String.valueOf(AsyncKuduClient.DEFAULT_OPERATION_TIMEOUT_MS) + "ms")
+            .defaultValue(AsyncKuduClient.DEFAULT_OPERATION_TIMEOUT_MS + "ms")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
@@ -127,7 +128,7 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
             .displayName("Kudu Keep Alive Period Timeout")
             .description("Default timeout used for user operations")
             .required(false)
-            .defaultValue(String.valueOf(AsyncKuduClient.DEFAULT_KEEP_ALIVE_PERIOD_MS) + "ms")
+            .defaultValue(AsyncKuduClient.DEFAULT_KEEP_ALIVE_PERIOD_MS + "ms")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
@@ -406,7 +407,9 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
                         row.addVarchar(columnIndex, DataTypeUtils.toString(value, recordFieldName));
                         break;
                     case DATE:
-                        row.addDate(columnIndex, getDate(value, recordFieldName));
+                        final Optional<DataType> fieldDataType = record.getSchema().getDataType(recordFieldName);
+                        final String format = fieldDataType.isPresent() ? fieldDataType.get().getFormat() : RecordFieldType.DATE.getDefaultFormat();
+                        row.addDate(columnIndex, getDate(value, recordFieldName, format));
                         break;
                     default:
                         throw new IllegalStateException(String.format("unknown column type %s", colType));
@@ -420,19 +423,21 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
      *
      * @param value Record Field Value
      * @param recordFieldName Record Field Name
+     * @param format Date Format Pattern
      * @return Date object or null when value is null
      */
-    private Date getDate(final Object value, final String recordFieldName) {
-        return DataTypeUtils.toDate(value, () -> getDateFormat(), recordFieldName);
+    private Date getDate(final Object value, final String recordFieldName, final String format) {
+        return DataTypeUtils.toDate(value, () -> getDateFormat(format), recordFieldName);
     }
 
     /**
      * Get Date Format using Date Record Field default pattern and system time zone to avoid unnecessary conversion
      *
+     * @param format Date Format Pattern
      * @return Date Format used to parsing date fields
      */
-    private DateFormat getDateFormat() {
-        return new SimpleDateFormat(RecordFieldType.DATE.getDefaultFormat());
+    private DateFormat getDateFormat(final String format) {
+        return new SimpleDateFormat(format);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -55,7 +55,10 @@ import org.apache.nifi.util.StringUtils;
 
 import javax.security.auth.login.LoginException;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -403,13 +406,33 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
                         row.addVarchar(columnIndex, DataTypeUtils.toString(value, recordFieldName));
                         break;
                     case DATE:
-                        row.addDate(columnIndex, DataTypeUtils.toDate(value, () -> DataTypeUtils.getDateFormat(RecordFieldType.DATE.getDefaultFormat()), recordFieldName));
+                        row.addDate(columnIndex, getDate(value, recordFieldName));
                         break;
                     default:
                         throw new IllegalStateException(String.format("unknown column type %s", colType));
                 }
             }
         }
+    }
+
+    /**
+     * Get java.sql.Date from Record Field Value with optional parsing when input value is a String
+     *
+     * @param value Record Field Value
+     * @param recordFieldName Record Field Name
+     * @return Date object or null when value is null
+     */
+    private Date getDate(final Object value, final String recordFieldName) {
+        return DataTypeUtils.toDate(value, () -> getDateFormat(), recordFieldName);
+    }
+
+    /**
+     * Get Date Format using Date Record Field default pattern and system time zone to avoid unnecessary conversion
+     *
+     * @return Date Format used to parsing date fields
+     */
+    private DateFormat getDateFormat() {
+        return new SimpleDateFormat(RecordFieldType.DATE.getDefaultFormat());
     }
 
     /**


### PR DESCRIPTION
#### Description of PR

NIFI-8748 Corrects `PutKudu` Date field parsing when converting from a `String` Record field value to a `java.sql.Date` for a Kudu `PartialRow`.

The `DataTypeUtils.getDateFormat()` method sets a default time zone of `GMT` on the `SimpleDateFormat` used for parsing, which results in subtracting one day from the input date string.  Changing the approach to use a `SimpleDateFormat` with the default system time zone avoids the implicit date conversion and preserves the original date value following the conversion to `java.sql.Date`.  The time zone setting is not necessary since the date field does not include precision beyond a day boundary.

Changes include a new unit test method to verify the corrected behavior.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
