### PR TITLE
NIFI-8741 Changed JettyServerGroovyTest to use Available Port

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/groovy/org/apache/nifi/web/server/JettyServerGroovyTest.groovy
@@ -23,6 +23,7 @@ import org.apache.nifi.nar.ExtensionManagerHolder
 import org.apache.nifi.nar.ExtensionMapping
 import org.apache.nifi.nar.SystemBundle
 import org.apache.nifi.processor.DataUnit
+import org.apache.nifi.remote.io.socket.NetworkUtils
 import org.apache.nifi.security.util.StandardTlsConfiguration
 import org.apache.nifi.security.util.TlsConfiguration
 import org.apache.nifi.security.util.TlsPlatform
@@ -49,7 +50,6 @@ import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
@@ -77,7 +77,10 @@ class JettyServerGroovyTest extends GroovyTestCase {
     @Rule
     public final SystemErrRule systemErrRule = new SystemErrRule().enableLog()
 
-    private static final int HTTPS_PORT = 8443
+    private static final int DEFAULT_HTTP_PORT = 8080
+    private static final int DEFAULT_HTTPS_PORT = 8443
+
+    private static final int HTTPS_PORT = NetworkUtils.getAvailableTcpPort()
     private static final String HTTPS_HOSTNAME = "localhost"
 
     private static final String KEYSTORE_PATH = "src/test/resources/keystore.jks"
@@ -139,8 +142,8 @@ class JettyServerGroovyTest extends GroovyTestCase {
                 (NiFiProperties.WEB_THREADS)   : NiFiProperties.DEFAULT_WEB_THREADS
         ]
         NiFiProperties mockProps = Mockito.mock(NiFiProperties.class)
-        Mockito.when(mockProps.getPort()).thenReturn(8080)
-        Mockito.when(mockProps.getSslPort()).thenReturn(8443)
+        Mockito.when(mockProps.getPort()).thenReturn(DEFAULT_HTTP_PORT)
+        Mockito.when(mockProps.getSslPort()).thenReturn(DEFAULT_HTTPS_PORT)
 
         Mockito.when(mockProps.getProperty(ArgumentMatchers.anyString())).thenAnswer(new Answer<Object>() {
             @Override
@@ -168,7 +171,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
                 (NiFiProperties.WEB_HTTPS_HOST): null,
         ]
         NiFiProperties httpProps = [
-                getPort    : { -> 8080 },
+                getPort    : { -> DEFAULT_HTTP_PORT },
                 getSslPort : { -> null },
                 getProperty: { String prop ->
                     String value = httpMap[prop] ?: "no_value"
@@ -183,7 +186,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
         ]
         NiFiProperties httpsProps = [
                 getPort    : { -> null },
-                getSslPort : { -> 8443 },
+                getSslPort : { -> DEFAULT_HTTPS_PORT },
                 getProperty: { String prop ->
                     String value = httpsMap[prop] ?: "no_value"
                     logger.mock("getProperty(${prop}) -> ${value}")
@@ -216,8 +219,8 @@ class JettyServerGroovyTest extends GroovyTestCase {
                 (NiFiProperties.WEB_HTTPS_HOST): "secure.host.com",
         ]
         NiFiProperties mockProps = [
-                getPort            : { -> 8080 },
-                getSslPort         : { -> 8443 },
+                getPort            : { -> DEFAULT_HTTP_PORT },
+                getSslPort         : { -> DEFAULT_HTTPS_PORT },
                 getProperty        : { String prop ->
                     String value = badProps[prop] ?: "no_value"
                     logger.mock("getProperty(${prop}) -> ${value}")
@@ -463,7 +466,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
     void testShouldEnableContentLengthFilterIfWebMaxContentSizeSet() {
         // Arrange
         Map defaultProps = [
-                (NiFiProperties.WEB_HTTP_PORT)       : "8080",
+                (NiFiProperties.WEB_HTTP_PORT)       : DEFAULT_HTTP_PORT as String,
                 (NiFiProperties.WEB_HTTP_HOST)       : "localhost",
                 (NiFiProperties.WEB_MAX_CONTENT_SIZE): "1 MB",
         ]
@@ -507,7 +510,7 @@ class JettyServerGroovyTest extends GroovyTestCase {
     void testShouldNotEnableContentLengthFilterIfWebMaxContentSizeEmpty() {
         // Arrange
         Map defaultProps = [
-                (NiFiProperties.WEB_HTTP_PORT): "8080",
+                (NiFiProperties.WEB_HTTP_PORT): DEFAULT_HTTP_PORT as String,
                 (NiFiProperties.WEB_HTTP_HOST): "localhost",
         ]
         NiFiProperties mockProps = new NiFiProperties(new Properties(defaultProps))


### PR DESCRIPTION
#### Description of PR

NIFI-8741 Updates `JettyServerGroovyTest` to use `NetworkUtils.getAvailableTcpPort()` instead of 8443.  This change avoids potential unit test failures when some other service is listening on port 8443.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
