### PR TITLE
NIFI-7443 Corrected SFTP Keep Alive behavior

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -90,6 +90,8 @@ import java.util.stream.Collectors;
 import static org.apache.nifi.processors.standard.util.FTPTransfer.createComponentProxyConfigSupplier;
 
 public class SFTPTransfer implements FileTransfer {
+    private static final int KEEP_ALIVE_INTERVAL_SECONDS = 5;
+
     private static final Set<String> DEFAULT_KEY_ALGORITHM_NAMES;
     private static final Set<String> DEFAULT_CIPHER_NAMES;
     private static final Set<String> DEFAULT_MESSAGE_AUTHENTICATION_CODE_NAMES;
@@ -162,7 +164,7 @@ public class SFTPTransfer implements FileTransfer {
         .build();
     public static final PropertyDescriptor USE_KEEPALIVE_ON_TIMEOUT = new PropertyDescriptor.Builder()
         .name("Send Keep Alive On Timeout")
-        .description("Indicates whether or not to send a single Keep Alive message when SSH socket times out")
+        .description("Send a Keep Alive message every 5 seconds up to 5 times for an overall timeout of 25 seconds.")
         .allowableValues("true", "false")
         .defaultValue("true")
         .required(true)
@@ -570,6 +572,20 @@ public class SFTPTransfer implements FileTransfer {
         }
     };
 
+    private static final KeepAliveProvider DEFAULT_KEEP_ALIVE_PROVIDER = new KeepAliveProvider() {
+        @Override
+        public KeepAlive provide(final ConnectionImpl connection) {
+            final KeepAlive keepAlive = KeepAliveProvider.KEEP_ALIVE.provide(connection);
+            keepAlive.setKeepAliveInterval(KEEP_ALIVE_INTERVAL_SECONDS);
+            return keepAlive;
+        }
+    };
+
+    protected KeepAliveProvider getKeepAliveProvider() {
+        final boolean useKeepAliveOnTimeout = ctx.getProperty(USE_KEEPALIVE_ON_TIMEOUT).asBoolean();
+        return useKeepAliveOnTimeout ? DEFAULT_KEEP_ALIVE_PROVIDER : NO_OP_KEEP_ALIVE;
+    }
+
     protected SFTPClient getSFTPClient(final FlowFile flowFile) throws IOException {
         // If the client is already initialized then compare the host that the client is connected to with the current
         // host from the properties/flow-file, and if different then we need to close and reinitialize, if same we can reuse
@@ -586,16 +602,8 @@ public class SFTPTransfer implements FileTransfer {
         }
 
         // Initialize a new SSHClient...
-
-        // If use keep-alive is set then set the provider which sends max of 5 keep-alives, otherwise set the no-op provider
         final DefaultConfig sshClientConfig = new DefaultConfig();
-        final boolean useKeepAliveOnTimeout = ctx.getProperty(USE_KEEPALIVE_ON_TIMEOUT).asBoolean();
-        if (useKeepAliveOnTimeout) {
-            sshClientConfig.setKeepAliveProvider(KeepAliveProvider.KEEP_ALIVE);
-        } else {
-            sshClientConfig.setKeepAliveProvider(NO_OP_KEEP_ALIVE);
-        }
-
+        sshClientConfig.setKeepAliveProvider(getKeepAliveProvider());
         updateConfigAlgorithms(sshClientConfig);
 
         final SSHClient sshClient = new SSHClient(sshClientConfig);


### PR DESCRIPTION
#### Description of PR

NIFI-7443 Corrects the behavior of SFTP processors when the `Send Keep Alive On Timeout` property is enabled. 

Although enabling `Send Keep Alive` configures a `KeepAliveProvider` for SSHJ, the internal default value for Keep Alive Interval is 0, which means that SSHJ never starts the Keep Alive Thread.

Setting a value of 5 seconds for the Keep Alive Interval works together with the default Max Alive Count value of 5, resulting in a timeout of 25 seconds before the Keep Alive Runner considers the connection lost.

This behavior can be verified at runtime by setting the `net.schmizz.sshj` logger to `DEBUG` and configuring the `FetchSFTP` processor with `Send Keep Alive On Timeout` set to `true`. SSHJ logs the following message when the Keep Alive Thread is running:

```
DEBUG [keep-alive] n.schmizz.sshj.connection.ConnectionImpl Making global request for `keepalive@openssh.com`
```

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
