### PR TITLE
NIFI-8784 Make NIFI_WEB_PROXY_HOST work with single user auth

### DIFF
--- a/nifi-docker/dockerhub/sh/secure.sh
+++ b/nifi-docker/dockerhub/sh/secure.sh
@@ -66,13 +66,6 @@ prop_replace 'nifi.cluster.protocol.is.secure' "${NIFI_CLUSTER_IS_NODE:-false}"
 # Setup nifi-toolkit
 prop_replace 'baseUrl' "https://${NIFI_WEB_HTTPS_HOST:-$HOSTNAME}:${NIFI_WEB_HTTPS_PORT:-8443}" ${nifi_toolkit_props_file}
 
-# Check if the user has specified a nifi.web.proxy.host setting and handle appropriately
-if [ -z "${NIFI_WEB_PROXY_HOST}" ]; then
-    echo 'NIFI_WEB_PROXY_HOST was not set but NiFi is configured to run in a secure mode.  The NiFi UI may be inaccessible if using port mapping.'
-else
-    prop_replace 'nifi.web.proxy.host' "${NIFI_WEB_PROXY_HOST}"
-fi
-
 # Configure Authorizer and Login Identity Provider
 prop_replace 'nifi.security.user.authorizer' "${NIFI_SECURITY_USER_AUTHORIZER:-managed-authorizer}"
 prop_replace 'nifi.security.user.login.identity.provider' "${NIFI_SECURITY_USER_LOGIN_IDENTITY_PROVIDER}"

--- a/nifi-docker/dockermaven/sh/secure.sh
+++ b/nifi-docker/dockermaven/sh/secure.sh
@@ -66,13 +66,6 @@ prop_replace 'nifi.cluster.protocol.is.secure' "${NIFI_CLUSTER_IS_NODE:-false}"
 # Setup nifi-toolkit
 prop_replace 'baseUrl' "https://${NIFI_WEB_HTTPS_HOST:-$HOSTNAME}:${NIFI_WEB_HTTPS_PORT:-8443}" ${nifi_toolkit_props_file}
 
-# Check if the user has specified a nifi.web.proxy.host setting and handle appropriately
-if [ -z "${NIFI_WEB_PROXY_HOST}" ]; then
-    echo 'NIFI_WEB_PROXY_HOST was not set but NiFi is configured to run in a secure mode.  The NiFi UI may be inaccessible if using port mapping.'
-else
-    prop_replace 'nifi.web.proxy.host' "${NIFI_WEB_PROXY_HOST}"
-fi
-
 # Configure Authorizer and Login Identity Provider
 prop_replace 'nifi.security.user.authorizer' "${NIFI_SECURITY_USER_AUTHORIZER:-managed-authorizer}"
 prop_replace 'nifi.security.user.login.identity.provider' "${NIFI_SECURITY_USER_LOGIN_IDENTITY_PROVIDER}"

--- a/nifi-docker/dockermaven/sh/start.sh
+++ b/nifi-docker/dockermaven/sh/start.sh
@@ -35,6 +35,7 @@ fi
 # Establish baseline properties
 prop_replace 'nifi.web.https.port'              "${NIFI_WEB_HTTPS_PORT:-8443}"
 prop_replace 'nifi.web.https.host'              "${NIFI_WEB_HTTPS_HOST:-$HOSTNAME}"
+prop_replace 'nifi.web.proxy.host'              "${NIFI_WEB_PROXY_HOST}"
 prop_replace 'nifi.remote.input.host'           "${NIFI_REMOTE_INPUT_HOST:-$HOSTNAME}"
 prop_replace 'nifi.remote.input.socket.port'    "${NIFI_REMOTE_INPUT_SOCKET_PORT:-10000}"
 prop_replace 'nifi.remote.input.secure'         'true'
@@ -66,6 +67,15 @@ if [ -n "${NIFI_WEB_HTTP_PORT}" ]; then
     prop_replace 'truststore'                                 '' ${nifi_toolkit_props_file}
     prop_replace 'truststoreType'                             '' ${nifi_toolkit_props_file}
     prop_replace 'baseUrl' "http://${NIFI_WEB_HTTP_HOST:-$HOSTNAME}:${NIFI_WEB_HTTP_PORT}" ${nifi_toolkit_props_file}
+
+    if [ -n "${NIFI_WEB_PROXY_HOST}" ]; then
+        echo 'NIFI_WEB_PROXY_HOST was set but NiFi is not configured to run in a secure mode. Unsetting nifi.web.proxy.host.'
+        prop_replace 'nifi.web.proxy.host' ''
+    fi
+else
+    if [ -z "${NIFI_WEB_PROXY_HOST}" ]; then
+        echo 'NIFI_WEB_PROXY_HOST was not set but NiFi is configured to run in a secure mode. The NiFi UI may be inaccessible if using port mapping or connecting through a proxy.'
+    fi
 fi
 
 prop_replace 'nifi.variable.registry.properties'    "${NIFI_VARIABLE_REGISTRY_PROPERTIES:-}"
@@ -110,14 +120,9 @@ case ${AUTH} in
         . "${scripts_dir}/secure.sh"
         . "${scripts_dir}/update_login_providers.sh"
         ;;
-    *)
-        if [ ! -z "${NIFI_WEB_PROXY_HOST}" ]; then
-            echo 'NIFI_WEB_PROXY_HOST was set but NiFi is not configured to run in a secure mode.  Will not update nifi.web.proxy.host.'
-        fi
-        ;;
 esac
 
-# Continuously provide logs so that 'docker logs' can    produce them
+# Continuously provide logs so that 'docker logs' can produce them
 tail -F "${NIFI_HOME}/logs/nifi-app.log" &
 "${NIFI_HOME}/bin/nifi.sh" run &
 nifi_pid="$!"


### PR DESCRIPTION
This fixes NIFI-8784 by moving the NIFI_WEB_PROXY_HOST and nifi.web.proxy.host property replacement in the Docker sh/secure.sh to sh/start.sh so nifi.web.proxy.host can be set when using single user auth.

nifi.web.proxy.host is now included as a "baseline" property and is unset for the non-default insecure configuration when NIFI_WEB_HTTP_PORT is set.

Will rebase when 5225 is merged.

- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?