### PR TITLE
NIFI-8956 Changed TestListenHTTP to expect IOException

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
@@ -391,7 +390,7 @@ public class TestListenHTTP {
     public void testSecureServerTrustStoreConfiguredClientAuthenticationRequired() throws Exception {
         configureProcessorSslContextService(ListenHTTP.ClientAuthentication.REQUIRED, serverConfiguration);
         startSecureServer();
-        assertThrows(SSLException.class, () -> postMessage(null, true, false));
+        assertThrows(IOException.class, () -> postMessage(null, true, false));
     }
 
     @Test
@@ -493,7 +492,7 @@ public class TestListenHTTP {
         startWebServer();
     }
 
-    private int postMessage(String message, boolean secure, boolean clientAuthRequired) throws Exception {
+    private int postMessage(String message, boolean secure, boolean clientAuthRequired) throws IOException {
         final OkHttpClient okHttpClient = getOkHttpClient(secure, clientAuthRequired);
         final Request.Builder requestBuilder = new Request.Builder();
         final String url = buildUrl(secure);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-web-test-utils/src/main/java/org/apache/nifi/web/util/ssl/SslContextUtils.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-web-test-utils/src/main/java/org/apache/nifi/web/util/ssl/SslContextUtils.java
@@ -22,31 +22,11 @@ import org.apache.nifi.security.util.SslContextFactory;
 import org.apache.nifi.security.util.StandardTlsConfiguration;
 import org.apache.nifi.security.util.TlsConfiguration;
 import org.apache.nifi.security.util.TlsException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.io.File;
-import java.security.Security;
 
 public class SslContextUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SslContextUtils.class);
-
-    private static final String TLS_DISABLED_ALGORITHMS_PROPERTY = "jdk.tls.disabledAlgorithms";
-
-    private static final String DISABLED_ALGORITHMS = "SSLv3, RC4, DES, MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, include jdk.disabled.namedCurves";
-
-    static {
-        final String disabledAlgorithms = Security.getProperty(TLS_DISABLED_ALGORITHMS_PROPERTY);
-        if (DISABLED_ALGORITHMS.equals(disabledAlgorithms)) {
-            LOGGER.debug("Found Expected Default TLS Disabled Algorithms: {}", DISABLED_ALGORITHMS);
-        } else {
-            LOGGER.warn("Found System Default TLS Disabled Algorithms: {}", disabledAlgorithms);
-            LOGGER.warn("Setting TLS Disabled Algorithms: {}", DISABLED_ALGORITHMS);
-            Security.setProperty(TLS_DISABLED_ALGORITHMS_PROPERTY, DISABLED_ALGORITHMS);
-        }
-    }
-
     private static final String KEYSTORE_PATH = "src/test/resources/keystore.jks";
 
     private static final String KEYSTORE_AND_TRUSTSTORE_PASSWORD = "passwordpassword";


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

NIFI-8956 Changes `TestListenHTTP.testSecureServerTrustStoreConfiguredClientAuthenticationRequired()` to expect an `IOException` instead of the more specific `SSLException`.

Azul Zulu JDK 11.0.12 included updates to `SSLSocketImpl` that altered the behavior of TLS connection failures when the server requires client authentication. The `okhttp3.Call.execute()` method throws a checked `IOException`, so changes include updating the test method signature to match that pattern. Additional changes include removing the unnecessary conditional override of the `jdk.tls.disabledAlgorithms` security property in the test class `SslContextUtils`.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
