### PR TITLE
NIFI-9035 Refactored isKeystoreValid() to avoid NullPointerException

### DIFF
--- a/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/StandardTlsConfigurationTest.groovy
+++ b/nifi-commons/nifi-security-utils/src/test/groovy/org/apache/nifi/security/util/StandardTlsConfigurationTest.groovy
@@ -171,6 +171,12 @@ class StandardTlsConfigurationTest extends GroovyTestCase {
     }
 
     @Test
+    void testIsKeystoreValidFalseNullKeystorePassword() {
+        TlsConfiguration configuration = new StandardTlsConfiguration(KEYSTORE_PATH, null, KEY_PASSWORD, KEYSTORE_TYPE, TRUSTSTORE_PATH, TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE)
+        assert !configuration.isKeystoreValid()
+    }
+
+    @Test
     void testShouldValidateKeystoreConfiguration() {
         // Arrange
         TlsConfiguration empty = new StandardTlsConfiguration()
@@ -234,7 +240,7 @@ class StandardTlsConfigurationTest extends GroovyTestCase {
         TlsConfiguration configuration = getTlsConfiguration(currentProtocol)
 
         String[] enabledProtocols = configuration.enabledProtocols
-        assert enabledProtocols == [currentProtocol]
+        assert enabledProtocols == [currentProtocol] as String[]
     }
 
     @Test


### PR DESCRIPTION
#### Description of PR

NIFI-9035 Refactors `StandardTlsConfiguration.isKeystoreValid()` to avoid a `NullPointerException` when `StandardTlsConfiguration` has a `null` keystore password.  Additional updates include removal of debug logging and introduction of an internal `StoreType` used for indicating whether a file should be validated as a KeyStore or TrustStore.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
