### PR TITLE
NIFI-9037 Simplify GitHub Workflow Configuration

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,247 +17,173 @@ name: ci-workflow
 
 on: [push, pull_request]
 
+env:
+  DEFAULT_MAVEN_OPTS: >-
+    -Xmx2g
+    -XX:ReservedCodeCacheSize=1g
+    -XX:+UseG1GC
+    -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+    -Dhttp.keepAlive=false
+    -Dmaven.wagon.http.pool=false
+  MAVEN_COMMAND: >-
+    mvn package verify
+    -V
+    -D dir-only
+    -D disableXmlReport
+    -nsu
+    -ntp
+    -ff
+  MAVEN_PROFILES: >-
+    -P contrib-check
+    -P include-grpc
+  MAVEN_PROJECTS: >-
+    -pl -nifi-assembly
+    -pl -nifi-toolkit/nifi-toolkit-assembly
+    -pl -nifi-registry/nifi-registry-assembly
+    -pl -minifi/minifi-assembly
+    -pl -nifi-system-tests
+
 jobs:
   ubuntu-build-en:
     timeout-minutes: 120
     runs-on: ubuntu-latest
-    name: Ubuntu Zulu JDK11 EN
+    name: Ubuntu Zulu JDK 11 EN
     steps:
-      - name: Disk Before Code and Cache
+      - name: System Information
         run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls -aq)
-          df -h
+          cat /proc/cpuinfo
+          cat /proc/meminfo
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Check NPM Cache
+      - name: Cache Maven Dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('**/package-lock.json') }}
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            npm-
-      - name: Check Maven Com Cache
+            ${{ runner.os }}-maven-
+      - name: Cache Node Modules
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository/com
-          key: mvn-com-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.npm
+            **/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            mvn-com-
-      - name: Check Maven Org Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/org
-          key: mvn-org-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-org-
-      - name: Check Maven Net Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/net
-          key: mvn-net-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-net-
-      - name: Check Maven IO Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/io
-          key: mvn-io-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-io-
-      - name: Check Maven BIZ Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/biz
-          key: mvn-biz-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-biz-
-      - name: Check Maven IT Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/it
-          key: mvn-it-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-it-
-      - name: Set up JDK 11 EN
+            ${{ runner.os }}-npm-
+      - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Disk After Cache
-        run: |
-          df -h
-      - name: Build with Maven
+      - name: Maven Build
         env:
-          MAVEN_OPTS: -Xmx2g -XX:ReservedCodeCacheSize=1g -XX:+UseG1GC -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -Duser.language=en -Duser.country=AU -Duser.region=AU -Duser.timezone=Australia/Melbourne -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-        run: |
-          mvn -V -T 0.7C package verify -B -Pcontrib-check,include-grpc,nifi-registry-no-integration-tests -Ddir-only -ntp -ff -pl -nifi-assembly,-nifi-toolkit/nifi-toolkit-assembly,-nifi-system-tests -nsu
-      - name: Upload JUnit Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: surefire-reports-en
-          path: "**/surefire-reports/TEST-*.xml"
-          retention-days: 1
-      - name: Disk After Build
-        run: |
-          df -h
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+            -Duser.language=en
+            -Duser.country=AU
+            -Duser.region=AU
+            -Duser.timezone=Australia/Melbourne
+        run: >
+          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_PROFILES }}
+          ${{ env.MAVEN_PROJECTS }}
 
-  osx-build-jp:
+  macos-build-jp:
     timeout-minutes: 120
     runs-on: macos-latest
-    name: MacOS Adopt JDK8 JP
+    name: MacOS Adopt JDK 8 JP
     steps:
-      - name: Disk Before Code and Cache
+      - name: System Information
         run: |
-          df -h
+          top -l 1 | grep PhysMem
+          sysctl machdep.cpu
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Check NPM Cache
+      - name: Cache Maven Dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('**/package-lock.json') }}
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            npm-
-      - name: Check Maven Com Cache
+            ${{ runner.os }}-maven-
+      - name: Cache Node Modules
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository/com
-          key: mvn-com-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.npm
+            **/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            mvn-com-
-      - name: Check Maven Org Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/org
-          key: mvn-org-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-org-
-      - name: Check Maven Net Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/net
-          key: mvn-net-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-net-
-      - name: Check Maven IO Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/io
-          key: mvn-io-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-io-
-      - name: Check Maven BIZ Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/biz
-          key: mvn-biz-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-biz-
-      - name: Check Maven IT Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/it
-          key: mvn-it-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mvn-it-
-      - name: Set up JDK 1.8 JP
+            ${{ runner.os }}-npm-
+      - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '8'
-      - name: Disk After Cache
-        run: |
-          df -h
-      - name: Build with Maven
+      - name: Maven Build
         env:
-          MAVEN_OPTS: -Xmx2g -XX:ReservedCodeCacheSize=1g -XX:+UseG1GC -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -Duser.language=ja -Duser.country=JP -Duser.region=JP -Duser.timezone=Asia/Tokyo -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-        run: |
-          mvn -V -T 0.7C package verify -B -Pcontrib-check,include-grpc,nifi-registry-no-integration-tests -Ddir-only -ntp -ff -pl -nifi-assembly,-nifi-toolkit/nifi-toolkit-assembly,-nifi-system-tests -nsu
-      - name: Upload JUnit Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: surefire-reports-ja
-          path: "**/surefire-reports/TEST-*.xml"
-          retention-days: 1
-      - name: Disk After Build
-        run: |
-          df -h
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+            -Duser.language=ja
+            -Duser.country=JP
+            -Duser.region=JP
+            -Duser.timezone=Asia/Tokyo
+        run: >-
+          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_PROFILES }}
+          ${{ env.MAVEN_PROJECTS }}
 
   windows-build:
     timeout-minutes: 120
     runs-on: windows-latest
-    name: Windows Zulu JDK8 FR
+    name: Windows Zulu JDK 8 FR
     steps:
+      - name: System Information
+        run: |
+          systeminfo
       - name: Setup Git
         run:  |
           git config --global core.autocrlf false
           git config --global core.longpaths true
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Check Maven Com Cache
+      - name: Cache Maven Dependencies
         uses: actions/cache@v2
         with:
-          path: ~\.m2\repository\com
-          key: win-mvn-com-${{ hashFiles('**\pom.xml') }}
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            win-mvn-com-
-      - name: Check Maven Org Cache
+            ${{ runner.os }}-maven-
+      - name: Get NPM Cache Directory
+        id: npm-cache-directory
+        run: |
+          echo "::set-output name=directory::$(npm config get cache)"
+      - name: Cache Node Modules
         uses: actions/cache@v2
         with:
-          path: ~\.m2\repository\org
-          key: win-mvn-org-${{ hashFiles('**\pom.xml') }}
+          path: |
+            ${{ steps.npm-cache-directory.outputs.directory }}
+            **/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            win-mvn-org-
-      - name: Check Maven Net Cache
-        uses: actions/cache@v2
-        with:
-          path: ~\.m2\repository\net
-          key: win-mvn-net-${{ hashFiles('**\pom.xml') }}
-          restore-keys: |
-            win-mvn-net-
-      - name: Check Maven IO Cache
-        uses: actions/cache@v2
-        with:
-          path: ~\.m2\repository\io
-          key: win-mvn-io-${{ hashFiles('**\pom.xml') }}
-          restore-keys: |
-            win-mvn-io-
-      - name: Check Maven BIZ Cache
-        uses: actions/cache@v2
-        with:
-          path: ~\.m2\repository\biz
-          key: win-mvn-biz-${{ hashFiles('**\pom.xml') }}
-          restore-keys: |
-            win-mvn-biz-
-      - name: Check Maven IT Cache
-        uses: actions/cache@v2
-        with:
-          path: ~\.m2\repository\it
-          key: win-mvn-it-${{ hashFiles('**\pom.xml') }}
-          restore-keys: |
-            win-mvn-it-
-      - name: Set up JDK 1.8
+            ${{ runner.os }}-npm-
+      - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Build with Maven
+      - name: Maven Build
         env:
-          MAVEN_OPTS: -Xmx2g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -Duser.language=fr -Duser.country=FR -Duser.region=FR -Duser.timezone=Europe/Paris -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-        run: |
-          mvn -V -T 0.7C package -B -Pnifi-registry-no-integration-tests -Ddir-only -ntp -ff -pl -nifi-assembly -pl -nifi-system-tests -nsu
-      - name: Upload JUnit Results
-        uses: actions/upload-artifact@v2
-        if: ${{ false }}
-        with:
-          name: surefire-reports-fr
-          path: |
-            '**/surefire-reports/TEST-*.xml'
-            '!**/node_modules/**'
-            '!**/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/**'
-          retention-days: 1
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+            -Duser.language=fr
+            -Duser.country=FR
+            -Duser.region=FR
+            -Duser.timezone=Europe/Paris
+        run: >-
+          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_PROJECTS }}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/pom.xml
@@ -165,6 +165,7 @@ language governing permissions and limitations under the License. -->
                                     <filtering>false</filtering>
                                     <includes>
                                         <include>package.json</include>
+                                        <include>package-lock.json</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/frontend/package-lock.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/frontend/package-lock.json
@@ -14,14 +14,26 @@
   "//": "See the License for the specific language governing permissions and",
   "//": "limitations under the License.",
   "name": "nifi-jolt-transform-json-ui",
-  "license": "Apache-2.0",
+  "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
-    "angular-ui-codemirror": "^0.3.0",
-    "angular-ui-router": "^0.2.18"
-  },
-  "description": "Apache NiFi Jolt Transform JSON UI 3rd party client side resources.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/apache/nifi"
+    "angular": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.2.tgz",
+      "integrity": "sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw=="
+    },
+    "angular-ui-codemirror": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/angular-ui-codemirror/-/angular-ui-codemirror-0.3.0.tgz",
+      "integrity": "sha1-5ChvxQ85PypuaXwb8xcEJOEsu2A="
+    },
+    "angular-ui-router": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.2.18.tgz",
+      "integrity": "sha1-Ha1wQVxz1wRv0uEw3wPWL7dGQ2A=",
+      "requires": {
+        "angular": "^1.0.8"
+      }
+    }
   }
 }

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -447,7 +447,7 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <phase>verify</phase>
+                        <phase>none</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -565,8 +565,8 @@
             </build>
         </profile>
         <profile>
-            <!-- Disables execution of integration tests managed by the Maven FailSafe plugin. -->
-            <id>nifi-registry-no-integration-tests</id>
+            <!-- Enables execution of integration tests managed by the Maven FailSafe plugin. -->
+            <id>nifi-registry-integration-tests</id>
             <build>
                 <plugins>
                     <plugin>
@@ -579,7 +579,7 @@
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
                                 </goals>
-                                <phase>none</phase>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <maven.surefire.arguments />
         <node.version>v12.22.2</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -99,7 +100,7 @@
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jackson.version>2.12.3</jackson.version>
         <nifi.groovy.version>2.5.14</nifi.groovy.version>
-        <surefire.version>2.22.2</surefire.version>
+        <surefire.version>3.0.0-M5</surefire.version>
         <!-- The Hadoop version used by nifi-hadoop-libraries-nar and any NARs that depend on it, other NARs that need
             a specific version should override this property, or use a more specific property like abc.hadoop.version -->
         <hadoop.version>3.3.0</hadoop.version>
@@ -484,15 +485,14 @@
                     <version>3.8.1</version>
                     <configuration>
                         <fork>true</fork>
-                        <optimize>true</optimize>
-                        <showDeprecation>true</showDeprecation>
+                        <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
                         <showWarnings>true</showWarnings>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-eclipse-compiler</artifactId>
-                    <version>3.4.0-01</version>
+                    <version>3.7.0</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
@@ -503,6 +503,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <systemPropertyVariables>
                             <java.awt.headless>true</java.awt.headless>
@@ -516,7 +517,8 @@
                             <exclude>**/*ITSpec.class</exclude>
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <argLine combine.children="append">-Xmx1G
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                        <argLine combine.children="append">-Xmx1g
                             -Djava.net.preferIPv4Stack=true
                             -Duser.language=${user.language}
                             -Duser.country=${user.country}
@@ -619,7 +621,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <executions>
                     <!-- Only run for tests -->
                     <execution>
@@ -629,6 +630,7 @@
                         </goals>
                         <configuration>
                             <compilerId>groovy-eclipse-compiler</compilerId>
+
                         </configuration>
                     </execution>
                 </executions>
@@ -640,7 +642,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>3.4.0-01</version>
+                        <version>3.7.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
@@ -652,7 +654,7 @@
             <plugin>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-nar-maven-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <enforceDocGeneration>true</enforceDocGeneration>
@@ -672,7 +674,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>


### PR DESCRIPTION
#### Description of PR

NIFI-9037 Simplifies the GitHub workflow configuration for automated builds using a combination of default variables and updated actions. Multiple arguments for various commands are now defined on separate lines with the [YAML Multiline Block Chomping](https://yaml-multiline.info/) indicator for improved readability.

Updates include the following:

- Created environment variables for shared Maven commands and projects
- Combined multiple Maven Cache actions
- Added System Information step with commands to print CPU and memory information for each platform
- Added node_modules to NPM Cache action configuration
- Disabled NiFi Registry integration tests in the default configuration
- Removed JUnit Results artifacts from workflow
- Removed parallel build argument from GitHub workflow Maven command
- Upgraded Surefire Plugin to 3.0.0-M5
- Upgraded Enforcer Plugin to 3.0.0
- Added package-lock.json for nifi-jolt-transform-json-ui

The Ubuntu and MacOS builds use the same parameters, while the Windows build does not include the `contrib-check` or `include-grpc` profiles. The Windows build includes an additional step to get the NPM cache directory, which is not necessary on Linux or MacOS. All builds use the same list of Maven projects, which exclude the `assembly` modules for each major component.

Upgrading the Maven Surefire plugin to 3.0.0-M5 supports [TCP socket communication](https://issues.apache.org/jira/browse/SUREFIRE-1658) with forked runners, which avoids the following error observed in current actions:

`Corrupted STDOUT by directly writing to native stream in forked JVM 1`

With most GitHub runners having one available core, removing argument for multi-threading Maven builds did not have a noticeable impact on performance, but it eliminated warnings due to the Apache RAT plugin not indicating support for parallel execution.

Removing the generation and storage of XML JUnit tests provide some amount of optimization over the entire job execution.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
