### PR TITLE
NIFI-9082 Add nifi.zookeeper.jute.maxbuffer property

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -274,6 +274,7 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String ZOOKEEPER_AUTH_TYPE = "nifi.zookeeper.auth.type";
     public static final String ZOOKEEPER_KERBEROS_REMOVE_HOST_FROM_PRINCIPAL = "nifi.zookeeper.kerberos.removeHostFromPrincipal";
     public static final String ZOOKEEPER_KERBEROS_REMOVE_REALM_FROM_PRINCIPAL = "nifi.zookeeper.kerberos.removeRealmFromPrincipal";
+    public static final String ZOOKEEPER_JUTE_MAXBUFFER = "nifi.zookeeper.jute.maxbuffer";
 
     // kerberos properties
     public static final String KERBEROS_KRB5_FILE = "nifi.kerberos.krb5.file";
@@ -350,6 +351,8 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String DEFAULT_ZOOKEEPER_AUTH_TYPE = "default";
     public static final String DEFAULT_ZOOKEEPER_KERBEROS_REMOVE_HOST_FROM_PRINCIPAL = "true";
     public static final String DEFAULT_ZOOKEEPER_KERBEROS_REMOVE_REALM_FROM_PRINCIPAL = "true";
+    // Based on org.apache.jute.BinaryInputArchive.maxBuffer from ZooKeeper NIOServerCnxn
+    public static final int DEFAULT_ZOOKEEPER_JUTE_MAXBUFFER = 1048575;
     public static final String DEFAULT_SECURITY_AUTO_RELOAD_INTERVAL = "10 secs";
     public static final String DEFAULT_SITE_TO_SITE_HTTP_TRANSACTION_TTL = "30 secs";
     public static final String DEFAULT_FLOW_CONFIGURATION_ARCHIVE_ENABLED = "true";

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -3915,6 +3915,7 @@ that is specified.
 |`nifi.zookeeper.security.truststore`|Filename of the Truststore that will be used to verify the ZooKeeper server(s).
 |`nifi.zookeeper.security.truststoreType`|Optional. The type of the Truststore. Must be `PKCS12`, `JKS`, or `PEM`. If not specified the type will be determined from the file extension (`.p12`, `.jks`, `.pem`).
 |`nifi.zookeeper.security.truststorePasswd`|The password for the Truststore.
+|`nifi.zookeeper.jute.maxbuffer`|Maximum buffer size in bytes for packets sent to and received from ZooKeeper. Defaults to `1048575` bytes following ZooKeeper default `jute.maxbuffer` property. Changing this property requires setting `jute.maxbuffer` on ZooKeeper servers.
 |====
 
 [[kerberos_properties]]

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/cluster/ZooKeeperClientConfig.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/cluster/ZooKeeperClientConfig.java
@@ -54,11 +54,13 @@ public class ZooKeeperClientConfig {
     private final String authPrincipal;
     private final String removeHostFromPrincipal;
     private final String removeRealmFromPrincipal;
+    private final int juteMaxbuffer;
 
     private ZooKeeperClientConfig(String connectString, int sessionTimeoutMillis, int connectionTimeoutMillis,
                                   String rootPath, String authType, String authPrincipal, String removeHostFromPrincipal,
                                   String removeRealmFromPrincipal, boolean clientSecure, String keyStore, String keyStoreType,
-                                  String keyStorePassword, String trustStore, String trustStoreType, String trustStorePassword) {
+                                  String keyStorePassword, String trustStore, String trustStoreType, String trustStorePassword,
+                                  final int juteMaxbuffer) {
         this.connectString = connectString;
         this.sessionTimeoutMillis = sessionTimeoutMillis;
         this.connectionTimeoutMillis = connectionTimeoutMillis;
@@ -74,6 +76,7 @@ public class ZooKeeperClientConfig {
         this.authPrincipal = authPrincipal;
         this.removeHostFromPrincipal = removeHostFromPrincipal;
         this.removeRealmFromPrincipal = removeRealmFromPrincipal;
+        this.juteMaxbuffer = juteMaxbuffer;
     }
 
     public String getConnectString() {
@@ -140,6 +143,10 @@ public class ZooKeeperClientConfig {
         return removeRealmFromPrincipal;
     }
 
+    public int getJuteMaxbuffer() {
+        return juteMaxbuffer;
+    }
+
     public String resolvePath(final String path) {
         if (path.startsWith("/")) {
             return rootPath + path;
@@ -174,6 +181,7 @@ public class ZooKeeperClientConfig {
                 NiFiProperties.DEFAULT_ZOOKEEPER_KERBEROS_REMOVE_HOST_FROM_PRINCIPAL);
         final String removeRealmFromPrincipal = nifiProperties.getProperty(NiFiProperties.ZOOKEEPER_KERBEROS_REMOVE_REALM_FROM_PRINCIPAL,
                 NiFiProperties.DEFAULT_ZOOKEEPER_KERBEROS_REMOVE_REALM_FROM_PRINCIPAL);
+        final int juteMaxbuffer = nifiProperties.getIntegerProperty(NiFiProperties.ZOOKEEPER_JUTE_MAXBUFFER, NiFiProperties.DEFAULT_ZOOKEEPER_JUTE_MAXBUFFER);
 
         try {
             PathUtils.validatePath(rootPath);
@@ -196,7 +204,8 @@ public class ZooKeeperClientConfig {
             keyStorePassword,
             trustStore,
             trustStoreType,
-            trustStorePassword
+            trustStorePassword,
+            juteMaxbuffer
         );
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
@@ -43,6 +43,7 @@ import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.PathUtils;
 import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.common.ZKConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -374,7 +375,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
                 }
 
                 @Override
-                public void takeLeadership(CuratorFramework client) throws Exception {
+                public void takeLeadership(CuratorFramework client) {
                 }
             };
 
@@ -645,7 +646,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
         public static final String NETTY_CLIENT_CNXN_SOCKET =
             org.apache.zookeeper.ClientCnxnSocketNetty.class.getName();
 
-        private ZKClientConfig zkSecureClientConfig;
+        private final ZKClientConfig zkSecureClientConfig;
 
         public SecureClientZooKeeperFactory(final ZooKeeperClientConfig zkConfig) {
             this.zkSecureClientConfig = new ZKClientConfig();
@@ -653,7 +654,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
             // Netty is required for the secure client config.
             final String cnxnSocket = zkConfig.getConnectionSocket();
             if (!NETTY_CLIENT_CNXN_SOCKET.equals(cnxnSocket)) {
-                throw new IllegalArgumentException(String.format("connection factory set to '%s', %s required", String.valueOf(cnxnSocket), NETTY_CLIENT_CNXN_SOCKET));
+                throw new IllegalArgumentException(String.format("connection factory set to '%s', %s required", cnxnSocket, NETTY_CLIENT_CNXN_SOCKET));
             }
             zkSecureClientConfig.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, cnxnSocket);
 
@@ -671,6 +672,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
             zkSecureClientConfig.setProperty(clientX509util.getSslTruststoreLocationProperty(), zkConfig.getTrustStore());
             zkSecureClientConfig.setProperty(clientX509util.getSslTruststoreTypeProperty(), zkConfig.getTrustStoreType());
             zkSecureClientConfig.setProperty(clientX509util.getSslTruststorePasswdProperty(), zkConfig.getTrustStorePassword());
+            zkSecureClientConfig.setProperty(ZKConfig.JUTE_MAXBUFFER, Integer.toString(zkConfig.getJuteMaxbuffer()));
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/ZooKeeperStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/ZooKeeperStateProvider.java
@@ -44,6 +44,8 @@ import org.apache.zookeeper.ZKUtil;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.client.ConnectStringParser;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -71,7 +73,6 @@ import java.util.stream.Collectors;
  */
 public class ZooKeeperStateProvider extends AbstractStateProvider {
     private static final Logger logger = LoggerFactory.getLogger(ZooKeeperStateProvider.class);
-    private static final int ONE_MB = 1024 * 1024;
     private NiFiProperties nifiProperties;
 
     static final AllowableValue OPEN_TO_WORLD = new AllowableValue("Open", "Open", "ZNodes will be open to any ZooKeeper client.");
@@ -212,25 +213,20 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
         }
 
         if (zooKeeper == null) {
-            if(clientConfig != null && clientConfig.isClientSecure()) {
+            if (clientConfig != null && clientConfig.isClientSecure()) {
                 SecureClientZooKeeperFactory factory = new SecureClientZooKeeperFactory(clientConfig);
                 try {
-                    zooKeeper = factory.newZooKeeper(connectionString, timeoutMillis, new Watcher() {
-                        @Override
-                        public void process(WatchedEvent event) {
-                        }
-                    }, true);
-                    logger.info("Secure Zookeeper client initialized successfully.");
-                } catch (Exception e) {
-                    logger.error("Secure Zookeeper configuration failed!", e);
+                    zooKeeper = factory.newZooKeeper(connectionString, timeoutMillis, new DefaultWatcher(), true);
+                    logger.debug("Secure ZooKeeper Client connection [{}] created", connectionString);
+                } catch (final Exception e) {
+                    logger.error("Secure ZooKeeper Client connection [{}] failed", connectionString, e);
                     invalidateClient();
                 }
             } else {
-                zooKeeper = new ZooKeeper(connectionString, timeoutMillis, new Watcher() {
-                    @Override
-                    public void process(WatchedEvent event) {
-                    }
-                });
+                final ZKClientConfig zkClientConfig = new ZKClientConfig();
+                zkClientConfig.setProperty(ZKConfig.JUTE_MAXBUFFER, Integer.toString(clientConfig.getJuteMaxbuffer()));
+                zooKeeper = new ZooKeeper(connectionString, timeoutMillis, new DefaultWatcher(), zkClientConfig);
+                logger.debug("Standard ZooKeeper Client connection [{}] created", connectionString);
             }
 
             if (auth != null) {
@@ -242,17 +238,15 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
     }
 
     private ZooKeeperClientConfig getZooKeeperConfig() {
-        if(zooKeeperClientConfig != null) {
-            return zooKeeperClientConfig;
-        } else {
+        if (zooKeeperClientConfig == null) {
             Properties stateProviderProperties = new Properties();
             stateProviderProperties.setProperty(NiFiProperties.ZOOKEEPER_SESSION_TIMEOUT, timeoutMillis + " millis");
             stateProviderProperties.setProperty(NiFiProperties.ZOOKEEPER_CONNECT_TIMEOUT, timeoutMillis + " millis");
             stateProviderProperties.setProperty(NiFiProperties.ZOOKEEPER_ROOT_NODE, rootNode);
             stateProviderProperties.setProperty(NiFiProperties.ZOOKEEPER_CONNECT_STRING, connectionString);
             zooKeeperClientConfig = ZooKeeperClientConfig.createConfig(combineProperties(nifiProperties, stateProviderProperties));
-            return zooKeeperClientConfig;
         }
+        return zooKeeperClientConfig;
     }
 
     private synchronized void invalidateClient() {
@@ -373,7 +367,7 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
      *
      * @throws IOException if unable to communicate with ZooKeeper
      * @throws NoNodeException if the corresponding ZNode does not exist in ZooKeeper and allowNodeCreation is set to <code>false</code>
-     * @throws StateTooLargeException if the state to be stored exceeds the maximum size allowed by ZooKeeper (1 MB, after serialization)
+     * @throws StateTooLargeException if the state to be stored exceeds the maximum size allowed by ZooKeeper (Based on jute.maxbuffer property, after serialization)
      */
     private void setState(final Map<String, String> stateValues, final int version, final String componentId, final boolean allowNodeCreation) throws IOException, NoNodeException {
         verifyEnabled();
@@ -381,13 +375,8 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
         try {
             final String path = getComponentPath(componentId);
             final byte[] data = serialize(stateValues);
-            if (data.length > ONE_MB) {
-                throw new StateTooLargeException("Failed to set cluster-wide state in ZooKeeper for component with ID " + componentId
-                    + " because the state had " + stateValues.size() + " values, which serialized to " + data.length
-                    + " bytes, and the maximum allowed by ZooKeeper is 1 MB (" + ONE_MB + " bytes)");
-            }
-
             final ZooKeeper keeper = getZooKeeper();
+            validateDataSize(keeper.getClientConfig(), data, componentId, stateValues.size());
             try {
                 keeper.setData(path, data, version);
             } catch (final NoNodeException nne) {
@@ -425,13 +414,9 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
 
     private void createNode(final String path, final byte[] data, final String componentId, final Map<String, String> stateValues, final List<ACL> acls) throws IOException, KeeperException {
         try {
-            if (data != null && data.length > ONE_MB) {
-                throw new StateTooLargeException("Failed to set cluster-wide state in ZooKeeper for component with ID " + componentId
-                    + " because the state had " + stateValues.size() + " values, which serialized to " + data.length
-                    + " bytes, and the maximum allowed by ZooKeeper is 1 MB (" + ONE_MB + " bytes)");
-            }
-
-            getZooKeeper().create(path, data, acls, CreateMode.PERSISTENT);
+            final ZooKeeper zooKeeper = getZooKeeper();
+            validateDataSize(zooKeeper.getClientConfig(), data, componentId, stateValues.size());
+            zooKeeper.create(path, data, acls, CreateMode.PERSISTENT);
         } catch (final InterruptedException ie) {
             throw new IOException("Failed to update cluster-wide state due to interruption", ie);
         } catch (final KeeperException ke) {
@@ -509,7 +494,7 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
             return false;
         } catch (final IOException ioe) {
             final Throwable cause = ioe.getCause();
-            if (cause != null && cause instanceof KeeperException) {
+            if (cause instanceof KeeperException) {
                 final KeeperException ke = (KeeperException) cause;
                 if (Code.BADVERSION == ke.code()) {
                     return false;
@@ -524,6 +509,23 @@ public class ZooKeeperStateProvider extends AbstractStateProvider {
     @Override
     public void clear(final String componentId) throws IOException {
         verifyEnabled();
-        setState(Collections.<String, String>emptyMap(), componentId);
+        setState(Collections.emptyMap(), componentId);
+    }
+
+    private void validateDataSize(final ZKClientConfig clientConfig, final byte[] data, final String componentId, final int totalStateValues) throws StateTooLargeException {
+        final int maximumSize = clientConfig.getInt(ZKConfig.JUTE_MAXBUFFER, NiFiProperties.DEFAULT_ZOOKEEPER_JUTE_MAXBUFFER);
+        if (data != null && data.length > maximumSize) {
+            final String message = String.format("Component [%s] State Values [%d] Data Size [%d B] exceeds nifi.zookeeper.jute.maxbuffer size [%d B]",
+                    componentId, totalStateValues, data.length, maximumSize);
+            throw new StateTooLargeException(message);
+        }
+    }
+
+    private static final class DefaultWatcher implements Watcher {
+
+        @Override
+        public void process(final WatchedEvent watchedEvent) {
+
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/zookeeper/TestZooKeeperStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/zookeeper/TestZooKeeperStateProvider.java
@@ -38,8 +38,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
 
@@ -188,7 +190,7 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
     }
 
     @Test(timeout = 30000)
-    public void testStateTooLargeExceptionThrownOnReplace() throws IOException, InterruptedException {
+    public void testStateTooLargeExceptionThrownOnReplace() throws InterruptedException {
         final Map<String, String> state = new HashMap<>();
         final StringBuilder sb = new StringBuilder();
 
@@ -218,15 +220,48 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
             }
         }
 
-        try {
-            getProvider().replace(getProvider().getState(componentId), state, componentId);
-            Assert.fail("Expected StateTooLargeException");
-        } catch (final StateTooLargeException stle) {
-            // expected behavior.
-        } catch (final Exception e) {
-            Assert.fail("Expected StateTooLargeException", e);
-        }
+        assertThrows(StateTooLargeException.class, () -> getProvider().replace(getProvider().getState(componentId), state, componentId));
+    }
 
+    @Test(timeout = 5000)
+    public void testStateTooLargeExceptionThrownOnReplaceSmallJuteMaxbuffer() throws Exception {
+        final Map<String, String> initialState = new HashMap<>();
+        final String stateValue = UUID.randomUUID().toString();
+        final int maxBufferSize = 100;
+        initialState.put("1", stateValue);
+
+        final Map<PropertyDescriptor, String> properties = new HashMap<>(defaultProperties);
+        properties.put(ZooKeeperStateProvider.CONNECTION_STRING, zkServer.getConnectString());
+
+        final ZooKeeperStateProvider stateProvider = new ZooKeeperStateProvider();
+        final Properties applicationProperties = new Properties();
+        applicationProperties.setProperty(NiFiProperties.ZOOKEEPER_JUTE_MAXBUFFER, Integer.toString(maxBufferSize));
+        final NiFiProperties providerProperties = NiFiProperties.createBasicNiFiProperties(null, applicationProperties);
+        stateProvider.setNiFiProperties(providerProperties);
+        initializeProvider(stateProvider, properties);
+
+        try {
+            stateProvider.enable();
+
+            while (true) {
+                try {
+                    stateProvider.setState(initialState, componentId);
+                    break;
+                } catch (final IOException ioe) {
+                    // Retry initial connection
+                    Thread.sleep(1000L);
+                }
+            }
+
+            final Map<String, String> state = new HashMap<>();
+            state.put("1", stateValue);
+            state.put("2", stateValue);
+            state.put("3", stateValue);
+            state.put("4", stateValue);
+            assertThrows(StateTooLargeException.class, () -> stateProvider.replace(getProvider().getState(componentId), state, componentId));
+        } finally {
+            stateProvider.shutdown();
+        }
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -233,6 +233,7 @@
         <nifi.zookeeper.session.timeout>10 secs</nifi.zookeeper.session.timeout>
         <nifi.zookeeper.root.node>/nifi</nifi.zookeeper.root.node>
         <nifi.zookeeper.client.secure>false</nifi.zookeeper.client.secure>
+        <nifi.zookeeper.jute.maxbuffer />
         <nifi.zookeeper.security.keystore />
         <nifi.zookeeper.security.keystoreType />
         <nifi.zookeeper.security.keystorePasswd />

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -290,6 +290,7 @@ nifi.zookeeper.security.keystorePasswd=${nifi.zookeeper.security.keystorePasswd}
 nifi.zookeeper.security.truststore=${nifi.zookeeper.security.truststore}
 nifi.zookeeper.security.truststoreType=${nifi.zookeeper.security.truststoreType}
 nifi.zookeeper.security.truststorePasswd=${nifi.zookeeper.security.truststorePasswd}
+nifi.zookeeper.jute.maxbuffer=${nifi.zookeeper.jute.maxbuffer}
 
 # Zookeeper properties for the authentication scheme used when creating acls on znodes used for cluster management
 # Values supported for nifi.zookeeper.auth.type are "default", which will apply world/anyone rights on znodes


### PR DESCRIPTION
#### Description of PR

NIFI-9082 Adds `nifi.zookeeper.jute.maxbuffer` as a configurable setting in `nifi.properties` for `ZooKeeperStateProvider` and ZooKeeper clustering. The default value is just under 1 MB based on the default value of `1048575` bytes described in the [ZooKeeper Administrator's Guide](https://zookeeper.apache.org/doc/r3.5.9/zookeeperAdmin.html#Unsafe+Options). This default value aligns with the current hard-coded data size limit of 1 MB defined in `ZooKeeperStateProvider`.

Although the default value applies to the majority of use cases, and increasing the value can have other performance impacts, ZooKeeper supports larger values. Introducing this configurable property in NiFi supports optional configuration of a larger buffer in conjunction with changing the property on ZooKeeper servers.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
