### PR TITLE
NIFI-9192: ResultSetRecordSet considers value of useLogicalTypes flag…

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -309,7 +309,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         final int decimalScale;
         final int resultSetPrecision = rs.getMetaData().getPrecision(columnIndex);
         final int resultSetScale = rs.getMetaData().getScale(columnIndex);
-        if (rs.getMetaData().getPrecision(columnIndex) > 0) {
+        if (resultSetPrecision > 0) {
             // When database returns a certain precision, we can rely on that.
             decimalPrecision = resultSetPrecision;
             //For the float data type Oracle return decimalScale < 0 which cause is not expected to org.apache.avro.LogicalTypes

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -256,7 +256,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 if (readerSchema != null) {
                     Optional<DataType> dataType = readerSchema.getDataType(columnName);
                     if (dataType.isPresent()) {
-                        return dataType.get();
+                        return determineDataTypeToReturn(dataType.get(), useLogicalTypes);
                     }
                 }
 
@@ -269,6 +269,19 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                     return fieldType.getDataType();
                 }
             }
+        }
+    }
+
+    private DataType determineDataTypeToReturn(DataType dataType, boolean useLogicalTypes) {
+        RecordFieldType fieldType = dataType.getFieldType();
+        if (!useLogicalTypes &&
+                (fieldType == RecordFieldType.DECIMAL ||
+                 fieldType == RecordFieldType.DATE ||
+                 fieldType == RecordFieldType.TIME ||
+                 fieldType == RecordFieldType.TIMESTAMP)) {
+            return RecordFieldType.STRING.getDataType();
+        } else {
+            return dataType;
         }
     }
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -274,11 +274,11 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
 
     private DataType determineDataTypeToReturn(DataType dataType, boolean useLogicalTypes) {
         RecordFieldType fieldType = dataType.getFieldType();
-        if (!useLogicalTypes &&
-                (fieldType == RecordFieldType.DECIMAL ||
-                 fieldType == RecordFieldType.DATE ||
-                 fieldType == RecordFieldType.TIME ||
-                 fieldType == RecordFieldType.TIMESTAMP)) {
+        if (!useLogicalTypes
+                && (fieldType == RecordFieldType.DECIMAL
+                || fieldType == RecordFieldType.DATE
+                || fieldType == RecordFieldType.TIME
+                || fieldType == RecordFieldType.TIMESTAMP)) {
             return RecordFieldType.STRING.getDataType();
         } else {
             return dataType;

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -227,7 +227,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 if (readerSchema != null) {
                     Optional<DataType> dataType = readerSchema.getDataType(columnName);
                     if (dataType.isPresent()) {
-                        return dataType.get();
+                        return determineDataTypeToReturn(dataType.get(), useLogicalTypes);
                     }
                 }
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -272,7 +272,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         }
     }
 
-    private DataType determineDataTypeToReturn(DataType dataType, boolean useLogicalTypes) {
+    private DataType determineDataTypeToReturn(final DataType dataType, final boolean useLogicalTypes) {
         RecordFieldType fieldType = dataType.getFieldType();
         if (!useLogicalTypes
                 && (fieldType == RecordFieldType.DECIMAL
@@ -285,7 +285,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         }
     }
 
-    private DataType getArrayDataType(ResultSet rs, int columnIndex, boolean useLogicalTypes) throws SQLException {
+    private DataType getArrayDataType(final ResultSet rs, final int columnIndex, final boolean useLogicalTypes) throws SQLException {
         // The JDBC API does not allow us to know what the base type of an array is through the metadata.
         // As a result, we have to obtain the actual Array for this record. Once we have this, we can determine
         // the base type. However, if the base type is, itself, an array, we will simply return a base type of
@@ -304,7 +304,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         }
     }
 
-    private DataType getDecimalDataType(ResultSet rs, int columnIndex) throws SQLException {
+    private DataType getDecimalDataType(final ResultSet rs, final int columnIndex) throws SQLException {
         int decimalPrecision;
         final int decimalScale;
         final int resultSetPrecision = rs.getMetaData().getPrecision(columnIndex);

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -68,18 +68,22 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
     }
 
     public ResultSetRecordSet(final ResultSet rs, final RecordSchema readerSchema, final int defaultPrecision, final int defaultScale) throws SQLException {
+        this(rs, readerSchema, defaultPrecision, defaultScale, true);
+    }
+
+    public ResultSetRecordSet(final ResultSet rs, final RecordSchema readerSchema, final int defaultPrecision, final int defaultScale, final boolean useLogicalTypes) throws SQLException {
         this.defaultPrecision = defaultPrecision;
         this.defaultScale = defaultScale;
         this.rs = rs;
         this.rsColumnNames = new HashSet<>();
         RecordSchema tempSchema;
         try {
-            tempSchema = createSchema(rs, readerSchema);
+            tempSchema = createSchema(rs, readerSchema, useLogicalTypes);
             moreRows = rs.next();
         } catch(SQLException se) {
             // Tried to create the schema with a ResultSet without calling next() first (probably for DB2), now try the other way around
             moreRows = rs.next();
-            tempSchema = createSchema(rs, readerSchema);
+            tempSchema = createSchema(rs, readerSchema, useLogicalTypes);
         }
         this.schema = tempSchema;
     }
@@ -168,7 +172,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         return value;
     }
 
-    private RecordSchema createSchema(final ResultSet rs, final RecordSchema readerSchema) throws SQLException {
+    private RecordSchema createSchema(final ResultSet rs, final RecordSchema readerSchema, final boolean useLogicalTypes) throws SQLException {
         final ResultSetMetaData metadata = rs.getMetaData();
         final int numCols = metadata.getColumnCount();
         final List<RecordField> fields = new ArrayList<>(numCols);
@@ -177,7 +181,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             final int column = i + 1;
             final int sqlType = metadata.getColumnType(column);
 
-            final DataType dataType = getDataType(sqlType, rs, column, readerSchema);
+            final DataType dataType = getDataType(sqlType, rs, column, readerSchema, useLogicalTypes);
             final String fieldName = metadata.getColumnLabel(column);
 
             final int nullableFlag = metadata.isNullable(column);
@@ -196,56 +200,22 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         return new SimpleRecordSchema(fields);
     }
 
-    private DataType getDataType(final int sqlType, final ResultSet rs, final int columnIndex, final RecordSchema readerSchema) throws SQLException {
+    private DataType getDataType(final int sqlType, final ResultSet rs, final int columnIndex, final RecordSchema readerSchema, final boolean useLogicalTypes)
+            throws SQLException {
         switch (sqlType) {
             case Types.ARRAY:
-                // The JDBC API does not allow us to know what the base type of an array is through the metadata.
-                // As a result, we have to obtain the actual Array for this record. Once we have this, we can determine
-                // the base type. However, if the base type is, itself, an array, we will simply return a base type of
-                // String because otherwise, we need the ResultSet for the array itself, and many JDBC Drivers do not
-                // support calling Array.getResultSet() and will throw an Exception if that is not supported.
-                try {
-                    final Array array = rs.getArray(columnIndex);
-
-                    if (array == null) {
-                        return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType());
-                    }
-                    final DataType baseType = getArrayBaseType(array);
-                    return RecordFieldType.ARRAY.getArrayDataType(baseType);
-                } catch (SQLFeatureNotSupportedException sfnse) {
-                    return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType());
-                }
+                return getArrayDataType(rs, columnIndex, useLogicalTypes);
             case Types.BINARY:
             case Types.LONGVARBINARY:
             case Types.VARBINARY:
                 return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType());
             case Types.NUMERIC:
             case Types.DECIMAL:
-                int decimalPrecision;
-                final int decimalScale;
-                final int resultSetPrecision = rs.getMetaData().getPrecision(columnIndex);
-                final int resultSetScale = rs.getMetaData().getScale(columnIndex);
-                if (rs.getMetaData().getPrecision(columnIndex) > 0) {
-                    // When database returns a certain precision, we can rely on that.
-                    decimalPrecision = resultSetPrecision;
-                    //For the float data type Oracle return decimalScale < 0 which cause is not expected to org.apache.avro.LogicalTypes
-                    //Hence falling back to default scale if decimalScale < 0
-                    decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+                if (useLogicalTypes) {
+                    return getDecimalDataType(rs, columnIndex);
                 } else {
-                    // If not, use default precision.
-                    decimalPrecision = defaultPrecision;
-                    // Oracle returns precision=0, scale=-127 for variable scale value such as ROWNUM or function result.
-                    // Specifying 'oracle.jdbc.J2EE13Compliant' SystemProperty makes it to return scale=0 instead.
-                    // Queries for example, 'SELECT 1.23 as v from DUAL' can be problematic because it can't be mapped with decimal with scale=0.
-                    // Default scale is used to preserve decimals in such case.
-                    decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+                    return RecordFieldType.STRING.getDataType();
                 }
-                // Scale can be bigger than precision in some cases (Oracle, e.g.) If this is the case, assume precision refers to the number of
-                // decimal digits and thus precision = scale
-                if (decimalScale > decimalPrecision) {
-                    decimalPrecision = decimalScale;
-                }
-                return RecordFieldType.DECIMAL.getDecimalDataType(decimalPrecision, decimalScale);
             case Types.OTHER: {
                 // If we have no records to inspect, we can't really know its schema so we simply use the default data type.
                 if (rs.isAfterLast()) {
@@ -259,6 +229,10 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                     if (dataType.isPresent()) {
                         return dataType.get();
                     }
+                }
+
+                if (!useLogicalTypes) {
+                    return RecordFieldType.STRING.getDataType();
                 }
 
                 final Object obj = rs.getObject(columnIndex);
@@ -286,7 +260,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                     }
                 }
 
-                final RecordFieldType fieldType = getFieldType(sqlType, rs.getMetaData().getColumnClassName(columnIndex));
+                final RecordFieldType fieldType = getFieldType(sqlType, rs.getMetaData().getColumnClassName(columnIndex), useLogicalTypes);
 
                 if (RecordFieldType.DECIMAL.equals(fieldType)) {
                     final BigDecimal bigDecimalValue = rs.getBigDecimal(columnIndex);
@@ -298,7 +272,54 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         }
     }
 
-    private static DataType getArrayBaseType(final Array array) throws SQLException {
+    private DataType getArrayDataType(ResultSet rs, int columnIndex, boolean useLogicalTypes) throws SQLException {
+        // The JDBC API does not allow us to know what the base type of an array is through the metadata.
+        // As a result, we have to obtain the actual Array for this record. Once we have this, we can determine
+        // the base type. However, if the base type is, itself, an array, we will simply return a base type of
+        // String because otherwise, we need the ResultSet for the array itself, and many JDBC Drivers do not
+        // support calling Array.getResultSet() and will throw an Exception if that is not supported.
+        try {
+            final Array array = rs.getArray(columnIndex);
+
+            if (array == null) {
+                return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType());
+            }
+            final DataType baseType = getArrayBaseType(array, useLogicalTypes);
+            return RecordFieldType.ARRAY.getArrayDataType(baseType);
+        } catch (SQLFeatureNotSupportedException sfnse) {
+            return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType());
+        }
+    }
+
+    private DataType getDecimalDataType(ResultSet rs, int columnIndex) throws SQLException {
+        int decimalPrecision;
+        final int decimalScale;
+        final int resultSetPrecision = rs.getMetaData().getPrecision(columnIndex);
+        final int resultSetScale = rs.getMetaData().getScale(columnIndex);
+        if (rs.getMetaData().getPrecision(columnIndex) > 0) {
+            // When database returns a certain precision, we can rely on that.
+            decimalPrecision = resultSetPrecision;
+            //For the float data type Oracle return decimalScale < 0 which cause is not expected to org.apache.avro.LogicalTypes
+            //Hence falling back to default scale if decimalScale < 0
+            decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+        } else {
+            // If not, use default precision.
+            decimalPrecision = defaultPrecision;
+            // Oracle returns precision=0, scale=-127 for variable scale value such as ROWNUM or function result.
+            // Specifying 'oracle.jdbc.J2EE13Compliant' SystemProperty makes it to return scale=0 instead.
+            // Queries for example, 'SELECT 1.23 as v from DUAL' can be problematic because it can't be mapped with decimal with scale=0.
+            // Default scale is used to preserve decimals in such case.
+            decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+        }
+        // Scale can be bigger than precision in some cases (Oracle, e.g.) If this is the case, assume precision refers to the number of
+        // decimal digits and thus precision = scale
+        if (decimalScale > decimalPrecision) {
+            decimalPrecision = decimalScale;
+        }
+        return RecordFieldType.DECIMAL.getDecimalDataType(decimalPrecision, decimalScale);
+    }
+
+    private static DataType getArrayBaseType(final Array array, final boolean useLogicalTypes) throws SQLException {
         final Object arrayValue = array.getArray();
         if (arrayValue == null) {
             return RecordFieldType.STRING.getDataType();
@@ -367,8 +388,12 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 return RecordFieldType.DOUBLE.getDataType();
             }
             if (valueToLookAt instanceof BigDecimal) {
-                final BigDecimal bigDecimal = (BigDecimal) valueToLookAt;
-                return RecordFieldType.DECIMAL.getDecimalDataType(bigDecimal.precision(), bigDecimal.scale());
+                if (useLogicalTypes) {
+                    final BigDecimal bigDecimal = (BigDecimal) valueToLookAt;
+                    return RecordFieldType.DECIMAL.getDecimalDataType(bigDecimal.precision(), bigDecimal.scale());
+                } else {
+                    return RecordFieldType.STRING.getDataType();
+                }
             }
             if (valueToLookAt instanceof Boolean) {
                 return RecordFieldType.BOOLEAN.getDataType();
@@ -383,13 +408,13 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                 return RecordFieldType.INT.getDataType();
             }
             if (valueToLookAt instanceof java.sql.Time) {
-                return RecordFieldType.TIME.getDataType();
+                return getDataType(RecordFieldType.TIME, useLogicalTypes);
             }
             if (valueToLookAt instanceof java.sql.Date) {
-                return RecordFieldType.DATE.getDataType();
+                return getDataType(RecordFieldType.DATE, useLogicalTypes);
             }
             if (valueToLookAt instanceof java.sql.Timestamp) {
-                return RecordFieldType.TIMESTAMP.getDataType();
+                return getDataType(RecordFieldType.TIMESTAMP, useLogicalTypes);
             }
             if (valueToLookAt instanceof Record) {
                 final Record record = (Record) valueToLookAt;
@@ -400,8 +425,15 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
         return RecordFieldType.STRING.getDataType();
     }
 
+    private static DataType getDataType(final RecordFieldType recordFieldType, final boolean useLogicalTypes) {
+        if (useLogicalTypes) {
+            return recordFieldType.getDataType();
+        } else {
+            return RecordFieldType.STRING.getDataType();
+        }
+    }
 
-    private static RecordFieldType getFieldType(final int sqlType, final String valueClassName) {
+    private static RecordFieldType getFieldType(final int sqlType, final String valueClassName, final boolean useLogicalTypes) {
         switch (sqlType) {
             case Types.BIGINT:
             case Types.ROWID:
@@ -412,10 +444,10 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             case Types.CHAR:
                 return RecordFieldType.CHAR;
             case Types.DATE:
-                return RecordFieldType.DATE;
+                return getRecordFieldType(RecordFieldType.DATE, useLogicalTypes);
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return RecordFieldType.DECIMAL;
+                return getRecordFieldType(RecordFieldType.DECIMAL, useLogicalTypes);
             case Types.DOUBLE:
             case Types.REAL:
                 return RecordFieldType.DOUBLE;
@@ -446,7 +478,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                     return RecordFieldType.LONG;
                 }
                 if (DATE_CLASS_NAME.equals(valueClassName)) {
-                    return RecordFieldType.DATE;
+                    return getRecordFieldType(RecordFieldType.DATE, useLogicalTypes);
                 }
                 if (FLOAT_CLASS_NAME.equals(valueClassName)) {
                     return RecordFieldType.FLOAT;
@@ -455,20 +487,28 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
                     return RecordFieldType.DOUBLE;
                 }
                 if (BIGDECIMAL_CLASS_NAME.equals(valueClassName)) {
-                    return RecordFieldType.DECIMAL;
+                    return getRecordFieldType(RecordFieldType.DECIMAL, useLogicalTypes);
                 }
 
                 return RecordFieldType.RECORD;
             case Types.TIME:
             case Types.TIME_WITH_TIMEZONE:
-                return RecordFieldType.TIME;
+                return getRecordFieldType(RecordFieldType.TIME, useLogicalTypes);
             case Types.TIMESTAMP:
             case Types.TIMESTAMP_WITH_TIMEZONE:
             case -101: // Oracle's TIMESTAMP WITH TIME ZONE
             case -102: // Oracle's TIMESTAMP WITH LOCAL TIME ZONE
-                return RecordFieldType.TIMESTAMP;
+                return getRecordFieldType(RecordFieldType.TIMESTAMP, useLogicalTypes);
         }
 
         return RecordFieldType.STRING;
+    }
+
+    private static RecordFieldType getRecordFieldType(final RecordFieldType recordFieldType, final boolean useLogicalTypes) {
+        if (useLogicalTypes) {
+            return recordFieldType;
+        } else {
+            return RecordFieldType.STRING;
+        }
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
@@ -307,8 +307,7 @@ public class ResultSetRecordSetTest {
         ResultSetMetaData resultSetMetaData = Mockito.mock(ResultSetMetaData.class);
         ResultSet resultSet = Mockito.mock(ResultSet.class);
 
-        RecordSchema expectedSchema = useLogicalTypes ?
-                givenRecordSchema(columns) : givenRecordSchemaWithOnlyStringType(columns);
+        RecordSchema expectedSchema = useLogicalTypes ? givenRecordSchema(columns) : givenRecordSchemaWithOnlyStringType(columns);
 
         // WHEN
         setUpMocks(columns, resultSetMetaData, resultSet);

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
@@ -51,6 +51,7 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -74,6 +75,8 @@ public class ResultSetRecordSetTest {
     private static final String COLUMN_NAME_BIG_DECIMAL_3 = "bigDecimal3";
     private static final String COLUMN_NAME_BIG_DECIMAL_4 = "bigDecimal4";
     private static final String COLUMN_NAME_BIG_DECIMAL_5 = "bigDecimal5";
+
+    private static final long TIMESTAMP_IN_MILLIS = 1631809132516L;
 
     private static final TestColumn[] COLUMNS = new TestColumn[] {
             new TestColumn(1, COLUMN_NAME_VARCHAR, Types.VARCHAR, RecordFieldType.STRING.getDataType()),
@@ -507,20 +510,20 @@ public class ResultSetRecordSetTest {
     private List<ArrayTestData> givenArrayTypesThatRequireLogicalTypes() {
         List<ArrayTestData> testData = new ArrayList<>();
         testData.add(new ArrayTestData("arrayBigDecimal",
-                new BigDecimalDummy[]{new BigDecimalDummy(), new BigDecimalDummy()}));
+                new ResultBigDecimal[]{new ResultBigDecimal(), new ResultBigDecimal()}));
         testData.add(new ArrayTestData("arrayDate",
-                new Date[]{new Date(1631809132516L), new Date(1631809132516L)}));
+                new Date[]{new Date(TIMESTAMP_IN_MILLIS), new Date(TIMESTAMP_IN_MILLIS)}));
         testData.add(new ArrayTestData("arrayTime",
-                new Time[]{new Time(1631809132516L), new Time(1631809132516L)}));
+                new Time[]{new Time(TIMESTAMP_IN_MILLIS), new Time(TIMESTAMP_IN_MILLIS)}));
         testData.add(new ArrayTestData("arrayTimestamp",
-                new Timestamp[]{new Timestamp(1631809132516L), new Timestamp(1631809132516L)}));
+                new Timestamp[]{new Timestamp(TIMESTAMP_IN_MILLIS), new Timestamp(TIMESTAMP_IN_MILLIS)}));
         return testData;
     }
 
     private Map<String, DataType> givenExpectedTypesForArrayTypesThatRequireLogicalTypes(final boolean useLogicalTypes) {
         Map<String, DataType> expectedTypes = new HashMap<>();
         if (useLogicalTypes) {
-            expectedTypes.put("arrayBigDecimal", RecordFieldType.DECIMAL.getDecimalDataType(BigDecimalDummy.PRECISION, BigDecimalDummy.SCALE));
+            expectedTypes.put("arrayBigDecimal", RecordFieldType.DECIMAL.getDecimalDataType(ResultBigDecimal.PRECISION, ResultBigDecimal.SCALE));
             expectedTypes.put("arrayDate", RecordFieldType.DATE.getDataType());
             expectedTypes.put("arrayTime", RecordFieldType.TIME.getDataType());
             expectedTypes.put("arrayTimestamp", RecordFieldType.TIMESTAMP.getDataType());
@@ -589,7 +592,7 @@ public class ResultSetRecordSetTest {
         for (int i = 0; i < testData.size(); ++i) {
             ArrayTestData testDatum = testData.get(i);
             int columnIndex = i + 1;
-            SqlArrayDummy arrayDummy = Mockito.mock(SqlArrayDummy.class);
+            ResultSqlArray arrayDummy = Mockito.mock(ResultSqlArray.class);
             when(arrayDummy.getArray()).thenReturn(testDatum.getTestArray());
             when(resultSet.getArray(columnIndex)).thenReturn(arrayDummy);
             when(resultSetMetaData.getColumnLabel(columnIndex)).thenReturn(testDatum.getFieldName());
@@ -634,12 +637,11 @@ public class ResultSetRecordSetTest {
         for (RecordField recordField : actualSchema.getFields()) {
             if (recordField.getDataType() instanceof ArrayDataType) {
                 ArrayDataType arrayType = (ArrayDataType) recordField.getDataType();
-                if (!arrayType.getElementType().equals(expectedTypes.get(recordField.getFieldName()))) {
-                    throw new AssertionError("Array element type for " + recordField.getFieldName()
-                            + " is not of expected type " + expectedTypes.get(recordField.getFieldName()).toString());
-                }
+                assertEquals("Array element type for " + recordField.getFieldName()
+                                + " is not of expected type " + expectedTypes.get(recordField.getFieldName()).toString(),
+                        expectedTypes.get(recordField.getFieldName()), arrayType.getElementType());
             } else {
-                throw new AssertionError("RecordField " + recordField.getFieldName() + " is not instance of ArrayDataType");
+                fail("RecordField " + recordField.getFieldName() + " is not instance of ArrayDataType");
             }
         }
     }
@@ -692,7 +694,7 @@ public class ResultSetRecordSetTest {
         }
     }
 
-    private static class SqlArrayDummy implements Array {
+    private static class ResultSqlArray implements Array {
 
         @Override
         public String getBaseTypeName() throws SQLException {
@@ -750,10 +752,10 @@ public class ResultSetRecordSetTest {
         }
     }
 
-    private static class BigDecimalDummy extends BigDecimal {
+    private static class ResultBigDecimal extends BigDecimal {
         public static int PRECISION = 3;
         public static int SCALE = 0;
-        public BigDecimalDummy() {
+        public ResultBigDecimal() {
             super("123");
         }
     }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -189,7 +189,7 @@ public class JdbcCommon {
             return defaultScale;
         }
 
-        public boolean getUseLogicalTypes() {
+        public boolean isUseLogicalTypes() {
             return useLogicalTypes;
         }
 

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -189,6 +189,10 @@ public class JdbcCommon {
             return defaultScale;
         }
 
+        public boolean getUseLogicalTypes() {
+            return useLogicalTypes;
+        }
+
         public static class Builder {
             private String recordName;
             private int maxRows = 0;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
@@ -70,7 +70,7 @@ public class RecordSqlWriter implements SqlWriter {
             if (fullRecordSet == null) {
                 final Schema avroSchema = JdbcCommon.createSchema(resultSet, options);
                 final RecordSchema recordAvroSchema = AvroTypeUtil.createSchema(avroSchema);
-                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.getDefaultPrecision(), options.getDefaultScale(), options.getUseLogicalTypes());
+                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.getDefaultPrecision(), options.getDefaultScale(), options.isUseLogicalTypes());
                 writeSchema = recordSetWriterFactory.getSchema(originalAttributes, fullRecordSet.getSchema());
             }
             recordSet = (maxRowsPerFlowFile > 0) ? fullRecordSet.limit(maxRowsPerFlowFile) : fullRecordSet;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
@@ -70,7 +70,7 @@ public class RecordSqlWriter implements SqlWriter {
             if (fullRecordSet == null) {
                 final Schema avroSchema = JdbcCommon.createSchema(resultSet, options);
                 final RecordSchema recordAvroSchema = AvroTypeUtil.createSchema(avroSchema);
-                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.getDefaultPrecision(), options.getDefaultScale());
+                fullRecordSet = new ResultSetRecordSetWithCallback(resultSet, recordAvroSchema, callback, options.getDefaultPrecision(), options.getDefaultScale(), options.getUseLogicalTypes());
                 writeSchema = recordSetWriterFactory.getSchema(originalAttributes, fullRecordSet.getSchema());
             }
             recordSet = (maxRowsPerFlowFile > 0) ? fullRecordSet.limit(maxRowsPerFlowFile) : fullRecordSet;
@@ -135,8 +135,8 @@ public class RecordSqlWriter implements SqlWriter {
         private final ResultSetRowCallback callback;
 
         ResultSetRecordSetWithCallback(ResultSet rs, RecordSchema readerSchema, ResultSetRowCallback callback,
-                                       final int defaultPrecision, final int defaultScale) throws SQLException {
-            super(rs, readerSchema, defaultPrecision, defaultScale);
+                                       final int defaultPrecision, final int defaultScale, final boolean useLogicalTypes) throws SQLException {
+            super(rs, readerSchema, defaultPrecision, defaultScale, useLogicalTypes);
             this.callback = callback;
         }
 


### PR DESCRIPTION
… when determining the object's schema.

Signed-off-by: Peter Gyori <peter.gyori.dev@gmail.com>

https://issues.apache.org/jira/browse/NIFI-9192

<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->

#### Description of PR

Introduces the useLogicalTypes flag to the ResultSetRecordSet and implements the logic in ResultSetRecordSet that considers the flag's value when determining the schema for the object that gets created.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
