### PR TITLE
NIFI-9235 - Improve PutHDFS documentation; conflict detection

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -471,8 +471,6 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor {
         getLogger().info("Initialized a new HDFS File System with working dir: {} default block size: {} default replication: {} config: {}",
                 new Object[]{workingDir, fs.getDefaultBlockSize(workingDir), fs.getDefaultReplication(workingDir), config.toString()});
 
-        preProcessFileSystem(fs, context);
-
         return new HdfsResources(config, fs, ugi, kerberosUser);
     }
 
@@ -514,10 +512,6 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor {
      * @param context the context that can be used to retrieve additional values
      */
     protected void preProcessConfiguration(final Configuration config, final ProcessContext context) {
-
-    }
-
-    protected void preProcessFileSystem(final FileSystem fileSystem, final ProcessContext context) throws IOException {
 
     }
 

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -471,6 +471,8 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor {
         getLogger().info("Initialized a new HDFS File System with working dir: {} default block size: {} default replication: {} config: {}",
                 new Object[]{workingDir, fs.getDefaultBlockSize(workingDir), fs.getDefaultReplication(workingDir), config.toString()});
 
+        preProcessFileSystem(fs, context);
+
         return new HdfsResources(config, fs, ugi, kerberosUser);
     }
 
@@ -512,6 +514,10 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor {
      * @param context the context that can be used to retrieve additional values
      */
     protected void preProcessConfiguration(final Configuration config, final ProcessContext context) {
+
+    }
+
+    protected void preProcessFileSystem(final FileSystem fileSystem, final ProcessContext context) throws IOException {
 
     }
 

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -79,6 +79,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.8.1</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.10.0</version>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>2.8.1</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -40,6 +40,7 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
@@ -246,6 +247,11 @@ public class PutHDFS extends AbstractHadoopProcessor {
                 .maximumSize(20L)
                 .expireAfterWrite(Duration.ofHours(1))
                 .build();
+    }
+
+    @OnStopped
+    public void onStopped() {
+        aclCache.invalidateAll();
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.util.Progressable;
@@ -43,6 +45,7 @@ import org.ietf.jgss.GSSException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.security.sasl.SaslException;
 import java.io.ByteArrayOutputStream;
@@ -51,6 +54,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,6 +66,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class PutHDFSTest {
 
@@ -432,6 +440,89 @@ public class PutHDFSTest {
             fileSystem.getFileStatus(new Path("target/test-classes/randombytes-1")).getPermission());
     }
 
+    /**
+     * Multiple invocations of PutHDFS on the same target directory should query the remote filesystem ACL once, and
+     * use the cached ACL afterwards.
+     */
+    @Test
+    public void testPutHDFSAclCache() {
+        final MockFileSystem fileSystem = Mockito.spy(new MockFileSystem());
+        final Path directory = new Path("/withACL");
+        assertTrue(fileSystem.mkdirs(directory));
+        final String acl = "user::rwx,group::rwx,other::rwx";
+        final String aclDefault = "default:user::rwx,default:group::rwx,default:other::rwx";
+        fileSystem.setAcl(directory, AclEntry.parseAclSpec(String.join(",", acl, aclDefault), true));
+
+        final PutHDFS processor = new TestablePutHDFS(kerberosProperties, fileSystem);
+        final TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setProperty(PutHDFS.DIRECTORY, directory.toString());
+        runner.setProperty(PutHDFS.UMASK, "077");
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "empty");
+        runner.enqueue(new byte[16], attributes);
+        runner.run(3);  // fetch data once; hit AclCache twice
+        verify(fileSystem, times(1)).getAclStatus(any(Path.class));
+    }
+
+    /**
+     * When no default ACL is present on the remote directory, usage of {@link PutHDFS#UMASK}
+     * should be ok.
+     */
+    @Test
+    public void testPutFileWithNoDefaultACL() {
+        final List<Boolean> setUmask = Arrays.asList(false, true);
+        for (boolean setUmaskIt : setUmask) {
+            final MockFileSystem fileSystem = new MockFileSystem();
+            final Path directory = new Path("/withNoDACL");
+            assertTrue(fileSystem.mkdirs(directory));
+            final String acl = "user::rwx,group::rwx,other::rwx";
+            fileSystem.setAcl(directory, AclEntry.parseAclSpec(acl, true));
+
+            final PutHDFS processor = new TestablePutHDFS(kerberosProperties, fileSystem);
+            final TestRunner runner = TestRunners.newTestRunner(processor);
+            runner.setProperty(PutHDFS.DIRECTORY, directory.toString());
+            if (setUmaskIt) {
+                runner.setProperty(PutHDFS.UMASK, "077");
+            }
+            final Map<String, String> attributes = new HashMap<>();
+            attributes.put(CoreAttributes.FILENAME.key(), "empty");
+            runner.enqueue(new byte[16], attributes);
+            runner.run();
+            assertEquals(1, runner.getFlowFilesForRelationship(PutHDFS.REL_SUCCESS).size());
+            assertEquals(0, runner.getFlowFilesForRelationship(PutHDFS.REL_FAILURE).size());
+        }
+    }
+
+    /**
+     * When default ACL is present on the remote directory, usage of {@link PutHDFS#UMASK}
+     * should trigger failure of the flow file.
+     */
+    @Test
+    public void testPutFileWithDefaultACL() {
+        final List<Boolean> setUmask = Arrays.asList(false, true);
+        for (boolean setUmaskIt : setUmask) {
+            final MockFileSystem fileSystem = new MockFileSystem();
+            final Path directory = new Path("/withACL");
+            assertTrue(fileSystem.mkdirs(directory));
+            final String acl = "user::rwx,group::rwx,other::rwx";
+            final String aclDefault = "default:user::rwx,default:group::rwx,default:other::rwx";
+            fileSystem.setAcl(directory, AclEntry.parseAclSpec(String.join(",", acl, aclDefault), true));
+
+            final PutHDFS processor = new TestablePutHDFS(kerberosProperties, fileSystem);
+            final TestRunner runner = TestRunners.newTestRunner(processor);
+            runner.setProperty(PutHDFS.DIRECTORY, directory.toString());
+            if (setUmaskIt) {
+                runner.setProperty(PutHDFS.UMASK, "077");
+            }
+            final Map<String, String> attributes = new HashMap<>();
+            attributes.put(CoreAttributes.FILENAME.key(), "empty");
+            runner.enqueue(new byte[16], attributes);
+            runner.run();
+            assertEquals(setUmaskIt ? 0 : 1, runner.getFlowFilesForRelationship(PutHDFS.REL_SUCCESS).size());
+            assertEquals(setUmaskIt ? 1 : 0, runner.getFlowFilesForRelationship(PutHDFS.REL_FAILURE).size());
+        }
+    }
+
     @Test
     public void testPutFileWithCloseException() throws IOException {
         mockFileSystem = new MockFileSystem(true);
@@ -486,8 +577,9 @@ public class PutHDFSTest {
         }
     }
 
-    private class MockFileSystem extends FileSystem {
+    private static class MockFileSystem extends FileSystem {
         private final Map<Path, FileStatus> pathToStatus = new HashMap<>();
+        private final Map<Path, List<AclEntry>> pathToAcl = new HashMap<>();
         private final boolean failOnClose;
 
         public MockFileSystem() {
@@ -496,6 +588,15 @@ public class PutHDFSTest {
 
         public MockFileSystem(boolean failOnClose) {
             this.failOnClose = failOnClose;
+        }
+
+        public void setAcl(final Path path, final List<AclEntry> aclSpec) {
+            pathToAcl.put(path, aclSpec);
+        }
+
+        @Override
+        public AclStatus getAclStatus(final Path path) {
+            return new AclStatus.Builder().addEntries(pathToAcl.getOrDefault(path, new ArrayList<>())).build();
         }
 
         @Override


### PR DESCRIPTION
#### Description of PR

Add hook to `AbstractHadoopProcessor.resetHDFSResources()`, allowing subclasses to operate on `FileSystem` after initialization.  Processor `PutHDFS` uses this hook to query the HDFS endpoint for default ACL.  If a default ACLis present, log warning when PutHDFS umask is configured, as HDFS ignores it by design.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
