### PR TITLE
NIFI-9253 Corrected SSLSocketChannel.available() for TLSv1.3

### DIFF
--- a/nifi-commons/nifi-security-socket-ssl/src/main/java/org/apache/nifi/remote/io/socket/ssl/SSLSocketChannelInputStream.java
+++ b/nifi-commons/nifi-security-socket-ssl/src/main/java/org/apache/nifi/remote/io/socket/ssl/SSLSocketChannelInputStream.java
@@ -58,8 +58,4 @@ public class SSLSocketChannelInputStream extends InputStream {
     public int available() throws IOException {
         return channel.available();
     }
-
-    public boolean isDataAvailable() throws IOException {
-        return available() > 0;
-    }
 }


### PR DESCRIPTION
#### Description of PR

NIFI-9253 Corrects `SSLSocketChannel` to avoid intermittent unit test and runtime failures related to TLSv1.3.  The `available()` method implementation resulted in sporadic unit test failures for TLSv1.3 due to partial reads from the connected channel while attempting to determine available bytes.  Partial reads produced incomplete TLS messages, causing AES-GCM decryption failures reported as `Tag mismatch` messages with `SSLException`.

The previous unit test used a loop for checking the `available()` bytes, causing intermittent failures. The updated unit test class includes separate methods with and without calls to `available()` in order to reproduce the potential problem. The corrected `available()` method in `SSLSocketChannel` avoids direct reads from the socket channel and instead returns the size of the application data buffer.  This approach aligns with the documentation for `InputStream.available()`, which states that the method returns an estimate of the number of bytes that may be read, without blocking. Additional changes include refactoring and isolating the `readChannel()` and `unwrap()` methods in `SSLSocketChannel` for more streamlined handling of buffer underflow status.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
