### PR TITLE
NIFI-9254 Updated default Stateless Sensitive Property configuration

### DIFF
--- a/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/PropertyEncryptionMethod.java
+++ b/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/PropertyEncryptionMethod.java
@@ -22,7 +22,7 @@ import org.apache.nifi.security.util.KeyDerivationFunction;
 /**
  * Property Encryption Method enumerates supported values in addition to {@link org.apache.nifi.security.util.EncryptionMethod}
  */
-enum PropertyEncryptionMethod {
+public enum PropertyEncryptionMethod {
     NIFI_ARGON2_AES_GCM_128(KeyDerivationFunction.ARGON2, EncryptionMethod.AES_GCM,128),
 
     NIFI_ARGON2_AES_GCM_256(KeyDerivationFunction.ARGON2, EncryptionMethod.AES_GCM, 256),

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParser.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParser.java
@@ -24,15 +24,19 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,6 +64,7 @@ public class PropertiesFileEngineConfigurationParser {
 
     private static final Pattern EXTENSION_CLIENT_PATTERN = Pattern.compile("\\Qnifi.stateless.extension.client.\\E(.*?)\\.(.+)");
 
+    private static final int PROPERTIES_KEY_LENGTH = 24;
 
     public StatelessEngineConfiguration parseEngineConfiguration(final File propertiesFile) throws IOException, StatelessConfigurationException {
         if (!propertiesFile.exists()) {
@@ -93,8 +98,7 @@ public class PropertiesFileEngineConfigurationParser {
         final String krb5Filename = properties.getProperty(KRB5_FILE, DEFAULT_KRB5_FILENAME);
         final File krb5File = new File(krb5Filename);
 
-        final String defaultEncryptionPassword = UUID.randomUUID().toString();
-        final String sensitivePropsKey = properties.getProperty(SENSITIVE_PROPS_KEY, defaultEncryptionPassword);
+        final String sensitivePropsKey = getSensitivePropsKey(propertiesFile, properties);
         final SslContextDefinition sslContextDefinition = parseSslContextDefinition(properties);
 
         final List<ExtensionClientDefinition> extensionClients = parseExtensionClients(properties);
@@ -219,4 +223,24 @@ public class PropertiesFileEngineConfigurationParser {
         return propertyValue.trim();
     }
 
+    private String getSensitivePropsKey(final File propertiesFile, final Properties properties) {
+        String sensitivePropsKey = properties.getProperty(SENSITIVE_PROPS_KEY);
+        if (sensitivePropsKey == null || sensitivePropsKey.isEmpty()) {
+            logger.warn("Generating Random Properties Encryption Key [{}]", SENSITIVE_PROPS_KEY);
+            final SecureRandom secureRandom = new SecureRandom();
+            final byte[] sensitivePropertiesKeyBinary = new byte[PROPERTIES_KEY_LENGTH];
+            secureRandom.nextBytes(sensitivePropertiesKeyBinary);
+            final Base64.Encoder encoder = Base64.getEncoder().withoutPadding();
+            sensitivePropsKey = encoder.encodeToString(sensitivePropertiesKeyBinary);
+
+            properties.put(SENSITIVE_PROPS_KEY, sensitivePropsKey);
+            try (final OutputStream outputStream = new FileOutputStream(propertiesFile)) {
+                properties.store(outputStream, StatelessEngineConfiguration.class.getSimpleName());
+            } catch (final IOException e) {
+                final String message = String.format("Store Configuration Properties [%s] Failed", propertiesFile);
+                throw new UncheckedIOException(message, e);
+            }
+        }
+        return sensitivePropsKey;
+    }
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParser.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParser.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -56,7 +57,6 @@ public class PropertiesFileEngineConfigurationParser {
     private static final String KRB5_FILE = PREFIX + "kerberos.krb5.file";
 
     private static final String DEFAULT_KRB5_FILENAME = "/etc/krb5.conf";
-    private static final String DEFAULT_ENCRYPTION_PASSWORD = "nifi-stateless";
 
     private static final Pattern EXTENSION_CLIENT_PATTERN = Pattern.compile("\\Qnifi.stateless.extension.client.\\E(.*?)\\.(.+)");
 
@@ -93,7 +93,8 @@ public class PropertiesFileEngineConfigurationParser {
         final String krb5Filename = properties.getProperty(KRB5_FILE, DEFAULT_KRB5_FILENAME);
         final File krb5File = new File(krb5Filename);
 
-        final String sensitivePropsKey = properties.getProperty(SENSITIVE_PROPS_KEY, DEFAULT_ENCRYPTION_PASSWORD);
+        final String defaultEncryptionPassword = UUID.randomUUID().toString();
+        final String sensitivePropsKey = properties.getProperty(SENSITIVE_PROPS_KEY, defaultEncryptionPassword);
         final SslContextDefinition sslContextDefinition = parseSslContextDefinition(properties);
 
         final List<ExtensionClientDefinition> extensionClients = parseExtensionClients(properties);

--- a/nifi-stateless/nifi-stateless-api/src/test/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParserTest.java
+++ b/nifi-stateless/nifi-stateless-api/src/test/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParserTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.stateless.config;
+
+import org.apache.nifi.stateless.engine.StatelessEngineConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class PropertiesFileEngineConfigurationParserTest {
+    private PropertiesFileEngineConfigurationParser parser;
+
+    private static Path narDirectory;
+
+    private static Path workingDirectory;
+
+    @BeforeAll
+    public static void setDirectories() throws IOException {
+        narDirectory = Files.createTempDirectory(PropertiesFileEngineConfigurationParserTest.class.getSimpleName());
+        workingDirectory = Files.createTempDirectory(PropertiesFileEngineConfigurationParserTest.class.getSimpleName());
+    }
+
+    @AfterAll
+    public static void deleteDirectories() throws IOException {
+        Files.deleteIfExists(narDirectory);
+        Files.deleteIfExists(workingDirectory);
+    }
+
+    @BeforeEach
+    public void setParser() {
+        parser = new PropertiesFileEngineConfigurationParser();
+    }
+
+    @Test
+    public void testParseEngineConfigurationRequiredProperties() throws IOException, StatelessConfigurationException {
+        final Properties properties = getRequiredProperties();
+        final File propertiesFile = getPropertiesFile(properties);
+
+        final StatelessEngineConfiguration configuration = parser.parseEngineConfiguration(propertiesFile);
+        assertNotNull(configuration);
+        assertEquals(narDirectory.toFile(), configuration.getNarDirectory());
+        assertEquals(workingDirectory.toFile(), configuration.getWorkingDirectory());
+    }
+
+    @Test
+    public void testParseEngineConfigurationRandomSensitivePropsKey() throws IOException, StatelessConfigurationException {
+        final Properties properties = getRequiredProperties();
+        final File propertiesFile = getPropertiesFile(properties);
+
+        final StatelessEngineConfiguration configuration = parser.parseEngineConfiguration(propertiesFile);
+        assertNotNull(configuration);
+
+        final String sensitivePropsKey = configuration.getSensitivePropsKey();
+        assertNotNull(sensitivePropsKey);
+        assertFalse(sensitivePropsKey.isEmpty());
+
+        final StatelessEngineConfiguration secondConfiguration = parser.parseEngineConfiguration(propertiesFile);
+        assertNotEquals(sensitivePropsKey, secondConfiguration.getSensitivePropsKey());
+    }
+
+    private Properties getRequiredProperties() {
+        final Properties properties = new Properties();
+
+        properties.setProperty("nifi.stateless.nar.directory", narDirectory.toString());
+        properties.setProperty("nifi.stateless.working.directory", workingDirectory.toString());
+
+        return properties;
+    }
+
+    private File getPropertiesFile(final Properties properties) throws IOException {
+        final File file = File.createTempFile(getClass().getSimpleName(), ".properties");
+        file.deleteOnExit();
+
+        try (final OutputStream outputStream = new FileOutputStream(file)) {
+            properties.store(outputStream, null);
+        }
+
+        return file;
+    }
+}

--- a/nifi-stateless/nifi-stateless-api/src/test/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParserTest.java
+++ b/nifi-stateless/nifi-stateless-api/src/test/java/org/apache/nifi/stateless/config/PropertiesFileEngineConfigurationParserTest.java
@@ -32,7 +32,6 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class PropertiesFileEngineConfigurationParserTest {
@@ -82,8 +81,8 @@ public class PropertiesFileEngineConfigurationParserTest {
         assertNotNull(sensitivePropsKey);
         assertFalse(sensitivePropsKey.isEmpty());
 
-        final StatelessEngineConfiguration secondConfiguration = parser.parseEngineConfiguration(propertiesFile);
-        assertNotEquals(sensitivePropsKey, secondConfiguration.getSensitivePropsKey());
+        final StatelessEngineConfiguration reloadedConfiguration = parser.parseEngineConfiguration(propertiesFile);
+        assertEquals(sensitivePropsKey, reloadedConfiguration.getSensitivePropsKey());
     }
 
     private Properties getRequiredProperties() {

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
@@ -31,7 +31,7 @@ import org.apache.nifi.controller.scheduling.StatelessProcessScheduler;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
 import org.apache.nifi.controller.service.StandardControllerServiceProvider;
 import org.apache.nifi.encrypt.PropertyEncryptor;
-import org.apache.nifi.encrypt.PropertyEncryptorFactory;
+import org.apache.nifi.encrypt.PropertyEncryptorBuilder;
 import org.apache.nifi.events.EventReporter;
 import org.apache.nifi.events.VolatileBulletinRepository;
 import org.apache.nifi.extensions.ExtensionClient;
@@ -51,7 +51,6 @@ import org.apache.nifi.registry.flow.InMemoryFlowRegistry;
 import org.apache.nifi.registry.flow.StandardFlowRegistryClient;
 import org.apache.nifi.registry.flow.VersionedFlowSnapshot;
 import org.apache.nifi.reporting.BulletinRepository;
-import org.apache.nifi.security.util.EncryptionMethod;
 import org.apache.nifi.stateless.bootstrap.ExtensionDiscovery;
 import org.apache.nifi.stateless.config.ExtensionClientDefinition;
 import org.apache.nifi.stateless.config.SslConfigurationUtil;
@@ -73,7 +72,6 @@ import org.apache.nifi.stateless.repository.StatelessFileSystemContentRepository
 import org.apache.nifi.stateless.repository.StatelessFlowFileRepository;
 import org.apache.nifi.stateless.repository.StatelessProvenanceRepository;
 import org.apache.nifi.stateless.repository.StatelessRepositoryContextFactory;
-import org.apache.nifi.util.NiFiProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,14 +81,12 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public class StandardStatelessDataflowFactory implements StatelessDataflowFactory<VersionedFlowSnapshot> {
     private static final Logger logger = LoggerFactory.getLogger(StandardStatelessDataflowFactory.class);
-    private static final EncryptionMethod ENCRYPTION_METHOD = EncryptionMethod.MD5_256AES;
+    private static final String PROPERTY_ENCRYPTION_METHOD = "NIFI_PBKDF2_AES_GCM_256";
 
     @Override
     public StatelessDataflow createDataflow(final StatelessEngineConfiguration engineConfiguration, final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition)
@@ -167,7 +163,9 @@ public class StandardStatelessDataflowFactory implements StatelessDataflowFactor
                         return created;
                     }
 
-                    created = getPropertyEncryptor(engineConfiguration.getSensitivePropsKey());
+                    created = new PropertyEncryptorBuilder(engineConfiguration.getSensitivePropsKey())
+                            .setAlgorithm(PROPERTY_ENCRYPTION_METHOD)
+                            .build();
                     return created;
                 }
             };
@@ -341,14 +339,5 @@ public class StandardStatelessDataflowFactory implements StatelessDataflowFactor
         }
 
         return Integer.parseInt(javaVersion.substring(0, dotIndex));
-    }
-
-    private PropertyEncryptor getPropertyEncryptor(final String sensitivePropertiesKey) {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put(NiFiProperties.SENSITIVE_PROPS_ALGORITHM, ENCRYPTION_METHOD.getAlgorithm());
-        properties.put(NiFiProperties.SENSITIVE_PROPS_PROVIDER, ENCRYPTION_METHOD.getProvider());
-        properties.put(NiFiProperties.SENSITIVE_PROPS_KEY, sensitivePropertiesKey);
-        final NiFiProperties niFiProperties = NiFiProperties.createBasicNiFiProperties(null, properties);
-        return PropertyEncryptorFactory.getPropertyEncryptor(niFiProperties);
     }
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
@@ -30,6 +30,7 @@ import org.apache.nifi.controller.repository.metrics.RingBufferEventRepository;
 import org.apache.nifi.controller.scheduling.StatelessProcessScheduler;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
 import org.apache.nifi.controller.service.StandardControllerServiceProvider;
+import org.apache.nifi.encrypt.PropertyEncryptionMethod;
 import org.apache.nifi.encrypt.PropertyEncryptor;
 import org.apache.nifi.encrypt.PropertyEncryptorBuilder;
 import org.apache.nifi.events.EventReporter;
@@ -86,7 +87,6 @@ import java.util.Optional;
 
 public class StandardStatelessDataflowFactory implements StatelessDataflowFactory<VersionedFlowSnapshot> {
     private static final Logger logger = LoggerFactory.getLogger(StandardStatelessDataflowFactory.class);
-    private static final String PROPERTY_ENCRYPTION_METHOD = "NIFI_PBKDF2_AES_GCM_256";
 
     @Override
     public StatelessDataflow createDataflow(final StatelessEngineConfiguration engineConfiguration, final DataflowDefinition<VersionedFlowSnapshot> dataflowDefinition)
@@ -164,7 +164,7 @@ public class StandardStatelessDataflowFactory implements StatelessDataflowFactor
                     }
 
                     created = new PropertyEncryptorBuilder(engineConfiguration.getSensitivePropsKey())
-                            .setAlgorithm(PROPERTY_ENCRYPTION_METHOD)
+                            .setAlgorithm(PropertyEncryptionMethod.NIFI_PBKDF2_AES_GCM_256.toString())
                             .build();
                     return created;
                 }


### PR DESCRIPTION
#### Description of PR

NIFI-9254 Updates the default Sensitive Properties Algorithm and Sensitive Properties Key values for NiFi Stateless to more secure settings.  Following the default configuration of the NiFi framework, `NIFI_PBKDF2_AES_GCM_256` is the new standard Sensitive Properties Algorithm, replacing the deprecated `PBEWITHMD5AND256BITAES-CBC-OPENSSL` setting.

Changes also include replacing a hard-coded default Sensitive Properties Key with a random generation key.

Additional changes include a new unit test for parsing Stateless properties and confirming random Sensitive Properties Key generation.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
