### PR TITLE
NIFI-9223 Correct ListenSyslog with default address of 0.0.0.0

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/netty/ByteArrayMessageNettyEventServerFactory.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/netty/ByteArrayMessageNettyEventServerFactory.java
@@ -27,6 +27,7 @@ import org.apache.nifi.event.transport.netty.channel.LogExceptionChannelHandler;
 import org.apache.nifi.event.transport.netty.codec.SocketByteArrayMessageDecoder;
 import org.apache.nifi.logging.ComponentLog;
 
+import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
 
@@ -40,15 +41,15 @@ public class ByteArrayMessageNettyEventServerFactory extends NettyEventServerFac
      * Netty Event Server Factory with configurable delimiter and queue of Byte Array Messages
      *
      * @param log Component Log
-     * @param address Remote Address
-     * @param port Remote Port Number
+     * @param address Listen Address
+     * @param port Listen Port Number
      * @param protocol Channel Protocol
      * @param delimiter Message Delimiter
      * @param maxFrameLength Maximum Frame Length for delimited TCP messages
      * @param messages Blocking Queue for events received
      */
     public ByteArrayMessageNettyEventServerFactory(final ComponentLog log,
-                                                   final String address,
+                                                   final InetAddress address,
                                                    final int port,
                                                    final TransportProtocol protocol,
                                                    final byte[] delimiter,

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/netty/NettyEventServerFactory.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/netty/NettyEventServerFactory.java
@@ -37,6 +37,7 @@ import org.apache.nifi.event.transport.netty.channel.ssl.ServerSslHandlerChannel
 import org.apache.nifi.security.util.ClientAuth;
 
 import javax.net.ssl.SSLContext;
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,7 @@ import java.util.function.Supplier;
  * Netty Event Server Factory
  */
 public class NettyEventServerFactory extends EventLoopGroupFactory implements EventServerFactory {
-    private final String address;
+    private final InetAddress address;
 
     private final int port;
 
@@ -65,7 +66,7 @@ public class NettyEventServerFactory extends EventLoopGroupFactory implements Ev
 
     private Duration shutdownTimeout = ShutdownTimeout.DEFAULT.getDuration();
 
-    public NettyEventServerFactory(final String address, final int port, final TransportProtocol protocol) {
+    public NettyEventServerFactory(final InetAddress address, final int port, final TransportProtocol protocol) {
         this.address = address;
         this.port = port;
         this.protocol = protocol;

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/test/java/org/apache/nifi/event/transport/netty/StringNettyEventSenderFactoryTest.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/test/java/org/apache/nifi/event/transport/netty/StringNettyEventSenderFactoryTest.java
@@ -36,6 +36,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.net.ssl.SSLContext;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -50,7 +52,7 @@ import static org.junit.Assert.assertThrows;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StringNettyEventSenderFactoryTest {
-    private static final String ADDRESS = "127.0.0.1";
+    private static final InetAddress ADDRESS;
 
     private static final int MAX_FRAME_LENGTH = 1024;
 
@@ -65,6 +67,14 @@ public class StringNettyEventSenderFactoryTest {
     private static final String DELIMITER = "\n";
 
     private static final int SINGLE_THREAD = 1;
+
+    static {
+        try {
+            ADDRESS = InetAddress.getByName("127.0.0.1");
+        } catch (final UnknownHostException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 
     @Mock
     private ComponentLog log;
@@ -130,12 +140,12 @@ public class StringNettyEventSenderFactoryTest {
         assertNotNull("Message not received", messageReceived);
         final String eventReceived = new String(messageReceived.getMessage(), CHARSET);
         assertEquals("Message not matched", MESSAGE, eventReceived);
-        assertEquals("Sender not matched", ADDRESS, messageReceived.getSender());
+        assertEquals("Sender not matched", ADDRESS.getHostAddress(), messageReceived.getSender());
     }
 
     private NettyEventSenderFactory<String> getEventSenderFactory(final int port) {
         final StringNettyEventSenderFactory senderFactory = new StringNettyEventSenderFactory(log,
-                ADDRESS, port, TransportProtocol.TCP, CHARSET, LineEnding.UNIX);
+                ADDRESS.getHostAddress(), port, TransportProtocol.TCP, CHARSET, LineEnding.UNIX);
         senderFactory.setTimeout(DEFAULT_TIMEOUT);
         senderFactory.setShutdownQuietPeriod(ShutdownQuietPeriod.QUICK.getDuration());
         senderFactory.setShutdownTimeout(ShutdownTimeout.QUICK.getDuration());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSyslog.java
@@ -31,6 +31,8 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -74,12 +76,15 @@ public class TestPutSyslog {
 
     private TestRunner runner;
 
-    private TransportProtocol protocol = TransportProtocol.UDP;
+    private final TransportProtocol protocol = TransportProtocol.UDP;
+
+    private InetAddress address;
 
     private int port;
 
     @Before
-    public void setRunner() {
+    public void setRunner() throws UnknownHostException {
+        address = InetAddress.getByName(ADDRESS);
         port = NetworkUtils.getAvailableUdpPort();
         runner = TestRunners.newTestRunner(PutSyslog.class);
         runner.setProperty(PutSyslog.HOSTNAME, ADDRESS);
@@ -132,7 +137,7 @@ public class TestPutSyslog {
     private void assertSyslogMessageSuccess(final String expectedSyslogMessage, final Map<String, String> attributes) throws InterruptedException {
         final BlockingQueue<ByteArrayMessage> messages = new LinkedBlockingQueue<>();
         final byte[] delimiter = DELIMITER.getBytes(CHARSET);
-        final NettyEventServerFactory serverFactory = new ByteArrayMessageNettyEventServerFactory(runner.getLogger(), ADDRESS, port, protocol, delimiter, MAX_FRAME_LENGTH, messages);
+        final NettyEventServerFactory serverFactory = new ByteArrayMessageNettyEventServerFactory(runner.getLogger(), address, port, protocol, delimiter, MAX_FRAME_LENGTH, messages);
         serverFactory.setShutdownQuietPeriod(ShutdownQuietPeriod.QUICK.getDuration());
         serverFactory.setShutdownTimeout(ShutdownTimeout.QUICK.getDuration());
         final EventServer eventServer = serverFactory.getEventServer();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutUDP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutUDP.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.BlockingQueue;
@@ -37,7 +38,6 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestPutUDP {
@@ -45,8 +45,6 @@ public class TestPutUDP {
     private final static String UDP_SERVER_ADDRESS = "127.0.0.1";
     private final static String SERVER_VARIABLE = "ALKJAFLKJDFLSKJSDFLKJSDF";
     private final static String UDP_SERVER_ADDRESS_EL = "${" + SERVER_VARIABLE + "}";
-    private final static String UNKNOWN_HOST = "fgdsfgsdffd";
-    private final static String INVALID_IP_ADDRESS = "300.300.300.300";
     private static final String DELIMITER = "\n";
     private static final Charset CHARSET = StandardCharsets.UTF_8;
     private final static int MAX_FRAME_LENGTH = 32800;
@@ -64,7 +62,6 @@ public class TestPutUDP {
 
     private TestRunner runner;
     private int port;
-    private TransportProtocol PROTOCOL = TransportProtocol.UDP;
     private EventServer eventServer;
     private BlockingQueue<ByteArrayMessage> messages;
 
@@ -78,13 +75,15 @@ public class TestPutUDP {
         runner = TestRunners.newTestRunner(PutUDP.class);
         runner.setVariable(SERVER_VARIABLE, UDP_SERVER_ADDRESS);
         port = NetworkUtils.getAvailableUdpPort();
-        createTestServer(UDP_SERVER_ADDRESS, port, VALID_LARGE_FILE_SIZE);
+        createTestServer(port, VALID_LARGE_FILE_SIZE);
     }
 
-    private void createTestServer(final String address, final int port, final int frameSize) throws Exception {
+    private void createTestServer(final int port, final int frameSize) throws Exception {
         messages = new LinkedBlockingQueue<>();
         final byte[] delimiter = DELIMITER.getBytes(CHARSET);
-        NettyEventServerFactory serverFactory = new ByteArrayMessageNettyEventServerFactory(runner.getLogger(), address, port, PROTOCOL, delimiter, frameSize, messages);
+        final InetAddress listenAddress = InetAddress.getByName(UDP_SERVER_ADDRESS);
+        NettyEventServerFactory serverFactory = new ByteArrayMessageNettyEventServerFactory(
+                runner.getLogger(), listenAddress, port, TransportProtocol.UDP, delimiter, frameSize, messages);
         serverFactory.setSocketReceiveBuffer(MAX_FRAME_LENGTH);
         serverFactory.setShutdownQuietPeriod(ShutdownQuietPeriod.QUICK.getDuration());
         serverFactory.setShutdownTimeout(ShutdownTimeout.QUICK.getDuration());
@@ -92,7 +91,7 @@ public class TestPutUDP {
     }
 
     @After
-    public void cleanup() throws Exception {
+    public void cleanup() {
         runner.shutdown();
         removeTestServer();
     }
@@ -106,7 +105,7 @@ public class TestPutUDP {
 
     @Test(timeout = DEFAULT_TEST_TIMEOUT_PERIOD)
     public void testValidFiles() throws Exception {
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        configureProperties(UDP_SERVER_ADDRESS);
         sendTestData(VALID_FILES);
         checkReceivedAllData(VALID_FILES);
         checkInputQueueIsEmpty();
@@ -114,7 +113,7 @@ public class TestPutUDP {
 
     @Test(timeout = DEFAULT_TEST_TIMEOUT_PERIOD)
     public void testValidFilesEL() throws Exception {
-        configureProperties(UDP_SERVER_ADDRESS_EL, true);
+        configureProperties(UDP_SERVER_ADDRESS_EL);
         sendTestData(VALID_FILES);
         checkReceivedAllData(VALID_FILES);
         checkInputQueueIsEmpty();
@@ -122,7 +121,7 @@ public class TestPutUDP {
 
     @Test(timeout = DEFAULT_TEST_TIMEOUT_PERIOD)
     public void testEmptyFile() throws Exception {
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        configureProperties(UDP_SERVER_ADDRESS);
         sendTestData(EMPTY_FILE);
         checkRelationships(EMPTY_FILE.length, 0);
         checkNoDataReceived();
@@ -131,7 +130,7 @@ public class TestPutUDP {
 
     @Test(timeout = LONG_TEST_TIMEOUT_PERIOD)
     public void testLargeValidFile() throws Exception {
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        configureProperties(UDP_SERVER_ADDRESS);
         final String[] testData = createContent(VALID_LARGE_FILE_SIZE);
         sendTestData(testData);
         checkReceivedAllData(testData);
@@ -140,7 +139,7 @@ public class TestPutUDP {
 
     @Test(timeout = LONG_TEST_TIMEOUT_PERIOD)
     public void testLargeInvalidFile() throws Exception {
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        configureProperties(UDP_SERVER_ADDRESS);
         String[] testData = createContent(INVALID_LARGE_FILE_SIZE);
         sendTestData(testData);
         checkRelationships(0, testData.length);
@@ -148,37 +147,17 @@ public class TestPutUDP {
         checkInputQueueIsEmpty();
     }
 
-    @Ignore("This test is failing intermittently as documented in NIFI-4288")
-    @Test(timeout = LONG_TEST_TIMEOUT_PERIOD)
-    public void testInvalidIPAddress() throws Exception {
-        configureProperties(INVALID_IP_ADDRESS, true);
-        sendTestData(VALID_FILES);
-        checkNoDataReceived();
-        checkRelationships(0, VALID_FILES.length);
-        checkInputQueueIsEmpty();
-    }
-
-    @Ignore("This test is failing incorrectly as documented in NIFI-1795")
-    @Test(timeout = LONG_TEST_TIMEOUT_PERIOD)
-    public void testUnknownHostname() throws Exception {
-        configureProperties(UNKNOWN_HOST, true);
-        sendTestData(VALID_FILES);
-        checkNoDataReceived();
-        checkRelationships(0, VALID_FILES.length);
-        checkInputQueueIsEmpty();
-    }
-
     @Test(timeout = LONG_TEST_TIMEOUT_PERIOD)
     public void testReconfiguration() throws Exception {
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        configureProperties(UDP_SERVER_ADDRESS);
         sendTestData(VALID_FILES);
         checkReceivedAllData(VALID_FILES);
-        reset(UDP_SERVER_ADDRESS, port, MAX_FRAME_LENGTH);
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        reset(port);
+        configureProperties(UDP_SERVER_ADDRESS);
         sendTestData(VALID_FILES);
         checkReceivedAllData(VALID_FILES);
-        reset(UDP_SERVER_ADDRESS, port, MAX_FRAME_LENGTH);
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        reset(port);
+        configureProperties(UDP_SERVER_ADDRESS);
         sendTestData(VALID_FILES);
         checkReceivedAllData(VALID_FILES);
         checkInputQueueIsEmpty();
@@ -187,28 +166,23 @@ public class TestPutUDP {
     @Test(timeout = LONG_TEST_TIMEOUT_PERIOD)
     public void testLoadTest() throws Exception {
         final String[] testData = createContent(VALID_SMALL_FILE_SIZE);
-        configureProperties(UDP_SERVER_ADDRESS, true);
+        configureProperties(UDP_SERVER_ADDRESS);
         sendTestData(testData, LOAD_TEST_ITERATIONS, LOAD_TEST_THREAD_COUNT);
         checkReceivedAllData(testData, LOAD_TEST_ITERATIONS);
         checkInputQueueIsEmpty();
     }
 
-    private void reset(final String address, final int port, final int frameSize) throws Exception {
+    private void reset(final int port) throws Exception {
         runner.clearTransferState();
         removeTestServer();
-        createTestServer(address, port, frameSize);
+        createTestServer(port, MAX_FRAME_LENGTH);
     }
 
-    private void configureProperties(final String host, final boolean expectValid) {
+    private void configureProperties(final String host) {
         runner.setProperty(PutUDP.HOSTNAME, host);
         runner.setProperty(PutUDP.PORT, Integer.toString(port));
         runner.setProperty(PutUDP.MAX_SOCKET_SEND_BUFFER_SIZE, "40000B");
-
-        if (expectValid) {
-            runner.assertValid();
-        } else {
-            runner.assertNotValid();
-        }
+        runner.assertValid();
     }
 
     private void sendTestData(final String[] testData) throws InterruptedException {


### PR DESCRIPTION
#### Description of PR

NIFI-9223 Corrects the behavior of `ListenSyslog` to listen on `0.0.0.0` when the `Local Network Interface` property is not configured. The was an unexpected change in the default behavior released in NiFi 1.13.2 as part of PR #5044 for NIFI-8462.

Changes include modifying the `NettyEventServerFactory` and sub-classes to accept a nullable `InetAddress` argument instead of a `String` for the listening address.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
