### PR TITLE
NIFI-9215: Fixing issue showing Controller Service APIs

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
@@ -595,7 +595,7 @@
 
                 // add the documented type
                 controllerServiceTypesData.addItem({
-                    id: id++,
+                    id: id++ + '',
                     label: nfCommon.substringAfterLast(documentedType.type, '.'),
                     type: documentedType.type,
                     bundle: documentedType.bundle,


### PR DESCRIPTION
NIFI-9215:
- During mouse over events the items in the Controller Service Types table could not be looked up because the identifier of the item was an integer value and the identifier was a string value. Addressing the issue by always using a string.