### PR TITLE
NIFI-9237: Fixing restricted usage tooltips in new Processor/Reporting Task dialog

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/header/components/nf-ng-processor-component.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/header/components/nf-ng-processor-component.js
@@ -542,7 +542,7 @@
 
                                 // create the row for the processor type
                                 processorTypesData.addItem({
-                                    id: i,
+                                    id: i + '',
                                     label: nfCommon.substringAfterLast(type, '.'),
                                     type: type,
                                     bundle: documentedType.bundle,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-settings.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-settings.js
@@ -828,7 +828,7 @@
 
                 // add the documented type
                 reportingTaskTypesData.addItem({
-                    id: id++,
+                    id: id++ + '',
                     label: nfCommon.substringAfterLast(documentedType.type, '.'),
                     type: documentedType.type,
                     bundle: documentedType.bundle,


### PR DESCRIPTION
NIFI-9237:
- Similar to NIFI-9215, converting integer identifiers to strings to ensure the items are successfully retrieved when attempting to apply a tooltip.