### PR TITLE
NIFI-3965 adding Hexdump processor to standard bundle

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HexDump.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HexDump.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Tags({"hex", "dump", "convert", "flowfile"})
+@WritesAttributes({@WritesAttribute(attribute="first16hex", description="A customizable Hexdump of incoming " +
+" FlowFiles. The attributes length, offset and name can be altered.")})
+@CapabilityDescription("Converts incoming FlowFiles into hexadecimal format. The processor can output the HexDump " +
+    "data in new FlowFiles or/and as an renamable Attribute.")
+public class HexDump extends AbstractProcessor {
+
+    public static final PropertyDescriptor OUT_MODE = new PropertyDescriptor
+            .Builder().name("OUT_MODE")
+            .displayName("Output Hexdump Mode")
+            .description("Selectable Mode, describing if the converted Hexdump data should yield FlowFile data, Attribute or"+
+            " Both.")
+            .required(true)
+            .defaultValue("BOTH")
+            .allowableValues("FLOWFILE","ATTRIBUTE","BOTH")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor FLOWFILE_OFFSET = new PropertyDescriptor
+            .Builder().name("FLOWFILE_OFFSET")
+            .displayName("FlowFile output offset")
+            .description("Non negative integer offset of Hexdump in FlowFile output. If offset is out of bounds no "+
+            " data will be transferred. This is only used if mode is FLOWFILE or BOTH")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor FLOWFILE_LENGTH = new PropertyDescriptor
+            .Builder().name("FLOWFILE_LENGTH")
+            .displayName("FlowFile output length")
+            .description("Non negative integer describing maximum size of Hexdump in FlowFile output. 0 = unlimited. "+
+            "This is only used if Mode is FLOWFILE or BOTH.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor ATTRIBUTE_NAME = new PropertyDescriptor
+            .Builder().name("ATTRIBUTE_NAME")
+            .displayName("Attribute hexdump name")
+            .description("String Hexdump output attribute name. This is only used if mode is ATTRIBUTE or BOTH.")
+            .required(true)
+            .defaultValue("first16hex")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+    
+    public static final PropertyDescriptor ATTRIBUTE_OFFSET = new PropertyDescriptor
+            .Builder().name("ATTRIBUTE_OFFSET")
+            .displayName("Attribute Hexdump Offset")
+            .description("Non negative integer offset of attribute Hexdump. If offset is out of bounds no data will be "+
+            " transferred. This is only used if mode is ATTRIBUTE or BOTH.")
+            .required(true)
+            .defaultValue("0")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor ATTRIBUTE_LENGTH = new PropertyDescriptor
+            .Builder().name("ATTRIBUTE_LENGTH")
+            .displayName("Attribute Hexdump Length")
+            .description("Non negative integer maximum size of attribute Hexdump. This is only used if mode is ATTRIBUTE or"+
+            " BOTH.")
+            .required(true)
+            .defaultValue("16")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Successfully converted FlowFile to Hexdump")
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("Failed to convert FlowFile to Hexdump")
+            .build();
+
+    private static final char hex[] = {
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+        };
+    
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        descriptors.add(OUT_MODE);
+        descriptors.add(FLOWFILE_LENGTH);
+        descriptors.add(FLOWFILE_OFFSET);
+        descriptors.add(ATTRIBUTE_NAME);
+        descriptors.add(ATTRIBUTE_OFFSET);
+        descriptors.add(ATTRIBUTE_LENGTH);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<Relationship>();
+        relationships.add(REL_SUCCESS);
+        relationships.add(REL_FAILURE);
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    private String outMode;
+	private int flowFileLength;
+	private int flowFileOffset;
+	private String attributeName;
+    private int attributeOffset;
+    private int attributeLength;
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        outMode = context.getProperty(OUT_MODE).getValue();
+        flowFileLength = context.getProperty(FLOWFILE_LENGTH).asInteger();
+        flowFileOffset = context.getProperty(FLOWFILE_OFFSET).asInteger();
+        attributeName = context.getProperty(ATTRIBUTE_NAME).getValue();
+        attributeLength = context.getProperty(ATTRIBUTE_LENGTH).asInteger();
+        attributeOffset = context.getProperty(ATTRIBUTE_OFFSET).asInteger();
+    }
+
+     /**
+     * Read incoming FlowFile and convert to Hexdump array
+     *
+     * @return
+     *  Hexdump converted byte array
+     */
+    private byte[] readFlowFileToHex(ProcessSession session, FlowFile flowFile) throws IOException{
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        final InputStream in = new BufferedInputStream( session.read(flowFile));
+           
+            while (true) {
+                final int nextByte = in.read();
+                if (nextByte == -1) {
+                    break;
+                }
+                buffer.write(hex[((nextByte >> 4) & 0xF)]);
+                buffer.write(hex[((nextByte >> 0) & 0xF)]);
+            }
+            in.close();
+            return buffer.toByteArray();
+    }
+
+    private boolean offsetOutOfBounds(int[] index){
+        return index[0] == -1;
+    }
+
+     /**
+     * Calculate limits for data from offsets and lengths
+     *
+     * @return
+     *  Array of size 2 describing max and min of Hexdump array interval
+     */
+    private int[] getArrayLimits(int offset, int length, int arrayLength, int intervalLimit){
+        int start = offset;
+        int end = length + offset;
+
+        if (length == 0){
+            end = arrayLength;
+        }
+
+        if (start > arrayLength){
+            // Offset out of bounds
+            start = -1;
+        }
+
+        if (end > arrayLength){
+            end = arrayLength;
+        }
+
+        if (intervalLimit > 0 && end > intervalLimit ){
+            end = intervalLimit;
+        }
+
+        return new int[] {start, end};
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if ( flowFile == null ) {
+            return;
+        }
+
+        try {
+            boolean transferFlowFile = false;
+            byte[] hexArray = readFlowFileToHex(session, flowFile);
+            FlowFile outFlowFile = session.create();
+            if (outMode.equals("BOTH") || outMode.equals("FLOWFILE")){
+                int[] index = getArrayLimits(flowFileOffset, flowFileLength, hexArray.length, 0);
+                if(!offsetOutOfBounds(index)) {
+                    session.write(outFlowFile, 
+                        outputStream -> outputStream.write(Arrays.copyOfRange(hexArray, index[0], index[1])));
+                    transferFlowFile = true;
+                }
+            }
+    
+            if (outMode.equals("BOTH") || outMode.equals("ATTRIBUTE")){
+                int[] index = getArrayLimits(attributeOffset, attributeLength, hexArray.length, 255);
+                if(!offsetOutOfBounds(index)) {
+                    session.putAttribute(outFlowFile, 
+                        attributeName, 
+                        new String(Arrays.copyOfRange(hexArray, index[0], index[1] ), StandardCharsets.UTF_8));
+                    transferFlowFile = true;
+                }
+            }
+
+            if (transferFlowFile){
+                session.transfer(outFlowFile, REL_SUCCESS);
+            }
+            session.remove(flowFile);
+        } catch (ProcessException | IOException e) {
+            getLogger().error(e.getMessage());
+            session.transfer(flowFile, REL_FAILURE);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HexDump.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HexDump.java
@@ -90,7 +90,7 @@ public class HexDump extends AbstractProcessor {
             .defaultValue("first16hex")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-    
+
     public static final PropertyDescriptor ATTRIBUTE_OFFSET = new PropertyDescriptor
             .Builder().name("ATTRIBUTE_OFFSET")
             .displayName("Attribute Hexdump Offset")
@@ -125,7 +125,6 @@ public class HexDump extends AbstractProcessor {
         '0', '1', '2', '3', '4', '5', '6', '7',
         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
         };
-    
     private List<PropertyDescriptor> descriptors;
 
     private Set<Relationship> relationships;
@@ -158,9 +157,9 @@ public class HexDump extends AbstractProcessor {
     }
 
     private String outMode;
-	private int flowFileLength;
-	private int flowFileOffset;
-	private String attributeName;
+    private int flowFileLength;
+    private int flowFileOffset;
+    private String attributeName;
     private int attributeOffset;
     private int attributeLength;
 
@@ -183,7 +182,6 @@ public class HexDump extends AbstractProcessor {
     private byte[] readFlowFileToHex(ProcessSession session, FlowFile flowFile) throws IOException{
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         final InputStream in = new BufferedInputStream( session.read(flowFile));
-           
             while (true) {
                 final int nextByte = in.read();
                 if (nextByte == -1) {
@@ -244,17 +242,16 @@ public class HexDump extends AbstractProcessor {
             if (outMode.equals("BOTH") || outMode.equals("FLOWFILE")){
                 int[] index = getArrayLimits(flowFileOffset, flowFileLength, hexArray.length, 0);
                 if(!offsetOutOfBounds(index)) {
-                    session.write(outFlowFile, 
+                    session.write(outFlowFile,
                         outputStream -> outputStream.write(Arrays.copyOfRange(hexArray, index[0], index[1])));
                     transferFlowFile = true;
                 }
             }
-    
             if (outMode.equals("BOTH") || outMode.equals("ATTRIBUTE")){
                 int[] index = getArrayLimits(attributeOffset, attributeLength, hexArray.length, 255);
                 if(!offsetOutOfBounds(index)) {
-                    session.putAttribute(outFlowFile, 
-                        attributeName, 
+                    session.putAttribute(outFlowFile,
+                        attributeName,
                         new String(Arrays.copyOfRange(hexArray, index[0], index[1] ), StandardCharsets.UTF_8));
                     transferFlowFile = true;
                 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HexDump.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HexDump.java
@@ -47,8 +47,8 @@ import java.nio.charset.StandardCharsets;
 @Tags({"hex", "dump", "convert", "flowfile"})
 @WritesAttributes({@WritesAttribute(attribute="first16hex", description="A customizable Hexdump of incoming " +
 " FlowFiles. The attributes length, offset and name can be altered.")})
-@CapabilityDescription("Converts incoming FlowFiles into hexadecimal format. The processor can output the HexDump " +
-    "data in new FlowFiles or/and as an renamable Attribute.")
+@CapabilityDescription("Converts incoming FlowFiles into hexadecimal format. Output HexDump " +
+    "data in new FlowFile or/and as Attribute.")
 public class HexDump extends AbstractProcessor {
 
     public static final PropertyDescriptor OUT_MODE = new PropertyDescriptor
@@ -64,7 +64,7 @@ public class HexDump extends AbstractProcessor {
 
     public static final PropertyDescriptor FLOWFILE_OFFSET = new PropertyDescriptor
             .Builder().name("FLOWFILE_OFFSET")
-            .displayName("FlowFile output offset")
+            .displayName("FlowFile Output Offset")
             .description("Non negative integer offset of Hexdump in FlowFile output. If offset is out of bounds no "+
             " data will be transferred. This is only used if mode is FLOWFILE or BOTH")
             .required(true)
@@ -74,7 +74,7 @@ public class HexDump extends AbstractProcessor {
 
     public static final PropertyDescriptor FLOWFILE_LENGTH = new PropertyDescriptor
             .Builder().name("FLOWFILE_LENGTH")
-            .displayName("FlowFile output length")
+            .displayName("FlowFile Output Length")
             .description("Non negative integer describing maximum size of Hexdump in FlowFile output. 0 = unlimited. "+
             "This is only used if Mode is FLOWFILE or BOTH.")
             .required(true)
@@ -84,7 +84,7 @@ public class HexDump extends AbstractProcessor {
 
     public static final PropertyDescriptor ATTRIBUTE_NAME = new PropertyDescriptor
             .Builder().name("ATTRIBUTE_NAME")
-            .displayName("Attribute hexdump name")
+            .displayName("Attribute Hexdump Name")
             .description("String Hexdump output attribute name. This is only used if mode is ATTRIBUTE or BOTH.")
             .required(true)
             .defaultValue("first16hex")

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -57,6 +57,7 @@ org.apache.nifi.processors.standard.HandleHttpRequest
 org.apache.nifi.processors.standard.HandleHttpResponse
 org.apache.nifi.processors.standard.HashAttribute
 org.apache.nifi.processors.standard.HashContent
+org.apache.nifi.processors.standard.HexDump
 org.apache.nifi.processors.standard.IdentifyMimeType
 org.apache.nifi.processors.standard.InvokeHTTP
 org.apache.nifi.processors.standard.JoltTransformJSON

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHexDump.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHexDump.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.processors.standard;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -32,10 +31,38 @@ import org.junit.Test;
 public class TestHexDump {
 
     private String shortTestString =  "Appropriate test string";
-    private String longTestString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu nibh turpis. Etiam leo leo, rutrum vel sapien vitae, faucibus fermentum lorem. Proin sit amet augue eleifend, vulputate leo in, porta mauris. Phasellus eros arcu, scelerisque pulvinar neque quis, pretium ullamcorper sem. Sed at suscipit odio. Cras lobortis orci arcu, ac vestibulum sem mollis at. Mauris mollis metus quis erat ultricies hendrerit. Aenean at justo vitae nisi dapibus egestas eget sed sem. Suspendisse mattis nunc risus, et consequat sem aliquet vel. Sed ut consectetur mi. Sed ut odio non ex pellentesque luctus ut at purus. Nunc tincidunt, tortor sit amet laoreet iaculis, leo ipsum porta ligula, ac lacinia libero orci id nibh. Ut mattis sapien ac finibus malesuada.";
+    private String longTestString = "Lorem ipsum dolor sit amet, consectetur adipiscing"+
+    " elit. Etiam eu nibh turpis. Etiam leo leo, rutrum vel sapien vitae, faucibus ferm"+
+    "entum lorem. Proin sit amet augue eleifend, vulputate leo in, porta mauris. Phasel"+
+    "lus eros arcu, scelerisque pulvinar neque quis, pretium ullamcorper sem. Sed at su"+
+    "scipit odio. Cras lobortis orci arcu, ac vestibulum sem mollis at. Mauris mollis m"+
+    "etus quis erat ultricies hendrerit. Aenean at justo vitae nisi dapibus egestas ege"+
+    "t sed sem. Suspendisse mattis nunc risus, et consequat sem aliquet vel. Sed ut con"+
+    "sectetur mi. Sed ut odio non ex pellentesque luctus ut at purus. Nunc tincidunt, t"+
+    "ortor sit amet laoreet iaculis, leo ipsum porta ligula, ac lacinia libero orci id "+
+    "nibh. Ut mattis sapien ac finibus malesuada.";
+
     private String specialTestString = "/^[!@#$%^&*()_+-=[]{};':|,.<>/?]*$/";
 
-    private String longHexString = "4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e20457469616d206575206e696268207475727069732e20457469616d206c656f206c656f2c2072757472756d2076656c2073617069656e2076697461652c206661756369627573206665726d656e74756d206c6f72656d2e2050726f696e2073697420616d657420617567756520656c656966656e642c2076756c707574617465206c656f20696e2c20706f727461206d61757269732e2050686173656c6c75732065726f7320617263752c207363656c657269737175652070756c76696e6172206e6571756520717569732c207072657469756d20756c6c616d636f727065722073656d2e20536564206174207375736369706974206f64696f2e2043726173206c6f626f72746973206f72636920617263752c20616320766573746962756c756d2073656d206d6f6c6c69732061742e204d6175726973206d6f6c6c6973206d657475732071756973206572617420756c747269636965732068656e6472657269742e2041656e65616e206174206a7573746f207669746165206e697369206461706962757320656765737461732065676574207365642073656d2e2053757370656e6469737365206d6174746973206e756e632072697375732c20657420636f6e7365717561742073656d20616c69717565742076656c2e2053656420757420636f6e7365637465747572206d692e20536564207574206f64696f206e6f6e2065782070656c6c656e746573717565206c75637475732075742061742070757275732e204e756e632074696e636964756e742c20746f72746f722073697420616d6574206c616f7265657420696163756c69732c206c656f20697073756d20706f727461206c6967756c612c206163206c6163696e6961206c696265726f206f726369206964206e6962682e205574206d61747469732073617069656e2061632066696e69627573206d616c6573756164612e";
+    private String longHexString = "4c6f72656d20697073756d20646f6c6f722073697420616d6"+
+    "5742c20636f6e73656374657475722061646970697363696e6720656c69742e20457469616d206575"+
+    "206e696268207475727069732e20457469616d206c656f206c656f2c2072757472756d2076656c207"+
+    "3617069656e2076697461652c206661756369627573206665726d656e74756d206c6f72656d2e2050"+
+    "726f696e2073697420616d657420617567756520656c656966656e642c2076756c707574617465206"+
+    "c656f20696e2c20706f727461206d61757269732e2050686173656c6c75732065726f732061726375"+
+    "2c207363656c657269737175652070756c76696e6172206e6571756520717569732c2070726574697"+
+    "56d20756c6c616d636f727065722073656d2e20536564206174207375736369706974206f64696f2e"+
+    "2043726173206c6f626f72746973206f72636920617263752c20616320766573746962756c756d207"+
+    "3656d206d6f6c6c69732061742e204d6175726973206d6f6c6c6973206d6574757320717569732065"+
+    "72617420756c747269636965732068656e6472657269742e2041656e65616e206174206a7573746f2"+
+    "07669746165206e697369206461706962757320656765737461732065676574207365642073656d2e"+
+    "2053757370656e6469737365206d6174746973206e756e632072697375732c20657420636f6e73657"+
+    "17561742073656d20616c69717565742076656c2e2053656420757420636f6e736563746574757220"+
+    "6d692e20536564207574206f64696f206e6f6e2065782070656c6c656e746573717565206c7563747"+
+    "5732075742061742070757275732e204e756e632074696e636964756e742c20746f72746f72207369"+
+    "7420616d6574206c616f7265657420696163756c69732c206c656f20697073756d20706f727461206"+
+    "c6967756c612c206163206c6163696e6961206c696265726f206f726369206964206e6962682e2055"+
+    "74206d61747469732073617069656e2061632066696e69627573206d616c6573756164612e";
     private String shortHexString = "417070726f707269617465207465737420737472696e67";
     private String specialHexString = "2f5e5b21402324255e262a28295f2b2d3d5b5d7b7d3b273a7c2c2e3c3e2f3f5d2a242f";
 
@@ -44,7 +71,7 @@ public class TestHexDump {
         /*
         Help function with purpose to minimize lines of code.
         Create TestRunner and returns runner reference.
-        */        
+        */
         return TestRunners.newTestRunner( new HexDump() );
     }
 
@@ -53,10 +80,9 @@ public class TestHexDump {
         Help function with purpose to minimize lines of code.
         Execute int amount of flowfiles with the input.
         Return runner reference.
-        */        
+        */
 
         InputStream content = new ByteArrayInputStream(input.getBytes());
-       
         runner.enqueue(content);
         runner.run(Amount);
         runner.assertQueueEmpty();
@@ -69,7 +95,7 @@ public class TestHexDump {
         Help function with purpose to minimize lines of code.
         Compares incoming flowfile with expected output string.
         Return runner reference.
-        */    
+        */
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
         MockFlowFile result = results.get(0);
         String resultValue = new String(runner.getContentAsByteArray(result));
@@ -80,7 +106,7 @@ public class TestHexDump {
         /*
         Help function with purpose to minimize lines of code.
         Return runner reference.
-        */    
+        */
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
         if (results.size() > 0){
             MockFlowFile result = results.get(0);
@@ -88,7 +114,7 @@ public class TestHexDump {
             assertEquals("", resultValue);
         } else {
             assertEquals(0, results.size());
-        }   
+        }
     }
 
     private void validateAttributeOutput(TestRunner runner, String expectedOutput){
@@ -96,7 +122,7 @@ public class TestHexDump {
         Help function with purpose to minimize lines of code.
         Compares incoming attribute data with expected output string.
         Return runner reference.
-        */    
+        */
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
         MockFlowFile result = results.get(0);
         result.assertAttributeExists(HexDump.ATTRIBUTE_NAME.getDefaultValue());
@@ -107,7 +133,7 @@ public class TestHexDump {
         /*
         Help function with purpose to minimize lines of code.
         Return runner reference.
-        */    
+        */
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
         MockFlowFile result = results.get(0);
         result.assertAttributeNotExists(attributeName);
@@ -242,7 +268,7 @@ public class TestHexDump {
         runner.setProperty(HexDump.FLOWFILE_LENGTH, "0");
         runner.setProperty(HexDump.FLOWFILE_OFFSET, "5000");
         runner = executeTestRunner(runner, shortHexString, 1);
-        validateNoFlowFileOutput(runner); 
+        validateNoFlowFileOutput(runner);
 
         // Test offset and length limits
         runner = createTestRunner();
@@ -262,7 +288,7 @@ public class TestHexDump {
 
     @Test
     public void testOutOfBoundsAttributeOffsetValid() {
-        // Test 255 > Attribute offset > incoming data 
+        // Test 255 > Attribute offset > incoming data
         TestRunner runner = createTestRunner();
         runner.setProperty(HexDump.ATTRIBUTE_OFFSET, "200");
         runner = executeTestRunner(runner, shortTestString, 1);
@@ -285,7 +311,6 @@ public class TestHexDump {
         for (int i=1; i<=run_amount; i++){
             runner = executeTestRunner(runner, shortTestString, 1);
         }
-       
         List<MockFlowFile> success_results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
         assertEquals(run_amount, success_results.size());
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHexDump.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHexDump.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Test;
+
+public class TestHexDump {
+
+    private String shortTestString =  "Appropriate test string";
+    private String longTestString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu nibh turpis. Etiam leo leo, rutrum vel sapien vitae, faucibus fermentum lorem. Proin sit amet augue eleifend, vulputate leo in, porta mauris. Phasellus eros arcu, scelerisque pulvinar neque quis, pretium ullamcorper sem. Sed at suscipit odio. Cras lobortis orci arcu, ac vestibulum sem mollis at. Mauris mollis metus quis erat ultricies hendrerit. Aenean at justo vitae nisi dapibus egestas eget sed sem. Suspendisse mattis nunc risus, et consequat sem aliquet vel. Sed ut consectetur mi. Sed ut odio non ex pellentesque luctus ut at purus. Nunc tincidunt, tortor sit amet laoreet iaculis, leo ipsum porta ligula, ac lacinia libero orci id nibh. Ut mattis sapien ac finibus malesuada.";
+    private String specialTestString = "/^[!@#$%^&*()_+-=[]{};':|,.<>/?]*$/";
+
+    private String longHexString = "4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e20457469616d206575206e696268207475727069732e20457469616d206c656f206c656f2c2072757472756d2076656c2073617069656e2076697461652c206661756369627573206665726d656e74756d206c6f72656d2e2050726f696e2073697420616d657420617567756520656c656966656e642c2076756c707574617465206c656f20696e2c20706f727461206d61757269732e2050686173656c6c75732065726f7320617263752c207363656c657269737175652070756c76696e6172206e6571756520717569732c207072657469756d20756c6c616d636f727065722073656d2e20536564206174207375736369706974206f64696f2e2043726173206c6f626f72746973206f72636920617263752c20616320766573746962756c756d2073656d206d6f6c6c69732061742e204d6175726973206d6f6c6c6973206d657475732071756973206572617420756c747269636965732068656e6472657269742e2041656e65616e206174206a7573746f207669746165206e697369206461706962757320656765737461732065676574207365642073656d2e2053757370656e6469737365206d6174746973206e756e632072697375732c20657420636f6e7365717561742073656d20616c69717565742076656c2e2053656420757420636f6e7365637465747572206d692e20536564207574206f64696f206e6f6e2065782070656c6c656e746573717565206c75637475732075742061742070757275732e204e756e632074696e636964756e742c20746f72746f722073697420616d6574206c616f7265657420696163756c69732c206c656f20697073756d20706f727461206c6967756c612c206163206c6163696e6961206c696265726f206f726369206964206e6962682e205574206d61747469732073617069656e2061632066696e69627573206d616c6573756164612e";
+    private String shortHexString = "417070726f707269617465207465737420737472696e67";
+    private String specialHexString = "2f5e5b21402324255e262a28295f2b2d3d5b5d7b7d3b273a7c2c2e3c3e2f3f5d2a242f";
+
+
+    private TestRunner createTestRunner(){
+        /*
+        Help function with purpose to minimize lines of code.
+        Create TestRunner and returns runner reference.
+        */        
+        return TestRunners.newTestRunner( new HexDump() );
+    }
+
+    private TestRunner executeTestRunner(TestRunner runner, String input, int Amount){
+        /*
+        Help function with purpose to minimize lines of code.
+        Execute int amount of flowfiles with the input.
+        Return runner reference.
+        */        
+
+        InputStream content = new ByteArrayInputStream(input.getBytes());
+       
+        runner.enqueue(content);
+        runner.run(Amount);
+        runner.assertQueueEmpty();
+
+        return runner;
+    }
+
+    private void validateFlowFileOutput(TestRunner runner, String expectedOutput){
+        /*
+        Help function with purpose to minimize lines of code.
+        Compares incoming flowfile with expected output string.
+        Return runner reference.
+        */    
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        MockFlowFile result = results.get(0);
+        String resultValue = new String(runner.getContentAsByteArray(result));
+        assertEquals(expectedOutput, resultValue);
+    }
+
+    private void validateNoFlowFileOutput(TestRunner runner){
+        /*
+        Help function with purpose to minimize lines of code.
+        Return runner reference.
+        */    
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        if (results.size() > 0){
+            MockFlowFile result = results.get(0);
+            String resultValue = new String(runner.getContentAsByteArray(result));
+            assertEquals("", resultValue);
+        } else {
+            assertEquals(0, results.size());
+        }   
+    }
+
+    private void validateAttributeOutput(TestRunner runner, String expectedOutput){
+        /*
+        Help function with purpose to minimize lines of code.
+        Compares incoming attribute data with expected output string.
+        Return runner reference.
+        */    
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        MockFlowFile result = results.get(0);
+        result.assertAttributeExists(HexDump.ATTRIBUTE_NAME.getDefaultValue());
+        result.assertAttributeEquals(HexDump.ATTRIBUTE_NAME.getDefaultValue(), expectedOutput);
+    }
+
+    private void validateNoAttributeOutput(TestRunner runner, String attributeName){
+        /*
+        Help function with purpose to minimize lines of code.
+        Return runner reference.
+        */    
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        MockFlowFile result = results.get(0);
+        result.assertAttributeNotExists(attributeName);
+    }
+
+    private void convertionInputOutputTest(String input, String expectedOutput){
+        /*
+         Help function with purpose to minimize lines of code.
+         Validation of hex convertion over different inputs and outputs.
+        */
+        TestRunner runner = createTestRunner();
+        runner = executeTestRunner(runner, input, 1);
+        validateFlowFileOutput(runner, expectedOutput);
+        validateAttributeOutput(runner, expectedOutput.substring(0,16));
+    }
+
+    @Test
+    public void testHexConvertionSpecialValuesValid() throws IOException  {
+        convertionInputOutputTest(specialTestString, specialHexString);
+    }
+
+    @Test
+    public void testHexConvertionShortValid() {
+        /* Validate hex convertion results for message < 256 bytes */
+        convertionInputOutputTest(shortTestString, shortHexString);
+    }
+
+    @Test
+    public void testHexConvertionLongValid() {
+         /* Validate hex convertion results for message > 256 bytes */
+         convertionInputOutputTest(longTestString, longHexString);
+    }
+
+    @Test
+    public void testModeFlowFileValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.OUT_MODE, "FLOWFILE");
+        runner = executeTestRunner(runner, longTestString, 1);
+        validateFlowFileOutput(runner, longHexString);
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        MockFlowFile result = results.get(0);
+        result.assertAttributeNotExists(HexDump.ATTRIBUTE_NAME.getDefaultValue());
+    }
+
+    @Test
+    public void testModeBothValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.OUT_MODE, "BOTH");
+        runner = executeTestRunner(runner, longTestString, 1);
+        validateFlowFileOutput(runner, longHexString);
+        validateAttributeOutput(runner, longHexString.substring(0,16));
+    }
+
+    @Test
+    public void testEmptyFlowFileValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.OUT_MODE, "BOTH");
+        runner = executeTestRunner(runner, "", 1);
+        validateFlowFileOutput(runner, "");
+        validateAttributeOutput(runner, "");
+    }
+
+    @Test
+    public void testModeAttributeValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.OUT_MODE, "ATTRIBUTE");
+        runner = executeTestRunner(runner, longTestString, 1);
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        MockFlowFile result = results.get(0);
+        String resultValue = new String(runner.getContentAsByteArray(result));
+        assertEquals("", resultValue);
+        validateAttributeOutput(runner, longHexString.substring(0,16));
+    }
+
+    @Test
+    public void testLimitedFlowFileLengthValid() {
+        // see that size is 16 and equals corresponding 16 bytes from testString
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.FLOWFILE_LENGTH, "18");
+        runner = executeTestRunner(runner, longTestString, 1);
+        validateFlowFileOutput(runner, longHexString.substring(0,18));
+    }
+
+    @Test
+    public void testFlowFileOffsetValid() {
+        // see that offset is 16 and equals corresponding to testString
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.FLOWFILE_OFFSET, "18");
+        runner = executeTestRunner(runner, longTestString, 1);
+        validateFlowFileOutput(runner, longHexString.substring(18,longHexString.length()));
+    }
+
+    @Test
+    public void testAttributeOffsetValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.ATTRIBUTE_OFFSET, "8");
+        runner = executeTestRunner(runner, shortTestString, 1);
+        validateAttributeOutput(runner, shortHexString.substring(8,24));
+    }
+
+    @Test
+    public void testLimitedAttributeLengthValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.ATTRIBUTE_LENGTH, "8");
+        runner = executeTestRunner(runner, shortTestString, 1);
+        validateAttributeOutput(runner, shortHexString.substring(0,8));
+    }
+
+    @Test
+    public void testAttributeNameChangeValid() {
+        String testName =  "testNewAttributeName8";
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.ATTRIBUTE_NAME, testName);
+        runner.setProperty(HexDump.ATTRIBUTE_LENGTH, "8");
+        runner = executeTestRunner(runner, longTestString, 1);
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        MockFlowFile result = results.get(0);
+        result.assertAttributeExists(testName);
+    }
+
+    @Test
+    public void testLargeFlowFileLengthValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.FLOWFILE_LENGTH, "5000");
+        runner = executeTestRunner(runner, longTestString, 1);
+        validateFlowFileOutput(runner, longHexString);
+    }
+
+    @Test
+    public void testOutOfBoundsFlowFileOffsetValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.FLOWFILE_LENGTH, "0");
+        runner.setProperty(HexDump.FLOWFILE_OFFSET, "5000");
+        runner = executeTestRunner(runner, shortHexString, 1);
+        validateNoFlowFileOutput(runner); 
+
+        // Test offset and length limits
+        runner = createTestRunner();
+        runner.setProperty(HexDump.FLOWFILE_LENGTH, "255");
+        runner.setProperty(HexDump.FLOWFILE_OFFSET, "10");
+        runner = executeTestRunner(runner, shortTestString, 1);
+        validateFlowFileOutput(runner, shortHexString.substring(10,shortHexString.length()));
+    }
+
+    @Test
+    public void testTooLongAttributeLengthValid() {
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.ATTRIBUTE_LENGTH, "30000");
+        runner = executeTestRunner(runner, longTestString, 1);
+        validateAttributeOutput(runner, longHexString.substring(0,255));
+    }
+
+    @Test
+    public void testOutOfBoundsAttributeOffsetValid() {
+        // Test 255 > Attribute offset > incoming data 
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.ATTRIBUTE_OFFSET, "200");
+        runner = executeTestRunner(runner, shortTestString, 1);
+        validateNoAttributeOutput(runner, HexDump.ATTRIBUTE_NAME.getDefaultValue());
+
+        // Test offset and length limits
+        runner = createTestRunner();
+        runner.setProperty(HexDump.ATTRIBUTE_LENGTH, "255");
+        runner.setProperty(HexDump.ATTRIBUTE_OFFSET, "8");
+        runner = executeTestRunner(runner, shortTestString, 1);
+        validateAttributeOutput(runner, shortHexString.substring(8,shortHexString.length()));
+    }
+
+    @Test
+    public void testDefaultLargerQueueValid() {
+        // Test queued capability of processor, without dropping content.
+        int run_amount = 25;
+        TestRunner runner = createTestRunner();
+        runner.setProperty(HexDump.OUT_MODE, "BOTH");
+        for (int i=1; i<=run_amount; i++){
+            runner = executeTestRunner(runner, shortTestString, 1);
+        }
+       
+        List<MockFlowFile> success_results = runner.getFlowFilesForRelationship(HexDump.REL_SUCCESS);
+        assertEquals(run_amount, success_results.size());
+    }
+
+}


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->


#### Description of : Adding Hexdump processor to standard bundle

 Fixes bug/feature NIFI-3965.

Adds Hexdump processor to the nifi standard processor bundle.
The purpose of this processor is to create hexdumps of arbitrary flowfiles and send them as output flowfiles or/and custom attribute.

<img width="294" alt="Skärmklipp" src="https://user-images.githubusercontent.com/8101164/142302526-f6bfe679-e911-4b94-9305-857d85ad7bd2.PNG">

<img width="580" alt="Skärmklipp2" src="https://user-images.githubusercontent.com/8101164/142302544-dc7bf93e-bcc0-4c23-8d42-c28238f782c2.PNG">

Processor Properties include:
**Mode** : Selectable Mode, describing if the converted Hexdump data should yield FlowFile data, Attribute or Both.

**Flowfile offset** : Non negative integer offset of Hexdump in FlowFile output. If offset is out of bounds no data will be transferred. This is only used if mode is FLOWFILE or BOTH.

**Flowfile length** : Non negative integer describing maximum size of Hexdump in FlowFile output. 0 = unlimited. This is only used if Mode is FLOWFILE or BOTH.

**Attribute name** : String Hexdump output attribute name. This is only used if mode is ATTRIBUTE or BOTH.

**Attribute offset** : Non negative integer offset of attribute Hexdump. If offset is out of bounds no data will be transferred. This is only used if mode is ATTRIBUTE or BOTH.

**Attribute length** : Non negative integer maximum size of attribute Hexdump. This is only used if mode is ATTRIBUTE or BOTH.


Adds 2 files:
HexDump.java
TestHexDump.java

Edits 1 file:
 nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor 

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
