### PR TITLE
NIFI-9333 add Geohash functions to Expression Language

### DIFF
--- a/nifi-commons/nifi-expression-language/pom.xml
+++ b/nifi-commons/nifi-expression-language/pom.xml
@@ -108,5 +108,10 @@
             <artifactId>commons-codec</artifactId>
             <version>1.14</version>
         </dependency>
+        <dependency>
+            <groupId>ch.hsr</groupId>
+            <artifactId>geohash</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
@@ -186,6 +186,8 @@ REPEAT : 'repeat';
 UUID3 : 'UUID3';
 UUID5 : 'UUID5';
 HASH : 'hash';
+GEOHASH_DECODE_LATITUDE : 'geohashDecodeLatitude';
+GEOHASH_DECODE_LONGITUDE : 'geohashDecodeLongitude';
 
 // 2 arg functions
 SUBSTRING	: 'substring';
@@ -199,8 +201,12 @@ JSON_PATH_PUT : 'jsonPathPut';
 PAD_LEFT : 'padLeft';
 PAD_RIGHT : 'padRight';
 
+//3 arg functions
+GEOHASH_LONG_ENCODE : 'geohashLongEncode';
+
 // 4 arg functions
 GET_DELIMITED_FIELD	: 'getDelimitedField';
+GEOHASH_STRING_ENCODE : 'geohashStringEncode';
 
 // unlimited arg functions
 IN : 'in';

--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
@@ -96,7 +96,8 @@ multiArgBool : (IN) LPAREN! anyArg (COMMA! anyArg)* RPAREN!;
 // functions that return Numbers (whole or decimal)
 zeroArgNum	: (LENGTH | TO_NUMBER | TO_DECIMAL | COUNT) LPAREN! RPAREN!;
 oneArgNum	: ((INDEX_OF | LAST_INDEX_OF) LPAREN! anyArg RPAREN!) |
-			  ((MOD | PLUS | MINUS | MULTIPLY | DIVIDE) LPAREN! anyArg RPAREN!);
+			  ((MOD | PLUS | MINUS | MULTIPLY | DIVIDE) LPAREN! anyArg RPAREN!) |
+			  ((GEOHASH_DECODE_LATITUDE | GEOHASH_DECODE_LONGITUDE) LPAREN! anyArg RPAREN!);
 oneOrTwoArgNum : MATH LPAREN! anyArg (COMMA! anyArg)? RPAREN!;
 zeroOrOneOrTwoArgNum : TO_DATE LPAREN! anyArg? (COMMA! anyArg)? RPAREN!;
 
@@ -136,7 +137,9 @@ booleanLiteral : TRUE | FALSE;
 zeroArgStandaloneFunction : (IP | UUID | NOW | NEXT_INT | HOSTNAME | THREAD | RANDOM) LPAREN! RPAREN!;
 oneArgStandaloneFunction : ((TO_LITERAL | MATH | GET_STATE_VALUE)^ LPAREN! anyArg RPAREN!) |
                            (HOSTNAME^ LPAREN! booleanLiteral RPAREN!);
-standaloneFunction : zeroArgStandaloneFunction | oneArgStandaloneFunction;
+threeArgStandaloneFunction : GEOHASH_LONG_ENCODE^ LPAREN! anyArg COMMA! anyArg COMMA! anyArg RPAREN!;
+threeOrFourArgStandaloneFunction : GEOHASH_STRING_ENCODE^ LPAREN! anyArg COMMA! anyArg COMMA! anyArg (COMMA! anyArg)? RPAREN!;
+standaloneFunction : zeroArgStandaloneFunction | oneArgStandaloneFunction | threeArgStandaloneFunction | threeOrFourArgStandaloneFunction;
 
 attributeRefOrFunctionCall	: (attributeRef | standaloneFunction | parameterReference);
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
@@ -49,7 +49,7 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashFormat geohashFormatValue;
         if (format != null) {
-            if(!EnumUtils.isValidEnum(GeohashFormat.class, format.evaluate(evaluationContext).getValue())) {
+            if (!EnumUtils.isValidEnum(GeohashFormat.class, format.evaluate(evaluationContext).getValue())) {
                 throw new AttributeExpressionLanguageException("Format values must be 'BASE32', 'BINARY' or 'LONG'");
             }
             geohashFormatValue = GeohashFormat.valueOf(format.evaluate(evaluationContext).getValue());
@@ -84,7 +84,8 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
             } else {
                 return new NumberQueryResult(boundingBoxCenter.getLongitude());
             }
-
+        } catch (NullPointerException e) {
+            throw new AttributeExpressionLanguageException("Invalid Geohash value is provided");
         } catch (IllegalArgumentException e) {
             throw new AttributeExpressionLanguageException("Unable to decode Geohash", e);
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import org.apache.nifi.attribute.expression.language.EvaluationContext;
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.NumberQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+
+import ch.hsr.geohash.GeoHash;
+import ch.hsr.geohash.WGS84Point;
+
+public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
+
+    public enum GeohashFormat {
+        BASE_32_STRING, BINARY_STRING, LONG
+    }
+    public enum GeoCoord {
+        LATITUDE, LONGITUDE
+    }
+    private final Evaluator<String> subject;
+    private final Evaluator<String> format;
+
+    public GeohashDecodeBaseEvaluator(final Evaluator<String> subject, final Evaluator<String> format) {
+        this.subject = subject;
+        this.format = format;
+    }
+
+    public QueryResult<Number> geohashDecodeEvaluate(final EvaluationContext evaluationContext, final GeoCoord geoCoord) {
+        //Optional argument. If not specified, defaults to BASE_32_STRING.
+        final GeohashFormat geohashFormatValue;
+        if(format != null) {
+            geohashFormatValue = GeohashFormat.valueOf(format.evaluate(evaluationContext).getValue());
+        }else {
+            geohashFormatValue = GeohashFormat.BASE_32_STRING;
+
+        }
+
+        final Long geohashLongValue = geohashFormatValue == GeohashFormat.LONG ? Long.valueOf(subject.evaluate(evaluationContext).getValue()) : null;
+        final String geohashStringValue = (geohashFormatValue == GeohashFormat.BASE_32_STRING
+                || geohashFormatValue == GeohashFormat.BINARY_STRING) ? subject.evaluate(evaluationContext).getValue() : null;
+
+        if (geohashLongValue == null && geohashStringValue == null) {
+            return new NumberQueryResult(null);
+        }
+
+        try {
+            WGS84Point boundingBoxCenter;
+            switch (geohashFormatValue) {
+                case LONG:
+                    String binaryString = Long.toBinaryString(geohashLongValue);
+                    boundingBoxCenter = GeoHash.fromBinaryString(binaryString).getBoundingBoxCenter();
+                    break;
+                case BINARY_STRING:
+                    boundingBoxCenter = GeoHash.fromBinaryString(geohashStringValue).getBoundingBoxCenter();
+                    break;
+                default:
+                    boundingBoxCenter = GeoHash.fromGeohashString(geohashStringValue).getBoundingBoxCenter();
+            }
+            if(geoCoord == GeoCoord.LATITUDE) {
+                return new NumberQueryResult(boundingBoxCenter.getLatitude());
+            }else {
+                return new NumberQueryResult(boundingBoxCenter.getLongitude());
+            }
+
+        } catch (IllegalArgumentException e) {
+            throw new AttributeExpressionLanguageException("Unable to decode Geohash", e);
+        }
+    }
+
+    @Override
+    public Evaluator<String> getSubjectEvaluator() {
+        return subject;
+    }
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
@@ -29,7 +29,7 @@ import ch.hsr.geohash.WGS84Point;
 public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
 
     public enum GeohashFormat {
-        BASE_32_STRING, BINARY_STRING, LONG
+        BASE32, BINARY, LONG
     }
     public enum GeoCoord {
         LATITUDE, LONGITUDE
@@ -42,19 +42,19 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
         this.format = format;
     }
 
-    public QueryResult<Number> geohashDecodeEvaluate(final EvaluationContext evaluationContext, final GeoCoord geoCoord) {
+    protected QueryResult<Number> geohashDecodeEvaluate(final EvaluationContext evaluationContext, final GeoCoord geoCoord) {
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashFormat geohashFormatValue;
         if(format != null) {
             geohashFormatValue = GeohashFormat.valueOf(format.evaluate(evaluationContext).getValue());
         }else {
-            geohashFormatValue = GeohashFormat.BASE_32_STRING;
+            geohashFormatValue = GeohashFormat.BASE32;
 
         }
 
         final Long geohashLongValue = geohashFormatValue == GeohashFormat.LONG ? Long.valueOf(subject.evaluate(evaluationContext).getValue()) : null;
-        final String geohashStringValue = (geohashFormatValue == GeohashFormat.BASE_32_STRING
-                || geohashFormatValue == GeohashFormat.BINARY_STRING) ? subject.evaluate(evaluationContext).getValue() : null;
+        final String geohashStringValue = (geohashFormatValue == GeohashFormat.BASE32
+                || geohashFormatValue == GeohashFormat.BINARY) ? subject.evaluate(evaluationContext).getValue() : null;
 
         if (geohashLongValue == null && geohashStringValue == null) {
             return new NumberQueryResult(null);
@@ -67,7 +67,7 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
                     String binaryString = Long.toBinaryString(geohashLongValue);
                     boundingBoxCenter = GeoHash.fromBinaryString(binaryString).getBoundingBoxCenter();
                     break;
-                case BINARY_STRING:
+                case BINARY:
                     boundingBoxCenter = GeoHash.fromBinaryString(geohashStringValue).getBoundingBoxCenter();
                     break;
                 default:

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
@@ -31,9 +31,11 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
     public enum GeohashFormat {
         BASE32, BINARY, LONG
     }
+
     public enum GeoCoord {
         LATITUDE, LONGITUDE
     }
+
     private final Evaluator<String> subject;
     private final Evaluator<String> format;
 
@@ -45,9 +47,9 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
     protected QueryResult<Number> geohashDecodeEvaluate(final EvaluationContext evaluationContext, final GeoCoord geoCoord) {
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashFormat geohashFormatValue;
-        if(format != null) {
+        if (format != null) {
             geohashFormatValue = GeohashFormat.valueOf(format.evaluate(evaluationContext).getValue());
-        }else {
+        } else {
             geohashFormatValue = GeohashFormat.BASE32;
 
         }
@@ -73,9 +75,9 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
                 default:
                     boundingBoxCenter = GeoHash.fromGeohashString(geohashStringValue).getBoundingBoxCenter();
             }
-            if(geoCoord == GeoCoord.LATITUDE) {
+            if (geoCoord == GeoCoord.LATITUDE) {
                 return new NumberQueryResult(boundingBoxCenter.getLatitude());
-            }else {
+            } else {
                 return new NumberQueryResult(boundingBoxCenter.getLongitude());
             }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeBaseEvaluator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.nifi.attribute.expression.language.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.NumberEvaluator;
@@ -48,6 +49,9 @@ public abstract class GeohashDecodeBaseEvaluator extends NumberEvaluator {
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashFormat geohashFormatValue;
         if (format != null) {
+            if(!EnumUtils.isValidEnum(GeohashFormat.class, format.evaluate(evaluationContext).getValue())) {
+                throw new AttributeExpressionLanguageException("Format values must be 'BASE32', 'BINARY' or 'LONG'");
+            }
             geohashFormatValue = GeohashFormat.valueOf(format.evaluate(evaluationContext).getValue());
         } else {
             geohashFormatValue = GeohashFormat.BASE32;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeLatitudeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeLatitudeEvaluator.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import org.apache.nifi.attribute.expression.language.EvaluationContext;
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+
+public class GeohashDecodeLatitudeEvaluator extends GeohashDecodeBaseEvaluator {
+
+    public GeohashDecodeLatitudeEvaluator(final Evaluator<String> subject, final Evaluator<String> format) {
+        super(subject, format);
+    }
+
+    @Override
+    public QueryResult<Number> evaluate(final EvaluationContext evaluationContext) {
+        return geohashDecodeEvaluate(evaluationContext, GeoCoord.LATITUDE);
+    }
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeLongitudeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashDecodeLongitudeEvaluator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import org.apache.nifi.attribute.expression.language.EvaluationContext;
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+
+public class GeohashDecodeLongitudeEvaluator extends GeohashDecodeBaseEvaluator {
+
+    public GeohashDecodeLongitudeEvaluator(final Evaluator<String> subject, final Evaluator<String> format) {
+        super(subject, format);
+    }
+
+    @Override
+    public QueryResult<Number> evaluate(final EvaluationContext evaluationContext) {
+        return geohashDecodeEvaluate(evaluationContext, GeoCoord.LONGITUDE);
+    }
+
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
@@ -41,23 +41,15 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
     public QueryResult<Long> evaluate(final EvaluationContext evaluationContext) {
         final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
         if (latitudeValue == null) {
-            if (!isProvidedValueEmpty(latitude, evaluationContext)) {
-                throw new AttributeExpressionLanguageException("Unable to cast provided latitude values to Number");
-            }
-            return new WholeNumberQueryResult(null);
-        }
-        if (latitudeValue.doubleValue() < -90 || latitudeValue.doubleValue() > 90) {
+            return getQueryResultWithEmptyCoord(latitude, evaluationContext, "latitude");
+        } else if (latitudeValue.doubleValue() < -90 || latitudeValue.doubleValue() > 90) {
             throw new AttributeExpressionLanguageException("Latitude values must be between -90 and 90.");
         }
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
-            if (!isProvidedValueEmpty(longitude, evaluationContext)) {
-                throw new AttributeExpressionLanguageException("Unable to cast provided longitude values to Number");
-            }
-            return new WholeNumberQueryResult(null);
-        }
-        if (longitudeValue.doubleValue() < -180 || longitudeValue.doubleValue() > 180) {
+            return getQueryResultWithEmptyCoord(longitude, evaluationContext, "longitude");
+        } else if (longitudeValue.doubleValue() < -180 || longitudeValue.doubleValue() > 180) {
             throw new AttributeExpressionLanguageException("Longitude values must be between -180 and 180.");
         }
 
@@ -73,12 +65,12 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
         }
     }
 
-    private Boolean isProvidedValueEmpty(final Evaluator<Number> evaluator, final EvaluationContext evaluationContext) {
+    private WholeNumberQueryResult getQueryResultWithEmptyCoord(final Evaluator<Number> evaluator, final EvaluationContext evaluationContext, String label) {
         final Object subjectValue = evaluator.getSubjectEvaluator().evaluate(evaluationContext).getValue();
         if (subjectValue != null && !subjectValue.toString().isEmpty()) {
-            return false;
+            throw new AttributeExpressionLanguageException("Unable to cast provided " + label + " values to Number");
         }
-        return true;
+        return new WholeNumberQueryResult(null);
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
@@ -36,21 +36,28 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
         this.longitude = longitude;
         this.level = level;
     }
+
     @Override
     public QueryResult<Long> evaluate(final EvaluationContext evaluationContext) {
         final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
         if (latitudeValue == null) {
             return new WholeNumberQueryResult(null);
         }
+        if (latitudeValue.doubleValue() < -90 || latitudeValue.doubleValue() > 90) {
+            throw new AttributeExpressionLanguageException("Latitude values must be between -90 and 90.");
+        }
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
             return new WholeNumberQueryResult(null);
         }
+        if (longitudeValue.doubleValue() < -180 || longitudeValue.doubleValue() > 180) {
+            throw new AttributeExpressionLanguageException("Longitude values must be between -180 and 180.");
+        }
 
         final Long levelValue = level.evaluate(evaluationContext).getValue();
-        if(levelValue == null) {
-            return new WholeNumberQueryResult(null);
+        if (levelValue == null || levelValue < 1 || levelValue > 12) {
+            throw new AttributeExpressionLanguageException("Level values must be between 1 and 12");
         }
 
         try {

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import org.apache.nifi.attribute.expression.language.EvaluationContext;
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberQueryResult;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+
+import ch.hsr.geohash.GeoHash;
+
+public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
+
+    private final Evaluator<Number> latitude;
+    private final Evaluator<Number> longitude;
+    private final Evaluator<Long> level;
+
+    public GeohashLongEncodeEvaluator(final Evaluator<Number> latitude, final Evaluator<Number> longitude, final Evaluator<Long> level) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.level = level;
+    }
+    @Override
+    public QueryResult<Long> evaluate(final EvaluationContext evaluationContext) {
+        final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
+        if (latitudeValue == null) {
+            return new WholeNumberQueryResult(null);
+        }
+
+        final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
+        if (longitudeValue == null) {
+            return new WholeNumberQueryResult(null);
+        }
+
+        final Long levelValue = level.evaluate(evaluationContext).getValue();
+        if(levelValue == null) {
+            return new WholeNumberQueryResult(null);
+        }
+
+        try {
+            return new WholeNumberQueryResult(GeoHash.withCharacterPrecision(latitudeValue.doubleValue(), longitudeValue.doubleValue(), levelValue.intValue()).longValue());
+        } catch (IllegalArgumentException e) {
+            throw new AttributeExpressionLanguageException("Unable to encode lat/lon to the long format of Geohash", e);
+        }
+    }
+
+    @Override
+    public Evaluator<?> getSubjectEvaluator() {
+        return null;
+    }
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
@@ -41,8 +41,7 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
     public QueryResult<Long> evaluate(final EvaluationContext evaluationContext) {
         final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
         if (latitudeValue == null) {
-            final Object latitudeSubjectValue = latitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
-            if (latitudeSubjectValue != null && !latitudeSubjectValue.toString().isEmpty()) {
+            if (!isProvidedValueEmpty(latitude, evaluationContext)) {
                 throw new AttributeExpressionLanguageException("Unable to cast provided latitude values to Number");
             }
             return new WholeNumberQueryResult(null);
@@ -53,8 +52,7 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
-            final Object longitudeSubjectValue = longitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
-            if (longitudeSubjectValue != null && !longitudeSubjectValue.toString().isEmpty()) {
+            if (!isProvidedValueEmpty(longitude, evaluationContext)) {
                 throw new AttributeExpressionLanguageException("Unable to cast provided longitude values to Number");
             }
             return new WholeNumberQueryResult(null);
@@ -73,6 +71,14 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
         } catch (IllegalArgumentException e) {
             throw new AttributeExpressionLanguageException("Unable to encode lat/lon to the long format of Geohash", e);
         }
+    }
+
+    private Boolean isProvidedValueEmpty(final Evaluator<Number> evaluator, final EvaluationContext evaluationContext) {
+        final Object subjectValue = evaluator.getSubjectEvaluator().evaluate(evaluationContext).getValue();
+        if (subjectValue != null && !subjectValue.toString().isEmpty()) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashLongEncodeEvaluator.java
@@ -41,6 +41,10 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
     public QueryResult<Long> evaluate(final EvaluationContext evaluationContext) {
         final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
         if (latitudeValue == null) {
+            final Object latitudeSubjectValue = latitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
+            if (latitudeSubjectValue != null && !latitudeSubjectValue.toString().isEmpty()) {
+                throw new AttributeExpressionLanguageException("Unable to cast provided latitude values to Number");
+            }
             return new WholeNumberQueryResult(null);
         }
         if (latitudeValue.doubleValue() < -90 || latitudeValue.doubleValue() > 90) {
@@ -49,6 +53,10 @@ public class GeohashLongEncodeEvaluator extends WholeNumberEvaluator {
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
+            final Object longitudeSubjectValue = longitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
+            if (longitudeSubjectValue != null && !longitudeSubjectValue.toString().isEmpty()) {
+                throw new AttributeExpressionLanguageException("Unable to cast provided longitude values to Number");
+            }
             return new WholeNumberQueryResult(null);
         }
         if (longitudeValue.doubleValue() < -180 || longitudeValue.doubleValue() > 180) {

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.nifi.attribute.expression.language.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
@@ -70,6 +71,9 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashStringFormat geohashStringFormatValue;
         if (format != null) {
+            if(!EnumUtils.isValidEnum(GeohashStringFormat.class, format.evaluate(evaluationContext).getValue())) {
+                throw new AttributeExpressionLanguageException("Format values must be either 'BASE32' or 'BINARY'");
+            }
             geohashStringFormatValue = GeohashStringFormat.valueOf(format.evaluate(evaluationContext).getValue());
         } else {
             geohashStringFormatValue = GeohashStringFormat.BASE32;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
@@ -50,22 +50,28 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
         if (latitudeValue == null) {
             return new StringQueryResult(null);
         }
+        if (latitudeValue.doubleValue() < -90 || latitudeValue.doubleValue() > 90) {
+            throw new AttributeExpressionLanguageException("Latitude values must be between -90 and 90.");
+        }
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
             return new StringQueryResult(null);
         }
+        if (longitudeValue.doubleValue() < -180 || longitudeValue.doubleValue() > 180) {
+            throw new AttributeExpressionLanguageException("Longitude values must be between -180 and 180.");
+        }
 
         final Long levelValue = level.evaluate(evaluationContext).getValue();
-        if(levelValue == null) {
-            return new StringQueryResult(null);
+        if (levelValue == null || levelValue < 1 || levelValue > 12) {
+            throw new AttributeExpressionLanguageException("Level values must be between 1 and 12");
         }
 
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashStringFormat geohashStringFormatValue;
-        if(format != null) {
+        if (format != null) {
             geohashStringFormatValue = GeohashStringFormat.valueOf(format.evaluate(evaluationContext).getValue());
-        }else {
+        } else {
             geohashStringFormatValue = GeohashStringFormat.BASE32;
         }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import org.apache.nifi.attribute.expression.language.EvaluationContext;
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+
+import ch.hsr.geohash.GeoHash;
+
+
+public class GeohashStringEncodeEvaluator extends StringEvaluator {
+
+    public enum GeohashStringFormat {
+        BASE_32_STRING, BINARY_STRING
+    }
+
+    private final Evaluator<Number> latitude;
+    private final Evaluator<Number> longitude;
+    private final Evaluator<Long> level;
+    private final Evaluator<String> format;
+
+    public GeohashStringEncodeEvaluator(final Evaluator<Number> latitude, final Evaluator<Number> longitude, final Evaluator<Long> level, final Evaluator<String> format) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.level = level;
+        this.format = format;
+    }
+
+    @Override
+    public QueryResult<String> evaluate(final EvaluationContext evaluationContext) {
+        final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
+        if (latitudeValue == null) {
+            return new StringQueryResult(null);
+        }
+
+        final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
+        if (longitudeValue == null) {
+            return new StringQueryResult(null);
+        }
+
+        final Long levelValue = level.evaluate(evaluationContext).getValue();
+        if(levelValue == null) {
+            return new StringQueryResult(null);
+        }
+
+        //Optional argument. If not specified, defaults to BASE_32_STRING.
+        final GeohashStringFormat geohashStringFormatValue;
+        if(format != null) {
+            geohashStringFormatValue = GeohashStringFormat.valueOf(format.evaluate(evaluationContext).getValue());
+        }else {
+            geohashStringFormatValue = GeohashStringFormat.BASE_32_STRING;
+        }
+
+        try {
+            GeoHash gh = GeoHash.withCharacterPrecision(latitudeValue.doubleValue(), longitudeValue.doubleValue(), levelValue.intValue());
+            switch (geohashStringFormatValue) {
+                case BINARY_STRING:
+                    return new StringQueryResult(gh.toBinaryString());
+                default:
+                    return new StringQueryResult(gh.toBase32());
+            }
+        } catch (IllegalArgumentException e) {
+            throw new AttributeExpressionLanguageException("Unable to encode lat/lon to the string format of Geohash", e);
+        }
+    }
+
+    @Override
+    public Evaluator<?> getSubjectEvaluator() {
+        return null;
+    }
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
@@ -49,6 +49,10 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
     public QueryResult<String> evaluate(final EvaluationContext evaluationContext) {
         final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
         if (latitudeValue == null) {
+            final Object latitudeSubjectValue = latitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
+            if (latitudeSubjectValue != null && !latitudeSubjectValue.toString().isEmpty()) {
+                throw new AttributeExpressionLanguageException("Unable to cast provided latitude values to Number");
+            }
             return new StringQueryResult(null);
         }
         if (latitudeValue.doubleValue() < -90 || latitudeValue.doubleValue() > 90) {
@@ -57,6 +61,10 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
+            final Object longitudeSubjectValue = longitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
+            if (longitudeSubjectValue != null && !longitudeSubjectValue.toString().isEmpty()) {
+                throw new AttributeExpressionLanguageException("Unable to cast provided longitude values to Number");
+            }
             return new StringQueryResult(null);
         }
         if (longitudeValue.doubleValue() < -180 || longitudeValue.doubleValue() > 180) {
@@ -71,7 +79,7 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
         //Optional argument. If not specified, defaults to BASE_32_STRING.
         final GeohashStringFormat geohashStringFormatValue;
         if (format != null) {
-            if(!EnumUtils.isValidEnum(GeohashStringFormat.class, format.evaluate(evaluationContext).getValue())) {
+            if (!EnumUtils.isValidEnum(GeohashStringFormat.class, format.evaluate(evaluationContext).getValue())) {
                 throw new AttributeExpressionLanguageException("Format values must be either 'BASE32' or 'BINARY'");
             }
             geohashStringFormatValue = GeohashStringFormat.valueOf(format.evaluate(evaluationContext).getValue());

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
@@ -22,6 +22,7 @@ import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.WholeNumberQueryResult;
 import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
 
 import ch.hsr.geohash.GeoHash;
@@ -49,8 +50,7 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
     public QueryResult<String> evaluate(final EvaluationContext evaluationContext) {
         final Number latitudeValue = latitude.evaluate(evaluationContext).getValue();
         if (latitudeValue == null) {
-            final Object latitudeSubjectValue = latitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
-            if (latitudeSubjectValue != null && !latitudeSubjectValue.toString().isEmpty()) {
+            if (!isProvidedValueEmpty(latitude, evaluationContext)) {
                 throw new AttributeExpressionLanguageException("Unable to cast provided latitude values to Number");
             }
             return new StringQueryResult(null);
@@ -61,8 +61,7 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
 
         final Number longitudeValue = longitude.evaluate(evaluationContext).getValue();
         if (longitudeValue == null) {
-            final Object longitudeSubjectValue = longitude.getSubjectEvaluator().evaluate(evaluationContext).getValue();
-            if (longitudeSubjectValue != null && !longitudeSubjectValue.toString().isEmpty()) {
+            if (!isProvidedValueEmpty(longitude, evaluationContext)) {
                 throw new AttributeExpressionLanguageException("Unable to cast provided longitude values to Number");
             }
             return new StringQueryResult(null);
@@ -98,6 +97,14 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
         } catch (IllegalArgumentException e) {
             throw new AttributeExpressionLanguageException("Unable to encode lat/lon to the string format of Geohash", e);
         }
+    }
+
+    private Boolean isProvidedValueEmpty(final Evaluator<Number> evaluator, final EvaluationContext evaluationContext) {
+        final Object subjectValue = evaluator.getSubjectEvaluator().evaluate(evaluationContext).getValue();
+        if (subjectValue != null && !subjectValue.toString().isEmpty()) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GeohashStringEncodeEvaluator.java
@@ -29,7 +29,7 @@ import ch.hsr.geohash.GeoHash;
 public class GeohashStringEncodeEvaluator extends StringEvaluator {
 
     public enum GeohashStringFormat {
-        BASE_32_STRING, BINARY_STRING
+        BASE32, BINARY
     }
 
     private final Evaluator<Number> latitude;
@@ -66,13 +66,13 @@ public class GeohashStringEncodeEvaluator extends StringEvaluator {
         if(format != null) {
             geohashStringFormatValue = GeohashStringFormat.valueOf(format.evaluate(evaluationContext).getValue());
         }else {
-            geohashStringFormatValue = GeohashStringFormat.BASE_32_STRING;
+            geohashStringFormatValue = GeohashStringFormat.BASE32;
         }
 
         try {
             GeoHash gh = GeoHash.withCharacterPrecision(latitudeValue.doubleValue(), longitudeValue.doubleValue(), levelValue.intValue());
             switch (geohashStringFormatValue) {
-                case BINARY_STRING:
+                case BINARY:
                     return new StringQueryResult(gh.toBinaryString());
                 default:
                     return new StringQueryResult(gh.toBase32());

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2204,21 +2204,35 @@ public class TestQuery {
 
     @Test
     public void testGeohashLongEncode(){
-        final Map<String, String> attrs = new HashMap<>();
-        attrs.put("lat", "41.702");
-        attrs.put("lon", "0.083");
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("lat", "41.702");
+        attributes.put("lon", "0.083");
+        attributes.put("invalid_lat", "441.702");
+        attributes.put("invalid_lon", "-183");
 
-        verifyEquals("${geohashLongEncode(${lat}, ${lon}, 12)}", attrs, -4231957587308838032L);
+        verifyEquals("${geohashLongEncode(${lat}, ${lon}, 12)}", attributes, -4231957587308838032L);
+
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat}, ${lon}, 15)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${invalid_lat}, ${lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat}, ${invalid_lon}, 12)}", attributes, ""));
     }
     @Test
     public void testGeohashStringEncode(){
-        final Map<String, String> attrs = new HashMap<>();
-        attrs.put("lat", "41.702");
-        attrs.put("lon", "0.083");
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("lat", "41.702");
+        attributes.put("lon", "0.083");
+        attributes.put("invalid_lat", "441.702");
+        attributes.put("invalid_lon", "-183");
 
-        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3)}", attrs, "sp2");
-        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'BASE32')}", attrs, "sp2j1zs7y01r");
-        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3, 'BINARY')}", attrs, "110001010100010");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3)}", attributes, "sp2");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'BASE32')}", attributes, "sp2j1zs7y01r");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3, 'BINARY')}", attributes, "110001010100010");
+
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${lon}, 15)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'NOT_A_FORMAT')}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${invalid_lat}, ${lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${invalid_lon}, 12)}", attributes, ""));
+
     }
     @Test
     public void testGeohashDecodeLatitude(){
@@ -2231,6 +2245,9 @@ public class TestQuery {
         verifyEquals("${geohash_binary:geohashDecodeLatitude('BINARY')}", attributes, 41.484375);
         verifyEquals("${geohash_long:geohashDecodeLatitude('LONG')}", attributes, 41.701999905053526);
 
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude('BINARY')}", attributes, 41.68212890625));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude('NOT_A_FORMAT')}", attributes, 41.68212890625));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude()}", attributes, 41.68212890625));
     }
     @Test
     public void testGeohashDecodeLongitude(){
@@ -2242,6 +2259,10 @@ public class TestQuery {
         verifyEquals("${geohash_base32:geohashDecodeLongitude('BASE32')}", attributes, 0.06591796875);
         verifyEquals("${geohash_binary:geohashDecodeLongitude('BINARY')}", attributes, 0.703125);
         verifyEquals("${geohash_long:geohashDecodeLongitude('LONG')}", attributes, 0.0829999940469861);
+
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_long:geohashDecodeLongitude('BINARY')}", attributes, 0.0829999940469861));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_long:geohashDecodeLongitude('NOT_A_FORMAT')}", attributes, 0.0829999940469861));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_long:geohashDecodeLongitude()}", attributes, 0.0829999940469861));
     }
 
     private void verifyEquals(final String expression, final Map<String, String> attributes, final Object expectedResult) {

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2217,30 +2217,30 @@ public class TestQuery {
         attrs.put("lon", "0.083");
 
         verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3)}", attrs, "sp2");
-        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'BASE_32_STRING')}", attrs, "sp2j1zs7y01r");
-        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3, 'BINARY_STRING')}", attrs, "110001010100010");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'BASE32')}", attrs, "sp2j1zs7y01r");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3, 'BINARY')}", attrs, "110001010100010");
     }
     @Test
     public void testGeohashDecodeLatitude(){
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("geohash_base_32_string", "sp2j1");
-        attributes.put("geohash_binary_string", "110001010100010");
+        attributes.put("geohash_base32", "sp2j1");
+        attributes.put("geohash_binary", "110001010100010");
         attributes.put("geohash_long", "-4231957587308838032");
 
-        verifyEquals("${geohash_base_32_string:geohashDecodeLatitude('BASE_32_STRING')}", attributes, 41.68212890625);
-        verifyEquals("${geohash_binary_string:geohashDecodeLatitude('BINARY_STRING')}", attributes, 41.484375);
+        verifyEquals("${geohash_base32:geohashDecodeLatitude('BASE32')}", attributes, 41.68212890625);
+        verifyEquals("${geohash_binary:geohashDecodeLatitude('BINARY')}", attributes, 41.484375);
         verifyEquals("${geohash_long:geohashDecodeLatitude('LONG')}", attributes, 41.701999905053526);
 
     }
     @Test
     public void testGeohashDecodeLongitude(){
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("geohash_base_32_string", "sp2j1");
-        attributes.put("geohash_binary_string", "110001010100010");
+        attributes.put("geohash_base32", "sp2j1");
+        attributes.put("geohash_binary", "110001010100010");
         attributes.put("geohash_long", "-4231957587308838032");
 
-        verifyEquals("${geohash_base_32_string:geohashDecodeLongitude('BASE_32_STRING')}", attributes, 0.06591796875);
-        verifyEquals("${geohash_binary_string:geohashDecodeLongitude('BINARY_STRING')}", attributes, 0.703125);
+        verifyEquals("${geohash_base32:geohashDecodeLongitude('BASE32')}", attributes, 0.06591796875);
+        verifyEquals("${geohash_binary:geohashDecodeLongitude('BINARY')}", attributes, 0.703125);
         verifyEquals("${geohash_long:geohashDecodeLongitude('LONG')}", attributes, 0.0829999940469861);
     }
 

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2203,39 +2203,54 @@ public class TestQuery {
     }
 
     @Test
-    public void testGeohashLongEncode(){
+    public void testGeohashLongEncode() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("lat", "41.702");
         attributes.put("lon", "0.083");
-        attributes.put("invalid_lat", "441.702");
-        attributes.put("invalid_lon", "-183");
+        attributes.put("lat_null", null);
+        attributes.put("lat_invalid", "441.702");
+        attributes.put("lon_invalid", "-183");
+        attributes.put("lat_illegal", "hello");
+        attributes.put("lon_illegal", "cat");
 
         verifyEquals("${geohashLongEncode(${lat}, ${lon}, 12)}", attributes, -4231957587308838032L);
+        verifyEmpty("${geohashLongEncode(${lat}, '', 12)}", attributes);
+        verifyEmpty("${geohashLongEncode(${lat_null}, ${lon}, 12)}", attributes);
 
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat}, ${lon}, 15)}", attributes, ""));
-        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${invalid_lat}, ${lon}, 12)}", attributes, ""));
-        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat}, ${invalid_lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat_invalid}, ${lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat}, ${lon_invalid}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat_illegal}, ${lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashLongEncode(${lat}, ${lon_illegal}, 12)}", attributes, ""));
     }
+
     @Test
-    public void testGeohashStringEncode(){
+    public void testGeohashStringEncode() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("lat", "41.702");
         attributes.put("lon", "0.083");
-        attributes.put("invalid_lat", "441.702");
-        attributes.put("invalid_lon", "-183");
+        attributes.put("lat_null", null);
+        attributes.put("lat_invalid", "441.702");
+        attributes.put("lon_invalid", "-183");
+        attributes.put("lat_illegal", "hello");
+        attributes.put("lon_illegal", "cat");
 
         verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3)}", attributes, "sp2");
         verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'BASE32')}", attributes, "sp2j1zs7y01r");
         verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3, 'BINARY')}", attributes, "110001010100010");
+        verifyEmpty("${geohashStringEncode('', ${lon}, 12)}", attributes);
+        verifyEmpty("${geohashStringEncode(${lat_null}, '', 12)}", attributes);
 
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${lon}, 15)}", attributes, ""));
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'NOT_A_FORMAT')}", attributes, ""));
-        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${invalid_lat}, ${lon}, 12)}", attributes, ""));
-        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${invalid_lon}, 12)}", attributes, ""));
-
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat_invalid}, ${lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${lon_invalid}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat_illegal}, ${lon}, 12)}", attributes, ""));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohashStringEncode(${lat}, ${lon_illegal}, 12)}", attributes, ""));
     }
+
     @Test
-    public void testGeohashDecodeLatitude(){
+    public void testGeohashDecodeLatitude() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("geohash_base32", "sp2j1");
         attributes.put("geohash_binary", "110001010100010");
@@ -2249,8 +2264,9 @@ public class TestQuery {
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude('NOT_A_FORMAT')}", attributes, 41.68212890625));
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude()}", attributes, 41.68212890625));
     }
+
     @Test
-    public void testGeohashDecodeLongitude(){
+    public void testGeohashDecodeLongitude() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("geohash_base32", "sp2j1");
         attributes.put("geohash_binary", "110001010100010");

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2202,6 +2202,48 @@ public class TestQuery {
         verifyEquals("${myattr0:UUID5(${UUID()}):length()}", attributes, 36L);
     }
 
+    @Test
+    public void testGeohashLongEncode(){
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("lat", "41.702");
+        attrs.put("lon", "0.083");
+
+        verifyEquals("${geohashLongEncode(${lat}, ${lon}, 12)}", attrs, -4231957587308838032L);
+    }
+    @Test
+    public void testGeohashStringEncode(){
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("lat", "41.702");
+        attrs.put("lon", "0.083");
+
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3)}", attrs, "sp2");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 12, 'BASE_32_STRING')}", attrs, "sp2j1zs7y01r");
+        verifyEquals("${geohashStringEncode(${lat}, ${lon}, 3, 'BINARY_STRING')}", attrs, "110001010100010");
+    }
+    @Test
+    public void testGeohashDecodeLatitude(){
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("geohash_base_32_string", "sp2j1");
+        attributes.put("geohash_binary_string", "110001010100010");
+        attributes.put("geohash_long", "-4231957587308838032");
+
+        verifyEquals("${geohash_base_32_string:geohashDecodeLatitude('BASE_32_STRING')}", attributes, 41.68212890625);
+        verifyEquals("${geohash_binary_string:geohashDecodeLatitude('BINARY_STRING')}", attributes, 41.484375);
+        verifyEquals("${geohash_long:geohashDecodeLatitude('LONG')}", attributes, 41.701999905053526);
+
+    }
+    @Test
+    public void testGeohashDecodeLongitude(){
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("geohash_base_32_string", "sp2j1");
+        attributes.put("geohash_binary_string", "110001010100010");
+        attributes.put("geohash_long", "-4231957587308838032");
+
+        verifyEquals("${geohash_base_32_string:geohashDecodeLongitude('BASE_32_STRING')}", attributes, 0.06591796875);
+        verifyEquals("${geohash_binary_string:geohashDecodeLongitude('BINARY_STRING')}", attributes, 0.703125);
+        verifyEquals("${geohash_long:geohashDecodeLongitude('LONG')}", attributes, 0.0829999940469861);
+    }
+
     private void verifyEquals(final String expression, final Map<String, String> attributes, final Object expectedResult) {
         verifyEquals(expression,attributes, null, ParameterLookup.EMPTY, expectedResult);
     }

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2255,14 +2255,20 @@ public class TestQuery {
         attributes.put("geohash_base32", "sp2j1");
         attributes.put("geohash_binary", "110001010100010");
         attributes.put("geohash_long", "-4231957587308838032");
+        attributes.put("geohash_base32_invalid", "cat");
+        attributes.put("geohash_empty", "");
+        attributes.put("geohash_null", null);
 
         verifyEquals("${geohash_base32:geohashDecodeLatitude('BASE32')}", attributes, 41.68212890625);
         verifyEquals("${geohash_binary:geohashDecodeLatitude('BINARY')}", attributes, 41.484375);
         verifyEquals("${geohash_long:geohashDecodeLatitude('LONG')}", attributes, 41.701999905053526);
+        verifyEquals("${geohash_empty:geohashDecodeLatitude('BASE32')}", attributes, 0.0);
+        verifyEmpty("${geohash_null:geohashDecodeLatitude('BASE32')}", attributes);
 
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude('BINARY')}", attributes, 41.68212890625));
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude('NOT_A_FORMAT')}", attributes, 41.68212890625));
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32:geohashDecodeLatitude()}", attributes, 41.68212890625));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32_invalid:geohashDecodeLatitude('BASE32')}", attributes, ""));
     }
 
     @Test
@@ -2271,14 +2277,20 @@ public class TestQuery {
         attributes.put("geohash_base32", "sp2j1");
         attributes.put("geohash_binary", "110001010100010");
         attributes.put("geohash_long", "-4231957587308838032");
+        attributes.put("geohash_base32_invalid", "hello");
+        attributes.put("geohash_empty", "");
+        attributes.put("geohash_null", null);
 
         verifyEquals("${geohash_base32:geohashDecodeLongitude('BASE32')}", attributes, 0.06591796875);
         verifyEquals("${geohash_binary:geohashDecodeLongitude('BINARY')}", attributes, 0.703125);
         verifyEquals("${geohash_long:geohashDecodeLongitude('LONG')}", attributes, 0.0829999940469861);
+        verifyEquals("${geohash_empty:geohashDecodeLongitude('BASE32')}", attributes, 0.0);
+        verifyEmpty("${geohash_null:geohashDecodeLongitude('BASE32')}", attributes);
 
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_long:geohashDecodeLongitude('BINARY')}", attributes, 0.0829999940469861));
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_long:geohashDecodeLongitude('NOT_A_FORMAT')}", attributes, 0.0829999940469861));
         assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_long:geohashDecodeLongitude()}", attributes, 0.0829999940469861));
+        assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${geohash_base32_invalid:geohashDecodeLongitude('BASE32')}", attributes, ""));
     }
 
     private void verifyEquals(final String expression, final Map<String, String> attributes, final Object expectedResult) {

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -1514,10 +1514,10 @@ An empty argument or an argument value with an invalid UUID results in an except
 	- [.argName]#_longitude_# : [.argDesc]#The longitude coordinate to encode.#
 
 	- [.argName]#_level_# : [.argDesc]#The integer value to specify the desired precision. This level value should be
-between 1 and 12, indicating the number of characters in a standard BASE_32 geohash string.#
+between 1 and 12, indicating the number of characters in a standard BASE32 geohash string.#
 
 	- [.argName]#_format_# : [.argDesc]#Optional argument that specifies the geohash string format. Supports one of
-[BASE_32_STRING, BINARY_STRING]. If not specified, defaults to the standard geohash ​​format BASE_32_STRING.#
+[BASE32, BINARY]. If not specified, defaults to the standard geohash ​​format BASE32.#
 
 *Return Type*: [.returnType]#String#
 
@@ -1541,7 +1541,7 @@ the highest precision, we can use the Expression `${geohashStringEncode(${lat}, 
 	- [.argName]#_longitude_# : [.argDesc]#The longitude coordinate to encode.#
 
 	- [.argName]#_level_# : [.argDesc]#The integer value to specify the desired precision. This level value should be
-between 1 and 12, indicating the number of characters in a standard BASE_32 geohash string.#
+between 1 and 12, indicating the number of characters in a standard BASE32 geohash string.#
 
 *Return Type*: [.returnType]#Number#
 
@@ -1561,12 +1561,12 @@ we can use the Expression `${geohashLongEncode(${lat}, ${lon}, 12)}`, which will
 *Arguments*:
 
 - [.argName]#_format_# : [.argDesc]#The format of the given geohash to decode. Supports one of
-[BASE_32_STRING, BINARY_STRING, LONG].#
+[BASE32, BINARY, LONG].#
 
 *Return Type*: [.returnType]#Number#
 
 *Examples*: If we have a geohash binary string attribute named "geohash" with a value of "110001010100010",
-then the Expression `${geohash:geohashDecodeLatitude('BINARY_STRING')}` will return 41.484375.
+then the Expression `${geohash:geohashDecodeLatitude('BINARY')}` will return 41.484375.
 
 
 
@@ -1580,12 +1580,12 @@ then the Expression `${geohash:geohashDecodeLatitude('BINARY_STRING')}` will ret
 *Arguments*:
 
 - [.argName]#_format_# : [.argDesc]#The format of the given geohash to decode. Supports one of
-[BASE_32_STRING, BINARY_STRING, LONG].#
+[BASE32, BINARY, LONG].#
 
 *Return Type*: [.returnType]#Number#
 
 *Examples*: If we have a standard geohash string attribute named "geohash" with a value of "sp2j1zs7y01r",
-then the Expression `${geohash:geohashDecodeLongitude('BASE_32_STRING')}` will return 0.08300011977553368.
+then the Expression `${geohash:geohashDecodeLongitude('BASE32')}` will return 0.08300011977553368.
 
 
 

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -1500,6 +1500,95 @@ An empty argument or an argument value with an invalid UUID results in an except
 
 
 
+[.function]
+=== geohashStringEncode
+
+*Description*: [.description]#This function encodes latitude and longitude coordinates to a geohash string of the given level.#
+
+*Subject Type*: [.subjectless]#No subject#
+
+*Arguments*:
+
+	- [.argName]#_latitude_# : [.argDesc]#The latitude coordinate to encode.#
+
+	- [.argName]#_longitude_# : [.argDesc]#The longitude coordinate to encode.#
+
+	- [.argName]#_level_# : [.argDesc]#The integer value to specify the desired precision. This level value should be
+between 1 and 12, indicating the number of characters in a standard BASE_32 geohash string.#
+
+	- [.argName]#_format_# : [.argDesc]#Optional argument that specifies the geohash string format. Supports one of
+[BASE_32_STRING, BINARY_STRING]. If not specified, defaults to the standard geohash ​​format BASE_32_STRING.#
+
+*Return Type*: [.returnType]#String#
+
+*Examples*: If we have an attribute named "lat" with a value of "41.702", an attribute named "lon" with
+a value of "0.083", and we want to encode the coordinates of this point to the standard geohash format with
+the highest precision, we can use the Expression `${geohashStringEncode(${lat}, ${lon}, 12)}`, which will return "sp2j1zs7y01r".
+
+
+
+[.function]
+=== geohashLongEncode
+
+*Description*: [.description]#This function encodes latitude and longitude coordinates to a 64-bit integer geohash of the given level.#
+
+*Subject Type*: [.subjectless]#No subject#
+
+*Arguments*:
+
+	- [.argName]#_latitude_# : [.argDesc]#The latitude coordinate to encode.#
+
+	- [.argName]#_longitude_# : [.argDesc]#The longitude coordinate to encode.#
+
+	- [.argName]#_level_# : [.argDesc]#The integer value to specify the desired precision. This level value should be
+between 1 and 12, indicating the number of characters in a standard BASE_32 geohash string.#
+
+*Return Type*: [.returnType]#Number#
+
+*Examples*: If we have an attribute named "lat" with a value of "41.702", an attribute named "lon" with
+a value of "0.083", and we want to encode the coordinates of this point to a 64-bit geohash integer of level 12,
+we can use the Expression `${geohashLongEncode(${lat}, ${lon}, 12)}`, which will return -4231957587308838032L.
+
+
+
+[.function]
+=== geohashDecodeLatitude
+
+*Description*: [.description]#Returns the latitude coordinates of the center of a given geohash cell.#
+
+*Subject Type*: [.subject]#String#
+
+*Arguments*:
+
+- [.argName]#_format_# : [.argDesc]#The format of the given geohash to decode. Supports one of
+[BASE_32_STRING, BINARY_STRING, LONG].#
+
+*Return Type*: [.returnType]#Number#
+
+*Examples*: If we have a geohash binary string attribute named "geohash" with a value of "110001010100010",
+then the Expression `${geohash:geohashDecodeLatitude('BINARY_STRING')}` will return 41.484375.
+
+
+
+[.function]
+=== geohashDecodeLongitude
+
+*Description*: [.description]#Returns the longitude coordinates of the center of a given geohash cell.#
+
+*Subject Type*: [.subject]#String#
+
+*Arguments*:
+
+- [.argName]#_format_# : [.argDesc]#The format of the given geohash to decode. Supports one of
+[BASE_32_STRING, BINARY_STRING, LONG].#
+
+*Return Type*: [.returnType]#Number#
+
+*Examples*: If we have a standard geohash string attribute named "geohash" with a value of "sp2j1zs7y01r",
+then the Expression `${geohash:geohashDecodeLongitude('BASE_32_STRING')}` will return 0.08300011977553368.
+
+
+
 [[searching]]
 == Searching
 

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -1525,6 +1525,7 @@ between 1 and 12, indicating the number of characters in a standard BASE32 geoha
 a value of "0.083", and we want to encode the coordinates of this point to the standard geohash format with
 the highest precision, we can use the Expression `${geohashStringEncode(${lat}, ${lon}, 12)}`, which will return "sp2j1zs7y01r".
 
+This function returns null if either latitude or longitude is empty and generates an exception bulletin if the latitude or longitude provided is invalid.
 
 
 [.function]
@@ -1549,7 +1550,7 @@ between 1 and 12, indicating the number of characters in a standard BASE32 geoha
 a value of "0.083", and we want to encode the coordinates of this point to a 64-bit geohash integer of level 12,
 we can use the Expression `${geohashLongEncode(${lat}, ${lon}, 12)}`, which will return -4231957587308838032L.
 
-
+This function returns null if either latitude or longitude is empty and generates an exception bulletin if the latitude or longitude provided is invalid.
 
 [.function]
 === geohashDecodeLatitude

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -1569,7 +1569,8 @@ This function returns null if either latitude or longitude is empty and generate
 *Examples*: If we have a geohash binary string attribute named "geohash" with a value of "110001010100010",
 then the Expression `${geohash:geohashDecodeLatitude('BINARY')}` will return 41.484375.
 
-
+This function returns null if geohash attribute is null and returns 0.0 if an empty value is provided.
+It generates an exception bulletin if the geohash value provided is invalid.
 
 [.function]
 === geohashDecodeLongitude
@@ -1588,7 +1589,8 @@ then the Expression `${geohash:geohashDecodeLatitude('BINARY')}` will return 41.
 *Examples*: If we have a standard geohash string attribute named "geohash" with a value of "sp2j1zs7y01r",
 then the Expression `${geohash:geohashDecodeLongitude('BASE32')}` will return 0.08300011977553368.
 
-
+This function returns null if geohash attribute is null and returns 0.0 if an empty value is provided.
+It generates an exception bulletin if the geohash value provided is invalid.
 
 [[searching]]
 == Searching


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_NIFI-9333 adds the geohash encoding/decoding functions to Expression Language. The changes in ##5476 for NIFI-9259 is created for record-based data, while this one can be used for data without schema._

#### This is how I tested:

1. Use a GeneraFlowFile processor to generate flowfiles with attributes “lat” and “lon”.

2. Use a UpdateAttribute processor to update an attribute “geohash”: 
    - Tested with combinations of different parameters.
    - For checking the presentation of its documentation, checked the expression-language-guide.html under nifi/nifi-assembly/target/nifi-1.16.0-SNAPSHOT-bin/nifi-1.16.0-SNAPSHOT/docs/html. Also checked the doc when writing the expression in this step 2.

3. Use a LogAttribute processor to log what has been generated. And I compared this results to the results generated by GeohashRecord Processor, making sure they are identical. 

Testing the decoding functions are very similar to the above process.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
