### PR TITLE
NIFI-9376 Update Documentation for Encrypted Passwords in Flows

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -1782,7 +1782,12 @@ Each Key Derivation Function uses the following default parameters:
 ** Block Size Factor (r): 8
 ** Parallelization Factor (p): 1
 
-All options require a password (`nifi.sensitive.props.key` value) of *at least 12 characters*. This means the "default" value (if left empty, a hard-coded default is used) will not be sufficient.
+All options require a password (`nifi.sensitive.props.key` value) of *at least 12 characters*.
+
+In new standalone installations of 1.14.0 or later, NiFi generates a random value when `nifi.sensitive.props.key` is
+empty. NiFi writes the generated value to `nifi.properties` and logs a warning.
+
+Clustered installations of NiFi require the same value to be configured on all nodes.
 
 [[encrypt-config_tool]]
 == Encrypted Passwords in Configuration Files


### PR DESCRIPTION
#### Description of PR

NIFI-9376 Updates the NiFi Administrator's Guide section `Encrypted Passwords in Flows` to remove the reference to a default hard-coded password when the `nifi.sensitive.props.key` is empty. NiFi 1.14.0 removed this feature and requires a value to be specified for `nifi.sensitive.props.key`. Changes include additional details describing the generation of a random value on standalone installations, and the requirement for a shared value in clustered installations.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
