### PR TITLE
NIFI-9378 Create new artifact in nifi-assembly that packages all exte…

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -39,6 +39,9 @@ language governing permissions and limitations under the License. -->
                             <stripClassifier>true</stripClassifier>
                             <stripVersion>true</stripVersion>
                             <silent>true</silent>
+                            <fileMappers>
+                                <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper />
+                            </fileMappers>
                         </configuration>
                     </execution>
                 </executions>
@@ -90,7 +93,6 @@ language governing permissions and limitations under the License. -->
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <formats>
-                                <format>dir</format>
                                 <format>zip</format>
                             </formats>
                         </configuration>

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -22,11 +22,29 @@ language governing permissions and limitations under the License. -->
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>extract-extension-manifests</id>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <includeTypes>nar</includeTypes>
+                            <includes>**/extension-manifest.xml</includes>
+                            <excludeTransitive>false</excludeTransitive>
+                            <outputDirectory>${project.build.directory}/extension-manifests</outputDirectory>
+                            <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
+                            <stripClassifier>true</stripClassifier>
+                            <stripVersion>true</stripVersion>
+                            <silent>true</silent>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <finalName>nifi-${project.version}</finalName>
-                    <attach>false</attach>
-                </configuration>
                 <executions>
                     <execution>
                         <id>make shared resource</id>
@@ -35,6 +53,8 @@ language governing permissions and limitations under the License. -->
                         </goals>
                         <phase>package</phase>
                         <configuration>
+                            <finalName>nifi-${project.version}</finalName>
+                            <attach>false</attach>
                             <archiverConfig>
                                 <defaultDirectoryMode>0775</defaultDirectoryMode>
                                 <directoryMode>0775</directoryMode>
@@ -48,6 +68,30 @@ language governing permissions and limitations under the License. -->
                                 <format>dir</format>
                                 <format>zip</format>
                                 <format>tar.gz</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make-extension-manifest-assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <finalName>nifi-${project.version}</finalName>
+                            <attach>true</attach>
+                            <archiverConfig>
+                                <defaultDirectoryMode>0775</defaultDirectoryMode>
+                                <directoryMode>0775</directoryMode>
+                                <fileMode>0664</fileMode>
+                            </archiverConfig>
+                            <descriptors>
+                                <descriptor>src/main/assembly/extension-manifests.xml</descriptor>
+                            </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                            <formats>
+                                <format>dir</format>
+                                <format>zip</format>
                             </formats>
                         </configuration>
                     </execution>
@@ -1335,10 +1379,6 @@ language governing permissions and limitations under the License. -->
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <finalName>nifi-${project.version}</finalName>
-                            <attach>false</attach>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>make shared resource</id>
@@ -1347,6 +1387,8 @@ language governing permissions and limitations under the License. -->
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>
+                                    <finalName>nifi-${project.version}</finalName>
+                                    <attach>false</attach>
                                     <archiverConfig>
                                         <defaultDirectoryMode>0775</defaultDirectoryMode>
                                         <directoryMode>0775</directoryMode>
@@ -1401,10 +1443,6 @@ language governing permissions and limitations under the License. -->
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <finalName>nifi-${project.version}</finalName>
-                            <attach>false</attach>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>make shared resource</id>
@@ -1413,6 +1451,8 @@ language governing permissions and limitations under the License. -->
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>
+                                    <finalName>nifi-${project.version}</finalName>
+                                    <attach>false</attach>
                                     <archiverConfig>
                                         <defaultDirectoryMode>0775</defaultDirectoryMode>
                                         <directoryMode>0775</directoryMode>

--- a/nifi-assembly/src/main/assembly/extension-manifests.xml
+++ b/nifi-assembly/src/main/assembly/extension-manifests.xml
@@ -16,7 +16,7 @@
 <assembly>
     <id>manifests</id>
     <includeBaseDirectory>true</includeBaseDirectory>
-    <baseDirectory>nifi-${project.version}-manifests</baseDirectory>
+    <baseDirectory>nifi-manifests</baseDirectory>
 
     <fileSets>
         <fileSet>

--- a/nifi-assembly/src/main/assembly/extension-manifests.xml
+++ b/nifi-assembly/src/main/assembly/extension-manifests.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<assembly>
+    <id>manifests</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>nifi-${project.version}-manifests</baseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/extension-manifests</directory>
+            <outputDirectory>./</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -583,6 +583,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
                     <configuration>
                         <tarLongFileMode>gnu</tarLongFileMode>
                     </configuration>
@@ -660,6 +661,11 @@
                             <version>8.29</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -665,7 +665,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
…nsion manifests.

This produces a new artifact during building of `nifi-assembly` - `nifi-1.16.0-SNAPSHOT-manifests.zip`. This must be done from `nifi-assembly` since that is where the determination is made about which NARs to include in the assembly. 

This zip file contains all of the `META-INF/docs/extension-manifest.xml` files from all NARs in the assembly. It is also attached to the build so it will be published as a Maven artifact on a release. This allows creating a dependency on this artifact with the following:
```
<dependency>
    <groupId>org.apache.nifi</groupId>
    <artifactId>nifi-assembly</artifactId>
    <version>1.16.0-SNAPSHOT</version>
    <classifier>manifests</classifier>
    <type>zip</type>
</dependency>
```