### PR TITLE
NIFI-9389 - NPE guard for ExecuteProcess on no OnTriggered

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -166,6 +166,21 @@ public class StandardProcessorTestRunner implements TestRunner {
     }
 
     @Override
+    public void doNotRun() {
+        ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnConfigurationRestored.class, processor, context);
+        try {
+            ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, processor, context);
+        } catch (final Exception e) {
+            Assertions.fail("Could not invoke methods annotated with @OnScheduled annotation " + e.getMessage());
+        }
+        try {
+            ReflectionUtils.invokeMethodsWithAnnotation(OnUnscheduled.class, processor, context);
+        } catch (final Exception e) {
+            Assertions.fail("Could not invoke methods annotated with @OnUnscheduled annotation " + e.getMessage());
+        }
+    }
+
+    @Override
     public void run() {
         run(1);
     }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -166,21 +166,6 @@ public class StandardProcessorTestRunner implements TestRunner {
     }
 
     @Override
-    public void doNotRun() {
-        ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnConfigurationRestored.class, processor, context);
-        try {
-            ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, processor, context);
-        } catch (final Exception e) {
-            Assertions.fail("Could not invoke methods annotated with @OnScheduled annotation " + e.getMessage());
-        }
-        try {
-            ReflectionUtils.invokeMethodsWithAnnotation(OnUnscheduled.class, processor, context);
-        } catch (final Exception e) {
-            Assertions.fail("Could not invoke methods annotated with @OnUnscheduled annotation " + e.getMessage());
-        }
-    }
-
-    @Override
     public void run() {
         run(1);
     }
@@ -202,7 +187,7 @@ public class StandardProcessorTestRunner implements TestRunner {
 
     @Override
     public void run(final int iterations, final boolean stopOnFinish, final boolean initialize, final long runWait) {
-        if (iterations < 1) {
+        if (iterations < 0) {
             throw new IllegalArgumentException();
         }
 

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -62,13 +62,6 @@ public interface TestRunner {
     ProcessContext getProcessContext();
 
     /**
-     * Call the {@link org.apache.nifi.annotation.lifecycle.OnScheduled} /
-     * {@link org.apache.nifi.annotation.lifecycle.OnUnscheduled} methods, to simulate a processor
-     * that is enabled but never triggered.
-     */
-    void doNotRun();
-
-    /**
      * Performs exactly the same operation as calling {@link #run(int)} with a
      * value of 1.
      */

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -62,6 +62,13 @@ public interface TestRunner {
     ProcessContext getProcessContext();
 
     /**
+     * Call the {@link org.apache.nifi.annotation.lifecycle.OnScheduled} /
+     * {@link org.apache.nifi.annotation.lifecycle.OnUnscheduled} methods, to simulate a processor
+     * that is enabled but never triggered.
+     */
+    void doNotRun();
+
+    /**
      * Performs exactly the same operation as calling {@link #run(int)} with a
      * value of 1.
      */

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
@@ -207,7 +207,7 @@ public class ExecuteProcess extends AbstractProcessor {
         try {
             executor.shutdown();
         } finally {
-            if (this.externalProcess.isAlive()) {
+            if ((this.externalProcess != null) && (this.externalProcess.isAlive())) {
                 this.getLogger().info("Process hasn't terminated, forcing the interrupt");
                 this.externalProcess.destroyForcibly();
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
@@ -313,4 +313,15 @@ public class TestExecuteProcess {
                     .anyMatch(m -> m.getMsg().contains("Failed to create process due to")));
     }
 
+    /**
+     * On configuration of this processor to run only on primary cluster node, other nodes call
+     * {@link org.apache.nifi.annotation.lifecycle.OnUnscheduled} method after an invocation (Start/Stop or RunOnce),
+     * causing an NPE.  NPE guard added; test for this situation.
+     */
+    @Test
+    public void testProcessorNotScheduled() {
+        final TestRunner runner = TestRunners.newTestRunner(ExecuteProcess.class);
+        runner.setProperty(ExecuteProcess.COMMAND, "ls");
+        runner.doNotRun();
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
@@ -322,6 +322,6 @@ public class TestExecuteProcess {
     public void testProcessorNotScheduled() {
         final TestRunner runner = TestRunners.newTestRunner(ExecuteProcess.class);
         runner.setProperty(ExecuteProcess.COMMAND, "ls");
-        runner.doNotRun();
+        runner.run(0);
     }
 }


### PR DESCRIPTION
#### Description of PR

Guard against NPE on certain usage scenarios of ExecuteProcess processor.  If processor is enabled but never scheduled, an NPE is thrown in the context of the "@OnUnscheduled" call.  Ran into this in cluster environment, where processor was configured to run only on primary node.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [-] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [-] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
