### PR TITLE
NIFI-9336 - Show icon for property values with leading or trailing whitespace

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1668,6 +1668,9 @@
         });
 
         if (options.readOnly !== true) {
+            propertyGrid.onBeforeEditCell.subscribe(function (e, args) {
+                nfCommon.cleanUpTooltips(table, 'div.fa-question-circle, div.fa-info');
+            });
             propertyGrid.onBeforeCellEditorDestroy.subscribe(function (e, args) {
                 setTimeout(function() {
                     var propertyData = propertyGrid.getData();
@@ -1966,8 +1969,7 @@
         table.removeData('descriptors history');
 
         // clean up any tooltips that may have been generated
-        nfCommon.cleanUpTooltips(table, 'div.fa-question-circle');
-        nfCommon.cleanUpTooltips(table, 'div.fa-info');
+        nfCommon.cleanUpTooltips(table, 'div.fa-question-circle, div.fa-info');
 
         // clear the data in the grid
         var propertyGrid = table.data('gridInstance');

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1326,7 +1326,7 @@
                             valueMarkup = '<div class="table-cell value"><pre class="ellipsis">' + nfCommon.escapeHtml(value) + '</pre></div>';
 
                             // add a tooltip icon for trailing and/or leading whitespace
-                            if (nfCommon.hasWhitespace(value)) {
+                            if (nfCommon.hasLeadTrailWhitespace(value)) {
                                 valueMarkup += '<div class="fa fa-info" alt="Info" style="float: right;"></div>';
                                 nameWidthOffset = 20; // 10 + icon width (10)
                             }
@@ -1967,6 +1967,7 @@
 
         // clean up any tooltips that may have been generated
         nfCommon.cleanUpTooltips(table, 'div.fa-question-circle');
+        nfCommon.cleanUpTooltips(table, 'div.fa-info');
 
         // clear the data in the grid
         var propertyGrid = table.data('gridInstance');

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1292,6 +1292,7 @@
         // function for formatting the property value
         var valueFormatter = function (row, cell, value, columnDef, dataContext) {
             var valueMarkup;
+            var nameWidthOffset = 0;
             if (nfCommon.isDefinedAndNotNull(value)) {
                 // get the property descriptor
                 var descriptors = table.data('descriptors');
@@ -1323,6 +1324,13 @@
                             valueMarkup = '<span class="table-cell blank">Incompatible Controller Service Configured</div>';
                         } else {
                             valueMarkup = '<div class="table-cell value"><pre class="ellipsis">' + nfCommon.escapeHtml(value) + '</pre></div>';
+
+                            // add a tooltip icon for trailing and/or leading whitespace
+                            if (nfCommon.hasWhitespace(value)) {
+                                valueMarkup += '<div class="fa fa-info" alt="Info" style="float: right;"></div>';
+                                nameWidthOffset = 20; // 10 + icon width (10)
+                            }
+
                         }
                     }
                 }
@@ -1335,7 +1343,7 @@
             if (dataContext.type === 'required') {
                 content.addClass('required');
             }
-            content.find('.ellipsis').width(columnDef.width - 10).ellipsis();
+            content.find('.ellipsis').width(columnDef.width - 10 - nameWidthOffset).ellipsis();
 
             // return the appropriate markup
             return $('<div />').append(content).html();
@@ -1763,13 +1771,26 @@
                 var propertyHistory = history[property];
 
                 // format the tooltip
-                var tooltip = nfCommon.formatPropertyTooltip(propertyDescriptor, propertyHistory);
+                var propertyTooltip = nfCommon.formatPropertyTooltip(propertyDescriptor, propertyHistory);
 
-                if (nfCommon.isDefinedAndNotNull(tooltip)) {
+                if (nfCommon.isDefinedAndNotNull(propertyTooltip)) {
                     infoIcon.qtip($.extend({},
                         nfCommon.config.tooltipConfig,
                         {
-                            content: tooltip
+                            content: propertyTooltip
+                        }));
+                }
+            }
+
+            var whitespaceIcon = $(this).find('div.fa-info');
+            if (whitespaceIcon.length && !whitespaceIcon.data('qtip')) {
+                var whitespaceTooltip = nfCommon.formatWhitespaceTooltip();
+
+                if (nfCommon.isDefinedAndNotNull(whitespaceTooltip)) {
+                    whitespaceIcon.qtip($.extend({},
+                        nfCommon.config.tooltipConfig,
+                        {
+                            content: whitespaceTooltip
                         }));
                 }
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -1012,8 +1012,8 @@
          *
          * @argument {string} value     The value to check
          */
-        hasWhitespace : function (value) {
-            if (!value) {
+        hasLeadTrailWhitespace : function (value) {
+            if ( !value || value.trim().length === 0 ) {
                 return false;
             }
             var leadOrTrailWhitespaceRegex = /^[ \s]+|[ \s]+$/;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -997,6 +997,30 @@
         },
 
         /**
+         * Returns a tooltip for leading and/or trailing whitespace.
+         *
+         * @returns {string}
+         */
+        formatWhitespaceTooltip: function () {
+            return nfCommon.escapeHtml('The specified value contains leading and/or trailing whitespace character(s). ' +
+                'This could produce unexpected results if it was not intentional.');
+
+        },
+
+        /**
+         * Checks the specified value for leading and/or trailing whitespace.
+         *
+         * @argument {string} value     The value to check
+         */
+        hasWhitespace : function (value) {
+            if (!value) {
+                return false;
+            }
+            var leadOrTrailWhitespaceRegex = /^[ \s]+|[ \s]+$/;
+            return leadOrTrailWhitespaceRegex.test(value);
+        },
+
+        /**
          * Formats the specified property (name and value) accordingly.
          *
          * @argument {string} name      The name of the property


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Jira: https://issues.apache.org/jira/browse/NIFI-9336

When configuring processors and controller services in the UI, if a user enters a property value that has leading or trailing whitespace, it's not always obvious and may not be desired. To indicate when a value contains leading/trailing whitespace, an icon with a tooltip will show next to the value in processor and controller services configurations.

To test:
- go to configurations in a processor or controller service
- enter a property value with leading and/or trailing whitespace
- you should see an info icon and tooltip show to the right of the value

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
