### PR TITLE
NIFI-9417 Fixes flaky BulletinMergerTest.java 

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/BulletinMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/BulletinMergerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +65,7 @@ public class BulletinMergerTest {
         final NodeIdentifier node1 = new NodeIdentifier("node-1", "host-1", 8080, "host-1", 19998, null, null, null, false);
         final NodeIdentifier node2 = new NodeIdentifier("node-2", "host-2", 8081, "host-2", 19999, null, null, null, false);
 
-        final Map<NodeIdentifier, List<BulletinEntity>> nodeMap = new HashMap<>();
+        final Map<NodeIdentifier, List<BulletinEntity>> nodeMap = new LinkedHashMap<>();
         nodeMap.put(node1, new ArrayList<>());
         nodeMap.put(node2, new ArrayList<>());
 
@@ -77,8 +77,8 @@ public class BulletinMergerTest {
 
         final List<BulletinEntity> bulletinEntities = BulletinMerger.mergeBulletins(nodeMap, nodeMap.size());
         assertEquals(bulletinEntities.size(), 3);
-        assertTrue(bulletinEntities.contains(copyOfBulletin1));
-        assertEquals(copyOfBulletin1.getNodeAddress(), ALL_NODES_MESSAGE);
+        assertTrue(bulletinEntities.contains(bulletinEntity1));
+        assertEquals(bulletinEntity1.getNodeAddress(), ALL_NODES_MESSAGE);
         assertTrue(bulletinEntities.contains(bulletinEntity2));
         assertTrue(bulletinEntities.contains(unauthorizedBulletin));
     }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.

SHA: 5aced2b4bc66d2dd85b1507755fff2b1fb8c4a64

The hashmap does not have a guaranteed iteration order, in the process of ```BulletinMerger.mergeBulletins()``` (line-78), the order of [copyOfBulletin1, bulletinEntity1] in the list can be eithter ```copyOfBulletin1``` first or ```bulletinEntity1``` first. The ```mergeBulletins()``` will keep the most recent bulletin with the larger time, and because all BulletinEntity are created from the function ```createBulletin()```(line-38) and have the same time property in this test, ```mergeBulletins()``` will just keep the first in the list. So sometimes bulletinEntity1 will be returned instead of ```copyOfBulletin1```, which results in the failure (line-80): ```assertTrue(bulletinEntities.contains(copyOfBulletin1));```

The proposed fix is replacing ```LinkedHashMap``` with ```Hashmap``` to insure the determinism. After this change, the order will always be ```bulletinEntity1``` before the ```copyOfBulletin1``` and the merge results will always contain ```bulletinEntity1``` instead of ```copyOfBulletin1```. So I also change the assertion to ```assertTrue(bulletinEntities.contains(bulletinEntity1)```;

// another fix can be using Thread.sleep() between the variable declaration of ```copyOfBulletin1``` and ```bulletinEntity1```, in this case, they should have different ```time``` property, and the code won't be flaky anymore

The way to reproduce the flaky test failure:
 - 0.Environment setup: Maven 3.6.0 and Java 1.8.0_292
 - 1.clone the repo:
   > git clone https://github.com/spring-projects/spring-data-cassandra
  cd spring-data-cassandra
  git checkout 5aced2b4bc66d2dd85b1507755fff2b1fb8c4a64

 - 2.run with [Nondex tool](https://github.com/TestingResearchIllinois/NonDex) (which explores different behaviors of under-determined APIs and reports test failures)
   >  mvn install -pl nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster -am -DskipTests
  mvn -pl nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster edu.illinois:nondex-maven-plugin:1.1.2:debug -Dtest=org.apache.nifi.cluster.manager.BulletinMergerTest#mergeBulletins
 
  - 3.then we can get the test failure:
    > [INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   BulletinMergerTest.mergeBulletins:80 expected [true] but found [false]
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

And ```BulletinMergerTest.mergeBulletins``` line-80 is :
```assertTrue(bulletinEntities.contains(copyOfBulletin1));```
in this case, the ```bulletinEntities``` did not contain ```copyOfBulletin1``` but ```bulletinEntity1```.

