### PR TITLE
NIFI-7835 Add authenticated SOCKS and HTTP proxy support for SFTP

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -142,6 +142,11 @@
             <artifactId>sshj</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.exceptionfactory.socketbroker</groupId>
+            <artifactId>socketbroker</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/socket/ProxySocketFactory.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/socket/ProxySocketFactory.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.processors.standard.ssh;
+package org.apache.nifi.processors.standard.socket;
 
 import javax.net.SocketFactory;
 import java.io.IOException;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/socket/SocketFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/socket/SocketFactoryProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.socket;
+
+import org.apache.nifi.proxy.ProxyConfiguration;
+
+import javax.net.SocketFactory;
+
+/**
+ * Socket Factory Provider abstracts implementation selection based on Proxy Configuration
+ */
+public interface SocketFactoryProvider {
+    /**
+     * Get Socket Factory based on provided Proxy Configuration
+     *
+     * @param proxyConfiguration Proxy Configuration required
+     * @return Socket Factory
+     */
+    SocketFactory getSocketFactory(ProxyConfiguration proxyConfiguration);
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/socket/StandardSocketFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/socket/StandardSocketFactoryProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.socket;
+
+import com.exceptionfactory.socketbroker.BrokeredSocketFactory;
+import com.exceptionfactory.socketbroker.configuration.AuthenticationCredentials;
+import com.exceptionfactory.socketbroker.configuration.BrokerConfiguration;
+import com.exceptionfactory.socketbroker.configuration.ProxyType;
+import com.exceptionfactory.socketbroker.configuration.StandardBrokerConfiguration;
+import com.exceptionfactory.socketbroker.configuration.StandardUsernamePasswordAuthenticationCredentials;
+import org.apache.nifi.proxy.ProxyConfiguration;
+
+import javax.net.SocketFactory;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.Objects;
+
+/**
+ * Standard implementation of Socket Factory Provider support authenticated or unauthenticated SOCKS or HTTP proxies
+ */
+public class StandardSocketFactoryProvider implements SocketFactoryProvider {
+    /**
+     * Get Socket Factory returns ProxySocketFactory without credentials and BrokeredSocketFactory with credentials
+     *
+     * @param proxyConfiguration Proxy Configuration required
+     * @return Socket Factory
+     */
+    @Override
+    public SocketFactory getSocketFactory(final ProxyConfiguration proxyConfiguration) {
+        Objects.requireNonNull(proxyConfiguration, "Proxy Configuration required");
+
+        final String userName = proxyConfiguration.getProxyUserName();
+        final SocketFactory socketFactory;
+        if (userName == null) {
+            final Proxy proxy = proxyConfiguration.createProxy();
+            socketFactory = new ProxySocketFactory(proxy);
+        } else {
+            final Proxy.Type proxyType = proxyConfiguration.getProxyType();
+            final ProxyType brokerProxyType = Proxy.Type.SOCKS == proxyType ? ProxyType.SOCKS5 : ProxyType.HTTP_CONNECT;
+            final InetSocketAddress proxySocketAddress = new InetSocketAddress(proxyConfiguration.getProxyServerHost(), proxyConfiguration.getProxyServerPort());
+
+            final String proxyPassword = proxyConfiguration.getProxyUserPassword();
+            final char[] brokerProxyPassword = proxyPassword == null ? new char[]{} : proxyPassword.toCharArray();
+            final AuthenticationCredentials credentials = new StandardUsernamePasswordAuthenticationCredentials(userName, brokerProxyPassword);
+
+            final BrokerConfiguration brokerConfiguration = new StandardBrokerConfiguration(brokerProxyType, proxySocketAddress, credentials);
+            socketFactory = new BrokeredSocketFactory(brokerConfiguration, SocketFactory.getDefault());
+        }
+        return socketFactory;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientProvider.java
@@ -34,6 +34,8 @@ import net.schmizz.sshj.userauth.password.PasswordFinder;
 import net.schmizz.sshj.userauth.password.PasswordUtils;
 
 import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.processors.standard.socket.SocketFactoryProvider;
+import org.apache.nifi.processors.standard.socket.StandardSocketFactoryProvider;
 import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.util.StringUtils;
 
@@ -67,6 +69,8 @@ import static org.apache.nifi.processors.standard.util.SFTPTransfer.USE_COMPRESS
  */
 public class StandardSSHClientProvider implements SSHClientProvider {
     private static final SSHConfigProvider SSH_CONFIG_PROVIDER = new StandardSSHConfigProvider();
+
+    private static final SocketFactoryProvider SOCKET_FACTORY_PROVIDER = new StandardSocketFactoryProvider();
 
     private static final List<Proxy.Type> SUPPORTED_PROXY_TYPES = Arrays.asList(Proxy.Type.HTTP, Proxy.Type.SOCKS);
 
@@ -170,8 +174,7 @@ public class StandardSSHClientProvider implements SSHClientProvider {
         final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context, createComponentProxyConfigSupplier(context));
         final Proxy.Type proxyType = proxyConfiguration.getProxyType();
         if (SUPPORTED_PROXY_TYPES.contains(proxyType)) {
-            final Proxy proxy = proxyConfiguration.createProxy();
-            final SocketFactory socketFactory = new ProxySocketFactory(proxy);
+            final SocketFactory socketFactory = SOCKET_FACTORY_PROVIDER.getSocketFactory(proxyConfiguration);
             client.setSocketFactory(socketFactory);
         }
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/socket/ProxySocketFactoryTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/socket/ProxySocketFactoryTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.processors.standard.ssh;
+package org.apache.nifi.processors.standard.socket;
 
 import org.junit.jupiter.api.Test;
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/socket/StandardSocketFactoryProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/socket/StandardSocketFactoryProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.socket;
+
+import com.exceptionfactory.socketbroker.BrokeredSocketFactory;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.net.SocketFactory;
+import java.net.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StandardSocketFactoryProviderTest {
+    private static final String HOST = "localhost";
+
+    private static final int PORT = 1080;
+
+    private static final String USERNAME = "user";
+
+    private static final String PASSWORD = "password";
+
+    private StandardSocketFactoryProvider provider;
+
+    @BeforeEach
+    public void setProvider() {
+        provider = new StandardSocketFactoryProvider();
+    }
+
+    @Test
+    public void testGetSocketFactoryWithoutCredentials() {
+        final ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setProxyType(Proxy.Type.SOCKS);
+        proxyConfiguration.setProxyServerHost(HOST);
+        proxyConfiguration.setProxyServerPort(PORT);
+
+        final SocketFactory socketFactory = provider.getSocketFactory(proxyConfiguration);
+        assertEquals(ProxySocketFactory.class, socketFactory.getClass());
+    }
+
+    @Test
+    public void testGetSocketFactoryWithUsername() {
+        final ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setProxyType(Proxy.Type.SOCKS);
+        proxyConfiguration.setProxyServerHost(HOST);
+        proxyConfiguration.setProxyServerPort(PORT);
+        proxyConfiguration.setProxyUserName(USERNAME);
+
+        final SocketFactory socketFactory = provider.getSocketFactory(proxyConfiguration);
+        assertEquals(BrokeredSocketFactory.class, socketFactory.getClass());
+    }
+
+    @Test
+    public void testGetSocketFactoryWithUsernamePassword() {
+        final ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setProxyType(Proxy.Type.SOCKS);
+        proxyConfiguration.setProxyServerHost(HOST);
+        proxyConfiguration.setProxyServerPort(PORT);
+        proxyConfiguration.setProxyUserName(USERNAME);
+        proxyConfiguration.setProxyUserPassword(PASSWORD);
+
+        final SocketFactory socketFactory = provider.getSocketFactory(proxyConfiguration);
+        assertEquals(BrokeredSocketFactory.class, socketFactory.getClass());
+    }
+}


### PR DESCRIPTION
#### Description of PR

NIFI-7835 Adds support for accessing SFTP servers through SOCKS 5 proxy servers that require authentication. Support for authenticated proxy server access also applies to HTTP proxy servers, resolving NIFI-7749.

NiFi SFTP components use SSHJ since version 1.10.0. SSHJ does not provide direct support for authenticated proxy server access, and the current NiFi implementation supports SOCKS and HTTP proxy access without authentication using a custom `ProxySocketFactory`. The `java.net.Authenticator` class does not support providing proxy username and password credentials for single instances of `java.net.Proxy`, instead requiring the use an `Authenticator` instance for the entire JVM using the `Authenticator.setDefault()` method. This approach is not suitable for NiFi components that may require different sets of credentials for different component instances.

This pull request integrates the [BrokeredSocketFactory](https://javadoc.io/doc/com.exceptionfactory.socketbroker/socketbroker/latest/com/exceptionfactory/socketbroker/BrokeredSocketFactory.html) from the [socketbroker](https://github.com/exceptionfactory/socketbroker) library to support authenticated access to SOCKS and HTTP proxy servers from NiFi SFTP components.

Runtime configurations can be tested using proxy servers that implement standard SOCKS 5 and HTTP CONNECT protocols. The following open source proxy servers can be configured with authentication for testing:

- [Dante](https://hub.docker.com/r/wernight/dante) SOCKS 5 Proxy
- [Tinyproxy](https://hub.docker.com/r/monokal/tinyproxy) HTTP Proxy
- [Squid](https://hub.docker.com/r/ubuntu/squid) HTTP Proxy

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
