### PR TITLE
NIFI-9548: When disabling RPG transmission, wait for the ports to com…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
@@ -549,7 +549,7 @@ public abstract class AbstractEventAccess implements EventAccess {
         }
 
         status.setId(remoteGroup.getIdentifier());
-        status.setTransmissionStatus(remoteGroup.isTransmitting() ? TransmissionStatus.Transmitting : TransmissionStatus.NotTransmitting);
+        status.setTransmissionStatus(remoteGroup.isConfiguredToTransmit() ? TransmissionStatus.Transmitting : TransmissionStatus.NotTransmitting);
         status.setActiveThreadCount(activeThreadCount);
         status.setReceivedContentSize(receivedContentSize);
         status.setReceivedCount(receivedCount);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/RemoteProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/RemoteProcessGroup.java
@@ -30,6 +30,7 @@ import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 public interface RemoteProcessGroup extends ComponentAuthorizable, Positionable, VersionedComponent {
@@ -107,10 +108,15 @@ public interface RemoteProcessGroup extends ComponentAuthorizable, Positionable,
     String getCommunicationsTimeout();
 
     /**
-     * @return Indicates whether or not the RemoteProcessGroup is currently scheduled to
-     * transmit data
+     * @return Indicates whether or not the RemoteProcessGroup is currently configured to transmit data OR if there are any threads that are currently
+     * active due to previously being scheduled to transmit that have not completed yet.
      */
     boolean isTransmitting();
+
+    /**
+     * @return <code>true</code> if the RPG is configured to transmit, <code>false</code> otherwise
+     */
+    boolean isConfiguredToTransmit();
 
     /**
      * Initiates communications between this instance and the remote instance.
@@ -121,7 +127,7 @@ public interface RemoteProcessGroup extends ComponentAuthorizable, Positionable,
      * Immediately terminates communications between this instance and the
      * remote instance.
      */
-    void stopTransmitting();
+    Future<?> stopTransmitting();
 
     /**
      * Initiates communications between this instance and the remote instance

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1114,6 +1114,8 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
                 startRemoteGroupPortsAfterInitialization.clear();
             }
 
+            flowManager.getRootGroup().findAllRemoteProcessGroups().forEach(RemoteProcessGroup::initialize);
+
             for (final Connection connection : flowManager.findAllConnections()) {
                 connection.getFlowFileQueue().startLoadBalancing();
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -703,8 +703,14 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
 
             // request to stop all remote process groups
             flowManager.getRootGroup().findAllRemoteProcessGroups()
-                    .stream().filter(rpg -> rpg.isTransmitting())
-                    .forEach(RemoteProcessGroup::stopTransmitting);
+                    .stream().filter(RemoteProcessGroup::isTransmitting)
+                    .forEach(rpg -> {
+                        try {
+                            rpg.stopTransmitting().get(rpg.getCommunicationsTimeout(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+                        } catch (final Exception e) {
+                            logger.warn("Encountered failure while waiting for {} to shutdown", rpg, e);
+                        }
+                    });
 
             // offload all queues on node
             final Set<Connection> connections = flowManager.findAllConnections();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -60,7 +60,6 @@ import org.apache.nifi.groups.ComponentIdGenerator;
 import org.apache.nifi.groups.ComponentScheduler;
 import org.apache.nifi.groups.GroupSynchronizationOptions;
 import org.apache.nifi.groups.ProcessGroup;
-import org.apache.nifi.groups.RemoteProcessGroup;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.parameter.Parameter;
 import org.apache.nifi.parameter.ParameterContext;
@@ -349,8 +348,6 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
 
                 // Inherit templates, now that all necessary Process Groups have been created
                 inheritTemplates(controller, versionedFlow);
-
-                rootGroup.findAllRemoteProcessGroups().forEach(RemoteProcessGroup::initialize);
             }
 
             inheritSnippets(controller, proposedFlow);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -1869,7 +1869,7 @@ public final class DtoFactory {
         dto.setName(group.getName());
         dto.setPosition(createPositionDto(group.getPosition()));
         dto.setComments(group.getComments());
-        dto.setTransmitting(group.isTransmitting());
+        dto.setTransmitting(group.isConfiguredToTransmit());
         dto.setCommunicationsTimeout(group.getCommunicationsTimeout());
         dto.setYieldDuration(group.getYieldDuration());
         dto.setParentGroupId(group.getProcessGroup().getIdentifier());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardRemoteProcessGroupDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardRemoteProcessGroupDAO.java
@@ -443,9 +443,9 @@ public class StandardRemoteProcessGroupDAO extends ComponentDAO implements Remot
         final Boolean isTransmitting = remoteProcessGroupDTO.isTransmitting();
         if (isNotNull(isTransmitting)) {
             // start or stop as necessary
-            if (!remoteProcessGroup.isTransmitting() && isTransmitting) {
+            if (!remoteProcessGroup.isConfiguredToTransmit() && isTransmitting) {
                 remoteProcessGroup.startTransmitting();
-            } else if (remoteProcessGroup.isTransmitting() && !isTransmitting) {
+            } else if (remoteProcessGroup.isConfiguredToTransmit() && !isTransmitting) {
                 remoteProcessGroup.stopTransmitting();
             }
         }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
@@ -683,7 +683,7 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
         connection.setDisconnectedNodeAcknowledged(true);
 
         // Delete the CountFlowFiles processor, and countB and countC services, disable A.
-        getNifiClient().getProcessorClient().stopProcessor(countFlowFiles);
+        getClientUtil().stopProcessor(countFlowFiles);
         getNifiClient().getConnectionClient().deleteConnection(connection);
         getNifiClient().getProcessorClient().deleteProcessor(countFlowFiles);
         getClientUtil().disableControllerServices("root", true);


### PR DESCRIPTION
…plete in a background thread instead of blocking the web thread. Also moved the RPG initialization logic into flow controller instead of flow service and added a delay in order to reduce likelihood of ConnectException  happening when pointing to nodes in the same cluster

<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
