### PR TITLE
NIFI-9563 Enable ListenTCP Pool Receive Buffers property

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/configuration/BufferAllocator.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/configuration/BufferAllocator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.event.transport.configuration;
+
+/**
+ * Byte Buffer Allocator configuration options
+ */
+public enum BufferAllocator {
+    /** Reusable pool of buffers */
+    POOLED,
+    /** New buffer for each allocation without any pooling */
+    UNPOOLED
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenTCP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenTCP.java
@@ -100,6 +100,7 @@ public class TestListenTCP {
     @Test
     public void testRunBatching() throws Exception {
         runner.setProperty(ListenerProperties.MAX_BATCH_SIZE, "3");
+        runner.setProperty(ListenTCP.POOL_RECV_BUFFERS, "False");
 
         final List<String> messages = new ArrayList<>();
         messages.add("This is message 1\n");


### PR DESCRIPTION
#### Description of PR

NIFI-9563 Removes the deprecation comments from the `Pool Receive Buffers` property in `ListenTCP`. Refactoring `ListenTCP` using Netty removed usage of this property, but it can be repurposed to control the Netty `ByteBufAllocator`.

The default Netty configuration uses the `PooledByteBufAllocator`, which aligns with the default value for the `Pool Receive Buffers` property.  Adding a new `BufferAllocator` enum as a property on `NettyEventServerFactory` provides the method for changing the Netty Channel Option to use the `UnpooledByteBufAllocator` when `Pool Receive Buffers` is disabled in `ListenTCP`.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
