### PR TITLE
NIFI-9562: add 'archive' conflict resolution strategy to PutFile

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
@@ -26,6 +26,7 @@ import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.RequiredPermission;
 import org.apache.nifi.components.ValidationContext;
@@ -44,6 +45,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StopWatch;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -52,14 +54,16 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -68,7 +72,14 @@ import java.util.regex.Pattern;
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"put", "local", "copy", "archive", "files", "filesystem"})
-@CapabilityDescription("Writes the contents of a FlowFile to the local file system")
+@CapabilityDescription("Writes the contents of a FlowFile to the local file system. There are four strategies for filename conflict resolution to define the behavior "
+        + "when a file currently exists in the output directory and risks being overwritten. The 'replace' strategy always writes FlowFile content, overwriting an existing file if necessary. "
+        + "The 'ignore' strategy writes to the output directory unless there is an existing file with the same name; the FlowFile is always routed to success even when "
+        + "content is not written to disk due to filename conflict. The 'fail' strategy writes to the output directory and routes the FlowFile to success unless there is a filename conflict. "
+        + "When a conflict exists, content is not written to disk and the FlowFile is routed to failure. The 'archive' strategy moves an existing file to the archive directory when a conflict "
+        + "exists, optionally applying an extension to the filename in the archive directory. If the filename already exists in the archive directory, content is not written to disk and the "
+        + "FlowFile is routed to failure."
++ "")
 @SeeAlso({FetchFile.class, GetFile.class})
 @ReadsAttribute(attribute = "filename", description = "The filename to use when writing the FlowFile to disk.")
 @Restricted(
@@ -83,10 +94,19 @@ public class PutFile extends AbstractProcessor {
     public static final String REPLACE_RESOLUTION = "replace";
     public static final String IGNORE_RESOLUTION = "ignore";
     public static final String FAIL_RESOLUTION = "fail";
-
-    public static final String FILE_MODIFY_DATE_ATTRIBUTE = "file.lastModifiedTime";
+    public static final String ARCHIVE_RESOLUTION = "archive";
+    public static final AllowableValue REPLACE = new AllowableValue(REPLACE_RESOLUTION, REPLACE_RESOLUTION,
+            "FlowFile content is written to a file in the output directory overwriting the file if it already exists");
+    public static final AllowableValue IGNORE = new AllowableValue(IGNORE_RESOLUTION, IGNORE_RESOLUTION,
+            "If a file exists in the output directory with the same name as the filename attribute of the FlowFile, the file in the output directory remains unchanged "
+                    + "and the FlowFile is routed to 'success'");
+    public static final AllowableValue FAIL = new AllowableValue(FAIL_RESOLUTION, FAIL_RESOLUTION,
+            "If a file exists in the output directory with the same name as the filename attribute of the FlowFile, the file in the output directory remains unchanged "
+                    + "and the FlowFile is routed to 'failure'");
+    public static final AllowableValue ARCHIVE = new AllowableValue(ARCHIVE_RESOLUTION, ARCHIVE_RESOLUTION,
+            "If a file exists in the output directory with the same name as the filename attribute of the FlowFile, the existing file is moved to an archive location prior to "
+                    + "writing FlowFile content to prevent the file from being overwritten");
     public static final String FILE_MODIFY_DATE_ATTR_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
-
     public static final Pattern RWX_PATTERN = Pattern.compile("^([r-][w-])([x-])([r-][w-])([x-])([r-][w-])([x-])$");
     public static final Pattern NUM_PATTERN = Pattern.compile("^[0-7]{3}$");
 
@@ -111,34 +131,40 @@ public class PutFile extends AbstractProcessor {
 
     public static final PropertyDescriptor DIRECTORY = new PropertyDescriptor.Builder()
             .name("Directory")
+            .displayName("Directory")
             .description("The directory to which files should be written. You may use expression language such as /aa/bb/${path}")
             .required(true)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
     public static final PropertyDescriptor MAX_DESTINATION_FILES = new PropertyDescriptor.Builder()
             .name("Maximum File Count")
+            .displayName("Maximum File Count")
             .description("Specifies the maximum number of files that can exist in the output directory")
             .required(false)
             .addValidator(StandardValidators.INTEGER_VALIDATOR)
             .build();
     public static final PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
             .name("Conflict Resolution Strategy")
-            .description("Indicates what should happen when a file with the same name already exists in the output directory")
+            .displayName("Conflict Resolution Strategy")
+            .description("Indicates what should happen when a file with the same name already exists in the output directory. "
+                    + "If strategy is 'archive', then 'Archive Directory' property must be specified.")
             .required(true)
             .defaultValue(FAIL_RESOLUTION)
-            .allowableValues(REPLACE_RESOLUTION, IGNORE_RESOLUTION, FAIL_RESOLUTION)
+            .allowableValues(REPLACE, IGNORE, FAIL, ARCHIVE)
             .build();
     public static final PropertyDescriptor CHANGE_LAST_MODIFIED_TIME = new PropertyDescriptor.Builder()
             .name("Last Modified Time")
+            .displayName("Last Modified Time")
             .description("Sets the lastModifiedTime on the output file to the value of this attribute.  Format must be yyyy-MM-dd'T'HH:mm:ssZ.  "
                     + "You may also use expression language such as ${file.lastModifiedTime}.")
             .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
     public static final PropertyDescriptor CHANGE_PERMISSIONS = new PropertyDescriptor.Builder()
             .name("Permissions")
+            .displayName("Permissions")
             .description("Sets the permissions on the output file to the value of this attribute.  Format must be either UNIX rwxrwxrwx with a - in "
                     + "place of denied permissions (e.g. rw-r--r--) or an octal number (e.g. 644).  You may also use expression language such as "
                     + "${file.permissions}.")
@@ -148,29 +174,68 @@ public class PutFile extends AbstractProcessor {
             .build();
     public static final PropertyDescriptor CHANGE_OWNER = new PropertyDescriptor.Builder()
             .name("Owner")
+            .displayName("Owner")
             .description("Sets the owner on the output file to the value of this attribute.  You may also use expression language such as "
                     + "${file.owner}. Note on many operating systems Nifi must be running as a super-user to have the permissions to set the file owner.")
             .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
     public static final PropertyDescriptor CHANGE_GROUP = new PropertyDescriptor.Builder()
             .name("Group")
+            .displayName("Group")
             .description("Sets the group on the output file to the value of this attribute.  You may also use expression language such "
                     + "as ${file.group}.")
             .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
     public static final PropertyDescriptor CREATE_DIRS = new PropertyDescriptor.Builder()
             .name("Create Missing Directories")
-            .description("If true, then missing destination directories will be created. If false, flowfiles are penalized and sent to failure.")
+            .displayName("Create Missing Directories")
+            .description("If true, then missing destination or archive directories will be created. "
+                    + "If false, missing destination or archive directories will cause the FlowFile to be penalized and sent to failure.")
             .required(true)
             .allowableValues("true", "false")
             .defaultValue("true")
             .build();
+    public static final PropertyDescriptor ARCHIVE_DIRECTORY = new PropertyDescriptor.Builder()
+            .name("Archive Directory")
+            .displayName("Archive Directory")
+            .description("Directory to place an existing file if the FlowFile would otherwise overwrite the file.")
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .dependsOn(CONFLICT_RESOLUTION, ARCHIVE_RESOLUTION)
+            .build();
+    public static final PropertyDescriptor ARCHIVE_FILENAME_EXTENSION = new PropertyDescriptor.Builder()
+            .name("Archive Filename Extension")
+            .displayName("Archive Filename Extension")
+            .description("Extension added to the end of the filename when it is archived.")
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .dependsOn(CONFLICT_RESOLUTION, ARCHIVE_RESOLUTION)
+            .build();
+    public static final PropertyDescriptor MAX_ARCHIVE_FILES = new PropertyDescriptor.Builder()
+            .name("Maximum Archive File Count")
+            .displayName("Maximum Archive File Count")
+            .description("Specifies the maximum number of archive files that can exist in the archive directory.")
+            .required(false)
+            .addValidator(StandardValidators.INTEGER_VALIDATOR)
+            .dependsOn(CONFLICT_RESOLUTION, ARCHIVE_RESOLUTION)
+            .build();
+    public static final PropertyDescriptor GUARANTEE_UNIQUE_ARCHIVE_FILENAME = new PropertyDescriptor.Builder()
+            .name("Guarantee Archive Filename Uniqueness")
+            .displayName("Guarantee Archive Filename Uniqueness")
+            .description("If true and the archive filename already exists, a unique identifier will be added to the end of the new archive filename being created.")
+            .required(false)
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .dependsOn(CONFLICT_RESOLUTION, ARCHIVE_RESOLUTION)
+            .build();
 
-    public static final int MAX_FILE_LOCK_ATTEMPTS = 10;
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("Files that have been successfully written to the output directory are transferred to this relationship")
@@ -182,6 +247,22 @@ public class PutFile extends AbstractProcessor {
 
     private List<PropertyDescriptor> properties;
     private Set<Relationship> relationships;
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        Collection<ValidationResult> results = new ArrayList<>();
+
+        if (validationContext.getProperty(CONFLICT_RESOLUTION).getValue().equals(ARCHIVE_RESOLUTION)) {
+            if (!validationContext.getProperty(ARCHIVE_DIRECTORY).isSet()) {
+                results.add(new ValidationResult.Builder()
+                        .subject(ARCHIVE_DIRECTORY.getName())
+                        .explanation("value must be provided when Conflict Resolution is set to 'archive'")
+                        .valid(false)
+                        .build());
+            }
+        }
+        return results;
+    }
 
     @Override
     protected void init(final ProcessorInitializationContext context) {
@@ -201,6 +282,10 @@ public class PutFile extends AbstractProcessor {
         supDescriptors.add(CHANGE_PERMISSIONS);
         supDescriptors.add(CHANGE_OWNER);
         supDescriptors.add(CHANGE_GROUP);
+        supDescriptors.add(ARCHIVE_DIRECTORY);
+        supDescriptors.add(ARCHIVE_FILENAME_EXTENSION);
+        supDescriptors.add(MAX_ARCHIVE_FILES);
+        supDescriptors.add(GUARANTEE_UNIQUE_ARCHIVE_FILENAME);
         properties = Collections.unmodifiableList(supDescriptors);
     }
 
@@ -225,79 +310,49 @@ public class PutFile extends AbstractProcessor {
         final Path configuredRootDirPath = Paths.get(context.getProperty(DIRECTORY).evaluateAttributeExpressions(flowFile).getValue());
         final String conflictResponse = context.getProperty(CONFLICT_RESOLUTION).getValue();
         final Integer maxDestinationFiles = context.getProperty(MAX_DESTINATION_FILES).asInteger();
+        final Integer maxArchiveFiles = context.getProperty(MAX_ARCHIVE_FILES).asInteger();
         final ComponentLog logger = getLogger();
+        final boolean archiveEnabled = context.getProperty(ARCHIVE_DIRECTORY).isSet();
 
         Path tempDotCopyFile = null;
         try {
             final Path rootDirPath = configuredRootDirPath.toAbsolutePath();
             String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
-            final Path tempCopyFile = rootDirPath.resolve("." + filename);
-            final Path copyFile = rootDirPath.resolve(filename);
+            final Path dotCopyFile = rootDirPath.resolve("." + filename); //tempCopyFile;
+            tempDotCopyFile = dotCopyFile;
+            Path finalCopyFile = rootDirPath.resolve(filename);
+
+            String archiveFilename = "";
+            Path archiveFile = Paths.get("");
+            Path archiveDirPath = Paths.get("");
+            if (archiveEnabled) {
+                final Path configuredArchiveDirPath = Paths.get(context.getProperty(ARCHIVE_DIRECTORY).evaluateAttributeExpressions(flowFile).getValue());
+                archiveDirPath = configuredArchiveDirPath.toAbsolutePath();
+                archiveFilename = archiveDirPath + "/" + filename;
+                String extension = context.getProperty(ARCHIVE_FILENAME_EXTENSION).evaluateAttributeExpressions(flowFile).getValue();
+                if (extension != null)
+                        archiveFilename += extension;
+                archiveFile = Paths.get(archiveFilename);
+
+                if (Files.exists(archiveFile) && context.getProperty(GUARANTEE_UNIQUE_ARCHIVE_FILENAME).asBoolean()) {
+                    archiveFilename = String.join("-", archiveFilename, UUID.randomUUID().toString());
+                    archiveFile = Paths.get(archiveFilename);
+                }
+            }
 
             final String permissions = context.getProperty(CHANGE_PERMISSIONS).evaluateAttributeExpressions(flowFile).getValue();
             final String owner = context.getProperty(CHANGE_OWNER).evaluateAttributeExpressions(flowFile).getValue();
             final String group = context.getProperty(CHANGE_GROUP).evaluateAttributeExpressions(flowFile).getValue();
-            if (!Files.exists(rootDirPath)) {
-                if (context.getProperty(CREATE_DIRS).asBoolean()) {
-                    Path existing = rootDirPath;
-                    while (!Files.exists(existing)) {
-                        existing = existing.getParent();
-                    }
-                    if (permissions != null && !permissions.trim().isEmpty()) {
-                        try {
-                            String perms = stringPermissions(permissions, true);
-                            if (!perms.isEmpty()) {
-                                Files.createDirectories(rootDirPath, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(perms)));
-                            } else {
-                                Files.createDirectories(rootDirPath);
-                            }
-                        } catch (Exception e) {
-                            flowFile = session.penalize(flowFile);
-                            session.transfer(flowFile, REL_FAILURE);
-                            logger.error("Could not set create directory with permissions {} because {}", new Object[]{permissions, e});
-                            return;
-                        }
-                    } else {
-                        Files.createDirectories(rootDirPath);
-                    }
-
-                    boolean chOwner = owner != null && !owner.trim().isEmpty();
-                    boolean chGroup = group != null && !group.trim().isEmpty();
-                    if (chOwner || chGroup) {
-                        Path currentPath = rootDirPath;
-                        while (!currentPath.equals(existing)) {
-                            if (chOwner) {
-                                try {
-                                    UserPrincipalLookupService lookupService = currentPath.getFileSystem().getUserPrincipalLookupService();
-                                    Files.setOwner(currentPath, lookupService.lookupPrincipalByName(owner));
-                                } catch (Exception e) {
-                                    logger.warn("Could not set directory owner to {} because {}", new Object[]{owner, e});
-                                }
-                            }
-                            if (chGroup) {
-                                try {
-                                    UserPrincipalLookupService lookupService = currentPath.getFileSystem().getUserPrincipalLookupService();
-                                    PosixFileAttributeView view = Files.getFileAttributeView(currentPath, PosixFileAttributeView.class);
-                                    view.setGroup(lookupService.lookupPrincipalByGroupName(group));
-                                } catch (Exception e) {
-                                    logger.warn("Could not set file group to {} because {}", new Object[]{group, e});
-                                }
-                            }
-                            currentPath = currentPath.getParent();
-                        }
-                    }
-                } else {
-                    flowFile = session.penalize(flowFile);
-                    session.transfer(flowFile, REL_FAILURE);
-                    logger.error("Penalizing {} and routing to 'failure' because the output directory {} does not exist and Processor is "
-                            + "configured not to create missing directories", new Object[]{flowFile, rootDirPath});
-                    return;
-                }
+            final boolean createDirectories = context.getProperty(CREATE_DIRS).asBoolean();
+            boolean success = createDirectory(rootDirPath, createDirectories, permissions, owner, group, flowFile, logger);
+            // Penalize FlowFile and send to failure if the target directory does not exist and cannot be created
+            if (!success) {
+                logger.warn("Penalizing {} and routing to 'failure' because output directory does not exist and could not be created: {}",
+                        flowFile, archiveDirPath.toAbsolutePath());
+                flowFile = session.penalize(flowFile);
+                session.transfer(flowFile, REL_FAILURE);
+                return;
             }
-
-            final Path dotCopyFile = tempCopyFile;
-            tempDotCopyFile = dotCopyFile;
-            Path finalCopyFile = copyFile;
 
             final Path finalCopyFileDir = finalCopyFile.getParent();
             if (Files.exists(finalCopyFileDir) && maxDestinationFiles != null) { // check if too many files already
@@ -305,8 +360,20 @@ public class PutFile extends AbstractProcessor {
 
                 if (numFiles >= maxDestinationFiles) {
                     flowFile = session.penalize(flowFile);
-                    logger.warn("Penalizing {} and routing to 'failure' because the output directory {} has {} files, which exceeds the "
-                            + "configured maximum number of files", new Object[]{flowFile, finalCopyFileDir, numFiles});
+                    logger.warn("Penalizing {} and routing to 'failure' because the output directory {} has {} files, which equals or exceeds the "
+                            + "configured maximum number of files", flowFile, finalCopyFileDir, numFiles );
+                    session.transfer(flowFile, REL_FAILURE);
+                    return;
+                }
+            }
+
+            if (archiveEnabled && Files.exists(archiveDirPath) && maxArchiveFiles != null) { // check if too many files in archive directory already
+                final long  numFiles = getFilesNumberInFolder(archiveDirPath, archiveFilename);
+
+                if (numFiles >= maxArchiveFiles) {
+                    flowFile = session.penalize(flowFile);
+                    logger.warn("Penalizing {} and routing to 'failure' because the archive directory {} has {} files, which equals or exceeds the "
+                            + "configured maximum number of files", flowFile, archiveDirPath, numFiles);
                     session.transfer(flowFile, REL_FAILURE);
                     return;
                 }
@@ -316,17 +383,38 @@ public class PutFile extends AbstractProcessor {
                 switch (conflictResponse) {
                     case REPLACE_RESOLUTION:
                         Files.delete(finalCopyFile);
-                        logger.info("Deleted {} as configured in order to replace with the contents of {}", new Object[]{finalCopyFile, flowFile});
+                        logger.info("Deleted {} as configured in order to replace with the contents of {}", finalCopyFile.toAbsolutePath(), flowFile);
                         break;
                     case IGNORE_RESOLUTION:
                         session.transfer(flowFile, REL_SUCCESS);
-                        logger.info("Transferring {} to success because file with same name already exists", new Object[]{flowFile});
+                        logger.info("Transferring {} to success and overwriting file '{}' because Conflict Resolution Strategy is set to 'ignore'", flowFile, finalCopyFile.toAbsolutePath());
                         return;
                     case FAIL_RESOLUTION:
                         flowFile = session.penalize(flowFile);
-                        logger.warn("Penalizing {} and routing to failure as configured because file with the same name already exists", new Object[]{flowFile});
+                        logger.warn("Penalizing {} and routing to 'failure' as configured because file with the same name already exists", flowFile);
                         session.transfer(flowFile, REL_FAILURE);
                         return;
+                    case ARCHIVE_RESOLUTION:
+                        // attempt to create archive directory
+                        success = createDirectory(archiveDirPath, createDirectories, permissions, owner, group, flowFile, logger);
+                        // Penalize FlowFile and send to failure if the archive directory does not exist and cannot be created
+                        if (!success) {
+                            logger.warn("Penalizing {} and routing to 'failure' because archive directory does not exist and could not be created: {}", flowFile, archiveDirPath.toAbsolutePath());
+                            flowFile = session.penalize(flowFile);
+                            session.transfer(flowFile, REL_FAILURE);
+                            return;
+                        }
+                        // If archive file already exists, follow fail resolution strategy: penalize and route to failure
+                        if (Files.exists(archiveFile)) {
+                            flowFile = session.penalize(flowFile);
+                            logger.warn("Penalizing {} and routing to 'failure' because archive file with the same name already exists: {}",
+                                    flowFile, archiveFile.toAbsolutePath());
+                            session.transfer(flowFile, REL_FAILURE);
+                            return;
+                        }
+                        // Archive existing file before writing current FlowFile to prevent overwriting the file
+                        logger.info("Archiving file {} to {} before replacing with FlowFile {}", finalCopyFile.toAbsolutePath(), archiveFile.toAbsolutePath(), flowFile);
+                        Files.move(finalCopyFile, archiveFile);
                     default:
                         break;
                 }
@@ -341,7 +429,7 @@ public class PutFile extends AbstractProcessor {
                     final Date fileModifyTime = formatter.parse(lastModifiedTime);
                     dotCopyFile.toFile().setLastModified(fileModifyTime.getTime());
                 } catch (Exception e) {
-                    logger.warn("Could not set file lastModifiedTime to {} because {}", new Object[]{lastModifiedTime, e});
+                    logger.warn("Could not set file lastModifiedTime to {} because {}", lastModifiedTime, e);
                 }
             }
 
@@ -352,7 +440,7 @@ public class PutFile extends AbstractProcessor {
                         Files.setPosixFilePermissions(dotCopyFile, PosixFilePermissions.fromString(perms));
                     }
                 } catch (Exception e) {
-                    logger.warn("Could not set file permissions to {} because {}", new Object[]{permissions, e});
+                    logger.warn("Could not set file permissions to {} because {}", permissions, e);
                 }
             }
 
@@ -361,7 +449,7 @@ public class PutFile extends AbstractProcessor {
                     UserPrincipalLookupService lookupService = dotCopyFile.getFileSystem().getUserPrincipalLookupService();
                     Files.setOwner(dotCopyFile, lookupService.lookupPrincipalByName(owner));
                 } catch (Exception e) {
-                    logger.warn("Could not set file owner to {} because {}", new Object[]{owner, e});
+                    logger.warn("Could not set file owner to {} because {}", owner, e);
                 }
             }
 
@@ -371,7 +459,7 @@ public class PutFile extends AbstractProcessor {
                     PosixFileAttributeView view = Files.getFileAttributeView(dotCopyFile, PosixFileAttributeView.class);
                     view.setGroup(lookupService.lookupPrincipalByGroupName(group));
                 } catch (Exception e) {
-                    logger.warn("Could not set file group to {} because {}", new Object[]{group, e});
+                    logger.warn("Could not set file group to {} because {}", group, e);
                 }
             }
 
@@ -386,11 +474,11 @@ public class PutFile extends AbstractProcessor {
 
             if (!renamed) {
                 if (Files.exists(dotCopyFile) && dotCopyFile.toFile().delete()) {
-                    logger.debug("Deleted dot copy file {}", new Object[]{dotCopyFile});
+                    logger.debug("Deleted dot copy file {}", dotCopyFile);
                 }
                 throw new ProcessException("Could not rename: " + dotCopyFile);
             } else {
-                logger.info("Produced copy of {} at location {}", new Object[]{flowFile, finalCopyFile});
+                logger.info("Produced copy of {} at location {}", flowFile, finalCopyFile);
             }
 
             session.getProvenanceReporter().send(flowFile, finalCopyFile.toFile().toURI().toString(), stopWatch.getElapsed(TimeUnit.MILLISECONDS));
@@ -400,21 +488,77 @@ public class PutFile extends AbstractProcessor {
                 try {
                     Files.deleteIfExists(tempDotCopyFile);
                 } catch (final Exception e) {
-                    logger.error("Unable to remove temporary file {} due to {}", new Object[]{tempDotCopyFile, e});
+                    logger.error("Unable to remove temporary file {} due to {}", tempDotCopyFile, e);
                 }
             }
 
             flowFile = session.penalize(flowFile);
-            logger.error("Penalizing {} and transferring to failure due to {}", new Object[]{flowFile, t});
+            logger.error("Penalizing {} and transferring to failure due to {}", flowFile, t);
             session.transfer(flowFile, REL_FAILURE);
         }
     }
 
-    private long getFilesNumberInFolder(Path folder, String filename) {
+    private long getFilesNumberInFolder(Path folder, String filenameToIgnore) {
         String[] filesInFolder = folder.toFile().list();
-        return Arrays.stream(filesInFolder)
-                .filter(eachFilename -> !eachFilename.equals(filename))
+        return filesInFolder == null ? 0 : Arrays.stream(filesInFolder)
+                .filter(eachFilename -> !eachFilename.equals(filenameToIgnore))
                 .count();
+    }
+
+    private boolean createDirectory(final Path rootDirPath, final boolean createDirs, final String permissions, final String owner, final String group,
+                                    final FlowFile flowFile, final ComponentLog logger) throws IOException {
+        if (!Files.exists(rootDirPath)) {
+            if (createDirs) {
+                Path existing = rootDirPath;
+                while (!Files.exists(existing)) {
+                    existing = existing.getParent();
+                }
+                if (permissions != null && !permissions.trim().isEmpty()) {
+                    try {
+                        String perms = stringPermissions(permissions, true);
+                        if (!perms.isEmpty()) {
+                            Files.createDirectories(rootDirPath, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(perms)));
+                        } else {
+                            Files.createDirectories(rootDirPath);
+                        }
+                    } catch (Exception e) {
+                        logger.error("Could not set create directory with permissions {} because {}", permissions, e);
+                        return false;
+                    }
+                } else {
+                    Files.createDirectories(rootDirPath);
+                }
+
+                boolean chOwner = owner != null && !owner.trim().isEmpty();
+                boolean chGroup = group != null && !group.trim().isEmpty();
+                if (chOwner || chGroup) {
+                    Path currentPath = rootDirPath;
+                    while (!currentPath.equals(existing)) {
+                        if (chOwner) {
+                            try {
+                                UserPrincipalLookupService lookupService = currentPath.getFileSystem().getUserPrincipalLookupService();
+                                Files.setOwner(currentPath, lookupService.lookupPrincipalByName(owner));
+                            } catch (Exception e) {
+                                logger.warn("Could not set directory owner to {} because {}", owner, e);
+                            }
+                        }
+                        if (chGroup) {
+                            try {
+                                UserPrincipalLookupService lookupService = currentPath.getFileSystem().getUserPrincipalLookupService();
+                                PosixFileAttributeView view = Files.getFileAttributeView(currentPath, PosixFileAttributeView.class);
+                                view.setGroup(lookupService.lookupPrincipalByGroupName(group));
+                            } catch (Exception e) {
+                                logger.warn("Could not set file group to {} because {}", group, e);
+                            }
+                        }
+                        currentPath = currentPath.getParent();
+                    }
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     protected String stringPermissions(String perms, boolean directory) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
@@ -20,8 +20,8 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.apache.nifi.util.file.FileUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -40,13 +40,21 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestPutFile {
 
-    public static final String TARGET_DIRECTORY = "target/put-file";
+    private static final String TARGET_DIRECTORY = "target/put-file";
+    private static final String ARCHIVE_DIRECTORY = "target/put-file-archive";
+    private static final String TARGET_FILENAME = "targetFile.txt";
     private File targetDir;
+    private File archiveDir;
 
     @BeforeClass
     public static void setUpSuite() {
@@ -55,15 +63,21 @@ public class TestPutFile {
 
     @Before
     public void prepDestDirectory() throws IOException {
-        targetDir = new File(TARGET_DIRECTORY);
+        targetDir = setupDirectory(TARGET_DIRECTORY);
+        archiveDir = setupDirectory(ARCHIVE_DIRECTORY);
+    }
+
+    private File setupDirectory(String directoryName) throws IOException {
+        File targetDir = new File(directoryName);
         if (!targetDir.exists()) {
             Files.createDirectories(targetDir.toPath());
-            return;
+            return targetDir;
         }
 
         targetDir.setReadable(true);
-
         deleteDirectoryContent(targetDir);
+
+        return targetDir;
     }
 
     private void deleteDirectoryContent(File directory) throws IOException {
@@ -83,13 +97,11 @@ public class TestPutFile {
         runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
 
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
         runner.enqueue("Hello world!!".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(TARGET_DIRECTORY + "/new-folder/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(newDir, TARGET_FILENAME, "Hello world!!"));
     }
 
     @Test
@@ -100,30 +112,23 @@ public class TestPutFile {
         runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
 
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
         runner.enqueue("Hello world!!".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(newDir + "/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(newDir, TARGET_FILENAME, "Hello world!!"));
     }
 
-    @Test(expected = AssertionError.class)
-    public void testCreateEmptyStringDirectory() throws IOException {
+    @Test
+    public void testCreateEmptyStringDirectory() {
         final TestRunner runner = TestRunners.newTestRunner(new PutFile());
         String newDir = "";
         runner.setProperty(PutFile.DIRECTORY, newDir);
         runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+        runner.assertNotValid();
 
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
-        runner.run();
-        runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(newDir + "/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        runner.setProperty(PutFile.DIRECTORY, "not-empty");
+        runner.assertValid();
     }
 
     @Test
@@ -133,24 +138,17 @@ public class TestPutFile {
         runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
 
         Map<String,String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
 
         //Second file
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Another file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
         runner.run();
         runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
-        File dir = new File(TARGET_DIRECTORY);
-        assertEquals(1, dir.list().length);
-        targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        content = Files.readAllBytes(targetPath);
-        assertEquals("Another file", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "Second file"));
     }
 
     @Test
@@ -160,24 +158,17 @@ public class TestPutFile {
         runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.IGNORE_RESOLUTION);
 
         Map<String,String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
 
         //Second file
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Another file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
         runner.run();
         runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
-        File dir = new File(TARGET_DIRECTORY);
-        assertEquals(1, dir.list().length);
-        targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
     }
 
     @Test
@@ -187,21 +178,20 @@ public class TestPutFile {
         runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.FAIL_RESOLUTION);
 
         Map<String,String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
 
         //Second file
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Another file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
         runner.run();
         runner.assertTransferCount(PutFile.REL_SUCCESS, 1);
         runner.assertTransferCount(PutFile.REL_FAILURE, 1);
         runner.assertPenalizeCount(1);
+        // Confirm file was not overwritten
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
     }
 
     @Test
@@ -212,20 +202,20 @@ public class TestPutFile {
         runner.setProperty(PutFile.MAX_DESTINATION_FILES, "1");
 
         Map<String,String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
 
         //Second file
         attributes.put(CoreAttributes.FILENAME.key(), "secondFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
         runner.run();
         runner.assertTransferCount(PutFile.REL_FAILURE, 1);
         runner.assertPenalizeCount(1);
+        // Confirm file was not overwritten; verifyOutput also confirms there is only 1 file in TARGET_DIRECTORY
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
     }
 
     @Test
@@ -236,24 +226,188 @@ public class TestPutFile {
         runner.setProperty(PutFile.MAX_DESTINATION_FILES, "1");
 
         Map<String,String> attributes = new HashMap<>();
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Hello world!!".getBytes(), attributes);
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(FetchFile.REL_SUCCESS, 1);
-        Path targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        byte[] content = Files.readAllBytes(targetPath);
-        assertEquals("Hello world!!", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "First file"));
 
         //Second file
-        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
-        runner.enqueue("Another file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
         runner.run();
         runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
-        File dir = new File(TARGET_DIRECTORY);
-        assertEquals(1, dir.list().length);
-        targetPath = Paths.get(TARGET_DIRECTORY+"/targetFile.txt");
-        content = Files.readAllBytes(targetPath);
-        assertEquals("Another file", new String(content));
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME, "Second file"));
+    }
+
+    @Test
+    public void testArchiveFile() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.ARCHIVE_RESOLUTION);
+        // Not valid yet because archive directory has not been configured
+        runner.assertNotValid();
+
+        runner.setProperty(PutFile.ARCHIVE_DIRECTORY, archiveDir.getAbsolutePath());
+        runner.assertValid();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
+        runner.run(2);
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+
+        // Check first file now in archive directory
+        assertTrue(verifyOutput(ARCHIVE_DIRECTORY, TARGET_FILENAME, "First file"));
+
+        // Check second file now in target directory
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "Second file"));
+    }
+
+    @Test
+    public void testArchiveFileWithExtension() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.ARCHIVE_RESOLUTION);
+        runner.setProperty(PutFile.ARCHIVE_DIRECTORY, archiveDir.getAbsolutePath());
+        // use expression language evaluation
+        runner.setProperty(PutFile.ARCHIVE_FILENAME_EXTENSION, "${archive.extension}");
+        runner.setProperty(PutFile.GUARANTEE_UNIQUE_ARCHIVE_FILENAME, "false");
+        runner.assertValid();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        // required attribute for expression language evaluation
+        attributes.put("archive.extension", ".arch");
+        runner.enqueue("First file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
+        runner.enqueue("Third file".getBytes(), attributes);
+        runner.run(3);
+
+        // Third file fails because filename already exists in archive directory and 'Guarantee Archive Filename Uniqueness' is false
+        runner.assertTransferCount(FetchFile.REL_FAILURE, 1);
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+
+        // Check first file now in archive directory
+        assertTrue(verifyOutput(ARCHIVE_DIRECTORY, TARGET_FILENAME + ".arch", "First file"));
+
+        // Check second file now in target directory
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "Second file"));
+    }
+
+    @Test
+    public void testArchiveFileWhenArchiveFileExistsAndUniqueGuarantee() throws IOException {
+        // PutFile.GUARANTEE_UNIQUE_ARCHIVE_FILENAME is 'true' by default
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.ARCHIVE_RESOLUTION);
+        runner.setProperty(PutFile.ARCHIVE_DIRECTORY, archiveDir.getAbsolutePath());
+        runner.setProperty(PutFile.ARCHIVE_FILENAME_EXTENSION, ".arch");
+        runner.assertValid();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
+        runner.enqueue("Third file".getBytes(), attributes);
+        runner.run(3);
+
+        // Third file adds UUID to filename because filename already exists in archive directory
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 3);
+
+        // Check that the first two files now in archive directory; both have ".arch" extension, and the second file archived has UUID appended
+        String[] dirList = new File(ARCHIVE_DIRECTORY).list();
+        assertNotNull(dirList);
+        assertEquals(2, dirList.length);
+
+        String uuidPattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+        // Check the first two files, both now in the archive directory
+        for (String actualFilename : dirList) {
+            Path path = Paths.get(String.join("/", ARCHIVE_DIRECTORY, actualFilename));
+            String actualContent = new String(Files.readAllBytes(path));
+            boolean filenameIncludesUUID = Pattern.matches(TARGET_FILENAME + ".arch-" + uuidPattern, actualFilename);
+            if (filenameIncludesUUID) {
+                // the filename including the UUID is the second file to reach the archive directory, or equivalently the second file processed in this unit test
+                assertEquals("Second file", actualContent);
+            } else {
+                // the filename without the UUID is the first file to reach the archive directory, or equivalently the first file processed in this unit test
+                assertEquals(TARGET_FILENAME + ".arch", actualFilename);
+                assertEquals("First file", actualContent);
+            }
+        }
+
+        // Check third file now in target directory
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "Third file"));
+    }
+
+    @Test
+    public void testArchiveDirDoesNotExist() throws IOException {
+        // ensure archive directory does not exist (remove it if necessary)
+        removeDirectoryNonRecursive("target/put-file-archive-dir-does-not-exist");
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.ARCHIVE_RESOLUTION);
+        runner.setProperty(PutFile.CREATE_DIRS, "false");
+        runner.setProperty(PutFile.ARCHIVE_DIRECTORY, "target/put-file-archive-dir-does-not-exist");
+        runner.assertValid();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
+        runner.run();
+
+        // First file succeeds because archive directory is not needed (filename does not exist in target directory)
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 1);
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "First file"));
+
+        runner.enqueue("Second file".getBytes(), attributes);
+        runner.run();
+
+        // Second file fails because archive directory is needed (filename exists in target directory) and 'Create Missing Directories' is set to false
+        runner.assertTransferCount(FetchFile.REL_FAILURE, 1);
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 1);
+        // Check first file still in target directory
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "First file"));
+
+        // Allow archive directory to be created
+        runner.setProperty(PutFile.CREATE_DIRS, "true");
+        runner.enqueue("Third file".getBytes(), attributes);
+        runner.run();
+
+        // Check first file now in archive directory and third file now in target directory
+        runner.assertTransferCount(FetchFile.REL_FAILURE, 1);
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "Third file"));
+        assertTrue(verifyOutput("target/put-file-archive-dir-does-not-exist", TARGET_FILENAME,  "First file"));
+
+        // Cleanup by removing the directory that should not exist
+        removeDirectoryNonRecursive("target/put-file-archive-dir-does-not-exist");
+    }
+
+    @Test
+    public void testArchiveDirMaxFileLimit() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.ARCHIVE_RESOLUTION);
+        runner.setProperty(PutFile.ARCHIVE_DIRECTORY, archiveDir.getAbsolutePath());
+        runner.setProperty(PutFile.MAX_ARCHIVE_FILES, "1");
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), TARGET_FILENAME);
+        runner.enqueue("First file".getBytes(), attributes);
+        runner.enqueue("Second file".getBytes(), attributes);
+        runner.enqueue("Third file".getBytes(), attributes);
+        runner.run(3);
+
+        // Third file fails because archive directory is full
+        runner.assertTransferCount(FetchFile.REL_FAILURE, 1);
+        runner.assertTransferCount(FetchFile.REL_SUCCESS, 2);
+
+        // Check first file now in archive directory
+        assertTrue(verifyOutput(ARCHIVE_DIRECTORY, TARGET_FILENAME, "First file"));
+
+        // Check second file now in target directory
+        assertTrue(verifyOutput(TARGET_DIRECTORY, TARGET_FILENAME,  "Second file"));
     }
 
     private TestRunner putFileRunner;
@@ -261,7 +415,7 @@ public class TestPutFile {
     private final String testFile = "src" + File.separator + "test" + File.separator + "resources" + File.separator + "hello.txt";
 
     @Before
-    public void setup() throws IOException{
+    public void setup() {
 
         putFileRunner = TestRunners.newTestRunner(PutFile.class);
         putFileRunner.setProperty(PutFile.CHANGE_OWNER, System.getProperty("user.name"));
@@ -292,34 +446,34 @@ public class TestPutFile {
         //verify directory exists
         Path newDirectory = Paths.get("target/test/data/out/PutFile/1/2/3/4/5");
         Path newFile = newDirectory.resolve("testfile.txt");
-        Assert.assertTrue("New directory not created.", newDirectory.toAbsolutePath().toFile().exists());
-        Assert.assertTrue("New File not created.", newFile.toAbsolutePath().toFile().exists());
+        assertTrue("New directory not created.", newDirectory.toAbsolutePath().toFile().exists());
+        assertTrue("New File not created.", newFile.toAbsolutePath().toFile().exists());
 
         PosixFileAttributeView filePosixAttributeView = Files.getFileAttributeView(newFile.toAbsolutePath(), PosixFileAttributeView.class);
-        Assert.assertEquals(System.getProperty("user.name"), filePosixAttributeView.getOwner().getName());
+        assertEquals(System.getProperty("user.name"), filePosixAttributeView.getOwner().getName());
         Set<PosixFilePermission> filePermissions = filePosixAttributeView.readAttributes().permissions();
-        Assert.assertTrue(filePermissions.contains(PosixFilePermission.OWNER_READ));
-        Assert.assertTrue(filePermissions.contains(PosixFilePermission.OWNER_WRITE));
-        Assert.assertFalse(filePermissions.contains(PosixFilePermission.OWNER_EXECUTE));
-        Assert.assertTrue(filePermissions.contains(PosixFilePermission.GROUP_READ));
-        Assert.assertFalse(filePermissions.contains(PosixFilePermission.GROUP_WRITE));
-        Assert.assertFalse(filePermissions.contains(PosixFilePermission.GROUP_EXECUTE));
-        Assert.assertFalse(filePermissions.contains(PosixFilePermission.OTHERS_READ));
-        Assert.assertFalse(filePermissions.contains(PosixFilePermission.OTHERS_WRITE));
-        Assert.assertFalse(filePermissions.contains(PosixFilePermission.OTHERS_EXECUTE));
+        assertTrue(filePermissions.contains(PosixFilePermission.OWNER_READ));
+        assertTrue(filePermissions.contains(PosixFilePermission.OWNER_WRITE));
+        assertFalse(filePermissions.contains(PosixFilePermission.OWNER_EXECUTE));
+        assertTrue(filePermissions.contains(PosixFilePermission.GROUP_READ));
+        assertFalse(filePermissions.contains(PosixFilePermission.GROUP_WRITE));
+        assertFalse(filePermissions.contains(PosixFilePermission.GROUP_EXECUTE));
+        assertFalse(filePermissions.contains(PosixFilePermission.OTHERS_READ));
+        assertFalse(filePermissions.contains(PosixFilePermission.OTHERS_WRITE));
+        assertFalse(filePermissions.contains(PosixFilePermission.OTHERS_EXECUTE));
 
         PosixFileAttributeView dirPosixAttributeView = Files.getFileAttributeView(newDirectory.toAbsolutePath(), PosixFileAttributeView.class);
-        Assert.assertEquals(System.getProperty("user.name"), dirPosixAttributeView.getOwner().getName());
+        assertEquals(System.getProperty("user.name"), dirPosixAttributeView.getOwner().getName());
         Set<PosixFilePermission> dirPermissions = dirPosixAttributeView.readAttributes().permissions();
-        Assert.assertTrue(dirPermissions.contains(PosixFilePermission.OWNER_READ));
-        Assert.assertTrue(dirPermissions.contains(PosixFilePermission.OWNER_WRITE));
-        Assert.assertTrue(dirPermissions.contains(PosixFilePermission.OWNER_EXECUTE));
-        Assert.assertTrue(dirPermissions.contains(PosixFilePermission.GROUP_READ));
-        Assert.assertFalse(dirPermissions.contains(PosixFilePermission.GROUP_WRITE));
-        Assert.assertTrue(dirPermissions.contains(PosixFilePermission.GROUP_EXECUTE));
-        Assert.assertFalse(dirPermissions.contains(PosixFilePermission.OTHERS_READ));
-        Assert.assertFalse(dirPermissions.contains(PosixFilePermission.OTHERS_WRITE));
-        Assert.assertFalse(dirPermissions.contains(PosixFilePermission.OTHERS_EXECUTE));
+        assertTrue(dirPermissions.contains(PosixFilePermission.OWNER_READ));
+        assertTrue(dirPermissions.contains(PosixFilePermission.OWNER_WRITE));
+        assertTrue(dirPermissions.contains(PosixFilePermission.OWNER_EXECUTE));
+        assertTrue(dirPermissions.contains(PosixFilePermission.GROUP_READ));
+        assertFalse(dirPermissions.contains(PosixFilePermission.GROUP_WRITE));
+        assertTrue(dirPermissions.contains(PosixFilePermission.GROUP_EXECUTE));
+        assertFalse(dirPermissions.contains(PosixFilePermission.OTHERS_READ));
+        assertFalse(dirPermissions.contains(PosixFilePermission.OTHERS_WRITE));
+        assertFalse(dirPermissions.contains(PosixFilePermission.OTHERS_EXECUTE));
 
         putFileRunner.clearTransferState();
     }
@@ -329,7 +483,7 @@ public class TestPutFile {
         Files.walkFileTree(Paths.get("target/test/data/out/PutFile"), new FileVisitor<Path>() {
 
             @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
                 return FileVisitResult.CONTINUE;
             }
 
@@ -340,7 +494,7 @@ public class TestPutFile {
             }
 
             @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
                 return FileVisitResult.CONTINUE;
             }
 
@@ -350,5 +504,43 @@ public class TestPutFile {
                 return FileVisitResult.CONTINUE;
             }
         });
+    }
+
+    private void removeDirectoryNonRecursive(String directoryName) throws IOException {
+        // This method does not recurse subdirectories
+        if (Files.exists(Paths.get(directoryName))) {
+            FileUtils.deleteFilesInDir(new File(directoryName), null, null);
+            Files.delete(Paths.get(directoryName));
+        }
+    }
+
+    /**
+     * This method verifies the following:
+     * 1) target directory contains exactly 1 file
+     * 2) expected name of the file in the target directory
+     * 3) contents of the file in the target directory
+     *
+     * @param directoryName   name of the target directory
+     * @param filename        name of the file in the target directory
+     * @param expectedContent content of the file in the target directory
+     * @return true if the above conditions are true
+     * @throws IOException when there is a failure accessing a file
+     */
+    private boolean verifyOutput(final String directoryName, final String filename, final String expectedContent) throws IOException {
+        File directory = new File(directoryName);
+        String[] dirList = directory.list();
+        if (dirList == null) {
+            fail("Directory is null; expected directory to exist and contain 1 file: " + directoryName);
+            return false;
+        }
+        assertEquals(1, dirList.length);
+        Path path = Paths.get(String.join("/", directoryName, filename));
+        if (!Files.exists(path)) {
+            fail("File does not exist in expected location: " + directoryName + "/" + filename);
+            return false;
+        }
+        String actualContent = new String(Files.readAllBytes(path));
+        assertEquals(expectedContent, actualContent);
+        return true;
     }
 }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

Adds a conflict resolution strategy of "archive" for PutFile. Instead of overwriting an existing file or failing, the existing file is moved to an archive directory. The filename is optionally changed when it is archived. See the updated processor description and description of new properties for more details.

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [X] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
