### PR TITLE
NIFI-9233 - Improve reliability of system integration tests

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/server/ZooKeeperStateServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/server/ZooKeeperStateServer.java
@@ -175,24 +175,32 @@ public class ZooKeeperStateServer extends ZooKeeperServerMain {
         if (started) {
             started = false;
 
+            if (quorumPeer != null && quorumPeer.isRunning()) {
+                quorumPeer.shutdown();
+            }
+
+            if (connectionFactory != null) {
+                try {
+                    connectionFactory.shutdown();
+                } catch (Exception e) {
+                    logger.warn("Failed to shutdown Connection Factory", e);
+                }
+            }
+
+            if (embeddedZkServer != null && embeddedZkServer.isRunning()) {
+                try {
+                    embeddedZkServer.shutdown();
+                } catch (Exception e) {
+                    logger.warn("Failed to shutdown Embedded Zookeeper", e);
+                }
+            }
+
             if (transactionLog != null) {
                 try {
                     transactionLog.close();
                 } catch (final IOException ioe) {
                     logger.warn("Failed to close Transaction Log", ioe);
                 }
-            }
-
-            if (connectionFactory != null) {
-                connectionFactory.shutdown();
-            }
-
-            if (quorumPeer != null && quorumPeer.isRunning()) {
-                quorumPeer.shutdown();
-            }
-
-            if (embeddedZkServer != null && embeddedZkServer.isRunning()) {
-                embeddedZkServer.shutdown();
             }
 
             if (datadirCleanupManager != null) {


### PR DESCRIPTION
#### Description of PR

Observed a NullPointerException in embedded ZooKeeper shutdown while running system tests.  This was causing FlowController shutdown to fail, which resulted in lingering threads and cluster node shutdown hang.  Catch and log the exception, which will allow the process to shutdown cleanly.

Also adjusted order of object cleanup to match that of initialization. 

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
