### PR TITLE
NIFI-XXXX Add Unit As Validated Parameter

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.aws.cloudwatch;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.apache.nifi.processors.aws.AbstractAWSCredentialsProviderProcessor;
@@ -23,18 +24,26 @@ import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredential
 import org.apache.nifi.processors.aws.sns.PutSNS;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.assumeThat;
 
 /**
- * Provides integration level testing with actual AWS CloudWatch resources for {@link PutCloudWatchMetric} and requires additional configuration and resources to work.
+ * Provides integration level testing with actual AWS CloudWatch resources for {@link PutCloudWatchMetric}
+ * and requires additional configuration and resources to work.
  */
 public class ITPutCloudWatchMetric {
 
-    private final String CREDENTIALS_FILE = System.getProperty("user.home") + "/aws-credentials.properties";
+    private final String CREDENTIALS_FILE = System.getProperty("user.home") + "/aws-credentials";
 
     @Test
-    public void testPublish() throws IOException {
+    public void ifCredentialsThenTestPublish() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
+        File credsFile = new File(CREDENTIALS_FILE);
+        assumeThat(credsFile.exists(), is(true));
 
         runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
         runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
@@ -48,8 +57,10 @@ public class ITPutCloudWatchMetric {
     }
 
     @Test
-    public void testPublishWithCredentialsProviderService() throws Throwable {
+    public void ifCredentialsThenTestPublishWithCredentialsProviderService() throws Throwable {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
+        File credsFile = new File(CREDENTIALS_FILE);
+        assumeThat(credsFile.exists(), is(true));
 
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
@@ -305,28 +305,6 @@ public class TestPutCloudWatchMetric {
         runner.assertValid();
     }
 
-
-    @ParameterizedTest
-    @CsvSource({"Count","Bytes","Percent"})
-    //figure out why this is not working...
-    public void testValidUnitRoutesToSuccess(String unit) {
-        MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
-        mockPutCloudWatchMetric.throwException = new InvalidParameterValueException("Unit error message");
-        final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
-
-        runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
-        runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
-        runner.setProperty(PutCloudWatchMetric.VALUE, "6");
-        runner.setProperty(PutCloudWatchMetric.UNIT, unit);
-        runner.assertValid();
-
-        runner.enqueue(new byte[] {});
-        runner.run();
-
-        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-//        runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-    }
-
     @Test
     public void testTimestampExpressionInvalidRoutesToFailure() throws Exception {
         MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

We are adding unit tests for the AWS region and Unit parameters for cloud watch metrics. We are additionally bypassing Integration tests when the static CREDENTIALS_FILE is not present on the system path. This stream lines the test and prevents build issues when a credentials file is not present for the integration test. It also introduces a warning to the user when the user goes to configure the Unit parameter in the processor's UI. It looks for the a blank default value or one of the values listed in https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
