### PR TITLE
NIFI-9638 Refactor Google Guava usage in extensions

### DIFF
--- a/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-processors/src/main/java/org/apache/nifi/accumulo/processors/BaseAccumuloProcessor.java
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-processors/src/main/java/org/apache/nifi/accumulo/processors/BaseAccumuloProcessor.java
@@ -17,12 +17,15 @@
  */
 package org.apache.nifi.accumulo.processors;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.accumulo.controllerservices.BaseAccumuloService;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Base Accumulo class that provides connector services, table name, and thread
@@ -79,7 +82,5 @@ public abstract class BaseAccumuloProcessor extends AbstractProcessor {
      * so that implementations must constructor their own lists knowingly
      */
 
-    protected static final ImmutableList<PropertyDescriptor> baseProperties = ImmutableList.of(ACCUMULO_CONNECTOR_SERVICE,TABLE_NAME,CREATE_TABLE,THREADS,ACCUMULO_TIMEOUT);
-
-
+    protected static final List<PropertyDescriptor> baseProperties = Collections.unmodifiableList(Arrays.asList(ACCUMULO_CONNECTOR_SERVICE, TABLE_NAME, CREATE_TABLE, THREADS, ACCUMULO_TIMEOUT));
 }

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestFetchS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestFetchS3Object.java
@@ -18,13 +18,14 @@ package org.apache.nifi.processors.aws.s3;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.SdkClientException;
-import com.google.common.collect.ImmutableMap;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -245,7 +246,7 @@ public class TestFetchS3Object {
 
 
     @Test
-    public void testGetObjectExceptionGoesToFailure() throws IOException {
+    public void testGetObjectExceptionGoesToFailure() {
         runner.setProperty(FetchS3Object.REGION, "us-east-1");
         runner.setProperty(FetchS3Object.BUCKET, "request-bucket");
         final Map<String, String> attrs = new HashMap<>();
@@ -267,7 +268,12 @@ public class TestFetchS3Object {
         runner.enqueue(new byte[0], attrs);
 
         final AmazonS3Exception exception = new AmazonS3Exception("The specified bucket does not exist");
-        exception.setAdditionalDetails(ImmutableMap.of("BucketName", "us-east-1", "Error", "ABC123"));
+
+        final Map<String, String> details = new LinkedHashMap<>();
+        details.put("BucketName", "us-east-1");
+        details.put("Error", "ABC123");
+
+        exception.setAdditionalDetails(details);
         exception.setErrorCode("NoSuchBucket");
         exception.setStatusCode(HttpURLConnection.HTTP_NOT_FOUND);
         Mockito.doThrow(exception).when(mockS3Client).getObject(Mockito.any());
@@ -291,7 +297,7 @@ public class TestFetchS3Object {
         runner.enqueue(new byte[0], attrs);
 
         final AmazonS3Exception exception = new AmazonS3Exception("signature");
-        exception.setAdditionalDetails(ImmutableMap.of("CanonicalRequestBytes", "AA BB CC DD EE FF"));
+        exception.setAdditionalDetails(Collections.singletonMap("CanonicalRequestBytes", "AA BB CC DD EE FF"));
         exception.setErrorCode("SignatureDoesNotMatch");
         exception.setStatusCode(HttpURLConnection.HTTP_FORBIDDEN);
         Mockito.doThrow(exception).when(mockS3Client).getObject(Mockito.any());
@@ -325,7 +331,7 @@ public class TestFetchS3Object {
     }
 
     @Test
-    public void testGetObjectReturnsNull() throws IOException {
+    public void testGetObjectReturnsNull() {
         runner.setProperty(FetchS3Object.REGION, "us-east-1");
         runner.setProperty(FetchS3Object.BUCKET, "request-bucket");
         final Map<String, String> attrs = new HashMap<>();
@@ -339,7 +345,7 @@ public class TestFetchS3Object {
     }
 
     @Test
-    public void testFlowFileAccessExceptionGoesToFailure() throws IOException {
+    public void testFlowFileAccessExceptionGoesToFailure() {
         runner.setProperty(FetchS3Object.REGION, "us-east-1");
         runner.setProperty(FetchS3Object.BUCKET, "request-bucket");
         final Map<String, String> attrs = new HashMap<>();
@@ -355,7 +361,7 @@ public class TestFetchS3Object {
     }
 
     @Test
-    public void testGetPropertyDescriptors() throws Exception {
+    public void testGetPropertyDescriptors() {
         FetchS3Object processor = new FetchS3Object();
         List<PropertyDescriptor> pd = processor.getSupportedPropertyDescriptors();
         assertEquals("size should be eq", 21, pd.size());

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-nar/pom.xml
@@ -44,6 +44,13 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-azure-graph-authorizer</artifactId>
             <version>1.16.0-SNAPSHOT</version>
+            <exclusions>
+                <!-- Exclude Guava provided in nifi-azure-services-api-nar -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -171,11 +171,6 @@
             <version>2.11.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>${jackson.version}</version>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.azure.storage.OperationContext;
 import org.apache.commons.codec.DecoderException;
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -194,7 +193,6 @@ public class PutAzureBlobStorage extends AbstractAzureBlobProcessor {
 
     }
 
-    @VisibleForTesting
     void uploadBlob(CloudBlob blob, OperationContext operationContext, BlobRequestOptions blobRequestOptions, InputStream in) throws StorageException, IOException {
         blob.upload(in, -1, null, blobRequestOptions, operationContext);
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -21,7 +21,6 @@ import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -173,7 +172,6 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         }
     }
 
-    @VisibleForTesting
     static void uploadContent(DataLakeFileClient fileClient, InputStream in, long length) {
         long chunkStart = 0;
         long chunkSize;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHubTest.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHubTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -56,7 +58,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
 
@@ -155,7 +156,7 @@ public class PutAzureEventHubTest {
         testRunner.setProperty(PutAzureEventHub.PARTITIONING_KEY_ATTRIBUTE_NAME, TEST_PARTITIONING_KEY_ATTRIBUTE_NAME);
 
         MockFlowFile flowFile = new MockFlowFile(1234);
-        flowFile.putAttributes(ImmutableMap.of(TEST_PARTITIONING_KEY_ATTRIBUTE_NAME, TEST_PARTITIONING_KEY));
+        flowFile.putAttributes(Collections.singletonMap(TEST_PARTITIONING_KEY_ATTRIBUTE_NAME, TEST_PARTITIONING_KEY));
         testRunner.enqueue(flowFile);
         testRunner.run(1, true);
 
@@ -178,7 +179,7 @@ public class PutAzureEventHubTest {
         setUpStandardTestConfig();
 
         MockFlowFile flowFile = new MockFlowFile(1234);
-        flowFile.putAttributes(ImmutableMap.of(TEST_PARTITIONING_KEY_ATTRIBUTE_NAME, TEST_PARTITIONING_KEY));
+        flowFile.putAttributes(Collections.singletonMap(TEST_PARTITIONING_KEY_ATTRIBUTE_NAME, TEST_PARTITIONING_KEY));
 
         // Key not specified
         testRunner.enqueue(flowFile);
@@ -210,7 +211,11 @@ public class PutAzureEventHubTest {
         setUpStandardTestConfig();
 
         MockFlowFile flowFile = new MockFlowFile(1234);
-        ImmutableMap<String, String> demoAttributes = ImmutableMap.of("A", "a", "B", "b", "D", "d", "C", "c");
+        final Map<String, String> demoAttributes = new LinkedHashMap<>();
+        demoAttributes.put("A", "a");
+        demoAttributes.put("B", "b");
+        demoAttributes.put("D", "d");
+        demoAttributes.put("C", "c");
         flowFile.putAttributes(demoAttributes);
 
         testRunner.enqueue(flowFile);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITDeleteAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITDeleteAzureBlobStorage_v12.java
@@ -18,7 +18,6 @@ package org.apache.nifi.processors.azure.storage;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.specialized.BlobClientBase;
-import com.google.common.collect.Sets;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
@@ -174,7 +173,7 @@ public class ITDeleteAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT
     }
 
     private void assertProvenanceEvents() {
-        Set<ProvenanceEventType> expectedEventTypes = Sets.newHashSet(ProvenanceEventType.REMOTE_INVOCATION);
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(ProvenanceEventType.REMOTE_INVOCATION);
 
         Set<ProvenanceEventType> actualEventTypes = runner.getProvenanceEvents().stream()
                 .map(ProvenanceEventRecord::getEventType)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITFetchAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITFetchAzureBlobStorage_v12.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.processors.azure.storage;
 
-import com.google.common.collect.Sets;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
@@ -187,7 +186,7 @@ public class ITFetchAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT 
     }
 
     private void assertProvenanceEvents() {
-        Set<ProvenanceEventType> expectedEventTypes = Sets.newHashSet(ProvenanceEventType.FETCH);
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(ProvenanceEventType.FETCH);
 
         Set<ProvenanceEventType> actualEventTypes = runner.getProvenanceEvents().stream()
                 .map(ProvenanceEventRecord::getEventType)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITFetchAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITFetchAzureDataLakeStorage.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.processors.azure.storage;
 
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
-import com.google.common.collect.Sets;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
@@ -25,8 +24,10 @@ import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -447,7 +448,7 @@ public class ITFetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT 
     private void testSuccessfulFetch(String fileSystem, String directory, String filename, String rangeStart, String rangeLength,
                                  Map<String, String> attributes, String inputFlowFileContent, String expectedFlowFileContent) {
         // GIVEN
-        Set<ProvenanceEventType> expectedEventTypes = Sets.newHashSet(ProvenanceEventType.CONTENT_MODIFIED, ProvenanceEventType.FETCH);
+        Set<ProvenanceEventType> expectedEventTypes = new LinkedHashSet<>(Arrays.asList(ProvenanceEventType.CONTENT_MODIFIED, ProvenanceEventType.FETCH));
 
         setRunnerProperties(fileSystem, directory, filename, rangeStart, rangeLength);
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
@@ -18,7 +18,6 @@ package org.apache.nifi.processors.azure.storage;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
-import com.google.common.collect.Sets;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
@@ -175,7 +174,7 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     }
 
     private void assertProvenanceEvents() {
-        Set<ProvenanceEventType> expectedEventTypes = Sets.newHashSet(ProvenanceEventType.SEND);
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(ProvenanceEventType.SEND);
 
         Set<ProvenanceEventType> actualEventTypes = runner.getProvenanceEvents().stream()
                 .map(ProvenanceEventRecord::getEventType)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureDataLakeStorage.java
@@ -18,8 +18,6 @@ package org.apache.nifi.processors.azure.storage;
 
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
-import com.google.common.collect.Sets;
-import com.google.common.net.UrlEscapers;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
@@ -40,7 +38,6 @@ import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_FILENAME;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_FILESYSTEM;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_LENGTH;
-import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_PRIMARY_URI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -299,14 +296,6 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         flowFile.assertAttributeEquals(ATTR_NAME_DIRECTORY, directory);
         flowFile.assertAttributeEquals(ATTR_NAME_FILENAME, fileName);
 
-        String urlEscapedDirectory = UrlEscapers.urlPathSegmentEscaper().escape(directory);
-        String urlEscapedFileName = UrlEscapers.urlPathSegmentEscaper().escape(fileName);
-        String urlEscapedPathSeparator = UrlEscapers.urlPathSegmentEscaper().escape("/");
-        String primaryUri = StringUtils.isNotEmpty(directory)
-                ? String.format("https://%s.dfs.core.windows.net/%s/%s%s%s", getAccountName(), fileSystemName, urlEscapedDirectory, urlEscapedPathSeparator, urlEscapedFileName)
-                : String.format("https://%s.dfs.core.windows.net/%s/%s", getAccountName(), fileSystemName, urlEscapedFileName);
-        flowFile.assertAttributeEquals(ATTR_NAME_PRIMARY_URI, primaryUri);
-
         flowFile.assertAttributeEquals(ATTR_NAME_LENGTH, Integer.toString(fileData.length));
     }
 
@@ -336,7 +325,7 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     }
 
     private void assertProvenanceEvents() {
-        Set<ProvenanceEventType> expectedEventTypes = Sets.newHashSet(ProvenanceEventType.SEND);
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(ProvenanceEventType.SEND);
 
         Set<ProvenanceEventType> actualEventTypes = runner.getProvenanceEvents().stream()
                 .map(ProvenanceEventRecord::getEventType)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/pom.xml
@@ -32,6 +32,10 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -55,8 +59,8 @@
                     <artifactId>azure-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -71,11 +75,6 @@
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
-            </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -98,6 +98,11 @@
                 <artifactId>commons-text</artifactId>
                 <version>1.8</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-nar/pom.xml
@@ -29,6 +29,17 @@
         <source.skip>true</source.skip>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Provided in nifi-cassandra-services-api-nar -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/pom.xml
@@ -43,6 +43,7 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <version>${cassandra.sdk.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.datastax.cassandra</groupId>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-services-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-services-nar/pom.xml
@@ -24,6 +24,17 @@
     <artifactId>nifi-cassandra-services-nar</artifactId>
     <packaging>nar</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Provided in nifi-cassandra-services-api-nar -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-services/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-services/pom.xml
@@ -48,6 +48,7 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <version>${cassandra.sdk.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/pom.xml
@@ -24,6 +24,7 @@
 
     <properties>
         <cassandra.sdk.version>3.10.2</cassandra.sdk.version>
+        <cassandra.guava.version>19.0</cassandra.guava.version>
     </properties>
 
     <artifactId>nifi-cassandra-bundle</artifactId>
@@ -62,6 +63,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.21</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${cassandra.guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/pom.xml
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/pom.xml
@@ -77,11 +77,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
-        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
@@ -18,8 +18,6 @@ package org.apache.nifi.reporting.datadog;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.AtomicDouble;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.status.ProcessGroupStatus;
 import org.apache.nifi.controller.status.ProcessorStatus;
@@ -37,6 +35,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,7 +50,7 @@ public class TestDataDogReportingTask {
 
     private ProcessGroupStatus status;
     private ProcessorStatus procStatus;
-    private ConcurrentHashMap<String, AtomicDouble> metricsMap;
+    private ConcurrentHashMap<String, Double> metricsMap;
     private MetricRegistry metricRegistry;
     private MetricsService metricsService;
     private String env = "dev";
@@ -114,7 +113,7 @@ public class TestDataDogReportingTask {
     public void testUpdateMetricsProcessor() throws InitializationException, IOException {
         MetricsService ms = new MetricsService();
         Map<String, Double> processorMetrics = ms.getProcessorMetrics(procStatus);
-        Map<String, String> tagsMap = ImmutableMap.of("env", "test");
+        Map<String, String> tagsMap = Collections.singletonMap("env", "test");
         DataDogReportingTask dataDogReportingTask = new TestableDataDogReportingTask();
         dataDogReportingTask.initialize(initContext);
         dataDogReportingTask.setup(configurationContext);
@@ -132,7 +131,7 @@ public class TestDataDogReportingTask {
     public void testUpdateMetricsJVM() throws InitializationException, IOException {
         MetricsService ms = new MetricsService();
         Map<String, Double> processorMetrics = ms.getJVMMetrics(virtualMachineMetrics);
-        Map<String, String> tagsMap = ImmutableMap.of("env", "test");
+        Map<String, String> tagsMap = Collections.singletonMap("env", "test");
 
         DataDogReportingTask dataDogReportingTask = new TestableDataDogReportingTask();
         dataDogReportingTask.initialize(initContext);
@@ -205,7 +204,7 @@ public class TestDataDogReportingTask {
         }
 
         @Override
-        protected ConcurrentHashMap<String, AtomicDouble> getMetricsMap() {
+        protected ConcurrentHashMap<String, Double> getMetricsMap() {
             return metricsMap;
         }
 

--- a/nifi-nar-bundles/nifi-enrich-bundle/nifi-enrich-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-enrich-bundle/nifi-enrich-processors/pom.xml
@@ -75,11 +75,6 @@
             <version>3.6</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
-        </dependency>
-        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>2.0.5</version>

--- a/nifi-nar-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/enrich/QueryWhois.java
+++ b/nifi-nar-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/enrich/QueryWhois.java
@@ -275,7 +275,7 @@ public class QueryWhois extends AbstractEnrichProcessor {
                     }
                 } else {
                     // Otherwise call the multiline parser and get the row map;
-                    final Map<String, Map<String, String>> rowMap = parseBatchResponse(result, queryParser, queryRegex, keyLookup, "whois").rowMap();
+                    final Map<String, Map<String, String>> rowMap = parseBatchResponse(result, queryParser, queryRegex, keyLookup, "whois");
 
                     // Identify the flowfile Lookupvalue and search against the rowMap
                     String ffLookupValue = context.getProperty(QUERY_INPUT).evaluateAttributeExpressions(flowFile).getValue();

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/AbstractGCPProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/AbstractGCPProcessor.java
@@ -21,7 +21,6 @@ import com.google.cloud.Service;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.TransportOptions;
 import com.google.cloud.http.HttpTransportOptions;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ConfigVerificationResult.Outcome;
@@ -35,6 +34,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.proxy.ProxyConfiguration;
 
 import java.net.Proxy;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -125,7 +125,7 @@ public abstract class AbstractGCPProcessor<
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.of(
+        return Collections.unmodifiableList(Arrays.asList(
                 PROJECT_ID,
                 GCP_CREDENTIALS_PROVIDER_SERVICE,
                 RETRY_COUNT,
@@ -133,7 +133,7 @@ public abstract class AbstractGCPProcessor<
                 PROXY_PORT,
                 HTTP_PROXY_USERNAME,
                 HTTP_PROXY_PASSWORD,
-                ProxyConfiguration.createProxyConfigPropertyDescriptor(true, ProxyAwareTransportFactory.PROXY_SPECS)
+                ProxyConfiguration.createProxyConfigPropertyDescriptor(true, ProxyAwareTransportFactory.PROXY_SPECS))
         );
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
@@ -23,7 +23,6 @@ import com.google.cloud.BaseServiceException;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.TableId;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
@@ -104,12 +103,12 @@ public abstract class AbstractBigQueryProcessor extends AbstractGCPProcessor<Big
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor> builder()
-                .addAll(super.getSupportedPropertyDescriptors())
-                .add(DATASET)
-                .add(TABLE_NAME)
-                .add(IGNORE_UNKNOWN)
-                .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.addAll(super.getSupportedPropertyDescriptors());
+        descriptors.add(DATASET);
+        descriptors.add(TABLE_NAME);
+        descriptors.add(IGNORE_UNKNOWN);
+        return Collections.unmodifiableList(descriptors);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryBatch.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryBatch.java
@@ -26,7 +26,6 @@ import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableDataWriteChannel;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.WriteChannelConfiguration;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
@@ -54,7 +53,9 @@ import org.threeten.bp.temporal.ChronoUnit;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -225,22 +226,21 @@ public class PutBigQueryBatch extends AbstractBigQueryProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor> builder()
-                .addAll(super.getSupportedPropertyDescriptors())
-                .add(TABLE_SCHEMA)
-                .add(READ_TIMEOUT)
-                .add(SOURCE_TYPE)
-                .add(CREATE_DISPOSITION)
-                .add(WRITE_DISPOSITION)
-                .add(MAXBAD_RECORDS)
-                .add(CSV_ALLOW_JAGGED_ROWS)
-                .add(CSV_ALLOW_QUOTED_NEW_LINES)
-                .add(CSV_CHARSET)
-                .add(CSV_FIELD_DELIMITER)
-                .add(CSV_QUOTE)
-                .add(CSV_SKIP_LEADING_ROWS)
-                .add(AVRO_USE_LOGICAL_TYPES)
-                .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
+        descriptors.add(TABLE_SCHEMA);
+        descriptors.add(READ_TIMEOUT);
+        descriptors.add(SOURCE_TYPE);
+        descriptors.add(CREATE_DISPOSITION);
+        descriptors.add(WRITE_DISPOSITION);
+        descriptors.add(MAXBAD_RECORDS);
+        descriptors.add(CSV_ALLOW_JAGGED_ROWS);
+        descriptors.add(CSV_ALLOW_QUOTED_NEW_LINES);
+        descriptors.add(CSV_CHARSET);
+        descriptors.add(CSV_FIELD_DELIMITER);
+        descriptors.add(CSV_QUOTE);
+        descriptors.add(CSV_SKIP_LEADING_ROWS);
+        descriptors.add(AVRO_USE_LOGICAL_TYPES);
+        return Collections.unmodifiableList(descriptors);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryStreaming.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryStreaming.java
@@ -21,7 +21,6 @@ import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SystemResource;
 import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
@@ -53,6 +52,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,11 +103,10 @@ public class PutBigQueryStreaming extends AbstractBigQueryProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor> builder()
-                .addAll(super.getSupportedPropertyDescriptors())
-                .add(RECORD_READER)
-                .add(SKIP_INVALID_ROWS)
-                .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
+        descriptors.add(RECORD_READER);
+        descriptors.add(SKIP_INVALID_ROWS);
+        return Collections.unmodifiableList(descriptors);
     }
 
     @Override
@@ -132,7 +131,7 @@ public class PutBigQueryStreaming extends AbstractBigQueryProcessor {
 
             try (final InputStream in = session.read(flowFile)) {
                 final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
-                try (final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger());) {
+                try (final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger())) {
                     Record currentRecord;
                     while ((currentRecord = reader.nextRecord()) != null) {
                         request.addRow(convertMapRecord(currentRecord.toMap()));

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
@@ -22,7 +22,6 @@ import com.google.api.pathtemplate.ValidationException;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
-import com.google.common.collect.ImmutableList;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.ProjectSubscriptionName;
@@ -51,6 +50,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -191,10 +191,10 @@ public class ConsumeGCPubSub extends AbstractGCPubSubProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.of(PROJECT_ID,
+        return Collections.unmodifiableList(Arrays.asList(PROJECT_ID,
                 GCP_CREDENTIALS_PROVIDER_SERVICE,
                 SUBSCRIPTION,
-                BATCH_SIZE);
+                BATCH_SIZE));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.stub.GrpcPublisherStub;
 import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
-import com.google.common.collect.ImmutableList;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.protobuf.ByteString;
@@ -109,10 +108,10 @@ public class PublishGCPubSub extends AbstractGCPubSubProcessor{
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.of(PROJECT_ID,
+        return Collections.unmodifiableList(Arrays.asList(PROJECT_ID,
                 GCP_CREDENTIALS_PROVIDER_SERVICE,
                 TOPIC_NAME,
-                BATCH_SIZE);
+                BATCH_SIZE));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/lite/ConsumeGCPubSubLite.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/lite/ConsumeGCPubSubLite.java
@@ -24,7 +24,6 @@ import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.cloudpubsub.Subscriber;
 import com.google.cloud.pubsublite.cloudpubsub.SubscriberSettings;
-import com.google.common.collect.ImmutableList;
 import com.google.pubsub.v1.PubsubMessage;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -53,6 +52,7 @@ import org.apache.nifi.processors.gcp.pubsub.AbstractGCPubSubProcessor;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -171,10 +171,10 @@ public class ConsumeGCPubSubLite extends AbstractGCPubSubProcessor implements Ve
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.of(SUBSCRIPTION,
+        return Collections.unmodifiableList(Arrays.asList(SUBSCRIPTION,
                 GCP_CREDENTIALS_PROVIDER_SERVICE,
                 BYTES_OUTSTANDING,
-                MESSAGES_OUTSTANDING);
+                MESSAGES_OUTSTANDING));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/lite/PublishGCPubSubLite.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/lite/PublishGCPubSubLite.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.cloudpubsub.Publisher;
 import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.pubsub.v1.PubsubMessage;
@@ -128,11 +127,11 @@ public class PublishGCPubSubLite extends AbstractGCPubSubProcessor implements Ve
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.of(TOPIC_NAME,
+        return Collections.unmodifiableList(Arrays.asList(TOPIC_NAME,
                 GCP_CREDENTIALS_PROVIDER_SERVICE,
                 ORDERING_KEY,
                 BATCH_SIZE,
-                BATCH_BYTES);
+                BATCH_BYTES));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/AbstractGCSProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/AbstractGCSProcessor.java
@@ -21,7 +21,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.BaseServiceException;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
@@ -68,9 +67,7 @@ public abstract class AbstractGCSProcessor extends AbstractGCPProcessor<Storage,
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor>builder()
-                .addAll(super.getSupportedPropertyDescriptors())
-                .build();
+        return Collections.unmodifiableList(super.getSupportedPropertyDescriptors());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObject.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObject.java
@@ -18,7 +18,6 @@ package org.apache.nifi.processors.gcp.storage;
 
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
@@ -32,6 +31,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -79,12 +79,12 @@ public class DeleteGCSObject extends AbstractGCSProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor>builder()
-                .addAll(super.getSupportedPropertyDescriptors())
-                .add(BUCKET)
-                .add(KEY)
-                .add(GENERATION)
-                .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.addAll(super.getSupportedPropertyDescriptors());
+        descriptors.add(BUCKET);
+        descriptors.add(KEY);
+        descriptors.add(GENERATION);
+        return Collections.unmodifiableList(descriptors);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/FetchGCSObject.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/FetchGCSObject.java
@@ -22,7 +22,6 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.output.CountingOutputStream;
@@ -192,15 +191,15 @@ public class FetchGCSObject extends AbstractGCSProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor>builder()
-            .add(BUCKET)
-            .add(KEY)
-            .addAll(super.getSupportedPropertyDescriptors())
-            .add(GENERATION)
-            .add(ENCRYPTION_KEY)
-            .add(RANGE_START)
-            .add(RANGE_LENGTH)
-            .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(BUCKET);
+        descriptors.add(KEY);
+        descriptors.addAll(super.getSupportedPropertyDescriptors());
+        descriptors.add(GENERATION);
+        descriptors.add(ENCRYPTION_KEY);
+        descriptors.add(RANGE_START);
+        descriptors.add(RANGE_LENGTH);
+        return Collections.unmodifiableList(descriptors);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/ListGCSBucket.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/ListGCSBucket.java
@@ -21,7 +21,6 @@ import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.PrimaryNodeOnly;
@@ -247,17 +246,17 @@ public class ListGCSBucket extends AbstractGCSProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor>builder()
-            .add(LISTING_STRATEGY)
-            .add(TRACKING_STATE_CACHE)
-            .add(INITIAL_LISTING_TARGET)
-            .add(TRACKING_TIME_WINDOW)
-            .add(BUCKET)
-            .add(RECORD_WRITER)
-            .addAll(super.getSupportedPropertyDescriptors())
-            .add(PREFIX)
-            .add(USE_GENERATIONS)
-            .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(LISTING_STRATEGY);
+        descriptors.add(TRACKING_STATE_CACHE);
+        descriptors.add(INITIAL_LISTING_TARGET);
+        descriptors.add(TRACKING_TIME_WINDOW);
+        descriptors.add(BUCKET);
+        descriptors.add(RECORD_WRITER);
+        descriptors.addAll(super.getSupportedPropertyDescriptors());
+        descriptors.add(PREFIX);
+        descriptors.add(USE_GENERATIONS);
+        return Collections.unmodifiableList(descriptors);
     }
 
     private static final Set<Relationship> relationships = Collections.singleton(REL_SUCCESS);

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
@@ -22,7 +22,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import com.google.common.collect.ImmutableList;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
@@ -290,18 +289,17 @@ public class PutGCSObject extends AbstractGCSProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return ImmutableList.<PropertyDescriptor>builder()
-                .addAll(super.getSupportedPropertyDescriptors())
-                .add(BUCKET)
-                .add(KEY)
-                .add(CONTENT_TYPE)
-                .add(MD5)
-                .add(CRC32C)
-                .add(ACL)
-                .add(ENCRYPTION_KEY)
-                .add(OVERWRITE)
-                .add(CONTENT_DISPOSITION_TYPE)
-                .build();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
+        descriptors.add(BUCKET);
+        descriptors.add(KEY);
+        descriptors.add(CONTENT_TYPE);
+        descriptors.add(MD5);
+        descriptors.add(CRC32C);
+        descriptors.add(ACL);
+        descriptors.add(ENCRYPTION_KEY);
+        descriptors.add(OVERWRITE);
+        descriptors.add(CONTENT_DISPOSITION_TYPE);
+        return Collections.unmodifiableList(descriptors);
     }
 
     @Override
@@ -406,7 +404,7 @@ public class PutGCSObject extends AbstractGCSProcessor {
                         }
 
                         try {
-                            final Blob blob = storage.create(blobInfoBuilder.build(),
+                            final Blob blob = storage.createFrom(blobInfoBuilder.build(),
                                     in,
                                     blobWriteOptions.toArray(new Storage.BlobWriteOption[blobWriteOptions.size()])
                             );

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/AbstractGCSTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/AbstractGCSTest.java
@@ -26,29 +26,25 @@ import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processors.gcp.credentials.service.GCPCredentialsControllerService;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
 /**
  * Base class for GCS Unit Tests. Provides a framework for creating a TestRunner instance with always-required credentials.
  */
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractGCSTest {
     private static final String PROJECT_ID = System.getProperty("test.gcp.project.id", "nifi-test-gcp-project");
     private static final Integer RETRIES = 9;
 
     static final String BUCKET = RemoteStorageHelper.generateBucketName();
-
-    @Before
-    public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
-    }
 
     public static TestRunner buildNewRunner(Processor processor) throws Exception {
         final GCPCredentialsService credentialsService = new GCPCredentialsControllerService();
@@ -84,13 +80,10 @@ public abstract class AbstractGCSTest {
         final StorageOptions options = processor.getServiceOptions(runner.getProcessContext(),
                 mockCredentials);
 
-        assertEquals("Project IDs should match",
-                PROJECT_ID, options.getProjectId());
+        assertEquals(PROJECT_ID, options.getProjectId(), "Project IDs should match");
 
-        assertEquals("Retry counts should match",
-                RETRIES.intValue(), options.getRetrySettings().getMaxAttempts());
+        assertEquals(RETRIES.intValue(), options.getRetrySettings().getMaxAttempts(), "Retry counts should match");
 
-        assertSame("Credentials should be configured correctly",
-                mockCredentials, options.getCredentials());
+        assertSame(mockCredentials, options.getCredentials(), "Credentials should be configured correctly");
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObjectIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObjectIT.java
@@ -16,10 +16,11 @@
  */
 package org.apache.nifi.processors.gcp.storage;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.util.TestRunner;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -39,7 +40,7 @@ public class DeleteGCSObjectIT extends AbstractGCSIT {
         runner.setProperty(DeleteGCSObject.BUCKET, BUCKET);
         runner.assertValid();
 
-        runner.enqueue("testdata", ImmutableMap.of(
+        runner.enqueue("testdata", Collections.singletonMap(
                 CoreAttributes.FILENAME.key(), KEY
         ));
 
@@ -61,7 +62,7 @@ public class DeleteGCSObjectIT extends AbstractGCSIT {
         runner.setProperty(DeleteGCSObject.KEY, KEY);
         runner.assertValid();
 
-        runner.enqueue("testdata", ImmutableMap.of(
+        runner.enqueue("testdata", Collections.singletonMap(
                 "filename", "different-filename"
         ));
 
@@ -79,7 +80,7 @@ public class DeleteGCSObjectIT extends AbstractGCSIT {
         runner.setProperty(DeleteGCSObject.BUCKET, BUCKET);
         runner.assertValid();
 
-        runner.enqueue("testdata", ImmutableMap.of(
+        runner.enqueue("testdata", Collections.singletonMap(
                 "filename", "nonexistant-file"
         ));
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObjectTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObjectTest.java
@@ -19,12 +19,14 @@ package org.apache.nifi.processors.gcp.storage;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import com.google.common.collect.ImmutableMap;
 import org.apache.nifi.util.TestRunner;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -35,6 +37,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link DeleteGCSObject}. No connections to the Google Cloud service are made.
  */
+@ExtendWith(MockitoExtension.class)
 public class DeleteGCSObjectTest extends AbstractGCSTest {
     public static final Long GENERATION = 42L;
     static final String KEY = "somefile";
@@ -46,11 +49,6 @@ public class DeleteGCSObjectTest extends AbstractGCSTest {
 
     @Mock
     Storage storage;
-
-    @Before
-    public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
-    }
 
     @Override
     protected void addRequiredPropertiesToRunner(TestRunner runner) {
@@ -107,17 +105,19 @@ public class DeleteGCSObjectTest extends AbstractGCSTest {
         final Long generation1 = GENERATION + 1L;
         final Long generation2 = GENERATION + 2L;
 
-        runner.enqueue("testdata1", ImmutableMap.of(
-                BUCKET_ATTR, bucket1,
-                KEY_ATTR, key1,
-                GENERATION_ATTR, String.valueOf(generation1)
-        ));
+        final Map<String, String> firstAttributes = new LinkedHashMap<>();
+        firstAttributes.put(BUCKET_ATTR, bucket1);
+        firstAttributes.put(KEY_ATTR, key1);
+        firstAttributes.put(GENERATION_ATTR, String.valueOf(generation1));
 
-        runner.enqueue("testdata2", ImmutableMap.of(
-                BUCKET_ATTR, bucket2,
-                KEY_ATTR, key2,
-                GENERATION_ATTR, String.valueOf(generation2)
-        ));
+        runner.enqueue("testdata1", firstAttributes);
+
+        final Map<String, String> secondAttributes = new LinkedHashMap<>();
+        secondAttributes.put(BUCKET_ATTR, bucket2);
+        secondAttributes.put(KEY_ATTR, key2);
+        secondAttributes.put(GENERATION_ATTR, String.valueOf(generation2));
+
+        runner.enqueue("testdata2", secondAttributes);
 
         runner.run(2);
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/FetchGCSObjectIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/FetchGCSObjectIT.java
@@ -16,12 +16,12 @@
  */
 package org.apache.nifi.processors.gcp.storage;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +44,7 @@ public class FetchGCSObjectIT extends AbstractGCSIT {
         final TestRunner runner = buildNewRunner(new FetchGCSObject());
         runner.setProperty(FetchGCSObject.BUCKET, BUCKET);
 
-        runner.enqueue(new byte[0], ImmutableMap.of(
+        runner.enqueue(new byte[0], Collections.singletonMap(
                 "filename", KEY
         ));
 
@@ -74,7 +74,7 @@ public class FetchGCSObjectIT extends AbstractGCSIT {
         runner.setProperty(FetchGCSObject.BUCKET, BUCKET);
         runner.setProperty(FetchGCSObject.ENCRYPTION_KEY, ENCRYPTION_KEY);
 
-        runner.enqueue(new byte[0], ImmutableMap.of(
+        runner.enqueue(new byte[0], Collections.singletonMap(
                 "filename", KEY
         ));
 
@@ -101,7 +101,7 @@ public class FetchGCSObjectIT extends AbstractGCSIT {
     public void testFetchNonexistantFile() throws Exception {
         final TestRunner runner = buildNewRunner(new FetchGCSObject());
         runner.setProperty(FetchGCSObject.BUCKET, BUCKET);
-        runner.enqueue(new byte[0], ImmutableMap.of(
+        runner.enqueue(new byte[0], Collections.singletonMap(
                 "filename", "non-existent"
         ));
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-services-api/pom.xml
@@ -25,6 +25,17 @@
     <artifactId>nifi-gcp-services-api</artifactId>
     <packaging>jar</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Guava version from google-auth-library-oauth2-http -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -40,10 +51,6 @@
                     <artifactId>jsr305</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
@@ -52,11 +59,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -56,6 +56,11 @@
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-processors/pom.xml
@@ -61,12 +61,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-graph-client-service-api</artifactId>
             <version>1.16.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-processors/src/main/java/org/apache/nifi/processors/grpc/FlowFileIngestService.java
+++ b/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-processors/src/main/java/org/apache/nifi/processors/grpc/FlowFileIngestService.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.grpc.stub.StreamObserver;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Simple gRPC service that handles receipt of FlowFileRequest messages from external-to-NiFi gRPC
@@ -69,9 +69,9 @@ public class FlowFileIngestService extends FlowFileServiceGrpc.FlowFileServiceIm
     public FlowFileIngestService(final ComponentLog logger,
                                  final AtomicReference<ProcessSessionFactory> sessionFactoryReference,
                                  final ProcessContext context) {
-        this.context = checkNotNull(context);
-        this.sessionFactoryReference = checkNotNull(sessionFactoryReference);
-        this.logger = checkNotNull(logger);
+        this.context = requireNonNull(context);
+        this.sessionFactoryReference = requireNonNull(sessionFactoryReference);
+        this.logger = requireNonNull(logger);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-processors/src/main/java/org/apache/nifi/processors/grpc/FlowFileIngestServiceInterceptor.java
+++ b/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-processors/src/main/java/org/apache/nifi/processors/grpc/FlowFileIngestServiceInterceptor.java
@@ -36,7 +36,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Simple gRPC service call interceptor that enforces various controls
@@ -59,7 +59,7 @@ public class FlowFileIngestServiceInterceptor implements ServerInterceptor {
      * @param logger the {@link ComponentLog} for the ListenGRPC processor
      */
     public FlowFileIngestServiceInterceptor(final ComponentLog logger) {
-        this.logger = checkNotNull(logger);
+        this.logger = requireNonNull(logger);
     }
 
     /**
@@ -70,7 +70,7 @@ public class FlowFileIngestServiceInterceptor implements ServerInterceptor {
      * @return this
      */
     public FlowFileIngestServiceInterceptor enforceDNPattern(final Pattern authorizedDNPattern) {
-        this.authorizedDNpattern = checkNotNull(authorizedDNPattern);
+        this.authorizedDNpattern = requireNonNull(authorizedDNPattern);
         return this;
     }
 

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/MoveHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/MoveHDFS.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.processors.hadoop;
 
-import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -57,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -334,7 +334,7 @@ public class MoveHDFS extends AbstractHadoopProcessor {
 
     protected void processBatchOfFiles(final List<Path> files, final ProcessContext context,
                                        final ProcessSession session, FlowFile parentFlowFile) {
-        Preconditions.checkState(parentFlowFile != null, "No parent flowfile for this batch was provided");
+        Objects.requireNonNull(parentFlowFile, "No parent flowfile for this batch was provided");
 
         // process the batch of files
         final Configuration conf = getConfiguration();

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcFlowFileWriter.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcFlowFileWriter.java
@@ -16,8 +16,6 @@
  */
 package org.apache.hadoop.hive.ql.io.orc;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
@@ -27,6 +25,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -2566,11 +2565,12 @@ public class OrcFlowFileWriter implements Writer, MemoryManager.Callback {
     public void appendStripe(byte[] stripe, int offset, int length,
                              StripeInformation stripeInfo,
                              OrcProto.StripeStatistics stripeStatistics) throws IOException {
-        checkArgument(stripe != null, "Stripe must not be null");
-        checkArgument(length <= stripe.length,
-                "Specified length must not be greater specified array length");
-        checkArgument(stripeInfo != null, "Stripe information must not be null");
-        checkArgument(stripeStatistics != null,
+        Objects.requireNonNull(stripe, "Stripe must not be null");
+        if (length > stripe.length) {
+            throw new IllegalArgumentException("Specified length must not be greater specified array length");
+        }
+        Objects.requireNonNull(stripeInfo, "Stripe information must not be null");
+        Objects.requireNonNull(stripeStatistics,
                 "Stripe statistics must not be null");
 
         getStream();

--- a/nifi-nar-bundles/nifi-influxdb-bundle/nifi-influxdb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-influxdb-bundle/nifi-influxdb-processors/pom.xml
@@ -56,11 +56,5 @@
             <artifactId>gson</artifactId>
             <version>2.7</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/AbstractKuduProcessor.java
@@ -30,7 +30,6 @@ import org.apache.kudu.client.OperationResponse;
 import org.apache.kudu.client.PartialRow;
 import org.apache.kudu.client.RowError;
 import org.apache.kudu.client.SessionConfiguration;
-import org.apache.kudu.shaded.com.google.common.annotations.VisibleForTesting;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyDescriptor.Builder;
@@ -378,7 +377,6 @@ public abstract class AbstractKuduProcessor extends AbstractProcessor {
         }
     }
 
-    @VisibleForTesting
     protected void buildPartialRow(Schema schema, PartialRow row, Record record, List<String> fieldNames, boolean ignoreNull, boolean lowercaseFields) {
         for (String recordFieldName : fieldNames) {
             String colName = recordFieldName;

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/pom.xml
@@ -75,12 +75,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-json-utils</artifactId>
             <version>1.16.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/GetMongoIT.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/GetMongoIT.java
@@ -19,7 +19,6 @@
 package org.apache.nifi.processors.mongodb;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoCollection;
@@ -41,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
@@ -60,10 +60,10 @@ public class GetMongoIT {
 
     static {
         CAL = Calendar.getInstance();
-        DOCUMENTS = Lists.newArrayList(
-            new Document("_id", "doc_1").append("a", 1).append("b", 2).append("c", 3),
-            new Document("_id", "doc_2").append("a", 1).append("b", 2).append("c", 4).append("date_field", CAL.getTime()),
-            new Document("_id", "doc_3").append("a", 1).append("b", 3)
+        DOCUMENTS = Arrays.asList(
+                new Document("_id", "doc_1").append("a", 1).append("b", 2).append("c", 3),
+                new Document("_id", "doc_2").append("a", 1).append("b", 2).append("c", 4).append("date_field", CAL.getTime()),
+                new Document("_id", "doc_3").append("a", 1).append("b", 3)
         );
     }
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
@@ -319,13 +319,13 @@ class TestQueryNiFiReportingTask {
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         properties.put(QueryMetricsUtil.QUERY, "select * from BULLETINS, PROVENANCE where " +
                 "bulletinTimestamp > $bulletinStartTime and bulletinTimestamp <= $bulletinEndTime " +
-                "and timestampMillis > $provenanceStartTime and timestampMillis <= $provenanceEndTime");
+                "and timestampMillis > $provenanceStartTime and timestampMillis <= $provenanceEndTime LIMIT 10");
         reportingTask = initTask(properties);
         currentTime.set(Instant.now().toEpochMilli());
         reportingTask.onTrigger(context);
 
         List<Map<String, Object>> rows = mockRecordSinkService.getRows();
-        assertEquals(3003, rows.size());
+        assertEquals(10, rows.size());
 
         final Bulletin bulletin = BulletinFactory.createBulletin(ComponentType.INPUT_PORT.name().toLowerCase(), "ERROR", "test bulletin 3", "testFlowFileUuid");
         mockBulletinRepository.addBulletin(bulletin);
@@ -341,7 +341,7 @@ class TestQueryNiFiReportingTask {
 
         mockProvenanceRepository.registerEvent(prov1002);
 
-        currentTime.set(bulletin.getTimestamp().getTime());
+        currentTime.set(bulletin.getTimestamp().toInstant().plusSeconds(1).toEpochMilli());
         reportingTask.onTrigger(context);
 
         List<Map<String, Object>> sameRows = mockRecordSinkService.getRows();

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -375,6 +375,11 @@
                 <artifactId>sshd-sftp</artifactId>
                 <version>2.8.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/pom.xml
@@ -34,6 +34,12 @@
                 <artifactId>commons-compress</artifactId>
                 <version>1.21</version>
             </dependency>
+            <!-- Override Guava from schema-registry-client -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
#### Description of PR

NIFI-9638 is the second set of changes refactoring Google Guava references across multiple extension modules.

The majority of the changes involve updates to test classes. Several updates include updating Google Guava to 31.0.1. Additional updates include removing direct references to Google Guava classes, although the library remains a required dependency in some modules.

Changes impact the following modules:

- nifi-accumulo-processors
  - Refactored collections references
- nifi-aws-processors
  - Updated unit test class
- nifi-azure-bundle
  - Removed direct references and upgraded transitive dependency to 31.0.1
- nifi-cassandra-bundle
  - Set provided scope in Processor and Services NAR modules to avoid unnecessary copies
  - Set cassandra.guava.version to 19.0, which is the latest version supported in the Cassandra driver
- nifi-datadog-reporting-task
  - Refactored references and removed direct dependency
- nifi-enrich-processors
  - Refactored references and removed direct dependency
- nifi-evtx-processors
  - Upgraded dependency from 28.0 to 31.0.1
- nifi-gcp-bundle
  - Removed direct references and upgraded transitive dependency to 31.0.1
- nifi-graph-processors
  - Removed unused test dependency
- nifi-hwx-schema-registry-bundle
  - Refactored references and upgraded transitive dependency to 31.0.1
- nifi-kudu-processors
  - Removed direct class references to shaded class
- nifi-mongo-processors
  - Refactored and removed test dependency
- nifi-sql-reporting-tasks
  - Removed reference in test class
- nifi-standard-bundle
  - Upgraded transitive dependency to 31.0.1 overriding version from Apache Calcite libraries


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
