### PR TITLE
NIFI-9492: Fix for Chinese VPCE - Tests included

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/sqs/ITPutSQS.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/sqs/ITPutSQS.java
@@ -120,5 +120,5 @@ public class ITPutSQS {
         runner.run(1);
 
         runner.assertAllFlowFilesTransferred(PutSQS.REL_SUCCESS, 1);
-    }    
+    }
 }


### PR DESCRIPTION
#### Description of PR

fixes bug NIFI-9492
The AWS Abstract Processor not handle Chinese VPCE. I made some changes to make it available to parse correctly Chinese VPCE

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message? **NIFI-9492**

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
