### PR TITLE
NIFI-6740: Add configuration options to specify NiFi/Bootstrap communication ports

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NiFiListener.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/NiFiListener.java
@@ -33,9 +33,9 @@ public class NiFiListener {
     private ServerSocket serverSocket;
     private volatile Listener listener;
 
-    int start(final RunNiFi runner) throws IOException {
+    int start(final RunNiFi runner, final int listenPort) throws IOException {
         serverSocket = new ServerSocket();
-        serverSocket.bind(new InetSocketAddress("localhost", 0));
+        serverSocket.bind(new InetSocketAddress("localhost", listenPort));
 
         final int localPort = serverSocket.getLocalPort();
         listener = new Listener(serverSocket, runner);

--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
@@ -111,6 +111,8 @@ public class RunNiFi {
     public static final String NIFI_LOCK_FILE_NAME = "nifi.lock";
     public static final String NIFI_BOOTSTRAP_SENSITIVE_KEY = "nifi.bootstrap.sensitive.key";
 
+    public static final String NIFI_BOOTSTRAP_LISTEN_PORT_PROP = "nifi.bootstrap.listen.port";
+
     public static final String PID_KEY = "pid";
 
     public static final int STARTUP_WAIT_SECONDS = 60;
@@ -1249,8 +1251,18 @@ public class RunNiFi {
             cmdLogger.error("Self-Signed Certificate Generation Failed", e);
         }
 
+        final String listenPortPropString = props.get(NIFI_BOOTSTRAP_LISTEN_PORT_PROP);
+        int listenPortPropInt = 0; // default to zero (random ephemeral port)
+        if (listenPortPropString != null) {
+            try {
+                listenPortPropInt = Integer.parseInt(listenPortPropString.trim());
+            } catch (final Exception e) {
+                // no-op, use the default
+            }
+        }
+
         final NiFiListener listener = new NiFiListener();
-        final int listenPort = listener.start(this);
+        final int listenPort = listener.start(this, listenPortPropInt);
 
         final List<String> cmd = new ArrayList<>();
 

--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -88,6 +88,7 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String PROCESSOR_SCHEDULING_TIMEOUT = "nifi.processor.scheduling.timeout";
     public static final String BACKPRESSURE_COUNT = "nifi.queue.backpressure.count";
     public static final String BACKPRESSURE_SIZE = "nifi.queue.backpressure.size";
+    public static final String LISTENER_BOOTSTRAP_PORT = "nifi.listener.bootstrap.port";
 
     // Encryption Properties for all Repositories
     public static final String REPOSITORY_ENCRYPTION_PROTOCOL_VERSION = "nifi.repository.encryption.protocol.version";
@@ -381,6 +382,7 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String DEFAULT_SECURITY_USER_SAML_HTTP_CLIENT_READ_TIMEOUT = "30 secs";
     private static final String DEFAULT_SECURITY_USER_JWS_KEY_ROTATION_PERIOD = "PT1H";
     public static final String DEFAULT_WEB_SHOULD_SEND_SERVER_VERSION = "true";
+    public static final int DEFAULT_LISTENER_BOOTSTRAP_PORT = 0;
 
     // cluster common defaults
     public static final String DEFAULT_CLUSTER_PROTOCOL_HEARTBEAT_INTERVAL = "5 sec";
@@ -1962,6 +1964,10 @@ public class NiFiProperties extends ApplicationProperties {
 
     public String getDefaultBackPressureDataSizeThreshold() {
         return getProperty(BACKPRESSURE_SIZE, DEFAULT_BACKPRESSURE_SIZE);
+    }
+
+    public int getDefaultListenerBootstrapPort() {
+        return getIntegerProperty(LISTENER_BOOTSTRAP_PORT, DEFAULT_LISTENER_BOOTSTRAP_PORT);
     }
 
     /**

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -89,6 +89,7 @@ The following table lists the default ports used by NiFi and the corresponding p
 |Cluster Node Protocol Port*      | `nifi.cluster.node.protocol.port`     | `11443`
 |Cluster Node Load Balancing Port | `nifi.cluster.node.load.balance.port` | `6342`
 |Web HTTP Forwarding Port         | `nifi.web.http.port.forwarding`       | _none_
+|Listener Bootstrap Port          | `nifi.listener.bootstrap.port`        | _random ephemeral_
 |==================================================================================================================================================
 
 NOTE: The ports marked with an asterisk (*) have property values that are blank by default in _nifi.properties_.  The values shown in the table are the default values for these ports when <<toolkit-guide.adoc#tls_toolkit,TLS Toolkit>> is used to generate _nifi.properties_ for a secured NiFi instance.  The default Certificate Authority Port used by <<toolkit-guide.adoc#tls_toolkit,TLS Toolkit>> is `9443`.
@@ -2748,6 +2749,7 @@ configured recipients whenever NiFi is stopped.
 |`nifi.diagnostics.on.shutdown.directory`|This property specifies the location of the NiFi diagnostics directory. The default value is `./diagnostics`.
 |`nifi.diagnostics.on.shutdown.max.filecount`|This property specifies the maximum permitted number of diagnostic files. If the limit is exceeded, the oldest files are deleted. The default value is `10`.
 |`nifi.diagnostics.on.shutdown.max.directory.size`|This property specifies the maximum permitted size of the diagnostics directory. If the limit is exceeded, the oldest files are deleted. The default value is `10 MB`.
+|`nifi.bootstrap.listen.port`|This property defines the port used to listen for communications from NiFi. If this property is missing, empty, or `0`, a random ephemeral port is used.
 |====
 
 [[notification_services]]
@@ -3924,6 +3926,15 @@ These properties pertain to various security features in NiFi. Many of these pro
 |`nifi.security.user.login.identity.provider`|This indicates what type of login identity provider to use. It can be set to the identifier from a provider in the file specified in `nifi.login.identity.provider.configuration.file`. Setting this property will trigger NiFi to support username/password authentication. The default value is `single-user-provider`.
 |`nifi.security.ocsp.responder.url`|This is the URL for the Online Certificate Status Protocol (OCSP) responder if one is being used. It is blank by default.
 |`nifi.security.ocsp.responder.certificate`|This is the location of the OCSP responder certificate if one is being used. It is blank by default.
+|====
+
+=== Bootstrap Properties
+
+These properties pertain to the connection NiFi uses to receive communications from NiFi Bootstrap.
+
+|====
+|*Property*|*Description*
+|`nifi.listener.bootstrap.port`|This property defines the port used to listen for communications from NiFi Bootstrap. If this property is missing, empty, or `0`, a random ephemeral port is used.
 |====
 
 === Identity Mapping Properties

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -156,6 +156,9 @@
         <nifi.security.ocsp.responder.url />
         <nifi.security.ocsp.responder.certificate />
 
+        <!-- nifi.properties: listener bootstrap -->
+        <nifi.listener.bootstrap.port>0</nifi.listener.bootstrap.port>
+
         <!-- nifi.properties: openid connect -->
         <nifi.security.user.oidc.discovery.url />
         <nifi.security.user.oidc.connect.timeout>5 secs</nifi.security.user.oidc.connect.timeout>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
@@ -114,3 +114,6 @@ notification.max.attempts=5
 # The first curator connection issue is logged as ERROR, for example when NiFi cannot connect to one of the Zookeeper nodes.
 # Additional connection issues are logged as DEBUG until the connection is restored.
 java.arg.curator.supress.excessive.logs=-Dcurator-log-only-first-connection-issue-as-error-level=true
+
+# Port used to listen for communications from NiFi. If this property is missing, empty, or 0, a random ephemeral port is used.
+nifi.bootstrap.listen.port=0

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -244,7 +244,9 @@ nifi.security.user.saml.http.client.read.timeout=${nifi.security.user.saml.http.
 # nifi.security.group.mapping.value.anygroup=$1
 # nifi.security.group.mapping.transform.anygroup=LOWER
 
-# listener bootstrap properties
+# Listener Bootstrap properties #
+# This property defines the port used to listen for communications from NiFi Bootstrap. If this property
+# is missing, empty, or 0, a random ephemeral port is used.
 nifi.listener.bootstrap.port=${nifi.listener.bootstrap.port}
 
 # cluster common properties (all nodes must have same values) #

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -244,6 +244,9 @@ nifi.security.user.saml.http.client.read.timeout=${nifi.security.user.saml.http.
 # nifi.security.group.mapping.value.anygroup=$1
 # nifi.security.group.mapping.transform.anygroup=LOWER
 
+# listener bootstrap properties
+nifi.listener.bootstrap.port=${nifi.listener.bootstrap.port}
+
 # cluster common properties (all nodes must have same values) #
 nifi.cluster.protocol.heartbeat.interval=${nifi.cluster.protocol.heartbeat.interval}
 nifi.cluster.protocol.heartbeat.missable.max=${nifi.cluster.protocol.heartbeat.missable.max}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/BootstrapListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/BootstrapListener.java
@@ -56,11 +56,11 @@ public class BootstrapListener {
         secretKey = UUID.randomUUID().toString();
     }
 
-    public void start() throws IOException {
+    public void start(final int listenPort) throws IOException {
         logger.debug("Starting Bootstrap Listener to communicate with Bootstrap Port {}", bootstrapPort);
 
         serverSocket = new ServerSocket();
-        serverSocket.bind(new InetSocketAddress("localhost", 0));
+        serverSocket.bind(new InetSocketAddress("localhost", listenPort));
         serverSocket.setSoTimeout(2000);
 
         final int localPort = serverSocket.getLocalPort();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/NiFi.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/NiFi.java
@@ -111,7 +111,7 @@ public class NiFi implements NiFiEntryPoint {
                 }
 
                 bootstrapListener = new BootstrapListener(this, port);
-                bootstrapListener.start();
+                bootstrapListener.start(properties.getDefaultListenerBootstrapPort());
             } catch (final NumberFormatException nfe) {
                 throw new RuntimeException("Failed to start NiFi because system property '" + BOOTSTRAP_PORT_PROPERTY + "' is not a valid integer in the range 1 - 65535");
             }


### PR DESCRIPTION
#### Description of PR

The NiFi and NiFi Bootstrap processes both bind to random ephemeral
ports to allow for inter-process communication (e.g. shutdown, port,
ping, etc.). However, the randomness of these ephemeral ports can pose
challenges for some security policies and firewall rules.

This adds two configuration options, nifi.bootstrap.listen.port and
nifi.listener.bootstrap.port, that allow an administrator to define
which ports the two processes should bind to for this communication,
making it easier to define security policies. The options default to
zero to maintain the current ephemeral port behavior.

fixes bug NIFI-6740

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced  in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes? *manual testing performed*
- [X] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? *no new depenencies*
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?  *not applicable*
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`? *not applicable*
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties? *not applicable*

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?
