### PR TITLE
NIFI-9655 Add Queue Logging to ListenUDP

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/queue/TrackingLinkedBlockingQueue.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/queue/TrackingLinkedBlockingQueue.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util.listen.queue;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracking extension of LinkedBlockingQueue to provide additional statistics
+ */
+public class TrackingLinkedBlockingQueue<E> extends LinkedBlockingQueue<E> {
+    private final AtomicInteger largestSize = new AtomicInteger();
+
+    public TrackingLinkedBlockingQueue() {
+        super();
+    }
+
+    public TrackingLinkedBlockingQueue(final int capacity) {
+        super(capacity);
+    }
+
+    @Override
+    public boolean offer(final E element) {
+        final boolean success = super.offer(element);
+        if (success) {
+            updateLargestSize();
+        }
+        return success;
+    }
+
+    @Override
+    public boolean offer(final E element, final long timeout, final TimeUnit unit) throws InterruptedException {
+        final boolean success = super.offer(element, timeout, unit);
+        if (success) {
+            updateLargestSize();
+        }
+        return success;
+    }
+
+    @Override
+    public void put(final E element) throws InterruptedException {
+        super.put(element);
+        updateLargestSize();
+    }
+
+    /**
+     * Get the largest size recorded
+     *
+     * @return Current largest size
+     */
+    public int getLargestSize() {
+        return largestSize.get();
+    }
+
+    private void updateLargestSize() {
+        largestSize.getAndAccumulate(size(), Math::max);
+    }
+}

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-listen/src/test/java/org/apache/nifi/processor/util/listen/queue/TrackingLinkedBlockingQueueTest.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-listen/src/test/java/org/apache/nifi/processor/util/listen/queue/TrackingLinkedBlockingQueueTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util.listen.queue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TrackingLinkedBlockingQueueTest {
+    private static final String ELEMENT = String.class.getSimpleName();
+
+    private static final long OFFER_TIMEOUT = 1;
+
+    private static final int INITIAL_CAPACITY = 1;
+
+    @Test
+    public void testAddRemoveGetLargestSize() {
+        final TrackingLinkedBlockingQueue<String> queue = new TrackingLinkedBlockingQueue<>(INITIAL_CAPACITY);
+
+        final boolean added = queue.add(ELEMENT);
+        assertTrue(added);
+
+        final int largestSize = queue.getLargestSize();
+        assertEquals(queue.size(), largestSize);
+
+        final boolean removed = queue.remove(ELEMENT);
+        assertTrue(removed);
+
+        assertEquals(largestSize, queue.getLargestSize());
+    }
+
+    @Test
+    public void testOfferGetLargestSize() {
+        final TrackingLinkedBlockingQueue<String> queue = new TrackingLinkedBlockingQueue<>();
+
+        final boolean success = queue.offer(ELEMENT);
+        assertTrue(success);
+
+        assertEquals(queue.size(), queue.getLargestSize());
+    }
+
+    @Test
+    public void testOfferTimeoutGetLargestSize() throws InterruptedException {
+        final TrackingLinkedBlockingQueue<String> queue = new TrackingLinkedBlockingQueue<>();
+
+        final boolean success = queue.offer(ELEMENT, OFFER_TIMEOUT, TimeUnit.SECONDS);
+        assertTrue(success);
+
+        assertEquals(queue.size(), queue.getLargestSize());
+    }
+
+    @Test
+    public void testPutGetLargestSize() throws InterruptedException {
+        final TrackingLinkedBlockingQueue<String> queue = new TrackingLinkedBlockingQueue<>();
+
+        queue.put(ELEMENT);
+
+        assertEquals(queue.size(), queue.getLargestSize());
+    }
+}


### PR DESCRIPTION
#### Description of PR

NIFI-9655 Adds queue size debug logging to `ListenUDP` and `ListenUDPRecord` through updates to the `AbstractListenEventProcessor`.

The debug logging occurs at most once per minute. The implementation uses an `AtomicLong` to track the minimum next timestamp in milliseconds for logging, and relies on processor scheduling for logging invocation. This approach avoids running an additional thread for background logging, and expects that the processor will be scheduled more often than 60 second intervals. The implementation leverages a custom `TrackingLinkedBlockingQueue` to maintain the largest queue size over the lifecycle of the processor.  Restarting the processor resets the queue and associated largest queue size tracking.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
