### PR TITLE
NIFI-9672 FIx Indeterminate Map Ordering in TestFetchHBaseRow

### DIFF
--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/TestFetchHBaseRow.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/test/java/org/apache/nifi/hbase/TestFetchHBaseRow.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class TestFetchHBaseRow {
@@ -124,7 +125,7 @@ public class TestFetchHBaseRow {
 
     @Test
     public void testFetchToAttributesWithStringValues() {
-        final Map<String, String> cells = new HashMap<>();
+        final Map<String, String> cells = new LinkedHashMap<>();
         cells.put("cq1", "val1");
         cells.put("cq2", "val2");
 
@@ -182,7 +183,7 @@ public class TestFetchHBaseRow {
 
     @Test
     public void testFetchToAttributesWithBase64Values() {
-        final Map<String, String> cells = new HashMap<>();
+        final Map<String, String> cells = new LinkedHashMap<>();
         cells.put("cq1", "val1");
         cells.put("cq2", "val2");
 
@@ -238,7 +239,7 @@ public class TestFetchHBaseRow {
 
     @Test
     public void testFetchToContentWithStringValues() {
-        final Map<String, String> cells = new HashMap<>();
+        final Map<String, String> cells = new LinkedHashMap<>();
         cells.put("cq1", "val1");
         cells.put("cq2", "val2");
 
@@ -293,7 +294,7 @@ public class TestFetchHBaseRow {
 
     @Test
     public void testFetchSpecificColumnsToContentWithBase64() {
-        final Map<String, String> cells = new HashMap<>();
+        final Map<String, String> cells = new LinkedHashMap<>();
         cells.put("cq1", "val1");
         cells.put("cq2", "val2");
 
@@ -332,7 +333,7 @@ public class TestFetchHBaseRow {
 
     @Test
     public void testFetchToContentWithQualifierAndValueJSON() {
-        final Map<String, String> cells = new HashMap<>();
+        final Map<String, String> cells = new LinkedHashMap<>();
         cells.put("cq1", "val1");
         cells.put("cq2", "val2");
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->

#### Description of PR
The undetermined iteration order of `HashMap` causes flakiness in class `org.apache.nifi.hbase.TestFetchHBaseRow` tests
`testFetchSpecificColumnsToContentWithBase64`, `testFetchToAttributesWithBase64Values`, `testFetchToAttributesWithStringValues`, `testFetchToContentWithQualifierAndValueJSON`, and `testFetchToContentWithStringValues`. The problem can be solved by replacing `HashMap` with `LinkedHashMap`, which has predictable iteration order.

One can reproduce the errors as follows:
1. compile `mvn install -DskipTests -pl nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors -am`
2. run tests with NonDex `mvn -pl nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.hbase.TestFetchHBaseRow`. One can also run the tests separately, by adding the name of the test: `mvn -pl nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.hbase.TestFetchHBaseRow#testFetchToContentWithQualifierAndValueJSON`

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
