### PR TITLE
NIFI-9688 Improve Logback shutdown handling

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
@@ -50,6 +50,9 @@ export NIFI_PID_DIR
 NIFI_LOG_DIR="$(setOrDefault "$NIFI_LOG_DIR" "$NIFI_HOME/logs")"
 export NIFI_LOG_DIR
 
+# Disable automatic Logback Initializer to avoid shutdown on web application termination
+export logbackDisableServletContainerInitializer="true"
+
 # Set to false to force the use of Keytab controller service in processors
 # that use Kerberos. If true, these processors will allow configuration of keytab
 # and principal directly within the processor. If false, these processors will be

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -15,6 +15,8 @@
 -->
 
 <configuration scan="true" scanPeriod="30 seconds">
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook" />
+
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>true</resetJUL>
     </contextListener>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/contextlistener/ApplicationStartupContextListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/contextlistener/ApplicationStartupContextListener.java
@@ -95,9 +95,9 @@ public class ApplicationStartupContextListener implements ServletContextListener
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-        logger.info("Initiating shutdown of flow service...");
+        logger.info("Flow Service shutdown started");
         shutdown();
-        logger.info("Flow service termination completed.");
+        logger.info("Flow Service shutdown completed");
     }
 
     private void shutdown() {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/bootstrap.conf
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/bootstrap.conf
@@ -30,3 +30,6 @@ java.arg.14=-Djava.awt.headless=true
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8002
 
 java.arg.nodeNum=-DnodeNumber=1
+
+# Disable Logback web shutdown hook using System property
+java.arg.logbackShutdown=-DlogbackDisableServletContainerInitializer=true

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/logback.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/logback.xml
@@ -15,6 +15,8 @@
 -->
 
 <configuration scan="true" scanPeriod="30 seconds">
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook" />
+
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>true</resetJUL>
     </contextListener>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/bootstrap.conf
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/bootstrap.conf
@@ -30,3 +30,6 @@ java.arg.14=-Djava.awt.headless=true
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8003
 
 java.arg.nodeNum=-DnodeNumber=2
+
+# Disable Logback web shutdown hook using System property
+java.arg.logbackShutdown=-DlogbackDisableServletContainerInitializer=true

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/logback.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/logback.xml
@@ -15,6 +15,8 @@
 -->
 
 <configuration scan="true" scanPeriod="30 seconds">
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook" />
+
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>true</resetJUL>
     </contextListener>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/bootstrap.conf
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/bootstrap.conf
@@ -28,3 +28,6 @@ java.arg.3=-Xmx512m
 java.arg.14=-Djava.awt.headless=true
 
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8002
+
+# Disable Logback web shutdown hook using System property
+java.arg.logbackShutdown=-DlogbackDisableServletContainerInitializer=true

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/logback.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/logback.xml
@@ -15,6 +15,8 @@
 -->
 
 <configuration scan="true" scanPeriod="30 seconds">
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook" />
+
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>true</resetJUL>
     </contextListener>


### PR DESCRIPTION
#### Description of PR

NIFI-9688 Improves Logback shutdown handling, avoiding premature closure of the Logback context during application shutdown, and enabling log messages to be written during application termination.

The default [LogbackServletContainerInitializer](https://github.com/qos-ch/logback/blob/v_1.2.10/logback-classic/src/main/java/ch/qos/logback/classic/servlet/LogbackServletContainerInitializer.java) registers a `LogbackServletContainerListener` that closes the Logback context on web application shutdown. When Jetty registers NiFi web applications, it configures the Logback initializer using the standard Java ServiceLoader. With this behavior, Jetty calls `contextDestroyed` on the Logback Listener before NiFi termination has completed. This results is missing a number of log messages when shutting down NiFi.

Setting the `logbackDisableServletContainerInitializer` environment variable to `true` disables the default Logback listener registration, avoiding the premature context shutdown. Adding the `DelayingShutdownHook` to the `logback.xml` configuration allows Logback to perform a clean shutdown after NiFi termination has finished.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
