### PR TITLE
NIFI-9734 Standardize exception cause message formatting

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
@@ -25,13 +25,12 @@ import org.apache.nifi.logging.LogRepositoryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedList;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SimpleProcessLogger implements ComponentLog {
 
-    public static final String NEW_LINE_ARROW = "\u21B3";
-    public static final String CAUSES = NEW_LINE_ARROW + " causes: ";
+    private static final String CAUSED_BY = String.format("%n- Caused by: ");
 
     private final Logger logger;
     private final LogRepository logRepository;
@@ -522,11 +521,10 @@ public class SimpleProcessLogger implements ComponentLog {
     }
 
     private String getCauses(final Throwable throwable) {
-        final LinkedList<String> causes = new LinkedList<>();
-        for (Throwable t = throwable; t != null; t = t.getCause()) {
-            causes.push(t.toString());
+        final List<String> causes = new ArrayList<>();
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            causes.add(cause.toString());
         }
-        return causes.stream().collect(Collectors.joining(System.lineSeparator() + CAUSES));
+        return String.join(CAUSED_BY, causes);
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 
 import java.lang.reflect.Field;
 
-import static org.apache.nifi.processor.SimpleProcessLogger.NEW_LINE_ARROW;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,11 +34,17 @@ import static org.mockito.Mockito.when;
 
 public class TestSimpleProcessLogger {
 
-    private static final String EXPECTED_CAUSES = "java.lang.RuntimeException: third" + System.lineSeparator() +
-            NEW_LINE_ARROW + " causes: java.lang.RuntimeException: second" + System.lineSeparator() +
-            NEW_LINE_ARROW + " causes: java.lang.RuntimeException: first";
+    private static final String FIRST_MESSAGE = "FIRST";
+    private static final String SECOND_MESSAGE = "SECOND";
+    private static final String THIRD_MESSAGE = "THIRD";
 
-    private final Exception e = new RuntimeException("first", new RuntimeException("second", new RuntimeException("third")));
+    private static final String EXPECTED_CAUSES = String.join(System.lineSeparator(),
+            String.format("%s: %s", IllegalArgumentException.class.getName(), FIRST_MESSAGE),
+            String.format("- Caused by: %s: %s", RuntimeException.class.getName(), SECOND_MESSAGE),
+            String.format("- Caused by: %s: %s", SecurityException.class.getName(), THIRD_MESSAGE)
+    );
+
+    private final Exception e = new IllegalArgumentException(FIRST_MESSAGE, new RuntimeException(SECOND_MESSAGE, new SecurityException(THIRD_MESSAGE)));
 
     private ReportingTask task;
 


### PR DESCRIPTION
#### Description of PR

NIFI-9734 Standardizes exception cause message formatting to follow standard Java logging conventions, listing the direct cause first and the root cause last.  This approach reverses the current order where the message lists the root cause first and the direct cause last.

The `TestSimpleProcessorLogger` changes illustrate the expected output, which appears as follows:

```
java.lang.IllegalArgumentException: FIRST
- Caused by: java.lang.RuntimeException: SECOND
- Caused by: java.lang.SecurityException: THIRD
```

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
