### PR TITLE
NIFI-9735 Correct Jetty Duplicate Mapping Warning

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -647,10 +647,6 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
             // Load the API docs
             final File webApiDocsDir = getWebApiDocsDir();
 
-            // Create the servlet which will serve the static resources
-            ServletHolder defaultHolder = new ServletHolder("default", DefaultServlet.class);
-            defaultHolder.setInitParameter("dirAllowed", "false");
-
             ServletHolder docs = new ServletHolder("docs", DefaultServlet.class);
             docs.setInitParameter("resourceBase", docsDir.getPath());
             docs.setInitParameter("dirAllowed", "false");
@@ -667,10 +663,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
             docsContext.addServlet(components, "/components/*");
             docsContext.addServlet(restApi, "/rest-api/*");
 
-            docsContext.addServlet(defaultHolder, "/");
-
-            logger.info("Loading documents web app with context path set to " + docsContext.getContextPath());
-
+            logger.info("Loading Docs [{}] Context Path [{}]", docsDir.getAbsolutePath(), docsContext.getContextPath());
         } catch (Exception ex) {
             logger.error("Unhandled Exception in createDocsWebApp: " + ex.getMessage());
             startUpFailure(ex);


### PR DESCRIPTION
#### Description of PR

NIFI-9735 Corrects the NiFi Jetty documentation servlet configuration to avoid the following warning:

```
WARN [main] o.e.j.webapp.StandardDescriptorProcessor Duplicate mapping from / to default
```

The `JettyServer.addDocsServlets()` method included a servlet mapping for the root context path, which unnecessarily overrides the default servlet mapping defined in `webdefault.xml`.  Removing this mapping eliminates the warning and maintains current web application behavior.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
