### PR TITLE
NIFI-9797 Correct AccessToken.isExpired() margin calculation

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/AccessToken.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/AccessToken.java
@@ -17,10 +17,11 @@
 
 package org.apache.nifi.oauth2;
 
-import java.time.Duration;
 import java.time.Instant;
 
 public class AccessToken {
+    private static final int EXPIRY_MARGIN_SECONDS = 5;
+
     private String accessToken;
     private String refreshToken;
     private String tokenType;
@@ -28,8 +29,6 @@ public class AccessToken {
     private String scopes;
 
     private final Instant fetchTime;
-
-    public static final int EXPIRY_MARGIN = 5000;
 
     public AccessToken() {
         this.fetchTime = Instant.now();
@@ -89,8 +88,7 @@ public class AccessToken {
     }
 
     public boolean isExpired() {
-        boolean expired = Duration.between(Instant.now(), fetchTime.plusSeconds(expiresIn - EXPIRY_MARGIN)).isNegative();
-
-        return expired;
+        final Instant expirationTime = fetchTime.plusSeconds(expiresIn).plusSeconds(EXPIRY_MARGIN_SECONDS);
+        return Instant.now().isAfter(expirationTime);
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/test/java/org/apache/nifi/oauth2/AccessTokenTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/test/java/org/apache/nifi/oauth2/AccessTokenTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.oauth2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AccessTokenTest {
+    private static final String ACCESS_TOKEN = "ACCESS";
+
+    private static final String REFRESH_TOKEN = "REFRESH";
+
+    private static final String TOKEN_TYPE = "Bearer";
+
+    private static final String SCOPES = "default";
+
+    private static final long TWO_SECONDS_AGO = -2;
+
+    private static final long TEN_SECONDS_AGO = -10;
+
+    private static final long IN_SIXTY_SECONDS = 60;
+
+    @Test
+    public void testIsExpiredTenSecondsAgo() {
+        final AccessToken accessToken = getAccessToken(TEN_SECONDS_AGO);
+
+        assertTrue(accessToken.isExpired());
+    }
+
+    @Test
+    public void testIsExpiredTwoSecondsAgo() {
+        final AccessToken accessToken = getAccessToken(TWO_SECONDS_AGO);
+
+        assertFalse(accessToken.isExpired());
+    }
+
+    @Test
+    public void testIsExpiredInSixtySeconds() {
+        final AccessToken accessToken = getAccessToken(IN_SIXTY_SECONDS);
+
+        assertFalse(accessToken.isExpired());
+    }
+
+    private AccessToken getAccessToken(final long expiresInSeconds) {
+        return new AccessToken(
+                ACCESS_TOKEN,
+                REFRESH_TOKEN,
+                TOKEN_TYPE,
+                expiresInSeconds,
+                SCOPES
+        );
+    }
+}


### PR DESCRIPTION
#### Description of PR

NIFI-9797 Corrects the `AccessToken.isExpired()` calculation using `5` seconds instead of `5000` seconds.  The current expiry margin value of `5000` results in incorrect expiration determination due to the OAuth2 `expiresIn` property being set in seconds. Additional changes include a new test for `AccessToken` and updates to existing unit tests.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
