### PR TITLE
NIFI-9807 Add Refresh Window Property to OAuth2 Token Provider

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/AccessToken.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/AccessToken.java
@@ -20,8 +20,6 @@ package org.apache.nifi.oauth2;
 import java.time.Instant;
 
 public class AccessToken {
-    private static final int EXPIRY_MARGIN_SECONDS = 300;
-
     private String accessToken;
     private String refreshToken;
     private String tokenType;
@@ -31,7 +29,7 @@ public class AccessToken {
     private final Instant fetchTime;
 
     public AccessToken() {
-        this.fetchTime = now();
+        this.fetchTime = Instant.now();
     }
 
     public AccessToken(String accessToken, String refreshToken, String tokenType, long expiresIn, String scopes) {
@@ -88,11 +86,8 @@ public class AccessToken {
     }
 
     public boolean isExpired() {
-        final Instant expirationTime = fetchTime.plusSeconds(expiresIn).minusSeconds(EXPIRY_MARGIN_SECONDS);
-
-        boolean expired = now().isAfter(expirationTime);
-
-        return expired;
+        final Instant expirationTime = fetchTime.plusSeconds(expiresIn);
+        return now().isAfter(expirationTime);
     }
 
     Instant now() {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/test/java/org/apache/nifi/oauth2/AccessTokenTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/test/java/org/apache/nifi/oauth2/AccessTokenTest.java
@@ -25,6 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccessTokenTest {
+    private static final long FIVE_MINUTES_AGO = -300;
+
+    private static final long IN_FIVE_MINUTES = 300;
+
     private Instant now;
 
     @BeforeEach
@@ -33,22 +37,15 @@ public class AccessTokenTest {
     }
 
     @Test
-    public void testIsExpiredInLessThan5Minutes() {
-        final AccessToken accessToken = getAccessToken(299);
+    public void testIsExpiredFiveMinutesAgo() {
+        final AccessToken accessToken = getAccessToken(FIVE_MINUTES_AGO);
 
         assertTrue(accessToken.isExpired());
     }
 
     @Test
-    public void testIsExpiredInExactly5Minutes() {
-        final AccessToken accessToken = getAccessToken(300);
-
-        assertFalse(accessToken.isExpired());
-    }
-
-    @Test
-    public void testIsExpiredInMoreThan5Minutes() {
-        final AccessToken accessToken = getAccessToken(301);
+    public void testIsExpiredInFiveMinutes() {
+        final AccessToken accessToken = getAccessToken(IN_FIVE_MINUTES);
 
         assertFalse(accessToken.isExpired());
     }


### PR DESCRIPTION
#### Description of PR

NIFI-9807 Adds a configurable `Refresh Window` property to the `StandardOauth2AccessTokenProvider` Controller Service and removes the hard-coded expiration margin from the `AccessToken.isExpired()` determination.

The change to `AccessToken` restores the behavior of `isExpired()` present in NiFi 1.12.0 to 1.15.3, implemented in NIFI-7299. The `isExpired()` method relies on the exact time specified in the `expiresIn` seconds property received from the OAuth2 Token Issuer Server. The new `Refresh Window` property defaults to `0 s`, following the same approach, but enabling configurable behavior based on whether the particular token issuer provides short-lived or long-lived tokens.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
