### PR TITLE
NIFI-9818: fix four flaky tests in nifi-record

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -548,7 +548,7 @@ public class DataTypeUtils {
                 map = (Map<String, Object>) value;
             } else {
                 final Map<?, ?> m = (Map<?, ?>) value;
-                map = new HashMap<>(m.size());
+                map = new LinkedHashMap<>(m.size());
                 m.forEach((k, v) -> map.put(k == null ? null : k.toString(), v));
             }
             return inferRecordDataType(map);

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -611,7 +612,7 @@ public class TestDataTypeUtils {
 
     @Test
     public void testInferTypeWithMapStringKeys() {
-        Map<String, String> map = new HashMap<>();
+        Map<String, String> map = new LinkedHashMap<>();
         map.put("a", "Hello");
         map.put("b", "World");
 
@@ -626,7 +627,7 @@ public class TestDataTypeUtils {
 
     @Test
     public void testInferTypeWithMapNonStringKeys() {
-        Map<Integer, String> map = new HashMap<>();
+        Map<Integer, String> map = new LinkedHashMap<>();
         map.put(1, "Hello");
         map.put(2, "World");
 

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestMapRecord.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestMapRecord.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +80,7 @@ public class TestMapRecord {
     }
 
     private Set<String> set(final String... values) {
-        final Set<String> set = new HashSet<>();
+        final Set<String> set = new LinkedHashSet<>();
         for (final String value : values) {
             set.add(value);
         }
@@ -122,7 +124,7 @@ public class TestMapRecord {
         fields.add(new RecordField("foo", RecordFieldType.STRING.getDataType(), null, set("bar", "baz")));
 
         final RecordSchema schema = new SimpleRecordSchema(fields);
-        final Map<String, Object> values = new HashMap<>();
+        final Map<String, Object> values = new LinkedHashMap<>();
         values.put("baz", 1);
         values.put("bar", 33);
 
@@ -161,7 +163,7 @@ public class TestMapRecord {
         fields.add(new RecordField("foo", RecordFieldType.STRING.getDataType(), "hello", set("bar", "baz")));
 
         final RecordSchema schema = new SimpleRecordSchema(fields);
-        final Map<String, Object> values = new HashMap<>();
+        final Map<String, Object> values = new LinkedHashMap<>();
         values.put("baz", 1);
         values.put("bar", 33);
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

Fixes bug [NIFI-9818](https://issues.apache.org/jira/browse/NIFI-9818)

**Description**
Four tests in `nifi-record` (`org.apache.nifi.serialization.record.TestMapRecord#testDefaultValueWithAliasValue` ,`org.apache.nifi.serialization.record.TestMapRecord#testAliasConflictingAliasValues`, `org.apache.nifi.serialization.record.TestDataTypeUtils#testInferTypeWithMapStringKeys`, and `org.apache.nifi.serialization.record.TestDataTypeUtils#testInferTypeWithMapNonStringKeys`) can fail due to the non-deterministic order of iteration of _HashMap_ and _HashSet_.

One can manifest this problem using [[NonDex](https://github.com/TestingResearchIllinois/NonDex)]:

```
mvn install -pl nifi-commons/nifi-record -am
mvn -pl nifi-commons/nifi-record edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.serialization.record.TestMapRecord#testAliasConflictingAliasValues
mvn -pl nifi-commons/nifi-record edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.serialization.record.TestMapRecord#testDefaultValueWithAliasValue
mvn -pl nifi-commons/nifi-record edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.serialization.record.TestDataTypeUtils#testInferTypeWithMapStringKeys
mvn -pl nifi-commons/nifi-record edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.serialization.record.TestDataTypeUtils#testInferTypeWithMapNonStringKe
```

**Fix Changes**
Use LinkedHashMap/LinkedHashSet instead of HashMap/HashSet in the test.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
