### PR TITLE
NIFI-9835: Fixed threading bug in which NioAsyncLoadBalanceClient cal…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -543,7 +543,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         LOG.debug("Successfully committed session {} for {}", this, connectableDescription);
     }
 
-    private void commit(final boolean asynchronous) {
+    private synchronized void commit(final boolean asynchronous) {
         checkpoint(this.checkpoint != null); // If a checkpoint already exists, we need to copy the collection
         commit(this.checkpoint, asynchronous);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/LoadBalanceSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/LoadBalanceSession.java
@@ -45,7 +45,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -64,7 +63,6 @@ import static org.apache.nifi.controller.queue.clustered.protocol.LoadBalancePro
 public class LoadBalanceSession {
     private static final Logger logger = LoggerFactory.getLogger(LoadBalanceSession.class);
     static final int MAX_DATA_FRAME_SIZE = 65535;
-    private static final long PENALTY_MILLIS = TimeUnit.SECONDS.toMillis(2L);
 
     private final RegisteredPartition partition;
     private final Supplier<FlowFileRecord> flowFileSupplier;
@@ -75,7 +73,6 @@ public class LoadBalanceSession {
     private final String peerDescription;
     private final String connectionId;
     private final TransactionThreshold transactionThreshold;
-    private volatile boolean canceled = false;
 
     final VersionNegotiator negotiator = new StandardVersionNegotiator(1);
     private int protocolVersion = 1;
@@ -85,13 +82,12 @@ public class LoadBalanceSession {
     // guarded by synchronizing on 'this'
     private ByteBuffer preparedFrame;
     private FlowFileRecord currentFlowFile;
-    private List<FlowFileRecord> flowFilesSent = new ArrayList<>();
+    private final List<FlowFileRecord> flowFilesSent = new ArrayList<>();
     private TransactionPhase phase = TransactionPhase.RECOMMEND_PROTOCOL_VERSION;
     private InputStream flowFileInputStream;
-    private byte[] byteBuffer = new byte[MAX_DATA_FRAME_SIZE];
-    private boolean complete = false;
+    private final byte[] byteBuffer = new byte[MAX_DATA_FRAME_SIZE];
     private long readTimeout;
-    private long penaltyExpiration = -1L;
+    private volatile LoadBalanceSessionState sessionState = LoadBalanceSessionState.ACTIVE;
 
     public LoadBalanceSession(final RegisteredPartition partition, final FlowFileContentAccess contentAccess, final LoadBalanceFlowFileCodec flowFileCodec, final PeerChannel peerChannel,
                               final int timeoutMillis, final TransactionThreshold transactionThreshold) {
@@ -124,17 +120,12 @@ public class LoadBalanceSession {
         return copy;
     }
 
-    public synchronized boolean isComplete() {
-        return complete;
+    public synchronized LoadBalanceSessionState getSessionState() {
+        return sessionState;
     }
 
     public synchronized boolean communicate() throws IOException {
-        if (isComplete()) {
-            return false;
-        }
-
-        if (isPenalized()) {
-            logger.debug("Will not communicate with Peer {} for Connection {} because session is penalized", peerDescription, connectionId);
+        if (sessionState.isComplete()) {
             return false;
         }
 
@@ -167,23 +158,18 @@ public class LoadBalanceSession {
             final int bytesWritten = channel.write(preparedFrame);
             return bytesWritten > 0;
         } catch (final Exception e) {
-            complete = true;
+            sessionState = LoadBalanceSessionState.COMPLETED_EXCEPTIONALLY;
             throw e;
         }
     }
 
     public synchronized boolean cancel() {
-        if (complete) {
+        if (sessionState.isComplete()) {
             return false;
         }
 
-        complete = true;
-        canceled = true;
+        sessionState = LoadBalanceSessionState.CANCELED;
         return true;
-    }
-
-    public boolean isCanceled() {
-        return canceled;
     }
 
     private boolean confirmTransactionComplete() throws IOException {
@@ -210,7 +196,7 @@ public class LoadBalanceSession {
             throw new IOException("Expected a CONFIRM_COMPLETE_TRANSACTION response from Peer " + peerDescription + " but received a value of " + response);
         }
 
-        complete = true;
+        sessionState = LoadBalanceSessionState.COMPLETED_SUCCESSFULLY;
         logger.debug("Successfully completed Transaction to send {} FlowFiles to Peer {} for Connection {}", flowFilesSent.size(), peerDescription, connectionId);
 
         return true;
@@ -496,21 +482,19 @@ public class LoadBalanceSession {
             protocolVersion = requestedVersion;
             phase = TransactionPhase.SEND_CONNECTION_ID;
             logger.debug("Peer {} recommended Protocol Version of {}. Accepting version.", peerDescription, requestedVersion);
-
-            return true;
         } else {
             final Integer preferred = negotiator.getPreferredVersion(requestedVersion);
             if (preferred == null) {
                 logger.debug("Peer {} requested version {} of the Load Balance Protocol. This version is not acceptable. Aborting communications.", peerDescription, requestedVersion);
                 phase = TransactionPhase.ABORT_PROTOCOL_NEGOTIATION;
-                return true;
             } else {
                 logger.debug("Peer {} requested version {} of the Protocol. Recommending version {} instead", peerDescription, requestedVersion, preferred);
                 protocolVersion = preferred;
                 phase = TransactionPhase.RECOMMEND_PROTOCOL_VERSION;
-                return true;
             }
         }
+
+        return true;
     }
 
     private ByteBuffer noMoreFlowFiles() {
@@ -592,7 +576,9 @@ public class LoadBalanceSession {
             logger.debug("Peer {} has confirmed that the queue is full for Connection {}", peerDescription, connectionId);
             phase = TransactionPhase.RECOMMEND_PROTOCOL_VERSION;
             checksum.reset(); // We are restarting the session entirely so we need to reset our checksum
-            complete = true; // consider complete because there's nothing else that we can do in this session. Allow client to move on to a different session.
+
+            // consider complete because there's nothing else that we can do in this session. Allow client to move on to a different session.
+            sessionState = LoadBalanceSessionState.COMPLETED_SUCCESSFULLY;
             partition.penalize(1000L);
         } else {
             throw new TransactionAbortedException("After requesting to know whether or not Peer " + peerDescription + " has space available in Connection " + connectionId
@@ -602,15 +588,6 @@ public class LoadBalanceSession {
         return true;
     }
 
-    private void penalize() {
-        penaltyExpiration = System.currentTimeMillis() + PENALTY_MILLIS;
-    }
-
-    private boolean isPenalized() {
-        // check for penaltyExpiration > -1L is not strictly necessary as it's implied by the second check but is still
-        // here because it's more efficient to check this than to make the system call to System.currentTimeMillis().
-        return penaltyExpiration > -1L && System.currentTimeMillis() < penaltyExpiration;
-    }
 
 
     private enum TransactionPhase {
@@ -651,6 +628,25 @@ public class LoadBalanceSession {
 
         public int getRequiredSelectionKey() {
             return requiredSelectionKey;
+        }
+    }
+
+    public enum LoadBalanceSessionState {
+        ACTIVE(false),
+
+        COMPLETED_SUCCESSFULLY(true),
+
+        COMPLETED_EXCEPTIONALLY(true),
+
+        CANCELED(true);
+
+        private final boolean complete;
+        LoadBalanceSessionState(final boolean complete) {
+            this.complete = complete;
+        }
+
+        public boolean isComplete() {
+            return complete;
         }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/client/async/nio/TestLoadBalanceSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/client/async/nio/TestLoadBalanceSession.java
@@ -136,7 +136,7 @@ public class TestLoadBalanceSession {
         while (transaction.communicate()) {
         }
 
-        assertTrue(transaction.isComplete());
+        assertTrue(transaction.getSessionState().isComplete());
         socketChannel.close();
 
         final Checksum expectedChecksum = new CRC32();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
@@ -195,7 +195,7 @@ public class MergeRecord extends AbstractSessionFactoryProcessor {
         .name("max.bin.count")
         .displayName("Maximum Number of Bins")
         .description("Specifies the maximum number of bins that can be held in memory at any one time. "
-            + "This number should not be smaller than the maximum number of conurrent threads for this Processor, "
+            + "This number should not be smaller than the maximum number of concurrent threads for this Processor, "
             + "or the bins that are created will often consist only of a single incoming FlowFile.")
         .defaultValue("10")
         .required(true)


### PR DESCRIPTION
…ls LoadBalanceSession.isComplete() followed by LoadBalanceSession.isCanceled() but it's possible for the complete flag to change before the canceled flag (they are not updated atomically). So changed to use a single LoadBalanceSessionState enum that represents the state. Also made the private StandardProcessSession.commit(boolean) method synchronized. When a processor is terminated (as is the case in Offload), we roll back sessions and both the commit() and rollback() need to be synchronized. Only the public commit() method was synchronized, and now with commitAsync() happening, we had the ability to commit without any synchronization. This addresses that concern. Also fixed a typo in docs for MergeRecord.

<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
