### PR TITLE
NIFI-9817 Add a Validator for the PutCloudWatchMetric Processor's Unit Field

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -72,17 +72,6 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
     public static final Set<Relationship> relationships = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
 
-    // public static final Set<String> units = Collections.unmodifiableSet(
-    //         new HashSet<>(Arrays.asList(
-    //                 "Seconds", "Microseconds", "Milliseconds", "Bytes",
-    //                 "Kilobytes", "Megabytes", "Gigabytes", "Terabytes",
-    //                 "Bits", "Kilobits", "Megabits", "Gigabits", "Terabits",
-    //                 "Percent", "Count", "Bytes/Second", "Kilobytes/Second",
-    //                 "Megabytes/Second", "Gigabytes/Second", "Terabytes/Second",
-    //                 "Bits/Second", "Kilobits/Second", "Megabits/Second",
-    //                 "Gigabits/Second", "Terabits/Second", "Count/Second",
-    //                 "None", "")));
-
     public static final Set<String> units = Arrays.stream(StandardUnit.values())
             .map(StandardUnit::toString).collect(Collectors.toSet());
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
@@ -56,6 +57,7 @@ import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
 import com.amazonaws.services.cloudwatch.model.StatisticSet;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
 
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -70,16 +72,19 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
     public static final Set<Relationship> relationships = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
 
-    public static final Set<String> units = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    "Seconds", "Microseconds", "Milliseconds", "Bytes",
-                    "Kilobytes", "Megabytes", "Gigabytes", "Terabytes",
-                    "Bits", "Kilobits", "Megabits", "Gigabits", "Terabits",
-                    "Percent", "Count", "Bytes/Second", "Kilobytes/Second",
-                    "Megabytes/Second", "Gigabytes/Second", "Terabytes/Second",
-                    "Bits/Second", "Kilobits/Second", "Megabits/Second",
-                    "Gigabits/Second", "Terabits/Second", "Count/Second",
-                    "None", "")));
+    // public static final Set<String> units = Collections.unmodifiableSet(
+    //         new HashSet<>(Arrays.asList(
+    //                 "Seconds", "Microseconds", "Milliseconds", "Bytes",
+    //                 "Kilobytes", "Megabytes", "Gigabytes", "Terabytes",
+    //                 "Bits", "Kilobits", "Megabits", "Gigabits", "Terabits",
+    //                 "Percent", "Count", "Bytes/Second", "Kilobytes/Second",
+    //                 "Megabytes/Second", "Gigabytes/Second", "Terabytes/Second",
+    //                 "Bits/Second", "Kilobits/Second", "Megabits/Second",
+    //                 "Gigabits/Second", "Terabits/Second", "Count/Second",
+    //                 "None", "")));
+
+    public static final Set<String> units = Arrays.stream(StandardUnit.values())
+            .map(StandardUnit::toString).collect(Collectors.toSet());
 
     private static final Validator UNIT_VALIDATOR = new Validator() {
         @Override

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -70,6 +70,33 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
     public static final Set<Relationship> relationships = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
 
+    private static final Set<String> units = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                    "Seconds", "Microseconds", "Milliseconds", "Bytes",
+                    "Kilobytes", "Megabytes", "Gigabytes", "Terabytes",
+                    "Bits", "Kilobits", "Megabits", "Gigabits", "Terabits",
+                    "Percent", "Count", "Bytes/Second", "Kilobytes/Second",
+                    "Megabytes/Second", "Gigabytes/Second", "Terabytes/Second",
+                    "Bits/Second", "Kilobits/Second", "Megabits/Second",
+                    "Gigabits/Second", "Terabits/Second", "Count/Second",
+                    "None", "")));
+
+    private static final Validator UNIT_VALIDATOR = new Validator() {
+        @Override
+        public ValidationResult validate(String subject, String input, ValidationContext context) {
+            if (context.isExpressionLanguageSupported(subject) && context.isExpressionLanguagePresent(input)) {
+                return (new ValidationResult.Builder()).subject(subject).input(input).explanation("Expression Language Present").valid(true).build();
+            } else {
+                String reason = null;
+
+                if (!units.contains(input)) {
+                    reason = "not a valid Unit";
+                }
+                return (new ValidationResult.Builder()).subject(subject).input(input).explanation(reason).valid(reason == null).build();
+            }
+        }
+    };
+
     private static final Validator DOUBLE_VALIDATOR = new Validator() {
         @Override
         public ValidationResult validate(String subject, String input, ValidationContext context) {
@@ -131,7 +158,7 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
             .description("The unit of the metric. (e.g Seconds, Bytes, Megabytes, Percent, Count,  Kilobytes/Second, Terabits/Second, Count/Second) For details see http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(UNIT_VALIDATOR)
             .build();
 
     public static final PropertyDescriptor MAXIMUM = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -81,10 +81,6 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
                     "Gigabits/Second", "Terabits/Second", "Count/Second",
                     "None", "")));
 
-    public static Set<String> getUnitParameters() {
-        return units;
-    }
-
     private static final Validator UNIT_VALIDATOR = new Validator() {
         @Override
         public ValidationResult validate(String subject, String input, ValidationContext context) {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -81,6 +81,10 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
                     "Gigabits/Second", "Terabits/Second", "Count/Second",
                     "None", "")));
 
+    public static Set<String> getUnitParameters() {
+        return units;
+    }
+
     private static final Validator UNIT_VALIDATOR = new Validator() {
         @Override
         public ValidationResult validate(String subject, String input, ValidationContext context) {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -70,7 +70,7 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
     public static final Set<Relationship> relationships = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
 
-    private static final Set<String> units = Collections.unmodifiableSet(
+    public static final Set<String> units = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
                     "Seconds", "Microseconds", "Milliseconds", "Bytes",
                     "Kilobytes", "Megabytes", "Gigabytes", "Terabytes",

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
@@ -16,6 +16,9 @@
  */
 package org.apache.nifi.processors.aws.cloudwatch;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.nifi.processors.aws.AbstractAWSCredentialsProviderProcessor;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService;
 import org.apache.nifi.processors.aws.sns.PutSNS;
@@ -23,18 +26,22 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.assumeThat;
 
 /**
- * Provides integration level testing with actual AWS CloudWatch resources for {@link PutCloudWatchMetric} and requires additional configuration and resources to work.
+ * Provides integration level testing with actual AWS CloudWatch resources for
+ * {@link PutCloudWatchMetric} and requires additional configuration and resources to work.
  */
 public class ITPutCloudWatchMetric {
 
     private final String CREDENTIALS_FILE = System.getProperty("user.home") + "/aws-credentials.properties";
 
     @Test
-    public void testPublish() throws IOException {
+    public void ifCredentialsThenTestPublish() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
+        File credsFile = new File(CREDENTIALS_FILE);
+        assumeThat(credsFile.exists(), is(true));
 
         runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
         runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
@@ -48,8 +55,10 @@ public class ITPutCloudWatchMetric {
     }
 
     @Test
-    public void testPublishWithCredentialsProviderService() throws Throwable {
+    public void ifCredentialsThenTestPublishWithCredentialsProviderService() throws Throwable {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
+        File credsFile = new File(CREDENTIALS_FILE);
+        assumeThat(credsFile.exists(), is(true));
 
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
@@ -24,7 +24,7 @@ import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredential
 import org.apache.nifi.processors.aws.sns.PutSNS;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.Assumptions;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,7 +39,7 @@ public class ITPutCloudWatchMetric {
     public void ifCredentialsThenTestPublish() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
         File credsFile = new File(CREDENTIALS_FILE);
-        Assumptions.assumeTrue(credsFile.exists());
+        assumeTrue(credsFile.exists());
 
         runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
         runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
@@ -56,7 +56,7 @@ public class ITPutCloudWatchMetric {
     public void ifCredentialsThenTestPublishWithCredentialsProviderService() throws Throwable {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
         File credsFile = new File(CREDENTIALS_FILE);
-        Assumptions.assumeTrue(credsFile.exists());
+        assumeTrue(credsFile.exists());
 
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
@@ -27,8 +27,6 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-
 /**
  * Provides integration level testing with actual AWS CloudWatch resources for
  * {@link PutCloudWatchMetric} and requires additional configuration and resources to work.

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/ITPutCloudWatchMetric.java
@@ -24,10 +24,10 @@ import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredential
 import org.apache.nifi.processors.aws.sns.PutSNS;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assume.assumeThat;
 
 /**
  * Provides integration level testing with actual AWS CloudWatch resources for
@@ -41,7 +41,7 @@ public class ITPutCloudWatchMetric {
     public void ifCredentialsThenTestPublish() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
         File credsFile = new File(CREDENTIALS_FILE);
-        assumeThat(credsFile.exists(), is(true));
+        Assumptions.assumeTrue(credsFile.exists());
 
         runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
         runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
@@ -58,7 +58,7 @@ public class ITPutCloudWatchMetric {
     public void ifCredentialsThenTestPublishWithCredentialsProviderService() throws Throwable {
         final TestRunner runner = TestRunners.newTestRunner(new PutCloudWatchMetric());
         File credsFile = new File(CREDENTIALS_FILE);
-        assumeThat(credsFile.exists(), is(true));
+        Assumptions.assumeTrue(credsFile.exists());
 
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
@@ -27,7 +27,7 @@ import org.apache.nifi.util.TestRunners;
 
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.Assert;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -282,17 +282,19 @@ public class TestPutCloudWatchMetric {
         runner.assertNotValid();
     }
 
-    @ParameterizedTest
-    @CsvSource({"Count","Bytes","Percent"})
-    public void testValidUnit(String unit) throws Exception {
+    @Test
+    public void testValidUnit() throws Exception {
         MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
         final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
 
-        runner.setProperty(PutCloudWatchMetric.NAMESPACE, "TestNamespace");
-        runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "TestMetric");
-        runner.setProperty(PutCloudWatchMetric.UNIT, unit);
-        runner.setProperty(PutCloudWatchMetric.VALUE, "1");
-        runner.assertValid();
+        for (String unit: PutCloudWatchMetric.getUnitParameters()) {
+
+            runner.setProperty(PutCloudWatchMetric.NAMESPACE, "TestNamespace");
+            runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "TestMetric");
+            runner.setProperty(PutCloudWatchMetric.UNIT, unit);
+            runner.setProperty(PutCloudWatchMetric.VALUE, "1");
+            runner.assertValid();
+        }
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
@@ -29,7 +29,7 @@ import org.apache.nifi.util.TestRunners;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import org.junit.jupiter.api.Test;
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -56,11 +56,11 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        Assert.assertEquals("TestMetric", datum.getMetricName());
-        Assert.assertEquals(1d, datum.getValue(), 0.0001d);
+        assertEquals("TestMetric", datum.getMetricName());
+        assertEquals(1d, datum.getValue(), 0.0001d);
     }
 
     @Test
@@ -147,11 +147,11 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        Assert.assertEquals("TestMetric", datum.getMetricName());
-        Assert.assertEquals(1.23d, datum.getValue(), 0.0001d);
+        assertEquals("TestMetric", datum.getMetricName());
+        assertEquals(1.23d, datum.getValue(), 0.0001d);
     }
 
     @Test
@@ -176,14 +176,14 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        Assert.assertEquals("TestMetric", datum.getMetricName());
-        Assert.assertEquals(1.0d, datum.getStatisticValues().getMinimum(), 0.0001d);
-        Assert.assertEquals(2.0d, datum.getStatisticValues().getMaximum(), 0.0001d);
-        Assert.assertEquals(3.0d, datum.getStatisticValues().getSum(), 0.0001d);
-        Assert.assertEquals(2.0d, datum.getStatisticValues().getSampleCount(), 0.0001d);
+        assertEquals("TestMetric", datum.getMetricName());
+        assertEquals(1.0d, datum.getStatisticValues().getMinimum(), 0.0001d);
+        assertEquals(2.0d, datum.getStatisticValues().getMaximum(), 0.0001d);
+        assertEquals(3.0d, datum.getStatisticValues().getSum(), 0.0001d);
+        assertEquals(2.0d, datum.getStatisticValues().getSampleCount(), 0.0001d);
     }
 
     @Test
@@ -206,19 +206,19 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        Assert.assertEquals("TestMetric", datum.getMetricName());
-        Assert.assertEquals(1d, datum.getValue(), 0.0001d);
+        assertEquals("TestMetric", datum.getMetricName());
+        assertEquals(1d, datum.getValue(), 0.0001d);
 
         List<Dimension> dimensions = datum.getDimensions();
         Collections.sort(dimensions, (d1, d2) -> d1.getName().compareTo(d2.getName()));
-        Assert.assertEquals(2, dimensions.size());
-        Assert.assertEquals("dim1", dimensions.get(0).getName());
-        Assert.assertEquals("1", dimensions.get(0).getValue());
-        Assert.assertEquals("dim2", dimensions.get(1).getName());
-        Assert.assertEquals("val2", dimensions.get(1).getValue());
+        assertEquals(2, dimensions.size());
+        assertEquals("dim1", dimensions.get(0).getName());
+        assertEquals("1", dimensions.get(0).getValue());
+        assertEquals("dim2", dimensions.get(1).getName());
+        assertEquals("val2", dimensions.get(1).getValue());
     }
 
     @Test
@@ -268,7 +268,7 @@ public class TestPutCloudWatchMetric {
         runner.enqueue(new byte[] {}, attributes);
         runner.run();
 
-        Assert.assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_FAILURE, 1);
     }
 
@@ -319,7 +319,7 @@ public class TestPutCloudWatchMetric {
         runner.enqueue(new byte[] {}, attributes);
         runner.run();
 
-        Assert.assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_FAILURE, 1);
     }
 
@@ -352,7 +352,7 @@ public class TestPutCloudWatchMetric {
         runner.enqueue(new byte[] {});
         runner.run();
 
-        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
     }
 }

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
@@ -16,20 +16,21 @@
  */
 package org.apache.nifi.processors.aws.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.Dimension;
-import com.amazonaws.services.cloudwatch.model.InvalidParameterValueException;
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Unit tests for {@link PutCloudWatchMetric}.
@@ -52,11 +53,11 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        assertEquals("TestMetric", datum.getMetricName());
-        assertEquals(1d, datum.getValue(), 0.0001d);
+        Assert.assertEquals("TestMetric", datum.getMetricName());
+        Assert.assertEquals(1d, datum.getValue(), 0.0001d);
     }
 
     @Test
@@ -143,11 +144,11 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        assertEquals("TestMetric", datum.getMetricName());
-        assertEquals(1.23d, datum.getValue(), 0.0001d);
+        Assert.assertEquals("TestMetric", datum.getMetricName());
+        Assert.assertEquals(1.23d, datum.getValue(), 0.0001d);
     }
 
     @Test
@@ -172,14 +173,14 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        assertEquals("TestMetric", datum.getMetricName());
-        assertEquals(1.0d, datum.getStatisticValues().getMinimum(), 0.0001d);
-        assertEquals(2.0d, datum.getStatisticValues().getMaximum(), 0.0001d);
-        assertEquals(3.0d, datum.getStatisticValues().getSum(), 0.0001d);
-        assertEquals(2.0d, datum.getStatisticValues().getSampleCount(), 0.0001d);
+        Assert.assertEquals("TestMetric", datum.getMetricName());
+        Assert.assertEquals(1.0d, datum.getStatisticValues().getMinimum(), 0.0001d);
+        Assert.assertEquals(2.0d, datum.getStatisticValues().getMaximum(), 0.0001d);
+        Assert.assertEquals(3.0d, datum.getStatisticValues().getSum(), 0.0001d);
+        Assert.assertEquals(2.0d, datum.getStatisticValues().getSampleCount(), 0.0001d);
     }
 
     @Test
@@ -202,19 +203,19 @@ public class TestPutCloudWatchMetric {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
-        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
+        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        Assert.assertEquals("TestNamespace", mockPutCloudWatchMetric.actualNamespace);
         MetricDatum datum = mockPutCloudWatchMetric.actualMetricData.get(0);
-        assertEquals("TestMetric", datum.getMetricName());
-        assertEquals(1d, datum.getValue(), 0.0001d);
+        Assert.assertEquals("TestMetric", datum.getMetricName());
+        Assert.assertEquals(1d, datum.getValue(), 0.0001d);
 
         List<Dimension> dimensions = datum.getDimensions();
         Collections.sort(dimensions, (d1, d2) -> d1.getName().compareTo(d2.getName()));
-        assertEquals(2, dimensions.size());
-        assertEquals("dim1", dimensions.get(0).getName());
-        assertEquals("1", dimensions.get(0).getValue());
-        assertEquals("dim2", dimensions.get(1).getName());
-        assertEquals("val2", dimensions.get(1).getValue());
+        Assert.assertEquals(2, dimensions.size());
+        Assert.assertEquals("dim1", dimensions.get(0).getName());
+        Assert.assertEquals("1", dimensions.get(0).getValue());
+        Assert.assertEquals("dim2", dimensions.get(1).getName());
+        Assert.assertEquals("val2", dimensions.get(1).getValue());
     }
 
     @Test
@@ -264,27 +265,34 @@ public class TestPutCloudWatchMetric {
         runner.enqueue(new byte[] {}, attributes);
         runner.run();
 
-        assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
+        Assert.assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_FAILURE, 1);
     }
 
-    @Test
-    public void testInvalidUnitRoutesToFailure() throws Exception {
+    @ParameterizedTest
+    @CsvSource({"nan","percent","count"})
+    public void testInvalidUnit(String unit) throws Exception {
         MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
-        mockPutCloudWatchMetric.throwException = new InvalidParameterValueException("Unit error message");
         final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
 
         runner.setProperty(PutCloudWatchMetric.NAMESPACE, "TestNamespace");
         runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "TestMetric");
-        runner.setProperty(PutCloudWatchMetric.UNIT, "BogusUnit");
+        runner.setProperty(PutCloudWatchMetric.UNIT, unit);
+        runner.setProperty(PutCloudWatchMetric.VALUE, "1.0");
+        runner.assertNotValid();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"Count","Bytes","Percent"})
+    public void testValidUnit(String unit) throws Exception {
+        MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
+        final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
+
+        runner.setProperty(PutCloudWatchMetric.NAMESPACE, "TestNamespace");
+        runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "TestMetric");
+        runner.setProperty(PutCloudWatchMetric.UNIT, unit);
         runner.setProperty(PutCloudWatchMetric.VALUE, "1");
         runner.assertValid();
-
-        runner.enqueue(new byte[] {});
-        runner.run();
-
-        assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
-        runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_FAILURE, 1);
     }
 
     @Test
@@ -304,8 +312,40 @@ public class TestPutCloudWatchMetric {
         runner.enqueue(new byte[] {}, attributes);
         runner.run();
 
-        assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
+        Assert.assertEquals(0, mockPutCloudWatchMetric.putMetricDataCallCount);
         runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_FAILURE, 1);
     }
 
+
+    @ParameterizedTest
+    @CsvSource({"null","us-west-100","us-east-a"})
+    public void testInvalidRegion(String region) {
+        MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
+        final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
+
+        runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
+        runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
+        runner.setProperty(PutCloudWatchMetric.VALUE, "6");
+        runner.setProperty(PutCloudWatchMetric.REGION, region);
+        runner.assertNotValid();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"us-east-1","us-west-1","us-east-2"})
+    public void testValidRegionRoutesToSuccess(String region) {
+        MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
+        final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
+
+        runner.setProperty(PutCloudWatchMetric.NAMESPACE, "Test");
+        runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "Test");
+        runner.setProperty(PutCloudWatchMetric.VALUE, "6");
+        runner.setProperty(PutCloudWatchMetric.REGION, region);
+        runner.assertValid();
+
+        runner.enqueue(new byte[] {});
+        runner.run();
+
+        Assert.assertEquals(1, mockPutCloudWatchMetric.putMetricDataCallCount);
+        runner.assertAllFlowFilesTransferred(PutCloudWatchMetric.REL_SUCCESS, 1);
+    }
 }

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.stream.Stream;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.util.TestRunner;
@@ -30,7 +31,9 @@ import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import org.junit.jupiter.api.Test;
 import org.junit.Assert;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link PutCloudWatchMetric}.
@@ -282,19 +285,21 @@ public class TestPutCloudWatchMetric {
         runner.assertNotValid();
     }
 
-    @Test
-    public void testValidUnit() throws Exception {
+    private static Stream<Arguments> data() {
+        return PutCloudWatchMetric.units.stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testValidUnit(String unit) {
         MockPutCloudWatchMetric mockPutCloudWatchMetric = new MockPutCloudWatchMetric();
         final TestRunner runner = TestRunners.newTestRunner(mockPutCloudWatchMetric);
 
-        for (String unit: PutCloudWatchMetric.getUnitParameters()) {
-
-            runner.setProperty(PutCloudWatchMetric.NAMESPACE, "TestNamespace");
-            runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "TestMetric");
-            runner.setProperty(PutCloudWatchMetric.UNIT, unit);
-            runner.setProperty(PutCloudWatchMetric.VALUE, "1");
-            runner.assertValid();
-        }
+        runner.setProperty(PutCloudWatchMetric.NAMESPACE, "TestNamespace");
+        runner.setProperty(PutCloudWatchMetric.METRIC_NAME, "TestMetric");
+        runner.setProperty(PutCloudWatchMetric.UNIT, unit);
+        runner.setProperty(PutCloudWatchMetric.VALUE, "1");
+        runner.assertValid();
     }
 
     @Test


### PR DESCRIPTION
# NiFi-9817 Add a Validator for the PutCloudWatchMetric Processor's Unit Field
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->

PR Description:

The AWS PutCloudWatchMetric processor has a Unit property that requires a value from AWS's CloudWatch API specifications. This value is a constant from a predefined set of string parameters. The API enforces casing so a unit value of "bytes" fails to make a successful API request, whereas "Bytes" succeeds.  This fix validates if a user is typing the correct Unit value parameter prior to starting the PutCloudWatchMetric processor.

The proposed fix includes a new Validator() to warn the user about the issues prior to starting the PutCloudWatchMetric processor and a set to determine the partitions for the Unit field in API requests to AWS. There are also updates to the integration tests and unit tests to check the validity of the processor.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
