### PR TITLE
NIFI-9841 changed expected exception to ProcessException in KeyedEncr…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/security/util/crypto/KeyedEncryptorGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/security/util/crypto/KeyedEncryptorGroovyTest.groovy
@@ -17,6 +17,7 @@
 package org.apache.nifi.security.util.crypto
 
 import org.apache.commons.codec.binary.Hex
+import org.apache.nifi.processor.exception.ProcessException
 import org.apache.nifi.processor.io.StreamCallback
 import org.apache.nifi.security.util.EncryptionMethod
 import org.apache.nifi.security.util.KeyDerivationFunction
@@ -211,12 +212,9 @@ class KeyedEncryptorGroovyTest {
         final byte[] removedIVCipherBytes = cipherString.split(IV_DELIMITER)[1].getBytes(StandardCharsets.UTF_8)
 
         InputStream cipherInputStream = new ByteArrayInputStream(removedIVCipherBytes)
-        Exception exception = Assert.assertThrows(Exception.class, () -> {
+        Exception exception = Assert.assertThrows(ProcessException.class, () -> {
             decryptionCallback.process(cipherInputStream, recoveredStream)
         })
-
-        // Assert
-        assert exception.getCause() instanceof BytePatternNotFoundException
     }
 
     @Test
@@ -249,11 +247,8 @@ class KeyedEncryptorGroovyTest {
 
         InputStream cipherInputStream = new ByteArrayInputStream(removedIVDelimiterCipherBytes)
 
-        Exception exception = Assert.assertThrows(Exception.class, () -> {
+        Exception exception = Assert.assertThrows(ProcessException.class, () -> {
             decryptionCallback.process(cipherInputStream, recoveredStream)
         })
-
-        // Assert
-        assert exception.getCause() instanceof BytePatternNotFoundException
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/security/util/crypto/PasswordBasedEncryptorGroovyTest.groovy
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/groovy/org/apache/nifi/security/util/crypto/PasswordBasedEncryptorGroovyTest.groovy
@@ -17,6 +17,7 @@
 package org.apache.nifi.security.util.crypto
 
 import org.apache.commons.codec.binary.Hex
+import org.apache.nifi.processor.exception.ProcessException
 import org.apache.nifi.processor.io.StreamCallback
 import org.apache.nifi.processors.standard.TestEncryptContentGroovy
 import org.apache.nifi.security.util.EncryptionMethod
@@ -552,14 +553,9 @@ class PasswordBasedEncryptorGroovyTest {
             InputStream cipherInputStream = new ByteArrayInputStream(cipherBytes)
             cipherInputStream.skip(skipLength)
 
-            Exception exception = Assert.assertThrows(Exception.class, () -> {
+            Exception exception = Assert.assertThrows(ProcessException.class, () -> {
                 decryptionCallback.process(cipherInputStream, recoveredStream)
             })
-
-            // Assert
-            if (!(cipherProvider instanceof OpenSSLPKCS5CipherProvider)) {
-                assert exception.getCause() instanceof IllegalArgumentException
-            }
 
             // This is necessary to run multiple iterations
             plainStream.reset()
@@ -599,12 +595,9 @@ class PasswordBasedEncryptorGroovyTest {
 
             InputStream cipherInputStream = new ByteArrayInputStream(removedDelimiterCipherString.getBytes(StandardCharsets.UTF_8))
 
-            Exception exception = Assert.assertThrows(Exception.class, () -> {
+            Exception exception = Assert.assertThrows(ProcessException.class, () -> {
                 decryptionCallback.process(cipherInputStream, recoveredStream)
             })
-
-            // Assert
-            assert exception.getCause() instanceof BytePatternNotFoundException
 
             // This is necessary to run multiple iterations
             plainStream.reset()
@@ -653,12 +646,9 @@ class PasswordBasedEncryptorGroovyTest {
 
             InputStream cipherInputStream = new ByteArrayInputStream(removedIVCipherString.getBytes(StandardCharsets.UTF_8))
 
-            Exception exception = Assert.assertThrows(Exception.class, () -> {
+            Exception exception = Assert.assertThrows(ProcessException.class, () -> {
                 decryptionCallback.process(cipherInputStream, recoveredStream)
             })
-
-            // Assert
-            assert exception.getCause() instanceof IllegalArgumentException
 
             // This is necessary to run multiple iterations
             plainStream.reset()
@@ -698,12 +688,9 @@ class PasswordBasedEncryptorGroovyTest {
 
             InputStream cipherInputStream = new ByteArrayInputStream(removedDelimiterCipherString.getBytes(StandardCharsets.UTF_8))
 
-            Exception exception = Assert.assertThrows(Exception.class, () -> {
+            Exception exception = Assert.assertThrows(ProcessException.class, () -> {
                 decryptionCallback.process(cipherInputStream, recoveredStream)
             })
-
-            // Assert
-            assert exception.getCause() instanceof BytePatternNotFoundException
 
             // This is necessary to run multiple iterations
             plainStream.reset()


### PR DESCRIPTION
…yptorGroovyTest and PasswordBasedEncryptorGroovyTest to avoid intermittent failures

<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
Thank you for submitting a contribution to Apache NiFi.

Please provide a short description of the PR here:
- `PasswordBasedEncryptorGroovyTest` had intermittent failures due to the exception sometimes having a `null` cause. Changed the exception expectation to just expect a `ProcessException` since that is what all errors are wrapped in, in the `DecryptCallback` class. Made changes for consistency also in `KeyedEncryptorTest`

#### Description of PR

_Enables X functionality; fixes bug NIFI-YYYY._

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
