### PR TITLE
NIFI-9850 Add support for multiple expressions to GrokReader

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/grok/GrokReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/grok/GrokReader.java
@@ -29,6 +29,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.resource.ResourceCardinality;
+import org.apache.nifi.components.resource.ResourceReference;
 import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.ConfigurationContext;
@@ -48,6 +49,7 @@ import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -60,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 @Tags({"grok", "logs", "logfiles", "parse", "unstructured", "text", "record", "reader", "regex", "pattern", "logstash"})
 @CapabilityDescription("Provides a mechanism for reading unstructured text data, such as log files, and structuring the data "
@@ -71,8 +74,7 @@ import java.util.regex.Matcher;
     + "no stack trace, it will have a NULL value for the stackTrace field (assuming that the schema does in fact include a stackTrace field of type String). "
     + "Assuming that the schema includes a '_raw' field of type String, the raw message will be included in the Record.")
 public class GrokReader extends SchemaRegistryService implements RecordReaderFactory {
-    private volatile GrokCompiler grokCompiler;
-    private volatile Grok grok;
+    private volatile List<Grok> groks;
     private volatile NoMatchStrategy noMatchStrategy;
     private volatile RecordSchema recordSchema;
     private volatile RecordSchema recordSchemaFromGrok;
@@ -102,10 +104,14 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
 
     static final PropertyDescriptor GROK_EXPRESSION = new PropertyDescriptor.Builder()
         .name("Grok Expression")
+        .displayName("Grok Expressions")
         .description("Specifies the format of a log line in Grok format. This allows the Record Reader to understand how to parse each log line. "
-            + "If a line in the log file does not match this pattern, the line will be assumed to belong to the previous log message."
-            + "If other Grok expressions are referenced by this expression, they need to be supplied in the Grok Pattern File")
+            + "The property supports one or more Grok expressions. The Reader attempts to parse input lines according to the configured order of the expressions."
+            + "If a line in the log file does not match any expressions, the line will be assumed to belong to the previous log message."
+            + "If other Grok patterns are referenced by this expression, they need to be supplied in the Grok Pattern File property."
+        )
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+        .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.TEXT, ResourceType.URL, ResourceType.FILE)
         .required(true)
         .build();
 
@@ -130,11 +136,10 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
 
     @OnEnabled
     public void preCompile(final ConfigurationContext context) throws GrokException, IOException {
-        grokCompiler = GrokCompiler.newInstance();
+        GrokCompiler grokCompiler = GrokCompiler.newInstance();
 
-        try (final InputStream in = getClass().getResourceAsStream(DEFAULT_PATTERN_NAME);
-            final Reader reader = new InputStreamReader(in)) {
-            grokCompiler.register(reader);
+        try (final Reader defaultPatterns = getDefaultPatterns()) {
+            grokCompiler.register(defaultPatterns);
         }
 
         if (context.getProperty(PATTERN_FILE).isSet()) {
@@ -144,10 +149,11 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
             }
         }
 
-        grok = grokCompiler.compile(context.getProperty(GROK_EXPRESSION).getValue());
+        groks = readGrokExpressions(context).stream()
+                .map(grokCompiler::compile)
+                .collect(Collectors.toList());
 
-
-        if(context.getProperty(NO_MATCH_BEHAVIOR).getValue().equalsIgnoreCase(APPEND_TO_PREVIOUS_MESSAGE.getValue())) {
+        if (context.getProperty(NO_MATCH_BEHAVIOR).getValue().equalsIgnoreCase(APPEND_TO_PREVIOUS_MESSAGE.getValue())) {
             noMatchStrategy = NoMatchStrategy.APPEND;
         } else if (context.getProperty(NO_MATCH_BEHAVIOR).getValue().equalsIgnoreCase(RAW_LINE.getValue())) {
             noMatchStrategy = NoMatchStrategy.RAW;
@@ -155,7 +161,7 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
             noMatchStrategy = NoMatchStrategy.SKIP;
         }
 
-        this.recordSchemaFromGrok = createRecordSchema(grok);
+        this.recordSchemaFromGrok = createRecordSchema(groks);
 
         final String schemaAccess = context.getProperty(getSchemaAcessStrategyDescriptor()).getValue();
         if (STRING_FIELDS_FROM_GROK_EXPRESSION.getValue().equals(schemaAccess)) {
@@ -167,42 +173,61 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
 
     @Override
     protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
-        ArrayList<ValidationResult> results = new ArrayList<>(super.customValidate(validationContext));
-        // validate the grok expression against configuration
-        GrokCompiler grokCompiler = GrokCompiler.newInstance();
-        String subject = GROK_EXPRESSION.getName();
-        String input = validationContext.getProperty(GROK_EXPRESSION).getValue();
-        GrokExpressionValidator validator;
+        final List<ValidationResult> results = new ArrayList<>(super.customValidate(validationContext));
+        final GrokCompiler grokCompiler = GrokCompiler.newInstance();
 
-        try (final InputStream in = getClass().getResourceAsStream(DEFAULT_PATTERN_NAME);
-             final Reader reader = new InputStreamReader(in)) {
-            grokCompiler.register(reader);
-        } catch (IOException e) {
+        final String expressionSubject = GROK_EXPRESSION.getDisplayName();
+
+        try (final Reader defaultPatterns = getDefaultPatterns()) {
+            grokCompiler.register(defaultPatterns);
+        } catch (final IOException e) {
             results.add(new ValidationResult.Builder()
-                    .input(input)
-                    .subject(subject)
+                    .input("Default Grok Patterns")
+                    .subject(expressionSubject)
                     .valid(false)
                     .explanation("Unable to load default patterns: " + e.getMessage())
                     .build());
         }
 
-        validator = new GrokExpressionValidator(validationContext.getProperty(PATTERN_FILE).evaluateAttributeExpressions().getValue(),grokCompiler);
-        results.add(validator.validate(subject,input,validationContext));
+        final String patternFileName = validationContext.getProperty(PATTERN_FILE).evaluateAttributeExpressions().getValue();
+        final GrokExpressionValidator validator = new GrokExpressionValidator(patternFileName, grokCompiler);
+
+        try {
+            final List<String> grokExpressions = readGrokExpressions(validationContext);
+            final List<ValidationResult> grokExpressionResults = grokExpressions.stream()
+                    .map(grokExpression -> validator.validate(expressionSubject, grokExpression, validationContext)).collect(Collectors.toList());
+            results.addAll(grokExpressionResults);
+        } catch (final IOException e) {
+            results.add(new ValidationResult.Builder()
+                    .input("Configured Grok Expressions")
+                    .subject(expressionSubject)
+                    .valid(false)
+                    .explanation(String.format("Read Grok Expressions failed: %s", e.getMessage()))
+                    .build());
+        }
+
         return results;
     }
 
-    static RecordSchema createRecordSchema(final Grok grok) {
+    private List<String> readGrokExpressions(final PropertyContext propertyContext) throws IOException {
+        final ResourceReference expressionsResource = propertyContext.getProperty(GROK_EXPRESSION).asResource();
+        try (
+                final InputStream expressionsStream = expressionsResource.read();
+                final BufferedReader expressionsReader = new BufferedReader(new InputStreamReader(expressionsStream))
+        ) {
+            return expressionsReader.lines().collect(Collectors.toList());
+        }
+    }
+
+    static RecordSchema createRecordSchema(final List<Grok> groks) {
         final Set<RecordField> fields = new LinkedHashSet<>();
 
-        String grokExpression = grok.getOriginalGrokPattern();
-        populateSchemaFieldNames(grok, grokExpression, fields);
+        groks.forEach(grok -> populateSchemaFieldNames(grok, grok.getOriginalGrokPattern(), fields));
 
         fields.add(new RecordField(GrokRecordReader.STACK_TRACE_COLUMN_NAME, RecordFieldType.STRING.getDataType(), true));
         fields.add(new RecordField(GrokRecordReader.RAW_MESSAGE_NAME, RecordFieldType.STRING.getDataType(), true));
 
-        final RecordSchema schema = new SimpleRecordSchema(new ArrayList<>(fields));
-
-        return schema;
+        return new SimpleRecordSchema(new ArrayList<>(fields));
     }
 
     private static void populateSchemaFieldNames(final Grok grok, String grokExpression, final Collection<RecordField> fields) {
@@ -267,7 +292,7 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
 
 
             @Override
-            public RecordSchema getSchema(Map<String, String> variables, InputStream contentStream, RecordSchema readSchema) throws SchemaNotFoundException {
+            public RecordSchema getSchema(Map<String, String> variables, InputStream contentStream, RecordSchema readSchema) {
                 return recordSchema;
             }
 
@@ -281,6 +306,14 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
     @Override
     public RecordReader createRecordReader(final Map<String, String> variables, final InputStream in, final long inputLength, final ComponentLog logger) throws IOException, SchemaNotFoundException {
         final RecordSchema schema = getSchema(variables, in, null);
-        return new GrokRecordReader(in, grok, schema, recordSchemaFromGrok, noMatchStrategy);
+        return new GrokRecordReader(in, groks, schema, recordSchemaFromGrok, noMatchStrategy);
+    }
+
+    private Reader getDefaultPatterns() throws IOException {
+        final InputStream inputStream = getClass().getResourceAsStream(DEFAULT_PATTERN_NAME);
+        if (inputStream == null) {
+            throw new IOException(String.format("Default Patterns [%s] not found", DEFAULT_PATTERN_NAME));
+        }
+        return new InputStreamReader(inputStream);
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/grok/GrokReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/grok/GrokReader.java
@@ -89,8 +89,10 @@ public class GrokReader extends SchemaRegistryService implements RecordReaderFac
             "The line of text that does not match the Grok Expression will only be added to the _raw field.");
 
     static final AllowableValue STRING_FIELDS_FROM_GROK_EXPRESSION = new AllowableValue("string-fields-from-grok-expression", "Use String Fields From Grok Expression",
-        "The schema will be derived by using the field names present in the Grok Expression. All fields will be assumed to be of type String. Additionally, a field will be included "
-            + "with a name of 'stackTrace' and a type of String.");
+            "The schema will be derived using the field names present in all configured Grok Expressions. "
+            + "All schema fields will have a String type and will be marked as nullable. "
+            + "The schema will also include a `stackTrace` field, and a `_raw` field containing the input line string."
+    );
 
     static final PropertyDescriptor PATTERN_FILE = new PropertyDescriptor.Builder()
         .name("Grok Pattern File")


### PR DESCRIPTION
#### Description of PR

NIFI-9850 Adds support for multiple expressions to `GrokReader`.

The implementation updates the existing `Grok Expression` property with a new display name of `Grok Expressions` and enhances the property descriptor to support reading multiple expressions from a resource reference. The resource reference enables reading Grok Expressions from the property value itself as well as an external file path or URL. This approach maintains compatibility with existing property values that define a single Grok Expression.

The updated `Grok Expressions` property descriptor enables `GrokReader` to load multiple expressions, separated by newlines. The `GrokRecordReader` iterates over the configured expressions and returns on the first match found.

Changes include unit test optimization as well as a new unit test that configures multiple patterns to parse different log lines.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
