### PR TITLE
NIFI-9879 Add min/max age and min/max size properties to ListAzure pr…

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/AbstractListAzureProcessor.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/AbstractListAzureProcessor.java
@@ -64,21 +64,20 @@ public abstract class AbstractListAzureProcessor<T extends ListableEntity> exten
         final long minAge = context.getProperty(MIN_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
         final Long maxAge = context.getProperty(MAX_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
 
-        if (lastModified >= minimumTimestamp) {
-            if (minSize > size) {
-                return false;
-            }
-            if (maxSize != null && maxSize < size) {
-                return false;
-            }
-            final long fileAge = System.currentTimeMillis() - lastModified;
-            if (minAge > fileAge) {
-                return false;
-            }
-            if (maxAge != null && maxAge < fileAge) {
-                return false;
-            }
-        } else {
+        if (lastModified < minimumTimestamp) {
+            return false;
+        }
+        final long fileAge = System.currentTimeMillis() - lastModified;
+        if (minAge > fileAge) {
+            return false;
+        }
+        if (maxAge != null && maxAge < fileAge) {
+            return false;
+        }
+        if (minSize > size) {
+            return false;
+        }
+        if (maxSize != null && maxSize < size) {
             return false;
         }
         return true;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/AbstractListAzureProcessor.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/AbstractListAzureProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processor.util.list.AbstractListProcessor;
+import org.apache.nifi.processor.util.list.ListableEntity;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.nifi.processor.util.StandardValidators.TIME_PERIOD_VALIDATOR;
+
+public abstract class AbstractListAzureProcessor<T extends ListableEntity> extends AbstractListProcessor<T> {
+    public static final PropertyDescriptor MIN_AGE = new PropertyDescriptor.Builder()
+            .name("Minimum File Age")
+            .description("The minimum age that a file must be in order to be pulled; any file younger than this amount of time (according to last modification date) will be ignored")
+            .required(true)
+            .addValidator(TIME_PERIOD_VALIDATOR)
+            .defaultValue("0 sec")
+            .build();
+
+    public static final PropertyDescriptor MAX_AGE = new PropertyDescriptor.Builder()
+            .name("Maximum File Age")
+            .description("The maximum age that a file must be in order to be pulled; any file older than this amount of time (according to last modification date) will be ignored")
+            .required(false)
+            .addValidator(StandardValidators.createTimePeriodValidator(100, TimeUnit.MILLISECONDS, Long.MAX_VALUE, TimeUnit.NANOSECONDS))
+            .build();
+
+    public static final PropertyDescriptor MIN_SIZE = new PropertyDescriptor.Builder()
+            .name("Minimum File Size")
+            .description("The minimum size that a file must be in order to be pulled")
+            .required(true)
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .defaultValue("0 B")
+            .build();
+
+    public static final PropertyDescriptor MAX_SIZE = new PropertyDescriptor.Builder()
+            .name("Maximum File Size")
+            .description("The maximum size that a file can be in order to be pulled")
+            .required(false)
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .build();
+
+    protected boolean isFileInfoMatchesWithAgeAndSize(final ProcessContext context, final long minimumTimestamp, final long lastModified, final long size) {
+        final long minSize = context.getProperty(MIN_SIZE).asDataSize(DataUnit.B).longValue();
+        final Double maxSize = context.getProperty(MAX_SIZE).asDataSize(DataUnit.B);
+        final long minAge = context.getProperty(MIN_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
+        final Long maxAge = context.getProperty(MAX_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
+
+        if (lastModified >= minimumTimestamp) {
+            if (minSize > size) {
+                return false;
+            }
+            if (maxSize != null && maxSize < size) {
+                return false;
+            }
+            final long fileAge = System.currentTimeMillis() - lastModified;
+            if (minAge > fileAge) {
+                return false;
+            }
+            if (maxAge != null && maxAge < fileAge) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+        return true;
+    }
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorageIT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorageIT.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import static org.apache.nifi.processors.azure.AzureServiceEndpoints.DEFAULT_BLOB_ENDPOINT_SUFFIX;
@@ -64,7 +65,7 @@ public abstract class AbstractAzureBlobStorageIT extends AbstractAzureStorageIT 
 
     protected void uploadTestBlob(final String blobName, final String fileContent) throws Exception {
         CloudBlob blob = container.getBlockBlobReference(blobName);
-        byte[] buf = fileContent.getBytes();
+        byte[] buf = fileContent.getBytes(StandardCharsets.UTF_8);
         InputStream in = new ByteArrayInputStream(buf);
         blob.upload(in, buf.length);
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorageIT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorageIT.java
@@ -59,8 +59,12 @@ public abstract class AbstractAzureBlobStorageIT extends AbstractAzureStorageIT 
     }
 
     protected void uploadTestBlob() throws Exception {
-        CloudBlob blob = container.getBlockBlobReference(TEST_BLOB_NAME);
-        byte[] buf = TEST_FILE_CONTENT.getBytes();
+        uploadTestBlob(TEST_BLOB_NAME, TEST_FILE_CONTENT);
+    }
+
+    protected void uploadTestBlob(final String blobName, final String fileContent) throws Exception {
+        CloudBlob blob = container.getBlockBlobReference(blobName);
+        byte[] buf = fileContent.getBytes();
         InputStream in = new ByteArrayInputStream(buf);
         blob.upload(in, buf.length);
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -43,7 +44,7 @@ import static org.apache.nifi.processors.azure.AzureServiceEndpoints.DEFAULT_BLO
 public abstract class AbstractAzureBlobStorage_v12IT extends AbstractAzureStorageIT {
 
     protected static final String BLOB_NAME = "blob1";
-    protected static final byte[] BLOB_DATA = "0123456789".getBytes();
+    protected static final byte[] BLOB_DATA = "0123456789".getBytes(StandardCharsets.UTF_8);
 
     protected static final String EL_CONTAINER_NAME = "az.containername";
     protected static final String EL_BLOB_NAME = "az.blobname";

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureDataLakeStorageIT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureDataLakeStorageIT.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import static org.apache.nifi.processors.azure.AzureServiceEndpoints.DEFAULT_ADLS_ENDPOINT_SUFFIX;
@@ -87,7 +88,7 @@ public abstract class AbstractAzureDataLakeStorageIT extends AbstractAzureStorag
     }
 
     protected void uploadFile(String directory, String filename, String fileContent) {
-        uploadFile(directory, filename, fileContent.getBytes());
+        uploadFile(directory, filename, fileContent.getBytes(StandardCharsets.UTF_8));
     }
 
     protected void uploadFile(TestFile testFile) {
@@ -102,7 +103,7 @@ public abstract class AbstractAzureDataLakeStorageIT extends AbstractAzureStorag
     }
 
     protected void createDirectoryAndUploadFile(String directory, String filename, String fileContent) {
-        createDirectoryAndUploadFile(directory, filename, fileContent.getBytes());
+        createDirectoryAndUploadFile(directory, filename, fileContent.getBytes(StandardCharsets.UTF_8));
     }
 
     protected void createDirectoryAndUploadFile(String directory, String filename, byte[] fileData) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage.java
@@ -55,12 +55,58 @@ public class ITListAzureBlobStorage extends AbstractAzureBlobStorageIT {
         assertResult();
     }
 
+    @Test
+    public void testListWithMinAge() throws Exception {
+        runner.setProperty(ListAzureBlobStorage.MIN_AGE, "1 hour");
+
+        runner.assertValid();
+        runner.run(1);
+
+        runner.assertTransferCount(ListAzureBlobStorage.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testListWithMaxAge() throws Exception {
+        runner.setProperty(ListAzureBlobStorage.MAX_AGE, "1 hour");
+
+        runner.assertValid();
+        runner.run(1);
+
+        assertResult(TEST_FILE_CONTENT);
+    }
+
+    @Test
+    public void testListWithMinSize() throws Exception {
+        uploadTestBlob("nifi-test-blob2", "Test");
+        runner.setProperty(ListAzureBlobStorage.MIN_SIZE, "5 B");
+
+        runner.assertValid();
+        runner.run(1);
+
+        assertResult(TEST_FILE_CONTENT);
+    }
+
+    @Test
+    public void testListWithMaxSize() throws Exception {
+        uploadTestBlob("nifi-test-blob2", "Test");
+        runner.setProperty(ListAzureBlobStorage.MAX_SIZE, "5 B");
+
+        runner.assertValid();
+        runner.run(1);
+
+        assertResult("Test");
+    }
+
     private void assertResult() {
+        assertResult(TEST_FILE_CONTENT);
+    }
+
+    private void assertResult(final String contentLengthAsString) {
         runner.assertTransferCount(ListAzureBlobStorage.REL_SUCCESS, 1);
         runner.assertAllFlowFilesTransferred(ListAzureBlobStorage.REL_SUCCESS, 1);
 
         for (MockFlowFile entry : runner.getFlowFilesForRelationship(ListAzureBlobStorage.REL_SUCCESS)) {
-            entry.assertAttributeEquals("azure.length", "36");
+            entry.assertAttributeEquals("azure.length", String.valueOf(contentLengthAsString.length()));
             entry.assertAttributeEquals("mime.type", "application/octet-stream");
         }
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage.java
@@ -37,8 +37,7 @@ public class ITListAzureBlobStorage extends AbstractAzureBlobStorageIT {
     @BeforeEach
     public void setUp() throws Exception {
         uploadTestBlob();
-
-        Thread.sleep(ListAzureBlobStorage.LISTING_LAG_MILLIS.get(TimeUnit.SECONDS) * 2);
+        waitForUpload();
     }
 
     @Test
@@ -82,7 +81,7 @@ public class ITListAzureBlobStorage extends AbstractAzureBlobStorageIT {
     @Test
     public void testListWithMinSize() throws Exception {
         uploadTestBlob("nifi-test-blob2", "Test");
-        Thread.sleep(ListAzureBlobStorage.LISTING_LAG_MILLIS.get(TimeUnit.SECONDS) * 2);
+        waitForUpload();
         assertListCount();
         runner.setProperty(ListAzureBlobStorage.MIN_SIZE, "5 B");
 
@@ -95,7 +94,7 @@ public class ITListAzureBlobStorage extends AbstractAzureBlobStorageIT {
     @Test
     public void testListWithMaxSize() throws Exception {
         uploadTestBlob("nifi-test-blob2", "Test");
-        Thread.sleep(ListAzureBlobStorage.LISTING_LAG_MILLIS.get(TimeUnit.SECONDS) * 2);
+        waitForUpload();
         assertListCount();
         runner.setProperty(ListAzureBlobStorage.MAX_SIZE, "5 B");
 
@@ -103,6 +102,10 @@ public class ITListAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.run(1);
 
         assertResult("Test");
+    }
+
+    private void waitForUpload() throws InterruptedException {
+        Thread.sleep(ListAzureBlobStorage.LISTING_LAG_MILLIS.get(TimeUnit.SECONDS) * 2);
     }
 
     private void assertResult() {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ITListAzureBlobStorage extends AbstractAzureBlobStorageIT {
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage_v12.java
@@ -23,6 +23,7 @@ import org.apache.nifi.serialization.record.MockRecordWriter;
 import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -145,7 +146,7 @@ public class ITListAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     public void testListWithMinSize() throws Exception {
         uploadBlobs();
         runner.setProperty(ListAzureBlobStorage_v12.MIN_SIZE, "5 B");
-        uploadBlob("blob5", "Test".getBytes());
+        uploadBlob("blob5", "Test".getBytes(StandardCharsets.UTF_8));
 
         runProcessor();
 
@@ -156,7 +157,7 @@ public class ITListAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     public void testListWithMaxSize() throws Exception {
         uploadBlobs();
         runner.setProperty(ListAzureBlobStorage_v12.MAX_SIZE, "5 B");
-        uploadBlob("blob5", "Test".getBytes());
+        uploadBlob("blob5", "Test".getBytes(StandardCharsets.UTF_8));
 
         runProcessor();
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureBlobStorage_v12.java
@@ -112,13 +112,57 @@ public class ITListAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
         MockRecordWriter recordWriter = new MockRecordWriter(null, false);
         runner.addControllerService("record-writer", recordWriter);
         runner.enableControllerService(recordWriter);
-        runner.setProperty(ListAzureDataLakeStorage.RECORD_WRITER, "record-writer");
+        runner.setProperty(ListAzureBlobStorage_v12.RECORD_WRITER, "record-writer");
 
         runner.run();
 
-        runner.assertAllFlowFilesTransferred(ListAzureDataLakeStorage.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ListAzureDataLakeStorage.REL_SUCCESS).get(0);
+        runner.assertAllFlowFilesTransferred(ListAzureBlobStorage_v12.REL_SUCCESS, 1);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ListAzureBlobStorage_v12.REL_SUCCESS).get(0);
         flowFile.assertAttributeEquals("record.count", "4");
+    }
+
+    @Test
+    public void testListWithMinAge() throws Exception {
+        uploadBlobs();
+        runner.setProperty(ListAzureBlobStorage_v12.MIN_AGE, "1 hour");
+
+        runProcessor();
+
+        runner.assertTransferCount(ListAzureBlobStorage_v12.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testListWithMaxAge() throws Exception {
+        uploadBlobs();
+        runner.setProperty(ListAzureBlobStorage_v12.MAX_AGE, "1 hour");
+
+        runProcessor();
+
+        assertSuccess(BLOB_NAME_1, BLOB_NAME_2, BLOB_NAME_3, BLOB_NAME_4);
+    }
+
+    @Test
+    public void testListWithMinSize() throws Exception {
+        uploadBlobs();
+        runner.setProperty(ListAzureBlobStorage_v12.MIN_SIZE, "5 B");
+        uploadBlob("blob5", "Test".getBytes());
+
+        runProcessor();
+
+        assertSuccess(BLOB_NAME_1, BLOB_NAME_2, BLOB_NAME_3, BLOB_NAME_4);
+    }
+
+    @Test
+    public void testListWithMaxSize() throws Exception {
+        uploadBlobs();
+        runner.setProperty(ListAzureBlobStorage_v12.MAX_SIZE, "5 B");
+        uploadBlob("blob5", "Test".getBytes());
+
+        runProcessor();
+
+        runner.assertAllFlowFilesTransferred(ListAzureBlobStorage_v12.REL_SUCCESS, 1);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ListAzureBlobStorage_v12.REL_SUCCESS).get(0);
+        assertFlowFileBlobAttributes(flowFile, getContainerName(), "blob5", "Test".length());
     }
 
     private void uploadBlobs() throws Exception {
@@ -134,9 +178,9 @@ public class ITListAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     }
 
     private void assertSuccess(String... blobNames) throws Exception {
-        runner.assertTransferCount(ListAzureDataLakeStorage.REL_SUCCESS, blobNames.length);
+        runner.assertTransferCount(ListAzureBlobStorage_v12.REL_SUCCESS, blobNames.length);
 
-        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListAzureDataLakeStorage.REL_SUCCESS);
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListAzureBlobStorage_v12.REL_SUCCESS);
 
         Set<String> expectedBlobNames = new HashSet<>(Arrays.asList(blobNames));
 
@@ -160,6 +204,6 @@ public class ITListAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
 
     private void assertFailure() {
         assertFalse(runner.getLogger().getErrorMessages().isEmpty());
-        runner.assertTransferCount(ListAzureDataLakeStorage.REL_SUCCESS, 0);
+        runner.assertTransferCount(ListAzureBlobStorage_v12.REL_SUCCESS, 0);
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureDataLakeStorage.java
@@ -24,6 +24,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -291,7 +292,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         flowFile.assertAttributeEquals(ATTR_NAME_FILE_PATH, testFile.getFilePath());
         flowFile.assertAttributeEquals(ATTR_NAME_DIRECTORY, testFile.getDirectory());
         flowFile.assertAttributeEquals(ATTR_NAME_FILENAME, testFile.getFilename());
-        flowFile.assertAttributeEquals(ATTR_NAME_LENGTH, String.valueOf(testFile.getFileContent().length()));
+        flowFile.assertAttributeEquals(ATTR_NAME_LENGTH, String.valueOf(testFile.getFileContent().getBytes(StandardCharsets.UTF_8).length));
 
         flowFile.assertAttributeExists(ATTR_NAME_LAST_MODIFIED);
         flowFile.assertAttributeExists(ATTR_NAME_ETAG);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureDataLakeStorage.java
@@ -72,7 +72,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         createDirectoryAndUploadFile(testFile111);
         testFiles.put(testFile111.getFilePath(), testFile111);
 
-        TestFile testFile21 = new TestFile("dir 2", "file 21");
+        TestFile testFile21 = new TestFile("dir 2", "file 21", "Test");
         createDirectoryAndUploadFile(testFile21);
         testFiles.put(testFile21.getFilePath(), testFile21);
 
@@ -223,6 +223,46 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         runner.assertAllFlowFilesTransferred(ListAzureDataLakeStorage.REL_SUCCESS, 1);
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(ListAzureDataLakeStorage.REL_SUCCESS).get(0);
         flowFile.assertAttributeEquals("record.count", "3");
+    }
+
+    @Test
+    public void testListWithMinAge() throws Exception {
+        runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
+        runner.setProperty(ListAzureDataLakeStorage.MIN_AGE, "1 hour");
+
+        runProcessor();
+
+        runner.assertTransferCount(ListAzureDataLakeStorage.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testListWithMaxAge() throws Exception {
+        runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
+        runner.setProperty(ListAzureDataLakeStorage.MAX_AGE, "1 hour");
+
+        runProcessor();
+
+        assertSuccess("file1", "file2", "dir1/file11", "dir1/file12", "dir1/dir11/file111", "dir 2/file 21");
+    }
+
+    @Test
+    public void testListWithMinSize() throws Exception {
+        runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
+        runner.setProperty(ListAzureDataLakeStorage.MIN_SIZE, "5 B");
+
+        runProcessor();
+
+        assertSuccess("file1", "file2", "dir1/file11", "dir1/file12", "dir1/dir11/file111");
+    }
+
+    @Test
+    public void testListWithMaxSize() throws Exception {
+        runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
+        runner.setProperty(ListAzureDataLakeStorage.MAX_SIZE, "5 B");
+
+        runProcessor();
+
+        assertSuccess("dir 2/file 21");
     }
 
     private void runProcessor() {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITMoveAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITMoveAzureDataLakeStorage.java
@@ -25,9 +25,10 @@ import org.apache.nifi.processor.Processor;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class ITMoveAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     private static final String SOURCE_DIRECTORY = "sourceDir1";
     private static final String DESTINATION_DIRECTORY = "destDir1";
     private static final String FILE_NAME = "file1";
-    private static final byte[] FILE_DATA = "0123456789".getBytes();
+    private static final byte[] FILE_DATA = "0123456789".getBytes(StandardCharsets.UTF_8);
 
     private static final String EL_FILESYSTEM = "az.filesystem";
     private static final String EL_DIRECTORY = "az.directory";
@@ -61,7 +62,7 @@ public class ITMoveAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         return MoveAzureDataLakeStorage.class;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws InterruptedException {
         runner.setProperty(MoveAzureDataLakeStorage.SOURCE_FILESYSTEM, fileSystemName);
         runner.setProperty(MoveAzureDataLakeStorage.SOURCE_DIRECTORY, SOURCE_DIRECTORY);
@@ -234,7 +235,7 @@ public class ITMoveAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
 
         runProcessor(FILE_DATA);
 
-        assertSuccessWithIgnoreResolution(DESTINATION_DIRECTORY, FILE_NAME, FILE_DATA, fileContent.getBytes());
+        assertSuccessWithIgnoreResolution(DESTINATION_DIRECTORY, FILE_NAME, FILE_DATA, fileContent.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage.java
@@ -25,6 +25,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,7 +55,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
     @Test
     public void testPutBlob() throws Exception {
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -74,7 +75,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_KEY_ID, KEY_ID_VALUE);
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_SYMMETRIC_KEY_HEX, KEY_128B_VALUE);
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -86,7 +87,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_KEY_ID, KEY_ID_VALUE);
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_SYMMETRIC_KEY_HEX, KEY_192B_VALUE);
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -98,7 +99,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_KEY_ID, KEY_ID_VALUE);
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_SYMMETRIC_KEY_HEX, KEY_256B_VALUE);
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -110,7 +111,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_KEY_ID, KEY_ID_VALUE);
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_SYMMETRIC_KEY_HEX, KEY_384B_VALUE);
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -122,7 +123,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_KEY_ID, KEY_ID_VALUE);
         runner.setProperty(AzureBlobClientSideEncryptionUtils.CSE_SYMMETRIC_KEY_HEX, KEY_512B_VALUE);
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -133,7 +134,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         configureCredentialsService();
 
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         assertResult();
@@ -144,7 +145,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.setProperty(AzureStorageUtils.ACCOUNT_NAME, "invalid");
         runner.setProperty(AzureStorageUtils.ACCOUNT_KEY, "aW52YWxpZGludmFsaWQ=");
         runner.assertValid();
-        runner.enqueue(TEST_FILE_CONTENT.getBytes());
+        runner.enqueue(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount(PutAzureBlobStorage.REL_FAILURE, 1);
@@ -154,7 +155,7 @@ public class ITPutAzureBlobStorage extends AbstractAzureBlobStorageIT {
         runner.assertAllFlowFilesTransferred(PutAzureBlobStorage.REL_SUCCESS, 1);
         List<MockFlowFile> flowFilesForRelationship = runner.getFlowFilesForRelationship(PutAzureBlobStorage.REL_SUCCESS);
         for (MockFlowFile flowFile : flowFilesForRelationship) {
-            flowFile.assertContentEquals(TEST_FILE_CONTENT.getBytes());
+            flowFile.assertContentEquals(TEST_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
             flowFile.assertAttributeEquals("azure.length", "10");
         }
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureDataLakeStorage.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +52,7 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
 
     private static final String DIRECTORY = "dir1";
     private static final String FILE_NAME = "file1";
-    private static final byte[] FILE_DATA = "0123456789".getBytes();
+    private static final byte[] FILE_DATA = "0123456789".getBytes(StandardCharsets.UTF_8);
 
     private static final String EL_FILESYSTEM = "az.filesystem";
     private static final String EL_DIRECTORY = "az.directory";
@@ -207,7 +208,7 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
 
         runProcessor(FILE_DATA);
 
-        assertSuccessWithIgnoreResolution(DIRECTORY, FILE_NAME, FILE_DATA, azureFileContent.getBytes());
+        assertSuccessWithIgnoreResolution(DIRECTORY, FILE_NAME, FILE_DATA, azureFileContent.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test


### PR DESCRIPTION
Add min/max age and min/max size properties to ListAzure processors
https://issues.apache.org/jira/browse/NIFI-9879

#### Description of PR

Enables filtering by file size and file age.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [x] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
