### PR TITLE
NIFI-9871 Correct Component Stack Trace Logging

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
@@ -51,37 +51,48 @@ public class SimpleProcessLogger implements ComponentLog {
     @Override
     public void warn(final String msg, final Throwable t) {
         if (isWarnEnabled()) {
-            final String message = getFormattedMessage(msg, t);
+            final String componentMessage = getComponentMessage(msg);
             final Object[] repositoryArguments = getRepositoryArguments(t);
 
             if (t == null) {
-                logger.warn(message, component);
-                logRepository.addLogMessage(LogLevel.WARN, message, repositoryArguments);
+                logger.warn(componentMessage, component);
+                logRepository.addLogMessage(LogLevel.WARN, componentMessage, repositoryArguments);
             } else {
-                logger.warn(message, component, t);
-                logRepository.addLogMessage(LogLevel.WARN, message, repositoryArguments, t);
+                logger.warn(componentMessage, component, t);
+                logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), repositoryArguments, t);
             }
         }
     }
 
     @Override
     public void warn(final String msg, final Object[] os) {
-        final Throwable lastThrowable = findLastThrowable(os);
-        warn(msg, removeLastThrowable(os, lastThrowable), lastThrowable);
+        if (isWarnEnabled()) {
+            final String componentMessage = getComponentMessage(msg);
+            final Object[] arguments = insertComponent(os);
+
+            final Throwable lastThrowable = findLastThrowable(os);
+            if (lastThrowable == null) {
+                logger.warn(componentMessage, arguments);
+                logRepository.addLogMessage(LogLevel.WARN, componentMessage, arguments);
+            } else {
+                logger.warn(componentMessage, setFormattedThrowable(arguments, lastThrowable));
+                logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+            }
+        }
     }
 
     @Override
     public void warn(final String msg, final Object[] os, final Throwable t) {
         if (isWarnEnabled()) {
             final String componentMessage = getComponentMessage(msg);
-            final Object[] arguments = addComponent(os);
+            final Object[] arguments = insertComponent(os);
 
             if (t == null) {
                 logger.warn(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.WARN, componentMessage, arguments);
             } else {
                 logger.warn(componentMessage, arguments, t);
-                logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
     }
@@ -117,8 +128,19 @@ public class SimpleProcessLogger implements ComponentLog {
 
     @Override
     public void trace(final String msg, final Object[] os) {
-        final Throwable lastThrowable = findLastThrowable(os);
-        trace(msg, removeLastThrowable(os, lastThrowable), lastThrowable);
+        if (isTraceEnabled()) {
+            final String componentMessage = getComponentMessage(msg);
+            final Object[] arguments = insertComponent(os);
+
+            final Throwable lastThrowable = findLastThrowable(os);
+            if (lastThrowable == null) {
+                logger.trace(componentMessage, arguments);
+                logRepository.addLogMessage(LogLevel.TRACE, componentMessage, arguments);
+            } else {
+                logger.trace(componentMessage, setFormattedThrowable(arguments, lastThrowable));
+                logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+            }
+        }
     }
 
     @Override
@@ -130,14 +152,14 @@ public class SimpleProcessLogger implements ComponentLog {
     public void trace(final String msg, final Object[] os, final Throwable t) {
         if (isTraceEnabled()) {
             final String componentMessage = getComponentMessage(msg);
-            final Object[] arguments = addComponent(os);
+            final Object[] arguments = insertComponent(os);
 
             if (t == null) {
                 logger.trace(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.TRACE, componentMessage, arguments);
             } else {
                 logger.trace(componentMessage, arguments, t);
-                logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
     }
@@ -178,23 +200,34 @@ public class SimpleProcessLogger implements ComponentLog {
     @Override
     public void info(final String msg, final Throwable t) {
         if (isInfoEnabled()) {
-            final String message = t == null ? getComponentMessage(msg) : getCausesMessage(msg);
+            final String componentMessage = getComponentMessage(msg);
             final Object[] repositoryArguments = getRepositoryArguments(t);
 
             if (t == null) {
-                logger.info(message, component);
-                logRepository.addLogMessage(LogLevel.INFO, message, repositoryArguments);
+                logger.info(componentMessage, component);
+                logRepository.addLogMessage(LogLevel.INFO, componentMessage, repositoryArguments);
             } else {
-                logger.info(message, component, t);
-                logRepository.addLogMessage(LogLevel.INFO, message, repositoryArguments, t);
+                logger.info(componentMessage, component, t);
+                logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), repositoryArguments, t);
             }
         }
     }
 
     @Override
     public void info(final String msg, final Object[] os) {
-        final Throwable lastThrowable = findLastThrowable(os);
-        info(msg, removeLastThrowable(os, lastThrowable), lastThrowable);
+        if (isInfoEnabled()) {
+            final String componentMessage = getComponentMessage(msg);
+            final Object[] arguments = insertComponent(os);
+
+            final Throwable lastThrowable = findLastThrowable(os);
+            if (lastThrowable == null) {
+                logger.info(componentMessage, arguments);
+                logRepository.addLogMessage(LogLevel.INFO, componentMessage, arguments);
+            } else {
+                logger.info(componentMessage, setFormattedThrowable(arguments, lastThrowable));
+                logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+            }
+        }
     }
 
     @Override
@@ -206,14 +239,14 @@ public class SimpleProcessLogger implements ComponentLog {
     public void info(final String msg, final Object[] os, final Throwable t) {
         if (isInfoEnabled()) {
             final String componentMessage = getComponentMessage(msg);
-            final Object[] arguments = addComponent(os);
+            final Object[] arguments = insertComponent(os);
 
             if (t == null) {
                 logger.info(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.INFO, componentMessage, arguments);
             } else {
                 logger.info(componentMessage, arguments, t);
-                logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
     }
@@ -240,35 +273,47 @@ public class SimpleProcessLogger implements ComponentLog {
     public void error(final String msg, final Throwable t) {
         if (isErrorEnabled()) {
             final String componentMessage = getComponentMessage(msg);
+            final Object[] repositoryArguments = getRepositoryArguments(t);
 
             if (t == null) {
                 logger.error(componentMessage, component);
-                logRepository.addLogMessage(LogLevel.ERROR, msg, new Object[]{component});
+                logRepository.addLogMessage(LogLevel.ERROR, componentMessage, repositoryArguments);
             } else {
                 logger.error(componentMessage, component, t);
-                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), repositoryArguments, t);
             }
         }
     }
 
     @Override
     public void error(final String msg, final Object[] os) {
-        final Throwable lastThrowable = findLastThrowable(os);
-        error(msg, removeLastThrowable(os, lastThrowable), lastThrowable);
+        if (isErrorEnabled()) {
+            final String componentMessage = getComponentMessage(msg);
+            final Object[] arguments = insertComponent(os);
+
+            final Throwable lastThrowable = findLastThrowable(os);
+            if (lastThrowable == null) {
+                logger.error(componentMessage, arguments);
+                logRepository.addLogMessage(LogLevel.ERROR, componentMessage, arguments);
+            } else {
+                logger.error(componentMessage, setFormattedThrowable(arguments, lastThrowable));
+                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+            }
+        }
     }
 
     @Override
     public void error(final String msg, final Object[] os, final Throwable t) {
         if (isErrorEnabled()) {
             final String componentMessage = getComponentMessage(msg);
-            final Object[] arguments = addComponent(os);
+            final Object[] arguments = insertComponent(os);
 
             if (t == null) {
                 logger.error(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.ERROR, componentMessage, arguments);
             } else {
                 logger.error(componentMessage, arguments, t);
-                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
     }
@@ -285,35 +330,47 @@ public class SimpleProcessLogger implements ComponentLog {
     public void debug(final String msg, final Throwable t) {
         if (isDebugEnabled()) {
             final String componentMessage = getComponentMessage(msg);
+            final Object[] repositoryArguments = getRepositoryArguments(t);
 
             if (t == null) {
                 logger.debug(componentMessage, component);
-                logRepository.addLogMessage(LogLevel.DEBUG, msg, new Object[]{component});
+                logRepository.addLogMessage(LogLevel.DEBUG, componentMessage, repositoryArguments);
             } else {
                 logger.debug(componentMessage, component, t);
-                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), repositoryArguments, t);
             }
         }
     }
 
     @Override
     public void debug(final String msg, final Object[] os) {
-        final Throwable lastThrowable = findLastThrowable(os);
-        debug(msg, removeLastThrowable(os, lastThrowable), lastThrowable);
+        if (isDebugEnabled()) {
+            final String componentMessage = getComponentMessage(msg);
+            final Object[] arguments = insertComponent(os);
+
+            final Throwable lastThrowable = findLastThrowable(os);
+            if (lastThrowable == null) {
+                logger.debug(componentMessage, arguments);
+                logRepository.addLogMessage(LogLevel.DEBUG, componentMessage, arguments);
+            } else {
+                logger.debug(componentMessage, setFormattedThrowable(arguments, lastThrowable));
+                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+            }
+        }
     }
 
     @Override
     public void debug(final String msg, final Object[] os, final Throwable t) {
         if (isDebugEnabled()) {
             final String componentMessage = getComponentMessage(msg);
-            final Object[] arguments = addComponent(os);
+            final Object[] arguments = insertComponent(os);
 
             if (t == null) {
                 logger.debug(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.DEBUG, componentMessage, arguments);
             } else {
                 logger.debug(componentMessage, arguments, t);
-                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), getComponentAndCauses(t), t);
+                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
     }
@@ -441,10 +498,6 @@ public class SimpleProcessLogger implements ComponentLog {
         }
     }
 
-    private String getFormattedMessage(final String message, final Throwable throwable) {
-        return throwable == null ? getComponentMessage(message) : getCausesMessage(message);
-    }
-
     /**
      * Get arguments for Log Repository including a summary of Throwable causes when Throwable is found
      *
@@ -464,23 +517,31 @@ public class SimpleProcessLogger implements ComponentLog {
     }
 
     private Object[] getComponentAndCauses(final Throwable throwable) {
+        final String causes = getCauses(throwable);
+        return new Object[]{component, causes};
+    }
+
+    private String getCauses(final Throwable throwable) {
         final List<String> causes = new ArrayList<>();
         for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
             causes.add(cause.toString());
         }
-        final String causesFormatted = String.join(CAUSED_BY, causes);
-        return new Object[]{component, causesFormatted};
+        return String.join(CAUSED_BY, causes);
     }
 
-    private Object[] addComponent(final Object[] originalArgs) {
-        return prependToArgs(originalArgs, component);
+    private Object[] insertComponent(final Object[] originalArgs) {
+        return ArrayUtils.insert(0, originalArgs, component);
     }
 
-    private Object[] prependToArgs(final Object[] originalArgs, final Object... toAdd) {
-        final Object[] newArgs = new Object[originalArgs.length + toAdd.length];
-        System.arraycopy(toAdd, 0, newArgs, 0, toAdd.length);
-        System.arraycopy(originalArgs, 0, newArgs, toAdd.length, originalArgs.length);
-        return newArgs;
+    private Object[] addCauses(final Object[] arguments, final Throwable throwable) {
+        final String causes = getCauses(throwable);
+        return ArrayUtils.add(arguments, causes);
+    }
+
+    private Object[] setFormattedThrowable(final Object[] arguments, final Throwable throwable) {
+        final int lastIndex = arguments.length - 1;
+        final Object[] argumentsThrowableRemoved = ArrayUtils.remove(arguments, lastIndex);
+        return ArrayUtils.addAll(argumentsThrowableRemoved, throwable.toString(), throwable);
     }
 
     private Throwable findLastThrowable(final Object[] arguments) {
@@ -490,9 +551,5 @@ public class SimpleProcessLogger implements ComponentLog {
             lastThrowable = (Throwable) lastArgument;
         }
         return lastThrowable;
-    }
-
-    private Object[] removeLastThrowable(final Object[] arguments, final Throwable lastThrowable) {
-        return lastThrowable == null ? arguments : ArrayUtils.removeElement(arguments, lastThrowable);
     }
 }


### PR DESCRIPTION
#### Description of PR

NIFI-9871 Corrects stack trace logging for extension components to avoid sending summarized stack trace causes to the SLF4J Logger. This change preserves the stack trace summary in bulletin messages and avoids writing duplicate information to application log files.

The `ConnectableTask` includes log wording adjustments to indicate the difference between termination, failure, and halted because of an uncaught exception.

The updated `TestSimpleProcessLogger` includes several new test methods to improve coverage and ensure consistent formatting.

The updated `SimpleProcessLogger` implementation of `ComponentLog` behaves as follows when logging an error:

1. Bulletin Messages contain a simple message with a summary of causes:

```
ListSFTP[id=d4ee5196-b059-3bab-4416-9f59a45cd7b0] Processing failed: org.apache.nifi.processors.standard.socket.ClientConnectException: SSH Client connection failed [192.168.1.1:22]
- Caused by: com.exceptionfactory.socketbroker.BrokeredConnectException: Proxy Address [/192.168.1.100:8888] connection failed
- Caused by: java.net.NoRouteToHostException: No route to host (Host unreachable)
```

2. Application Log Messages contain a simple message and full stack trace without duplicating the summary of causes:

```
2022-04-07 12:30:45,500 ERROR [Timer-Driven Process Thread-7] o.a.nifi.processors.standard.ListSFTP ListSFTP[id=d4ee5196-b059-3bab-4416-9f59a45cd7b0] Processing failed
org.apache.nifi.processors.standard.socket.ClientConnectException: SSH Client connection failed [192.168.1.1:22]
	at org.apache.nifi.processors.standard.ssh.StandardSSHClientProvider.getClient(StandardSSHClientProvider.java:115)
	at org.apache.nifi.processors.standard.util.SFTPTransfer.getSFTPClient(SFTPTransfer.java:598)
	at org.apache.nifi.processors.standard.util.SFTPTransfer.getListing(SFTPTransfer.java:302)
	at org.apache.nifi.processors.standard.util.SFTPTransfer.getListing(SFTPTransfer.java:264)
	at org.apache.nifi.processors.standard.ListFileTransfer.performListing(ListFileTransfer.java:120)
	at org.apache.nifi.processors.standard.ListSFTP.performListing(ListSFTP.java:151)
	at org.apache.nifi.processors.standard.ListFileTransfer.performListing(ListFileTransfer.java:112)
	at org.apache.nifi.processor.util.list.AbstractListProcessor.listByNoTracking(AbstractListProcessor.java:562)
	at org.apache.nifi.processor.util.list.AbstractListProcessor.onTrigger(AbstractListProcessor.java:532)
	at org.apache.nifi.processor.AbstractProcessor.onTrigger(AbstractProcessor.java:27)
	at org.apache.nifi.controller.StandardProcessorNode.onTrigger(StandardProcessorNode.java:1283)
	at org.apache.nifi.controller.tasks.ConnectableTask.invoke(ConnectableTask.java:214)
	at org.apache.nifi.controller.scheduling.AbstractTimeBasedSchedulingAgent.lambda$doScheduleOnce$0(AbstractTimeBasedSchedulingAgent.java:63)
	at org.apache.nifi.engine.FlowEngine$2.run(FlowEngine.java:110)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.exceptionfactory.socketbroker.BrokeredConnectException: Proxy Address [/192.168.1.100:8888] connection failed
	at com.exceptionfactory.socketbroker.BrokeredSocket.connect(BrokeredSocket.java:100)
	at net.schmizz.sshj.SocketClient.connect(SocketClient.java:138)
	at org.apache.nifi.processors.standard.ssh.StandardSSHClientProvider.getClient(StandardSSHClientProvider.java:112)
	... 20 common frames omitted
Caused by: java.net.NoRouteToHostException: No route to host (Host unreachable)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:607)
	at com.exceptionfactory.socketbroker.BrokeredSocket.connect(BrokeredSocket.java:97)
	... 22 common frames omitted

```

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
