### PR TITLE
NIFI-9923 Correct SimpleProcessLogger handling of Throwable causes

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
@@ -76,7 +76,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logRepository.addLogMessage(LogLevel.WARN, componentMessage, arguments);
             } else {
                 logger.warn(componentMessage, setFormattedThrowable(arguments, lastThrowable));
-                logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+                logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), setCauses(arguments, lastThrowable), lastThrowable);
             }
         }
     }
@@ -138,7 +138,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logRepository.addLogMessage(LogLevel.TRACE, componentMessage, arguments);
             } else {
                 logger.trace(componentMessage, setFormattedThrowable(arguments, lastThrowable));
-                logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+                logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), setCauses(arguments, lastThrowable), lastThrowable);
             }
         }
     }
@@ -225,7 +225,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logRepository.addLogMessage(LogLevel.INFO, componentMessage, arguments);
             } else {
                 logger.info(componentMessage, setFormattedThrowable(arguments, lastThrowable));
-                logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+                logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), setCauses(arguments, lastThrowable), lastThrowable);
             }
         }
     }
@@ -297,7 +297,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logRepository.addLogMessage(LogLevel.ERROR, componentMessage, arguments);
             } else {
                 logger.error(componentMessage, setFormattedThrowable(arguments, lastThrowable));
-                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+                logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), setCauses(arguments, lastThrowable), lastThrowable);
             }
         }
     }
@@ -354,7 +354,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logRepository.addLogMessage(LogLevel.DEBUG, componentMessage, arguments);
             } else {
                 logger.debug(componentMessage, setFormattedThrowable(arguments, lastThrowable));
-                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), addCauses(arguments, lastThrowable), lastThrowable);
+                logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), setCauses(arguments, lastThrowable), lastThrowable);
             }
         }
     }
@@ -536,6 +536,13 @@ public class SimpleProcessLogger implements ComponentLog {
     private Object[] addCauses(final Object[] arguments, final Throwable throwable) {
         final String causes = getCauses(throwable);
         return ArrayUtils.add(arguments, causes);
+    }
+
+    private Object[] setCauses(final Object[] arguments, final Throwable throwable) {
+        final String causes = getCauses(throwable);
+        final int lastIndex = arguments.length - 1;
+        final Object[] argumentsThrowableRemoved = ArrayUtils.remove(arguments, lastIndex);
+        return ArrayUtils.add(argumentsThrowableRemoved, causes);
     }
 
     private Object[] setFormattedThrowable(final Object[] arguments, final Throwable throwable) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
@@ -83,7 +83,7 @@ public class TestSimpleProcessLogger {
 
     private Object[] componentValueArguments;
 
-    private Object[] componentValueExceptionStringCausesArguments;
+    private Object[] componentValueCausesArguments;
 
     private Object[] componentCausesArguments;
 
@@ -96,7 +96,7 @@ public class TestSimpleProcessLogger {
 
         componentArguments = new Object[]{component};
         componentValueArguments = new Object[]{component, FIRST, SECOND};
-        componentValueExceptionStringCausesArguments = new Object[]{component, FIRST, SECOND, EXCEPTION, EXPECTED_CAUSES};
+        componentValueCausesArguments = new Object[]{component, FIRST, SECOND, EXPECTED_CAUSES};
         componentCausesArguments = new Object[]{component, EXPECTED_CAUSES};
 
         when(logger.isTraceEnabled()).thenReturn(true);
@@ -218,7 +218,7 @@ public class TestSimpleProcessLogger {
                     continue;
             }
 
-            verify(logRepository).addLogMessage(eq(logLevel), eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT_AND_CAUSES), eq(componentValueExceptionStringCausesArguments), eq(EXCEPTION));
+            verify(logRepository).addLogMessage(eq(logLevel), eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT_AND_CAUSES), eq(componentValueCausesArguments), eq(EXCEPTION));
         }
     }
 


### PR DESCRIPTION
#### Description of PR

NIFI-9923 Corrects the behavior of `SimpleProcessLogger` to format the array of arguments for Bulletin Messages in order to log the summary of Throwable causes.

The correction updates log methods that accept a `String` and `Object` array to replace the last `Throwable` argument with a formatted summary of causes when calling `LogRepository.addLogMessage()`.

This corrects behavior introduced for NIFI-9871 in PR #5945. The problem and resolution can be observed on processors such as `EvaluateXPath`, which write error logs with one format argument and an exception.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
