### PR TITLE
NIFI-9899  Bug Fix for MongoDBLookupService  to read database and collection name properties  value from flowfile attribute 

### DIFF
--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBLookupService.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBLookupService.java
@@ -138,7 +138,7 @@ public class MongoDBLookupService extends JsonInferenceSchemaRegistryService imp
         }
 
         try {
-            Document result = findOne(query, projection);
+            Document result = findOne(query, projection,context);
 
             if(result == null) {
                 return Optional.empty();
@@ -223,7 +223,9 @@ public class MongoDBLookupService extends JsonInferenceSchemaRegistryService imp
         return Collections.unmodifiableList(_temp);
     }
 
-    private Document findOne(Document query, Document projection) {
+    private Document findOne(Document query, Document projection,Map<String, String> context) {
+        final String databaseName = getProperty(DATABASE_NAME).evaluateAttributeExpressions(context).getValue();
+        final String collection = getProperty(COLLECTION_NAME).evaluateAttributeExpressions(context).getValue();
         MongoCollection col = controllerService.getDatabase(databaseName).getCollection(collection);
         MongoCursor<Document> it = (projection != null ? col.find(query).projection(projection) : col.find(query)).iterator();
         Document retVal = it.hasNext() ? it.next() : null;

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBLookupService.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBLookupService.java
@@ -70,8 +70,6 @@ public class MongoDBLookupService extends JsonInferenceSchemaRegistryService imp
             .fromPropertyDescriptor(SCHEMA_NAME)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
-    private volatile String databaseName;
-    private volatile String collection;
 
     public static final PropertyDescriptor CONTROLLER_SERVICE = new PropertyDescriptor.Builder()
         .name("mongo-lookup-client-service")
@@ -173,17 +171,12 @@ public class MongoDBLookupService extends JsonInferenceSchemaRegistryService imp
         this.controllerService = context.getProperty(CONTROLLER_SERVICE).asControllerService(MongoDBClientService.class);
 
         this.schemaNameProperty = context.getProperty(LOCAL_SCHEMA_NAME).evaluateAttributeExpressions().getValue();
-
-        this.databaseName = context.getProperty(DATABASE_NAME).evaluateAttributeExpressions().getValue();
-        this.collection   = context.getProperty(COLLECTION_NAME).evaluateAttributeExpressions().getValue();
-
         String configuredProjection = context.getProperty(PROJECTION).isSet()
             ? context.getProperty(PROJECTION).getValue()
             : null;
         if (!StringUtils.isBlank(configuredProjection)) {
             projection = Document.parse(configuredProjection);
         }
-
         super.onEnabled(context);
     }
 


### PR DESCRIPTION
NIFI-9899-  Provide  bug fix to MongoDBLookupService ,now the   service can take the database and collection name from flowfile attributes