### PR TITLE
NIFI-9938  Error Reporting message has been Fixed for Kafka Bundle 

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
@@ -70,7 +70,7 @@ public class InFlightMessageTracker {
 
     public void fail(final FlowFile flowFile, final Exception exception) {
         failures.putIfAbsent(flowFile, exception);
-        logger.error("Failed to send " + flowFile + " to Kafka", exception);
+        logger.error("Failed to send {} to Kafka", flowFile, exception);
 
         synchronized (progressMutex) {
             progressMutex.notify();


### PR DESCRIPTION
Error reporting  statement has been changed such that it will write flowfile UUID attribute to bulletin 