### PR TITLE
NIFI-9950 Identify MariaDB database type and use MySQL migration scripts

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/CustomFlywayConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/CustomFlywayConfiguration.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.internal.database.DatabaseTypeRegister;
 import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabaseType;
 import org.flywaydb.core.internal.jdbc.JdbcUtils;
 import org.flywaydb.database.mysql.MySQLDatabaseType;
+import org.flywaydb.database.mysql.mariadb.MariaDBDatabaseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
@@ -58,7 +59,7 @@ public class CustomFlywayConfiguration implements FlywayConfigurationCustomizer 
         final DatabaseType databaseType = getDatabaseType(configuration.getDataSource());
         LOGGER.info("Determined database type is {}", databaseType.getName());
 
-        if (databaseType instanceof MySQLDatabaseType) {
+        if (databaseType instanceof MySQLDatabaseType || databaseType instanceof MariaDBDatabaseType) {
             LOGGER.info("Setting migration locations to {}", Arrays.asList(LOCATIONS_MYSQL));
             configuration.locations(LOCATIONS_MYSQL);
         } else if (databaseType instanceof PostgreSQLDatabaseType) {

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -183,6 +183,32 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>mariadb-10_2-test</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <spring.profiles.active>mariadb-10-2</spring.profiles.active>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>mariadb-10_3-test</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <spring.profiles.active>mariadb-10-3</spring.profiles.active>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>postgres10-test</id>
                                 <phase>verify</phase>
                                 <goals>


### PR DESCRIPTION
Build NiFi Registry with `-Ptest-all-dbs` or specify `-Dspring.profiles.active=mariadb-10-3` or `-Dspring.profiles.active=mariadb-10-2`.