### PR TITLE
NIFI-9964: Change assertion to prevent TestLookupRecord from failing due to indeterminate map ordering

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
@@ -464,7 +464,12 @@ public class TestLookupRecord {
         runner.run();
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(LookupRecord.REL_SUCCESS).get(0);
-        out.assertContentEquals("John Doe,48,soccer,basketball\nJane Doe,47\n");
+        if(out.getContent().equals("John Doe,48,soccer,basketball\nJane Doe,47\n")){
+            out.assertContentEquals("John Doe,48,soccer,basketball\nJane Doe,47\n");
+        }
+        else{
+            out.assertContentEquals("John Doe,48,basketball,soccer\nJane Doe,47\n");
+        }
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
@@ -464,11 +464,9 @@ public class TestLookupRecord {
         runner.run();
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(LookupRecord.REL_SUCCESS).get(0);
-        if(out.getContent().equals("John Doe,48,soccer,basketball\nJane Doe,47\n")) {
-            out.assertContentEquals("John Doe,48,soccer,basketball\nJane Doe,47\n");
-        } else {
-            out.assertContentEquals("John Doe,48,basketball,soccer\nJane Doe,47\n");
-        }
+        assertTrue(out.getContent().equals("John Doe,48,soccer,basketball\nJane Doe,47\n") 
+            || out.getContent().equals("John Doe,48,basketball,soccer\nJane Doe,47\n"));
+
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
@@ -464,10 +464,9 @@ public class TestLookupRecord {
         runner.run();
 
         final MockFlowFile out = runner.getFlowFilesForRelationship(LookupRecord.REL_SUCCESS).get(0);
-        if(out.getContent().equals("John Doe,48,soccer,basketball\nJane Doe,47\n")){
+        if(out.getContent().equals("John Doe,48,soccer,basketball\nJane Doe,47\n")) {
             out.assertContentEquals("John Doe,48,soccer,basketball\nJane Doe,47\n");
-        }
-        else{
+        } else {
             out.assertContentEquals("John Doe,48,basketball,soccer\nJane Doe,47\n");
         }
     }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->


#### Description of PR

The test `org.apache.nifi.processors.standard.TestLookupRecord#testAddFieldsToExistingRecordRouteToSuccess` can fail based on the order of iteration in `HashMap`. 
In line 437 to 441:
```
        final List<RecordField> fields = new ArrayList<>();
        fields.add(new RecordField("favorite", RecordFieldType.STRING.getDataType(), false));
        fields.add(new RecordField("least", RecordFieldType.STRING.getDataType(), true));
        final RecordSchema schema = new SimpleRecordSchema(fields);
        final Record sports = new MapRecord(schema, new HashMap<>());
```
It creates two ```RecordField``` ```favorite``` and ```least``` and adds them into ```Record``` ```sports```. Since ```sports``` is created by a HashMap, the order of ```favorite``` and ```least``` are indeterminate in ```sports```. Therefore, in the actual ```MockFlowFile``` content, the order of "soccer" and "basketball" is also indeterminate.
I found the issue using [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn install -DskipTests -pl nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors -am
mvn -pl nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.processors.standard.TestLookupRecord#testAddFieldsToExistingRecordRouteToSuccess
```
The proposed fix changes the assertion to endure the indeterminacy.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFI-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [ ] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi` folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [ ] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-assembly`?
- [ ] If adding new Properties, have you added `.displayName` in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
