### PR TITLE
NIFI-8971 Removed support for legacy attributes for NiFi 2.0

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -870,13 +870,6 @@ public class MergeContent extends BinFiles {
                                     public void process(final InputStream rawIn) throws IOException {
                                         try (final InputStream in = new BufferedInputStream(rawIn)) {
                                             final Map<String, String> attributes = new HashMap<>(flowFile.getAttributes());
-
-                                            // for backward compatibility purposes, we add the "legacy" NiFi attributes
-                                            attributes.put("nf.file.name", attributes.get(CoreAttributes.FILENAME.key()));
-                                            attributes.put("nf.file.path", attributes.get(CoreAttributes.PATH.key()));
-                                            if (attributes.containsKey(CoreAttributes.MIME_TYPE.key())) {
-                                                attributes.put("content-type", attributes.get(CoreAttributes.MIME_TYPE.key()));
-                                            }
                                             packager.packageFlowFile(in, out, attributes, flowFile.getSize());
                                         }
                                     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -547,12 +547,6 @@ public class UnpackContent extends AbstractProcessor {
                             // and later unpack it -- in this case, we have two FlowFiles with the same UUID.
                             attributes.remove(CoreAttributes.UUID.key());
 
-                            // maintain backward compatibility with legacy NiFi attribute names
-                            mapAttributes(attributes, "nf.file.name", CoreAttributes.FILENAME.key());
-                            mapAttributes(attributes, "nf.file.path", CoreAttributes.PATH.key());
-                            mapAttributes(attributes, "content-encoding", CoreAttributes.MIME_TYPE.key());
-                            mapAttributes(attributes, "content-type", CoreAttributes.MIME_TYPE.key());
-
                             if (!attributes.containsKey(CoreAttributes.MIME_TYPE.key())) {
                                 attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
                             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -334,17 +334,6 @@ public class ListenHTTPServlet extends HttpServlet {
                     }
                     attributes.putAll(unpackager.unpackageFlowFile(in, bos));
 
-                    if (destinationIsLegacyNiFi) {
-                        if (attributes.containsKey("nf.file.name")) {
-                            // for backward compatibility with old nifi...
-                            attributes.put(CoreAttributes.FILENAME.key(), attributes.remove("nf.file.name"));
-                        }
-
-                        if (attributes.containsKey("nf.file.path")) {
-                            attributes.put(CoreAttributes.PATH.key(), attributes.remove("nf.file.path"));
-                        }
-                    }
-
                     hasMoreData.set(unpackager.hasMoreData());
                 }
             }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

_[NIFI-8971](https://issues.apache.org/jira/browse/NIFI-0000) includes the following changes..._
NIFI-8971 Removed nf.file.name, nf.file.path, content-encoding, content-type from MergeContent, UnpackContent, ListenHTTPServlet
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [NIFI-8971] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
