### PR TITLE
NIFI-9975 Upgrade OWASP Dependency Check from 6.5.3 to 7.1.0

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -20,33 +20,13 @@
         <cpe regex="true">^cpe:.*$</cpe>
     </suppress>
     <suppress>
-        <notes>Jetty Test Helper is incorrectly identified as part of Jetty Server</notes>
-        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty-test-helper.*$</packageUrl>
-        <cpe regex="true">^cpe:.*$</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache FTP Server library is incorrectly identified with Apache HTTP Server</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/ftpserver\-core@.*$</packageUrl>
-        <cpe>cpe:/a:apache:http_server</cpe>
-    </suppress>
-    <suppress>
         <notes>Meta MX HTTP Client is incorrectly identified as Netty</notes>
         <packageUrl regex="true">^pkg:maven/com\.metamx/http\-client@.*$</packageUrl>
         <cpe>cpe:/a:netty:netty</cpe>
     </suppress>
     <suppress>
-        <notes>Servlet API libraries with the Jetty package are incorrectly associated with Jetty Server</notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jetty/servlet\-api@.*$</packageUrl>
-        <cpe regex="true">^cpe:/a:.*:jetty:.*$</cpe>
-    </suppress>
-    <suppress>
         <notes>Testcontainers MySQL is incorrectly identified with MySQL server</notes>
         <packageUrl regex="true">^pkg:maven/org\.testcontainers/mysql@.*$</packageUrl>
         <cpe>cpe:/a:mysql:mysql</cpe>
-    </suppress>
-    <suppress>
-        <notes>Vorbis Java Tika is incorrectly linked to flac_project</notes>
-        <packageUrl regex="true">^pkg:maven/org\.gagravarr/vorbis\-java\-tika@.*$</packageUrl>
-        <cpe>cpe:/a:flac_project:flac</cpe>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1205,7 +1205,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.5.3</version>
+                        <version>7.1.0</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-9975](https://issues.apache.org/jira/browse/NIFI-9975) Upgrades the Maven OWASP Dependency Check Plugin from version 6.5.3 to 7.1.0. Additional changes include removing entries from the suppression configuration that are no longer necessary following improvements in the detection of false positives.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
