### PR TITLE
NIFI-9976 Upgrade json-smart to 2.4.8

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -322,11 +322,6 @@
                 <version>9.10.2</version>
             </dependency>
             <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>2.4.7</version>
-            </dependency>
-            <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>lang-tag</artifactId>
                 <version>1.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <jackson.bom.version>2.13.2.20220328</jackson.bom.version>
         <jaxb.runtime.version>2.3.5</jaxb.runtime.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
+        <json.smart.version>2.4.8</json.smart.version>
         <nifi.groovy.version>3.0.8</nifi.groovy.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <!-- The Hadoop version used by nifi-hadoop-libraries-nar and any NARs that depend on it, other NARs that need
@@ -513,6 +514,11 @@
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjweaver</artifactId>
                 <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json.smart.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
# Summary

[NIFI-9976](https://issues.apache.org/jira/browse/NIFI-9976) Upgrades json-smart transitive dependency references from 2.3.0 and 2.4.7 to [2.4.8](https://github.com/netplex/json-smart-v2#v-248) for all modules. This upgrade address known vulnerabilities in earlier versions and also corrects several other issues.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
