### PR TITLE
NIFI-9980 Correct conflicting GCP dependencies

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-core</artifactId>
-            <version>2.1.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
@@ -108,7 +107,6 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsublite</artifactId>
-            <version>1.3.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-services-api/pom.xml
@@ -25,17 +25,6 @@
     <artifactId>nifi-gcp-services-api</artifactId>
     <packaging>jar</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override Guava version from google-auth-library-oauth2-http -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>31.0.1-jre</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -44,7 +33,6 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>1.2.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -26,23 +26,17 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.cloud.sdk.version>0.172.0</google.cloud.sdk.version>
+        <google.libraries.version>25.2.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-            	<!-- https://github.com/googleapis/java-cloud-bom -->
                 <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-bom</artifactId>
-                <version>${google.cloud.sdk.version}</version>
+                <artifactId>libraries-bom</artifactId>
+                <version>${google.libraries.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>31.0.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-9980](https://issues.apache.org/jira/browse/NIFI-99800) Corrects conflicting dependencies for GCP Processors and Controller Services in the `nifi-gcp-bundle` and related modules.

The current configuration of the `google-cloud-bom` version `0.172.0` conflicts with the `google-cloud-core` version `2.1.7`, resulting in `NoClassDefFoundError` messages when attempting to run `ConsumeGCPubSub` and `PublishGCPubSub` Processors.

Replacing `google-cloud-bom` with `libraries-bom` and removing specific version numbers of individual libraries as described in [Using Cloud Client Libraries](https://cloud.google.com/java/docs/bom) resolves this problem.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
