### PR TITLE
NIFI-9986 Upgrade commons-configuration2 to 2.7 for Accumulo

### DIFF
--- a/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
@@ -41,6 +41,12 @@
                 <artifactId>nifi-accumulo-processors</artifactId>
                 <version>1.17.0-SNAPSHOT</version>
             </dependency>
+            <!-- Override commons-configuration2:2.5 from accumulo-core -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.7</version>
+            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
# Summary

[NIFI-9986](https://issues.apache.org/jira/browse/NIFI-9986) Upgrades `commons-configuration2` from 2.5 to [2.7](https://commons.apache.org/proper/commons-configuration/changes-report.html#a2.7) in the `nifi-accumulo-bundle` to resolve a vulnerability associated with version 2.5.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
