### PR TITLE
NIFI-9984 Allow 200-series responses in OAuth2 Access Token Provider

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -315,19 +315,18 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         this.accessDetails = getAccessDetails(refreshRequest);
     }
 
-    private AccessToken getAccessDetails(Request newRequest) {
+    private AccessToken getAccessDetails(final Request newRequest) {
         try {
-            Response response = httpClient.newCall(newRequest).execute();
-            String responseBody = response.body().string();
-            if (response.code() != 200) {
+            final Response response = httpClient.newCall(newRequest).execute();
+            final String responseBody = response.body().string();
+            if (response.isSuccessful()) {
+                getLogger().debug("OAuth2 Access Token retrieved [HTTP {}]", response.code());
+                return ACCESS_DETAILS_MAPPER.readValue(responseBody, AccessToken.class);
+            } else {
                 getLogger().error(String.format("OAuth2 access token request failed [HTTP %d], response:%n%s", response.code(), responseBody));
                 throw new ProcessException(String.format("OAuth2 access token request failed [HTTP %d]", response.code()));
             }
-
-            AccessToken accessDetails = ACCESS_DETAILS_MAPPER.readValue(responseBody, AccessToken.class);
-
-            return accessDetails;
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new UncheckedIOException("OAuth2 access token request failed", e);
         }
     }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/test/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/test/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProviderTest.java
@@ -64,6 +64,9 @@ public class StandardOauth2AccessTokenProviderTest {
     private static final String CLIENT_SECRET = "clientSecret";
     private static final long FIVE_MINUTES = 300;
 
+    private static final int HTTP_OK = 200;
+    private static final int HTTP_ACCEPTED = 201;
+
     private StandardOauth2AccessTokenProvider testSubject;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -146,7 +149,7 @@ public class StandardOauth2AccessTokenProviderTest {
 
         // GIVEN
         Response response = buildResponse(
-            200,
+            HTTP_OK,
             "{ \"access_token\":\"" + accessTokenValue + "\" }"
         );
 
@@ -166,12 +169,12 @@ public class StandardOauth2AccessTokenProviderTest {
         String expectedToken = "second_token";
 
         Response response1 = buildResponse(
-            200,
+                HTTP_OK,
             "{ \"access_token\":\"" + firstToken + "\", \"expires_in\":\"0\", \"refresh_token\":\"not_checking_in_this_test\" }"
         );
 
         Response response2 = buildResponse(
-            200,
+                HTTP_OK,
             "{ \"access_token\":\"" + expectedToken + "\" }"
         );
 
@@ -230,7 +233,7 @@ public class StandardOauth2AccessTokenProviderTest {
         String expectedToken = "expected_token";
 
         Response successfulAcquireResponse = buildResponse(
-            200,
+                HTTP_ACCEPTED,
             "{ \"access_token\":\"" + expectedToken + "\", \"expires_in\":\"0\", \"refresh_token\":\"not_checking_in_this_test\" }"
         );
 
@@ -319,7 +322,7 @@ public class StandardOauth2AccessTokenProviderTest {
 
         Response errorRefreshResponse = buildResponse(500, expectedRefreshErrorResponse);
         Response successfulAcquireResponse = buildResponse(
-            200,
+                HTTP_OK,
             "{ \"access_token\":\"" + expectedToken + "\", \"expires_in\":\"0\", \"refresh_token\":\"not_checking_in_this_test\" }"
         );
 
@@ -358,7 +361,7 @@ public class StandardOauth2AccessTokenProviderTest {
 
     private Response buildSuccessfulInitResponse() {
         return buildResponse(
-            200,
+                HTTP_OK,
             "{ \"access_token\":\"exists_but_value_irrelevant\", \"expires_in\":\"0\", \"refresh_token\":\"not_checking_in_this_test\" }"
         );
     }


### PR DESCRIPTION
# Summary

[NIFI-9984](https://issues.apache.org/jira/browse/NIFI-9984) Updates the `StandardOauth2AccessTokenProvider` to allow processing all 200-series HTTP responses as successful.

The update changes from checking if the response code equals to 200 to calling [Response.isSuccessful()](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response/is-successful/), which allows all 200-series response codes.

[RFC 6749 Section 5.1](https://www.rfc-editor.org/rfc/rfc6749#section-5.1) describes a successful response with an HTTP 200 response code, but some OAuth2 providers, such as [IBM Cloud Pak](https://www.ibm.com/docs/en/dbaoc?topic=applications-using-oauth-20-based-authentication) return HTTP 201. Making adjustments to support other successful HTTP response codes enables compatibility with a wider array of OAuth2 providers.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
