### PR TITLE
NIFI-9988 Correct Property Decryption for Authorizers and Providers

### DIFF
--- a/nifi-commons/nifi-property-protection-factory/src/main/java/org/apache/nifi/properties/scheme/StandardProtectionSchemeResolver.java
+++ b/nifi-commons/nifi-property-protection-factory/src/main/java/org/apache/nifi/properties/scheme/StandardProtectionSchemeResolver.java
@@ -37,7 +37,9 @@ public class StandardProtectionSchemeResolver implements ProtectionSchemeResolve
     public ProtectionScheme getProtectionScheme(final String scheme) {
         Objects.requireNonNull(scheme, "Scheme required");
         return Arrays.stream(PropertyProtectionScheme.values())
-                .filter(propertyProtectionScheme -> propertyProtectionScheme.name().equals(scheme))
+                .filter(propertyProtectionScheme ->
+                        propertyProtectionScheme.name().equals(scheme) || scheme.startsWith(propertyProtectionScheme.getPath())
+                )
                 .findFirst()
                 .orElseThrow(() -> new SensitivePropertyProtectionException(String.format("Protection Scheme [%s] not supported", scheme)));
     }

--- a/nifi-commons/nifi-property-protection-factory/src/test/java/org/apache/nifi/properties/scheme/StandardProtectionSchemeResolverTest.java
+++ b/nifi-commons/nifi-property-protection-factory/src/test/java/org/apache/nifi/properties/scheme/StandardProtectionSchemeResolverTest.java
@@ -30,6 +30,8 @@ public class StandardProtectionSchemeResolverTest {
 
     private static final String AES_GCM_PATH = "aes/gcm";
 
+    private static final String AES_GCM_256_PATH = "aes/gcm/256";
+
     private static final String UNKNOWN = "UNKNOWN";
 
     private StandardProtectionSchemeResolver resolver;
@@ -42,6 +44,13 @@ public class StandardProtectionSchemeResolverTest {
     @Test
     public void getProtectionSchemeAesGcmFound() {
         final ProtectionScheme protectionScheme = resolver.getProtectionScheme(AES_GCM);
+        assertNotNull(protectionScheme);
+        assertEquals(AES_GCM_PATH, protectionScheme.getPath());
+    }
+
+    @Test
+    public void getProtectionSchemeAesGcm256Found() {
+        final ProtectionScheme protectionScheme = resolver.getProtectionScheme(AES_GCM_256_PATH);
         assertNotNull(protectionScheme);
         assertEquals(AES_GCM_PATH, protectionScheme.getPath());
     }


### PR DESCRIPTION
# Summary

[NIFI-9988](https://issues.apache.org/jira/browse/NIFI-9988) Corrects Sensitive Property Provider decryption for encrypted property values in `authorizers.xml` and `login-identity-providers.xml`.

Refactoring Sensitive Property Providers to use isolated class-loading for NIFI-9883 involved changes to the configuration classes for Authorizers and Login Identity Providers, leveraging the `ProtectionSchemeResolver` to determine the Protection Scheme based on the value of the `encryption` attribute, such as `aes/gcm/256`.

The `StandardProtectionSchemeResolver` worked with the encrypt-config command, which specifies the scheme using one of the known enumerated values, but did not work with the Authorizers or Login Identity Providers configurations, which used the path value. Updating the `StandardProtectionSchemeResolver` to support resolution based on either the Name or the Path prefix resolves the problem.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
