### PR TITLE
NIFI-9963: Configure JsonTreeReader with Schema Application Strategy in case of Nested Field Strategy

### DIFF
--- a/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
+++ b/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
@@ -36,6 +36,7 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.json.JsonTreeRowRecordReader;
+import org.apache.nifi.json.SchemaApplicationStrategy;
 import org.apache.nifi.json.StartingFieldStrategy;
 import org.apache.nifi.oauth2.OAuth2AccessTokenProvider;
 import org.apache.nifi.processor.AbstractProcessor;
@@ -350,7 +351,8 @@ public class QuerySalesforceObject extends AbstractProcessor {
                             TIME_FORMAT,
                             DATE_TIME_FORMAT,
                             StartingFieldStrategy.NESTED_FIELD,
-                            STARTING_FIELD_NAME
+                            STARTING_FIELD_NAME,
+                            SchemaApplicationStrategy.SELECTED_PART
                     );
 
                     RecordSetWriter writer = writerFactory.createWriter(

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -223,6 +223,7 @@
                         <exclude>src/test/resources/json/single-bank-account.json</exclude>
                         <exclude>src/test/resources/json/single-bank-account-wrong-field-type.json</exclude>
                         <exclude>src/test/resources/json/single-element-nested-array.json</exclude>
+                        <exclude>src/test/resources/json/single-element-deep-nested.json</exclude>
                         <exclude>src/test/resources/json/single-element-nested.json</exclude>
                         <exclude>src/test/resources/json/single-element-nested-array-middle.json</exclude>
                         <exclude>src/test/resources/json/nested-array-then-start-object.json</exclude>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -64,7 +64,6 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
     private JsonNode firstJsonNode;
     private StartingFieldStrategy strategy;
 
-
     private AbstractJsonRowRecordReader(final ComponentLog logger, final String dateFormat, final String timeFormat, final String timestampFormat) {
         this.logger = logger;
 
@@ -80,25 +79,7 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
     protected AbstractJsonRowRecordReader(final InputStream in, final ComponentLog logger, final String dateFormat, final String timeFormat, final String timestampFormat)
             throws IOException, MalformedRecordException {
 
-        this(logger, dateFormat, timeFormat, timestampFormat);
-
-        try {
-            jsonParser = jsonFactory.createParser(in);
-            jsonParser.setCodec(codec);
-
-            JsonToken token = jsonParser.nextToken();
-            if (token == JsonToken.START_ARRAY) {
-                token = jsonParser.nextToken(); // advance to START_OBJECT token
-            }
-
-            if (token == JsonToken.START_OBJECT) { // could be END_ARRAY also
-                firstJsonNode = jsonParser.readValueAsTree();
-            } else {
-                firstJsonNode = null;
-            }
-        } catch (final JsonParseException e) {
-            throw new MalformedRecordException("Could not parse data as JSON", e);
-        }
+        this(in, logger, dateFormat, timeFormat, timestampFormat, null, null);
     }
 
     protected AbstractJsonRowRecordReader(final InputStream in, final ComponentLog logger, final String dateFormat, final String timeFormat, final String timestampFormat,

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
@@ -44,13 +44,12 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
-    private final RecordSchema schema;
 
+    private final RecordSchema schema;
 
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,
                                    final String dateFormat, final String timeFormat, final String timestampFormat) throws IOException, MalformedRecordException {
-        super(in, logger, dateFormat, timeFormat, timestampFormat);
-        this.schema = schema;
+        this(in, logger, schema, dateFormat, timeFormat, timestampFormat, null, null, null);
     }
 
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/SchemaApplicationStrategy.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/SchemaApplicationStrategy.java
@@ -19,28 +19,32 @@ package org.apache.nifi.json;
 import org.apache.nifi.components.DescribedValue;
 
 public enum SchemaApplicationStrategy implements DescribedValue {
-    WHOLE_JSON {
-        @Override
-        public String getDisplayName() {
-            return "Whole JSON";
-        }
+    WHOLE_JSON(
+            "Whole JSON",
+            "Applies the schema for the whole JSON."
+    ),
+    SELECTED_PART(
+            "Selected Part",
+            "Applies the schema for the selected part starting from the \"Starting Field Name\"."
+    );
 
-        @Override
-        public String getDescription() {
-            return "Applies the schema for the whole JSON.";
-        }
-    },
-    SELECTED_PART {
-        @Override
-        public String getDisplayName() {
-            return "Selected Part";
-        }
+    private final String displayName;
+    private final String description;
 
-        @Override
-        public String getDescription() {
-            return "Applies the schema for the selected part starting from the \"Starting Field Name\".";
-        }
-    };
+    SchemaApplicationStrategy(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
 
     @Override
     public String getValue() {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/SchemaApplicationStrategy.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/SchemaApplicationStrategy.java
@@ -18,26 +18,27 @@ package org.apache.nifi.json;
 
 import org.apache.nifi.components.DescribedValue;
 
-public enum StartingFieldStrategy implements DescribedValue {
-    ROOT_NODE {
+public enum SchemaApplicationStrategy implements DescribedValue {
+    WHOLE_JSON {
         @Override
         public String getDisplayName() {
-            return "Root Node";
+            return "Whole JSON";
         }
 
         @Override
         public String getDescription() {
-            return "Begins processing from the root node.";
+            return "Applies the schema for the whole JSON.";
         }
-    }, NESTED_FIELD {
+    },
+    SELECTED_PART {
         @Override
         public String getDisplayName() {
-            return "Nested Field";
+            return "Selected Part";
         }
 
         @Override
         public String getDescription() {
-            return "Skips forward to the given nested JSON field (array or object) to begin processing.";
+            return "Applies the schema for the selected part starting from the \"Starting Field Name\".";
         }
     };
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/StartingFieldStrategy.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/StartingFieldStrategy.java
@@ -19,27 +19,32 @@ package org.apache.nifi.json;
 import org.apache.nifi.components.DescribedValue;
 
 public enum StartingFieldStrategy implements DescribedValue {
-    ROOT_NODE {
-        @Override
-        public String getDisplayName() {
-            return "Root Node";
-        }
+    ROOT_NODE(
+            "Root Node",
+            "Begins processing from the root node."
+    ),
+    NESTED_FIELD(
+            "Nested Field",
+            "Skips forward to the given nested JSON field (array or object) to begin processing."
+    );
 
-        @Override
-        public String getDescription() {
-            return "Begins processing from the root node.";
-        }
-    }, NESTED_FIELD {
-        @Override
-        public String getDisplayName() {
-            return "Nested Field";
-        }
+    private final String displayName;
+    private final String description;
 
-        @Override
-        public String getDescription() {
-            return "Skips forward to the given nested JSON field (array or object) to begin processing.";
-        }
-    };
+    StartingFieldStrategy(final String displayName, final String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
 
     @Override
     public String getValue() {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/resources/docs/org.apache.nifi.json.JsonTreeReader/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/resources/docs/org.apache.nifi.json.JsonTreeReader/additionalDetails.html
@@ -407,5 +407,12 @@
             </tr>
         </table>
 
+        <h2>Schema Application Strategies</h2>
+
+        <p>
+            When using JsonTreeReader with "Nested Field Strategy" and the "Schema Access Strategy" is not "Infer Schema",
+            it can be configured for the entire original JSON ("Whole JSON" strategy) or for the nested field section ("Selected part" strategy).
+        </p>
+
     </body>
 </html>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -1053,8 +1053,7 @@ class TestJsonTreeRowRecordReader {
                 }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD,
-                "accounts", SchemaApplicationStrategy.SELECTED_PART);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accounts");
     }
 
     @Test
@@ -1073,8 +1072,7 @@ class TestJsonTreeRowRecordReader {
                 }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD,
-                "account", SchemaApplicationStrategy.SELECTED_PART);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "account");
     }
 
     @Test
@@ -1097,16 +1095,14 @@ class TestJsonTreeRowRecordReader {
                     }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD,
-                "accountIds", SchemaApplicationStrategy.SELECTED_PART);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accountIds");
     }
 
     @Test
     void testStartFromSimpleFieldReturnsEmptyJson() throws IOException, MalformedRecordException {
         String jsonPath = "src/test/resources/json/single-element-nested.json";
 
-        testReadRecords(jsonPath, Collections.emptyList(), StartingFieldStrategy.NESTED_FIELD,
-                "name", SchemaApplicationStrategy.SELECTED_PART);
+        testReadRecords(jsonPath, Collections.emptyList(), StartingFieldStrategy.NESTED_FIELD, "name");
     }
 
     @Test
@@ -1211,11 +1207,11 @@ class TestJsonTreeRowRecordReader {
     }
 
     private void testReadRecords(String jsonPath, List<Object> expected, StartingFieldStrategy strategy,
-                                 String startingFieldName, SchemaApplicationStrategy schemaApplicationStrategy) throws IOException, MalformedRecordException {
+                                 String startingFieldName) throws IOException, MalformedRecordException {
         final File jsonFile = new File(jsonPath);
         try (InputStream jsonStream = new ByteArrayInputStream(FileUtils.readFileToByteArray(jsonFile))) {
             RecordSchema schema = inferSchema(jsonStream, strategy, startingFieldName);
-            testReadRecords(jsonStream, schema, expected, strategy, startingFieldName, schemaApplicationStrategy);
+            testReadRecords(jsonStream, schema, expected, strategy, startingFieldName, SchemaApplicationStrategy.SELECTED_PART);
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/single-element-deep-nested.json
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/single-element-deep-nested.json
@@ -1,0 +1,12 @@
+{
+  "rootInt": 100,
+  "rootString": "root_string",
+  "nestedLevel1Record": {
+    "nestedLevel1Int": 110,
+    "nestedLevel1String": "root.level1:string",
+    "nestedLevel2Record": {
+      "nestedLevel2Int": 111,
+      "nestedLevel2String": "root.level1.level2:string"
+    }
+  }
+}


### PR DESCRIPTION
… Root Node or the Nested Node

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Schema can be defined either for the whole original JSON input or for the selected part when using Nested Field Strategy.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-9963) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
