### PR TITLE
NIFI-9997 Upgrade Ranger from 2.1.0 to 2.2.0

### DIFF
--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-ranger-plugin</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <ranger.hadoop.version>3.1.1</ranger.hadoop.version>
+        <ranger.hadoop.version>3.3.2</ranger.hadoop.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
@@ -25,8 +25,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <ranger.version>2.1.0</ranger.version>
-        <ranger.hadoop.version>3.1.4</ranger.hadoop.version>
+        <ranger.hadoop.version>3.3.2</ranger.hadoop.version>
         <ranger.ozone.version>1.2.1</ranger.ozone.version>
         <ranger.gcs.version>2.1.5</ranger.gcs.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <org.apache.httpcomponents.httpcore.version>4.4.15</org.apache.httpcomponents.httpcore.version>
         <org.bouncycastle.version>1.70</org.bouncycastle.version>
         <org.slf4j.version>1.7.36</org.slf4j.version>
-        <ranger.version>2.1.0</ranger.version>
+        <ranger.version>2.2.0</ranger.version>
         <jetty.version>9.4.46.v20220331</jetty.version>
         <jackson.bom.version>2.13.2</jackson.bom.version>
         <avro.version>1.11.0</avro.version>


### PR DESCRIPTION
# Summary

[NIFI-9997](https://issues.apache.org/jira/browse/NIFI-9997) Upgrades Apache Ranger dependencies from 2.1.0 to 2.2.0 for both NiFi and NiFi Registry Ranger Plugins.

Ranger 2.2.0 depends on Hadoop 3.3.0, so the upgrade also includes updating the Hadoop version from 3.1.1 to the latest patch version of 3.3.2.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
