### PR TITLE
NIFI-9999 Refactor MiNiFi tests using JUnit 5

### DIFF
--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/RunMiNiFiTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/RunMiNiFiTest.java
@@ -20,13 +20,17 @@ import org.apache.nifi.minifi.bootstrap.util.BootstrapTransformer;
 import org.apache.nifi.minifi.commons.schema.ProvenanceReportingSchema;
 import org.apache.nifi.minifi.commons.schema.SecurityPropertiesSchema;
 import org.apache.nifi.minifi.commons.schema.SensitivePropsSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RunMiNiFiTest {
 
@@ -35,7 +39,7 @@ public class RunMiNiFiTest {
         final RunMiNiFi testMiNiFi = new RunMiNiFi(null);
         final Properties bootstrapProperties = getTestBootstrapProperties("bootstrap-ssl-ctx/bootstrap.conf.default");
         final Optional<SecurityPropertiesSchema> securityPropsOptional = BootstrapTransformer.buildSecurityPropertiesFromBootstrap(bootstrapProperties);
-        Assert.assertTrue(!securityPropsOptional.isPresent());
+        assertFalse(securityPropsOptional.isPresent());
     }
 
     @Test
@@ -43,28 +47,28 @@ public class RunMiNiFiTest {
         final RunMiNiFi testMiNiFi = new RunMiNiFi(null);
         final Properties bootstrapProperties = getTestBootstrapProperties("bootstrap-ssl-ctx/bootstrap.conf.configured");
         final Optional<SecurityPropertiesSchema> securityPropsOptional = BootstrapTransformer.buildSecurityPropertiesFromBootstrap(bootstrapProperties);
-        Assert.assertTrue(securityPropsOptional.isPresent());
+        assertTrue(securityPropsOptional.isPresent());
 
         final SecurityPropertiesSchema securityPropertiesSchema = securityPropsOptional.get();
-        Assert.assertEquals("/my/test/keystore.jks", securityPropertiesSchema.getKeystore());
-        Assert.assertEquals("JKS", securityPropertiesSchema.getKeystoreType());
-        Assert.assertEquals("mykeystorepassword", securityPropertiesSchema.getKeystorePassword());
-        Assert.assertEquals("mykeypassword", securityPropertiesSchema.getKeyPassword());
+        assertEquals("/my/test/keystore.jks", securityPropertiesSchema.getKeystore());
+        assertEquals("JKS", securityPropertiesSchema.getKeystoreType());
+        assertEquals("mykeystorepassword", securityPropertiesSchema.getKeystorePassword());
+        assertEquals("mykeypassword", securityPropertiesSchema.getKeyPassword());
 
-        Assert.assertEquals("/my/test/truststore.jks", securityPropertiesSchema.getTruststore());
-        Assert.assertEquals("JKS", securityPropertiesSchema.getTruststoreType());
-        Assert.assertEquals("mytruststorepassword", securityPropertiesSchema.getTruststorePassword());
+        assertEquals("/my/test/truststore.jks", securityPropertiesSchema.getTruststore());
+        assertEquals("JKS", securityPropertiesSchema.getTruststoreType());
+        assertEquals("mytruststorepassword", securityPropertiesSchema.getTruststorePassword());
 
-        Assert.assertEquals("TLS", securityPropertiesSchema.getSslProtocol());
+        assertEquals("TLS", securityPropertiesSchema.getSslProtocol());
 
         final SensitivePropsSchema sensitiveProps = securityPropertiesSchema.getSensitiveProps();
-        Assert.assertNotNull(sensitiveProps);
+        assertNotNull(sensitiveProps);
 
-        Assert.assertEquals("sensitivepropskey", sensitiveProps.getKey());
-        Assert.assertEquals("algo", sensitiveProps.getAlgorithm());
+        assertEquals("sensitivepropskey", sensitiveProps.getKey());
+        assertEquals("algo", sensitiveProps.getAlgorithm());
 
 
-        Assert.assertTrue(securityPropertiesSchema.isValid());
+        assertTrue(securityPropertiesSchema.isValid());
     }
 
     @Test
@@ -72,26 +76,25 @@ public class RunMiNiFiTest {
         final RunMiNiFi testMiNiFi = new RunMiNiFi(null);
         final Properties bootstrapProperties = getTestBootstrapProperties("bootstrap-ssl-ctx/bootstrap.conf.configured.invalid");
         final Optional<SecurityPropertiesSchema> securityPropsOptional = BootstrapTransformer.buildSecurityPropertiesFromBootstrap(bootstrapProperties);
-        Assert.assertTrue(securityPropsOptional.isPresent());
+        assertTrue(securityPropsOptional.isPresent());
 
         final SecurityPropertiesSchema securityPropertiesSchema = securityPropsOptional.get();
-        Assert.assertEquals("/my/test/keystore.jks", securityPropertiesSchema.getKeystore());
-        Assert.assertEquals("NOTAKEYSTORETYPE", securityPropertiesSchema.getKeystoreType());
-        Assert.assertEquals("mykeystorepassword", securityPropertiesSchema.getKeystorePassword());
-        Assert.assertEquals("mykeypassword", securityPropertiesSchema.getKeyPassword());
+        assertEquals("/my/test/keystore.jks", securityPropertiesSchema.getKeystore());
+        assertEquals("NOTAKEYSTORETYPE", securityPropertiesSchema.getKeystoreType());
+        assertEquals("mykeystorepassword", securityPropertiesSchema.getKeystorePassword());
+        assertEquals("mykeypassword", securityPropertiesSchema.getKeyPassword());
 
-        Assert.assertEquals("/my/test/truststore.jks", securityPropertiesSchema.getTruststore());
-        Assert.assertEquals("JKS", securityPropertiesSchema.getTruststoreType());
-        Assert.assertEquals("mytruststorepassword", securityPropertiesSchema.getTruststorePassword());
+        assertEquals("/my/test/truststore.jks", securityPropertiesSchema.getTruststore());
+        assertEquals("JKS", securityPropertiesSchema.getTruststoreType());
+        assertEquals("mytruststorepassword", securityPropertiesSchema.getTruststorePassword());
 
         final SensitivePropsSchema sensitiveProps = securityPropertiesSchema.getSensitiveProps();
-        Assert.assertNotNull(sensitiveProps);
+        assertNotNull(sensitiveProps);
 
-        Assert.assertEquals("sensitivepropskey", sensitiveProps.getKey());
-        Assert.assertEquals("algo", sensitiveProps.getAlgorithm());
+        assertEquals("sensitivepropskey", sensitiveProps.getKey());
+        assertEquals("algo", sensitiveProps.getAlgorithm());
 
-        Assert.assertFalse(securityPropertiesSchema.isValid());
-
+        assertFalse(securityPropertiesSchema.isValid());
     }
 
     @Test
@@ -99,7 +102,7 @@ public class RunMiNiFiTest {
         final RunMiNiFi testMiNiFi = new RunMiNiFi(null);
         final Properties bootstrapProperties = getTestBootstrapProperties("bootstrap-provenance-reporting/bootstrap.conf.default");
         final Optional<ProvenanceReportingSchema> provenanceReportingPropsOptional = BootstrapTransformer.buildProvenanceReportingPropertiesFromBootstrap(bootstrapProperties);
-        Assert.assertTrue(!provenanceReportingPropsOptional.isPresent());
+        assertFalse(provenanceReportingPropsOptional.isPresent());
     }
 
     @Test
@@ -107,16 +110,16 @@ public class RunMiNiFiTest {
         final RunMiNiFi testMiNiFi = new RunMiNiFi(null);
         final Properties bootstrapProperties = getTestBootstrapProperties("bootstrap-provenance-reporting/bootstrap.conf.configured");
         final Optional<ProvenanceReportingSchema> provenanceReportingPropsOptional = BootstrapTransformer.buildProvenanceReportingPropertiesFromBootstrap(bootstrapProperties);
-        Assert.assertTrue(provenanceReportingPropsOptional.isPresent());
+        assertTrue(provenanceReportingPropsOptional.isPresent());
 
         final ProvenanceReportingSchema provenanceReportingSchema = provenanceReportingPropsOptional.get();
-        Assert.assertEquals("This is a comment!", provenanceReportingSchema.getComment());
-        Assert.assertEquals("TIMER_DRIVEN", provenanceReportingSchema.getSchedulingStrategy());
-        Assert.assertEquals("15 secs", provenanceReportingSchema.getSchedulingPeriod());
-        Assert.assertEquals("http://localhost:8080/", provenanceReportingSchema.getDestinationUrl());
-        Assert.assertEquals("provenance", provenanceReportingSchema.getPortName());
-        Assert.assertEquals("http://${hostname(true)}:8081/nifi", provenanceReportingSchema.getOriginatingUrl());
-        Assert.assertEquals("10 secs", provenanceReportingSchema.getTimeout());
+        assertEquals("This is a comment!", provenanceReportingSchema.getComment());
+        assertEquals("TIMER_DRIVEN", provenanceReportingSchema.getSchedulingStrategy());
+        assertEquals("15 secs", provenanceReportingSchema.getSchedulingPeriod());
+        assertEquals("http://localhost:8080/", provenanceReportingSchema.getDestinationUrl());
+        assertEquals("provenance", provenanceReportingSchema.getPortName());
+        assertEquals("http://${hostname(true)}:8081/nifi", provenanceReportingSchema.getOriginatingUrl());
+        assertEquals("10 secs", provenanceReportingSchema.getTimeout());
     }
 
 

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ConfigurationChangeCoordinatorTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ConfigurationChangeCoordinatorTest.java
@@ -18,10 +18,9 @@
 package org.apache.nifi.minifi.bootstrap.configuration;
 
 import org.apache.nifi.minifi.bootstrap.ConfigurationFileHolder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
@@ -30,25 +29,26 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
 public class ConfigurationChangeCoordinatorTest {
 
     private ConfigurationChangeCoordinator coordinatorSpy;
-    private Properties properties = new Properties();
+    private final Properties properties = new Properties();
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         coordinatorSpy = Mockito.spy(new ConfigurationChangeCoordinator());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         coordinatorSpy.close();
     }
 
     @Test
-    public void testInit() throws Exception {
+    public void testInit() {
         properties.put("nifi.minifi.notifier.ingestors", "org.apache.nifi.minifi.bootstrap.configuration.ingestors.RestChangeIngestor");
         final ConfigurationChangeListener testListener = Mockito.mock(ConfigurationChangeListener.class);
         coordinatorSpy.initialize(properties, Mockito.mock(ConfigurationFileHolder.class), Collections.singleton(testListener));
@@ -59,7 +59,7 @@ public class ConfigurationChangeCoordinatorTest {
         final ConfigurationChangeListener testListener = Mockito.mock(ConfigurationChangeListener.class);
         coordinatorSpy.initialize(properties, Mockito.mock(ConfigurationFileHolder.class), Collections.singleton(testListener));
 
-        Assert.assertEquals("Did not receive the correct number of registered listeners", coordinatorSpy.getChangeListeners().size(), 1);
+        assertEquals(coordinatorSpy.getChangeListeners().size(), 1, "Did not receive the correct number of registered listeners");
 
         coordinatorSpy.notifyListeners(ByteBuffer.allocate(1));
 
@@ -67,18 +67,18 @@ public class ConfigurationChangeCoordinatorTest {
     }
 
     @Test
-    public void testRegisterListener() throws Exception {
+    public void testRegisterListener() {
         final ConfigurationChangeListener firstListener = Mockito.mock(ConfigurationChangeListener.class);
         coordinatorSpy.initialize(properties, Mockito.mock(ConfigurationFileHolder.class), Collections.singleton(firstListener));
 
-        Assert.assertEquals("Did not receive the correct number of registered listeners", coordinatorSpy.getChangeListeners().size(), 1);
+        assertEquals(coordinatorSpy.getChangeListeners().size(), 1, "Did not receive the correct number of registered listeners");
 
         coordinatorSpy.initialize(properties, Mockito.mock(ConfigurationFileHolder.class), Arrays.asList(firstListener, firstListener));
-        Assert.assertEquals("Did not receive the correct number of registered listeners", coordinatorSpy.getChangeListeners().size(), 1);
+        assertEquals(coordinatorSpy.getChangeListeners().size(), 1, "Did not receive the correct number of registered listeners");
 
         final ConfigurationChangeListener secondListener = Mockito.mock(ConfigurationChangeListener.class);
         coordinatorSpy.initialize(properties, Mockito.mock(ConfigurationFileHolder.class), Arrays.asList(firstListener, secondListener));
-        Assert.assertEquals("Did not receive the correct number of registered listeners", coordinatorSpy.getChangeListeners().size(), 2);
+        assertEquals(coordinatorSpy.getChangeListeners().size(), 2, "Did not receive the correct number of registered listeners");
 
     }
 }

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/differentiators/WholeConfigDifferentiatorTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/differentiators/WholeConfigDifferentiatorTest.java
@@ -21,9 +21,8 @@ import okhttp3.Request;
 import org.apache.commons.io.FileUtils;
 import org.apache.nifi.minifi.bootstrap.ConfigurationFileHolder;
 import org.apache.nifi.minifi.bootstrap.configuration.differentiators.interfaces.Differentiator;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.FileInputStream;
@@ -35,8 +34,8 @@ import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class WholeConfigDifferentiatorTest {
@@ -51,8 +50,8 @@ public class WholeConfigDifferentiatorTest {
 
     public static Request dummyRequest;
 
-    @BeforeClass
-    public static void beforeClass() throws IOException {
+    @BeforeAll
+    public static void setConfiguration() throws IOException {
         dummyRequest = new Request.Builder()
                 .get()
                 .url("https://nifi.apache.org/index.html")
@@ -64,10 +63,6 @@ public class WholeConfigDifferentiatorTest {
         configurationFileHolder = Mockito.mock(ConfigurationFileHolder.class);
 
         when(configurationFileHolder.getConfigFileReference()).thenReturn(new AtomicReference<>(defaultConfigBuffer));
-    }
-
-    @Before
-    public void beforeEach() {
     }
 
     // InputStream differentiator methods

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/PullHttpChangeIngestorSSLTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/PullHttpChangeIngestorSSLTest.java
@@ -21,14 +21,14 @@ import org.apache.nifi.minifi.bootstrap.ConfigurationFileHolder;
 import org.apache.nifi.minifi.bootstrap.configuration.ingestors.common.PullHttpChangeIngestorCommonTest;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
 
 import java.util.Properties;
 
 public class PullHttpChangeIngestorSSLTest extends PullHttpChangeIngestorCommonTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         PullHttpChangeIngestorCommonTest.init();
 

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/PullHttpChangeIngestorTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/PullHttpChangeIngestorTest.java
@@ -20,14 +20,14 @@ package org.apache.nifi.minifi.bootstrap.configuration.ingestors;
 import org.apache.nifi.minifi.bootstrap.ConfigurationFileHolder;
 import org.apache.nifi.minifi.bootstrap.configuration.ingestors.common.PullHttpChangeIngestorCommonTest;
 import org.eclipse.jetty.server.ServerConnector;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
 
 import java.util.Properties;
 
 public class PullHttpChangeIngestorTest extends PullHttpChangeIngestorCommonTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         PullHttpChangeIngestorCommonTest.init();
 

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorSSLTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorSSLTest.java
@@ -17,15 +17,14 @@
 
 package org.apache.nifi.minifi.bootstrap.configuration.ingestors;
 
-
 import okhttp3.OkHttpClient;
 import org.apache.nifi.minifi.bootstrap.ConfigurationFileHolder;
 import org.apache.nifi.minifi.bootstrap.configuration.ConfigurationChangeListener;
 import org.apache.nifi.minifi.bootstrap.configuration.ConfigurationChangeNotifier;
 import org.apache.nifi.minifi.bootstrap.configuration.ListenerHandleResult;
 import org.apache.nifi.minifi.bootstrap.configuration.ingestors.common.RestChangeIngestorCommonTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -47,11 +46,9 @@ import java.util.Properties;
 
 import static org.mockito.Mockito.when;
 
-
 public class RestChangeIngestorSSLTest extends RestChangeIngestorCommonTest {
 
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpHttps() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, UnrecoverableKeyException, KeyManagementException, InterruptedException {
         Properties properties = new Properties();
         properties.setProperty(RestChangeIngestor.TRUSTSTORE_LOCATION_KEY, "./src/test/resources/localhost-ts.jks");
@@ -125,26 +122,9 @@ public class RestChangeIngestorSSLTest extends RestChangeIngestorCommonTest {
         client = clientBuilder.build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stop() throws Exception {
         restChangeIngestor.close();
         client = null;
-    }
-
-    private static KeyStore readKeyStore(String path) throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-        KeyStore ks = KeyStore.getInstance("jks");
-
-        char[] password = "localtest".toCharArray();
-
-        java.io.FileInputStream fis = null;
-        try {
-            fis = new java.io.FileInputStream(path);
-            ks.load(fis, password);
-        } finally {
-            if (fis != null) {
-                fis.close();
-            }
-        }
-        return ks;
     }
 }

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorTest.java
@@ -17,22 +17,20 @@
 
 package org.apache.nifi.minifi.bootstrap.configuration.ingestors;
 
-
 import okhttp3.OkHttpClient;
 import org.apache.nifi.minifi.bootstrap.ConfigurationFileHolder;
 import org.apache.nifi.minifi.bootstrap.configuration.ConfigurationChangeNotifier;
 import org.apache.nifi.minifi.bootstrap.configuration.ingestors.common.RestChangeIngestorCommonTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
 
 import java.net.MalformedURLException;
 import java.util.Properties;
 
-
 public class RestChangeIngestorTest extends RestChangeIngestorCommonTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws InterruptedException, MalformedURLException {
         Properties properties = new Properties();
         restChangeIngestor = new RestChangeIngestor();
@@ -49,7 +47,7 @@ public class RestChangeIngestorTest extends RestChangeIngestorCommonTest {
         Thread.sleep(1000);
     }
 
-    @AfterClass
+    @AfterAll
     public static void stop() throws Exception {
         restChangeIngestor.close();
         client = null;

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/common/PullHttpChangeIngestorCommonTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/common/PullHttpChangeIngestorCommonTest.java
@@ -34,13 +34,12 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -53,8 +52,8 @@ import java.util.Collections;
 import java.util.Properties;
 
 import static org.apache.nifi.minifi.bootstrap.configuration.ingestors.PullHttpChangeIngestor.PATH_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,15 +83,15 @@ public abstract class PullHttpChangeIngestorCommonTest {
 
     public abstract void pullHttpChangeIngestorInit(Properties properties);
 
-    @Before
-    public void before() {
+    @BeforeEach
+    public void setListeners() {
         Mockito.reset(testNotifier);
         ConfigurationChangeListener testListener = Mockito.mock(ConfigurationChangeListener.class);
         when(testListener.getDescriptor()).thenReturn("MockChangeListener");
         Mockito.when(testNotifier.notifyListeners(Mockito.any())).thenReturn(Collections.singleton(new ListenerHandleResult(testListener)));
     }
 
-    @AfterClass
+    @AfterAll
     public static void shutdown() throws Exception {
         jetty.stop();
     }
@@ -226,7 +225,7 @@ public abstract class PullHttpChangeIngestorCommonTest {
 
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                throws IOException, ServletException {
+                throws IOException {
 
             baseRequest.setHandled(true);
 

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/ConfigTransformerTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/ConfigTransformerTest.java
@@ -36,10 +36,8 @@ import org.apache.nifi.minifi.commons.schema.serialization.SchemaLoader;
 import org.apache.nifi.util.StringUtils;
 import org.apache.nifi.xml.processing.parsers.DocumentProvider;
 import org.apache.nifi.xml.processing.parsers.StandardDocumentProvider;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -67,11 +65,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConfigTransformerTest {
     public static final Map<String, Integer> PG_ELEMENT_ORDER_MAP = generateOrderMap(
@@ -79,10 +77,7 @@ public class ConfigTransformerTest {
     private XPathFactory xPathFactory;
     private Element config;
 
-    @Rule
-    final public TemporaryFolder tempOutputFolder = new TemporaryFolder();
-
-    @Before
+    @BeforeEach
     public void setup() {
         final DocumentProvider documentProvider = new StandardDocumentProvider();
         final Document document = documentProvider.newDocument();
@@ -174,7 +169,7 @@ public class ConfigTransformerTest {
         properties.load(new ByteArrayInputStream(outputStream.toByteArray()));
 
         for (String name : pre216Properties.stringPropertyNames()) {
-            assertEquals("Property key " + name + " doesn't match.", pre216Properties.getProperty(name), properties.getProperty(name));
+            assertEquals(pre216Properties.getProperty(name), properties.getProperty(name), "Property key " + name + " doesn't match.");
         }
     }
 
@@ -197,7 +192,7 @@ public class ConfigTransformerTest {
         properties.load(new ByteArrayInputStream(outputStream.toByteArray()));
 
         for (String name : pre216Properties.stringPropertyNames()) {
-            assertEquals("Property key " + name + " doesn't match.", pre216Properties.getProperty(name), properties.getProperty(name));
+            assertEquals(pre216Properties.getProperty(name), properties.getProperty(name), "Property key " + name + " doesn't match.");
         }
     }
 
@@ -216,7 +211,7 @@ public class ConfigTransformerTest {
         properties.load(new ByteArrayInputStream(outputStream.toByteArray()));
 
         for (String name : initialProperties.stringPropertyNames()) {
-            assertEquals("Property key " + name + " doesn't match.", initialProperties.getProperty(name), properties.getProperty(name));
+            assertEquals(initialProperties.getProperty(name), properties.getProperty(name), "Property key " + name + " doesn't match.");
         }
     }
 
@@ -701,9 +696,9 @@ public class ConfigTransformerTest {
         for (String name : pre216Properties.stringPropertyNames()) {
             // Verify the Content Repo property was overridden
             if ("nifi.content.repository.implementation".equals(name)) {
-                assertNotEquals("Property key " + name + " was not overridden.", pre216Properties.getProperty(name), properties.getProperty(name));
+                assertNotEquals(pre216Properties.getProperty(name), properties.getProperty(name), "Property key " + name + " was not overridden.");
             } else {
-                assertEquals("Property key " + name + " doesn't match.", pre216Properties.getProperty(name), properties.getProperty(name));
+                assertEquals(pre216Properties.getProperty(name), properties.getProperty(name), "Property key " + name + " doesn't match.");
             }
         }
     }
@@ -724,9 +719,9 @@ public class ConfigTransformerTest {
         for (String name : pre216Properties.stringPropertyNames()) {
             // Verify the Content Repo property was overridden
             if ("nifi.flowfile.repository.implementation".equals(name)) {
-                assertNotEquals("Property key " + name + " was not overridden.", pre216Properties.getProperty(name), properties.getProperty(name));
+                assertNotEquals(pre216Properties.getProperty(name), properties.getProperty(name), "Property key " + name + " was not overridden.");
             } else {
-                assertEquals("Property key " + name + " doesn't match.", pre216Properties.getProperty(name), properties.getProperty(name));
+                assertEquals(pre216Properties.getProperty(name), properties.getProperty(name), "Property key " + name + " doesn't match.");
             }
         }
     }
@@ -769,7 +764,7 @@ public class ConfigTransformerTest {
             if (index != null) {
                 if (elementOrderList > index) {
                     fail("Found " + nodeName + " after " + lastOrderedElementName + "; expected all " + nodeName + " elements to come before the following elements: " + orderMap.entrySet().stream()
-                            .filter(e -> e.getValue() > index).sorted(Comparator.comparingInt(e -> e.getValue())).map(e -> e.getKey()).collect(Collectors.joining(", ")));
+                            .filter(e -> e.getValue() > index).sorted(Comparator.comparingInt(Map.Entry::getValue)).map(Map.Entry::getKey).collect(Collectors.joining(", ")));
                 }
                 lastOrderedElementName = nodeName;
                 elementOrderList = index;

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/OrderedPropertiesTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/OrderedPropertiesTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.nifi.minifi.bootstrap.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import static org.apache.nifi.minifi.bootstrap.util.ConfigTransformer.PROPERTIES_FILE_APACHE_2_0_LICENSE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class OrderedPropertiesTest {
     @Test

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/ParentGroupIdResolverTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/ParentGroupIdResolverTest.java
@@ -21,17 +21,16 @@ package org.apache.nifi.minifi.bootstrap.util;
 
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
 import org.apache.nifi.minifi.commons.schema.serialization.SchemaLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ParentGroupIdResolverTest {
 
@@ -195,7 +194,7 @@ public class ParentGroupIdResolverTest {
     }
 
     private ParentGroupIdResolver createParentGroupIdResolver(List<String> configLines) throws IOException, SchemaLoaderException {
-        return new ParentGroupIdResolver(SchemaLoader.loadConfigSchemaFromYaml(new ByteArrayInputStream(configLines.stream().collect(Collectors.joining("\n"))
+        return new ParentGroupIdResolver(SchemaLoader.loadConfigSchemaFromYaml(new ByteArrayInputStream(String.join("\n", configLines)
                 .getBytes(StandardCharsets.UTF_8))).getProcessGroupSchema());
     }
 }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/pom.xml
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/pom.xml
@@ -55,8 +55,8 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>com.palantir.docker.compose</groupId>
-            <artifactId>docker-compose-rule-junit4</artifactId>
-            <version>1.7.0</version>
+            <artifactId>docker-compose-junit-jupiter</artifactId>
+            <version>1.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestUnsecure.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestUnsecure.java
@@ -17,20 +17,20 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerPort;
 import org.apache.nifi.minifi.commons.schema.ConfigSchema;
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
 import org.apache.nifi.minifi.commons.schema.serialization.SchemaLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class AbstractTestUnsecure {
     protected String c2Url;
@@ -40,11 +40,11 @@ public abstract class AbstractTestUnsecure {
         return "http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort() + "/c2/config";
     }
 
-    protected void setup(DockerComposeRule docker) {
+    protected void setup(DockerComposeExtension docker) {
         c2Url = getConfigUrl(docker);
     }
 
-    protected String getConfigUrl(DockerComposeRule docker) {
+    protected String getConfigUrl(DockerComposeExtension docker) {
         return getUnsecureConfigUrl(docker.containers().container("c2"));
     }
 

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/DelegatingConfigurationProviderSecureTest.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/DelegatingConfigurationProviderSecureTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import org.apache.nifi.minifi.c2.integration.test.health.HttpsStatusCodeHealthCheck;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -37,7 +37,7 @@ public class DelegatingConfigurationProviderSecureTest extends AbstractTestSecur
     private static SSLContext trustSslContext;
 
     // Not annotated as rule because we need to generate certificatesDirectory first
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static DockerComposeExtension docker = DockerComposeExtension.builder()
             .file("target/test-classes/docker-compose-DelegatingProviderSecureTest.yml")
             .waitingForServices(Arrays.asList("squid", "c2-upstream"),
                     new HttpsStatusCodeHealthCheck(container -> C2_UPSTREAM_URL, containers -> containers.get(0), containers -> containers.get(1), () -> healthCheckSocketFactory, 403))
@@ -52,7 +52,7 @@ public class DelegatingConfigurationProviderSecureTest extends AbstractTestSecur
     /**
      * Generates certificates with the tls-toolkit and then starts up the docker compose file
      */
-    @BeforeClass
+    @BeforeAll
     public static void initCertificates() throws Exception {
         certificatesDirectory = Paths.get(DelegatingConfigurationProviderSecureTest.class.getClassLoader()
                 .getResource("docker-compose-DelegatingProviderSecureTest.yml").getFile()).getParent().toAbsolutePath().resolve("certificates-DelegatingConfigurationProviderSecureTest");
@@ -62,12 +62,12 @@ public class DelegatingConfigurationProviderSecureTest extends AbstractTestSecur
         docker.before();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         docker.after();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         super.setup(docker);
     }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/DelegatingConfigurationProviderUnsecureTest.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/DelegatingConfigurationProviderUnsecureTest.java
@@ -17,20 +17,20 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import org.apache.nifi.minifi.c2.integration.test.health.HttpStatusCodeHealthCheck;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DelegatingConfigurationProviderUnsecureTest extends AbstractTestUnsecure {
-    @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    @RegisterExtension
+    public static DockerComposeExtension docker = DockerComposeExtension.builder()
             .file("target/test-classes/docker-compose-DelegatingProviderUnsecureTest.yml")
             .waitingForService("c2-upstream", new HttpStatusCodeHealthCheck(DelegatingConfigurationProviderUnsecureTest::getUnsecureConfigUrl, 400))
             .waitingForService("c2", new HttpStatusCodeHealthCheck(DelegatingConfigurationProviderUnsecureTest::getUnsecureConfigUrl, 400))
             .build();
 
-    @Before
+    @BeforeEach
     public void setup() {
         super.setup(docker);
     }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/FileSystemCacheProviderSecureTest.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/FileSystemCacheProviderSecureTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import org.apache.nifi.minifi.c2.integration.test.health.HttpsStatusCodeHealthCheck;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -33,7 +33,7 @@ public class FileSystemCacheProviderSecureTest extends AbstractTestSecure {
     private static SSLSocketFactory healthCheckSocketFactory;
 
     // Not annotated as rule because we need to generate certificatesDirectory first
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static DockerComposeExtension docker = DockerComposeExtension.builder()
             .file("target/test-classes/docker-compose-FileSystemCacheProviderSecureTest.yml")
             .waitingForServices(Arrays.asList("squid", "c2"),
                     new HttpsStatusCodeHealthCheck(container -> C2_URL, containers -> containers.get(0), containers -> containers.get(1), () -> healthCheckSocketFactory, 403))
@@ -48,7 +48,7 @@ public class FileSystemCacheProviderSecureTest extends AbstractTestSecure {
     /**
      * Generates certificates with the tls-toolkit and then starts up the docker compose file
      */
-    @BeforeClass
+    @BeforeAll
     public static void initCertificates() throws Exception {
         certificatesDirectory = Paths.get(FileSystemCacheProviderSecureTest.class.getClassLoader()
                 .getResource("docker-compose-FileSystemCacheProviderSecureTest.yml").getFile()).getParent().toAbsolutePath().resolve("certificates-FileSystemCacheProviderSecureTest");
@@ -57,12 +57,12 @@ public class FileSystemCacheProviderSecureTest extends AbstractTestSecure {
         docker.before();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         docker.after();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         super.setup(docker);
     }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/FileSystemCacheProviderUnsecureTest.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/FileSystemCacheProviderUnsecureTest.java
@@ -17,19 +17,19 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import org.apache.nifi.minifi.c2.integration.test.health.HttpStatusCodeHealthCheck;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class FileSystemCacheProviderUnsecureTest extends AbstractTestUnsecure {
-    @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    @RegisterExtension
+    public static DockerComposeExtension docker = DockerComposeExtension.builder()
             .file("target/test-classes/docker-compose-FileSystemProviderUnsecureTest.yml")
             .waitingForService("c2", new HttpStatusCodeHealthCheck(FileSystemCacheProviderUnsecureTest::getUnsecureConfigUrl, 400))
             .build();
 
-    @Before
+    @BeforeEach
     public void setup() {
         super.setup(docker);
     }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/NiFiRestConfigurationProviderSecureTest.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/NiFiRestConfigurationProviderSecureTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import org.apache.nifi.minifi.c2.integration.test.health.HttpsStatusCodeHealthCheck;
 import org.apache.nifi.security.util.KeystoreType;
 import org.apache.nifi.security.util.SslContextFactory;
@@ -26,9 +26,9 @@ import org.apache.nifi.security.util.TlsConfiguration;
 import org.apache.nifi.toolkit.tls.standalone.TlsToolkitStandalone;
 import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.bouncycastle.util.io.pem.PemWriter;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -47,7 +47,7 @@ public class NiFiRestConfigurationProviderSecureTest extends AbstractTestSecure 
     private static SSLContext trustSslContext;
 
     // Not annotated as rule because we need to generate certificatesDirectory first
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static DockerComposeExtension docker = DockerComposeExtension.builder()
             .file("target/test-classes/docker-compose-NiFiRestConfigurationProviderSecureTest.yml")
             .waitingForServices(Arrays.asList("squid", "mocknifi"),
                     new HttpsStatusCodeHealthCheck(container -> "https://mocknifi:8443/", containers -> containers.get(0), containers -> containers.get(1), () -> {
@@ -77,7 +77,7 @@ public class NiFiRestConfigurationProviderSecureTest extends AbstractTestSecure 
     /**
      * Generates certificates with the tls-toolkit and then starts up the docker compose file
      */
-    @BeforeClass
+    @BeforeAll
     public static void initCertificates() throws Exception {
         certificatesDirectory = Paths.get(NiFiRestConfigurationProviderSecureTest.class.getClassLoader()
                 .getResource("docker-compose-NiFiRestConfigurationProviderSecureTest.yml").getFile()).getParent().toAbsolutePath().resolve("certificates-NiFiRestConfigurationProviderSecureTest");
@@ -106,12 +106,12 @@ public class NiFiRestConfigurationProviderSecureTest extends AbstractTestSecure 
         docker.before();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         docker.after();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         super.setup(docker);
     }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/NiFiRestConfigurationProviderUnsecureTest.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/NiFiRestConfigurationProviderUnsecureTest.java
@@ -17,22 +17,22 @@
 
 package org.apache.nifi.minifi.c2.integration.test;
 
-import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.DockerComposeExtension;
 import com.palantir.docker.compose.connection.waiting.HealthChecks;
 import org.apache.nifi.minifi.c2.integration.test.health.HttpStatusCodeHealthCheck;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NiFiRestConfigurationProviderUnsecureTest extends AbstractTestUnsecure {
-    @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    @RegisterExtension
+    public static DockerComposeExtension docker = DockerComposeExtension.builder()
             .file("target/test-classes/docker-compose-NiFiRestConfigurationProviderUnsecureTest.yml")
             .waitingForService("mocknifi", HealthChecks.toRespond2xxOverHttp(8080,
                     dockerPort -> "http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort() + "/"))
             .waitingForService("c2", new HttpStatusCodeHealthCheck(FileSystemCacheProviderUnsecureTest::getUnsecureConfigUrl, 400))
             .build();
 
-    @Before
+    @BeforeEach
     public void setup() {
         super.setup(docker);
     }

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-cache/src/test/java/org/apache/nifi/minifi/c2/provider/cache/CacheConfigurationProviderTest.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-cache/src/test/java/org/apache/nifi/minifi/c2/provider/cache/CacheConfigurationProviderTest.java
@@ -21,14 +21,14 @@ import org.apache.nifi.minifi.c2.api.ConfigurationProviderException;
 import org.apache.nifi.minifi.c2.api.cache.ConfigurationCache;
 import org.apache.nifi.minifi.c2.api.cache.ConfigurationCacheFileInfo;
 import org.apache.nifi.minifi.c2.api.cache.WriteableConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +39,7 @@ public class CacheConfigurationProviderTest {
     private CacheConfigurationProvider cacheConfigurationProvider;
     private ConfigurationCache configConfigurationCache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         configConfigurationCache = mock(ConfigurationCache.class);
         cacheConfigurationProvider = new CacheConfigurationProvider(Arrays.asList(TEST_CONTENT_TYPE, TEST_CONTENT_TYPE_2), configConfigurationCache);

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-delegating/src/test/java/org/apache/nifi/minifi/c2/provider/delegating/DelegatingConfigurationProviderTest.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-delegating/src/test/java/org/apache/nifi/minifi/c2/provider/delegating/DelegatingConfigurationProviderTest.java
@@ -24,8 +24,8 @@ import org.apache.nifi.minifi.c2.api.cache.ConfigurationCacheFileInfo;
 import org.apache.nifi.minifi.c2.api.cache.WriteableConfiguration;
 import org.apache.nifi.minifi.c2.api.security.authorization.AuthorizationException;
 import org.apache.nifi.minifi.c2.provider.util.HttpConnector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,8 +38,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,7 +55,7 @@ public class DelegatingConfigurationProviderTest {
     private String endpointPath;
     private String contentType;
 
-    @Before
+    @BeforeEach
     public void setup() throws ConfigurationProviderException {
         contentType = "text/yml";
         version = 2;
@@ -88,38 +89,38 @@ public class DelegatingConfigurationProviderTest {
         verify(httpURLConnection).setRequestProperty("Accepts", contentType);
     }
 
-    @Test(expected = AuthorizationException.class)
-    public void testGetDelegateConnection403() throws ConfigurationProviderException, IOException {
+    @Test
+    public void testGetDelegateConnection403() throws IOException {
         when(httpURLConnection.getResponseCode()).thenReturn(403);
-        delegatingConfigurationProvider.getDelegateConnection(contentType, parameters);
+        assertThrows(AuthorizationException.class, () -> delegatingConfigurationProvider.getDelegateConnection(contentType, parameters));
     }
 
-    @Test(expected = InvalidParameterException.class)
-    public void testGetDelegateConnection400() throws IOException, ConfigurationProviderException {
+    @Test
+    public void testGetDelegateConnection400() throws IOException {
         when(httpURLConnection.getResponseCode()).thenThrow(new IOException("Server returned HTTP response code: 400 for URL: " + endpointPath));
-        delegatingConfigurationProvider.getDelegateConnection(contentType, parameters);
+        assertThrows(InvalidParameterException.class, () -> delegatingConfigurationProvider.getDelegateConnection(contentType, parameters));
     }
 
-    @Test(expected = ConfigurationProviderException.class)
-    public void testGetDelegateConnection401() throws IOException, ConfigurationProviderException {
+    @Test
+    public void testGetDelegateConnection401() throws IOException {
         when(httpURLConnection.getResponseCode()).thenReturn(401);
-        delegatingConfigurationProvider.getDelegateConnection(contentType, parameters);
+        assertThrows(ConfigurationProviderException.class, () -> delegatingConfigurationProvider.getDelegateConnection(contentType, parameters));
     }
 
-    @Test(expected = ConfigurationProviderException.class)
+    @Test
     public void testGetContentTypesMalformed() throws ConfigurationProviderException, IOException {
         endpointPath = "/c2/config/contentTypes";
         initMocks();
         when(httpURLConnection.getInputStream()).thenReturn(new ByteArrayInputStream("[malformed".getBytes(StandardCharsets.UTF_8)));
-        delegatingConfigurationProvider.getContentTypes();
+        assertThrows(ConfigurationProviderException.class, () -> delegatingConfigurationProvider.getContentTypes());
     }
 
-    @Test(expected = ConfigurationProviderException.class)
+    @Test
     public void testGetContentTypesIOE() throws ConfigurationProviderException, IOException {
         endpointPath = "/c2/config/contentTypes";
         initMocks();
         when(httpURLConnection.getInputStream()).thenThrow(new IOException());
-        delegatingConfigurationProvider.getContentTypes();
+        assertThrows(ConfigurationProviderException.class, () -> delegatingConfigurationProvider.getContentTypes());
     }
 
     @Test

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-nifi-rest/src/test/java/org/apache/nifi/minifi/c2/provider/nifi/rest/NiFiRestConfigurationProviderTest.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-nifi-rest/src/test/java/org/apache/nifi/minifi/c2/provider/nifi/rest/NiFiRestConfigurationProviderTest.java
@@ -19,9 +19,9 @@ package org.apache.nifi.minifi.c2.provider.nifi.rest;
 
 import org.apache.nifi.minifi.c2.api.cache.ConfigurationCache;
 import org.apache.nifi.minifi.c2.provider.util.HttpConnector;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class NiFiRestConfigurationProviderTest {
@@ -38,7 +38,7 @@ public class NiFiRestConfigurationProviderTest {
     private NiFiRestConfigurationProvider niFiRestConfigurationProvider;
     private Path cachePath;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         configConfigurationCache = mock(ConfigurationCache.class);
         httpConnector = mock(HttpConnector.class);
@@ -46,7 +46,7 @@ public class NiFiRestConfigurationProviderTest {
         cachePath = Files.createTempDirectory(NiFiRestConfigurationProviderTest.class.getCanonicalName());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws IOException {
         Files.walk(cachePath)
                 .sorted(Comparator.reverseOrder())

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-nifi-rest/src/test/java/org/apache/nifi/minifi/c2/provider/nifi/rest/TemplatesIteratorExceptionTest.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-nifi-rest/src/test/java/org/apache/nifi/minifi/c2/provider/nifi/rest/TemplatesIteratorExceptionTest.java
@@ -17,12 +17,11 @@
 
 package org.apache.nifi.minifi.c2.provider.nifi.rest;
 
-import org.apache.nifi.minifi.c2.provider.nifi.rest.TemplatesIteratorException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class TemplatesIteratorExceptionTest {

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-nifi-rest/src/test/java/org/apache/nifi/minifi/c2/provider/nifi/rest/TemplatesIteratorTest.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-nifi-rest/src/test/java/org/apache/nifi/minifi/c2/provider/nifi/rest/TemplatesIteratorTest.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.core.JsonFactory;
 import org.apache.nifi.minifi.c2.api.ConfigurationProviderException;
 import org.apache.nifi.minifi.c2.api.util.Pair;
 import org.apache.nifi.minifi.c2.provider.util.HttpConnector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -30,8 +30,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,7 +42,7 @@ public class TemplatesIteratorTest {
     private HttpURLConnection httpURLConnection;
     private HttpConnector httpConnector;
 
-    @Before
+    @BeforeEach
     public void setup() throws ConfigurationProviderException {
         jsonFactory = new JsonFactory();
         httpURLConnection = mock(HttpURLConnection.class);
@@ -49,13 +50,13 @@ public class TemplatesIteratorTest {
         when(httpConnector.get(TemplatesIterator.FLOW_TEMPLATES)).thenReturn(httpURLConnection);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testIteratorNoSuchElementException() throws ConfigurationProviderException, IOException {
         when(httpURLConnection.getInputStream()).thenReturn(TemplatesIteratorTest.class.getClassLoader().getResourceAsStream("noTemplates.json"));
 
         try (TemplatesIterator templatesIterator = new TemplatesIterator(httpConnector, jsonFactory)) {
             assertFalse(templatesIterator.hasNext());
-            templatesIterator.next();
+            assertThrows(NoSuchElementException.class, templatesIterator::next);
         } finally {
             verify(httpURLConnection).disconnect();
         }

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/ConfigSchemaTest.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/ConfigSchemaTest.java
@@ -20,7 +20,7 @@ package org.apache.nifi.minifi.commons.schema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
 import org.apache.nifi.minifi.commons.schema.serialization.SchemaLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,10 +33,10 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.ID_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConfigSchemaTest {
     @Test
@@ -128,10 +128,6 @@ public class ConfigSchemaTest {
         assertEquals(overrides, configSchema.toMap().get(CommonPropertyKeys.NIFI_PROPERTIES_OVERRIDES_KEY));
     }
 
-    public static List<Map<String, Object>> getListWithNames(String... names) {
-        return getListWithKeyValues(CommonPropertyKeys.NAME_KEY, names);
-    }
-
     public static List<Map<String, Object>> getListWithKeyValues(String key, String... values) {
         List<Map<String, Object>> result = new ArrayList<>(values.length);
         for (String value : values) {
@@ -142,7 +138,7 @@ public class ConfigSchemaTest {
 
     public static void assertMessageDoesNotExist(ConfigSchema configSchema, String message) {
         for (String validationIssue : configSchema.getValidationIssues()) {
-            assertFalse("Did not expect to find message: " + validationIssue, validationIssue.startsWith(message));
+            assertFalse(validationIssue.startsWith(message), "Did not expect to find message: " + validationIssue);
         }
     }
 

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/ConnectionSchemaTest.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/ConnectionSchemaTest.java
@@ -20,8 +20,8 @@
 package org.apache.nifi.minifi.commons.schema;
 
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConnectionSchemaTest {
     private String testId;
@@ -46,7 +46,7 @@ public class ConnectionSchemaTest {
     private String testFlowfileExpiration;
     private String testQueuePrioritizerClass;
 
-    @Before
+    @BeforeEach
     public void setup() {
         testId = UUID.nameUUIDFromBytes("testId".getBytes(StandardCharsets.UTF_8)).toString();
         testName = "testName";
@@ -67,7 +67,7 @@ public class ConnectionSchemaTest {
 
     private ConnectionSchema createSchema(Map<String, Object> map, int expectedValidationIssues) {
         ConnectionSchema connectionSchema = new ConnectionSchema(map);
-        assertEquals(connectionSchema.getValidationIssues().toString(), expectedValidationIssues, connectionSchema.getValidationIssues().size());
+        assertEquals(expectedValidationIssues, connectionSchema.getValidationIssues().size(), connectionSchema.getValidationIssues().toString());
         return connectionSchema;
     }
 

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/ProcessGroupSchemaTest.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/ProcessGroupSchemaTest.java
@@ -20,14 +20,14 @@
 package org.apache.nifi.minifi.commons.schema;
 
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProcessGroupSchemaTest {
     @Test
@@ -38,14 +38,14 @@ public class ProcessGroupSchemaTest {
     @Test
     public void testInputPortsRootGroup() {
         Map<String, Object> map = new HashMap<>();
-        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, Arrays.asList(createPortSchema("testId", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
+        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, Collections.singletonList(createPortSchema("testId", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
         validateIssuesNumMatches(1, new ProcessGroupSchema(map, ConfigSchema.TOP_LEVEL_NAME));
     }
 
     @Test
     public void testOutputPortsRootGroup() {
         Map<String, Object> map = new HashMap<>();
-        map.put(CommonPropertyKeys.OUTPUT_PORTS_KEY, Arrays.asList(createPortSchema("testId", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
+        map.put(CommonPropertyKeys.OUTPUT_PORTS_KEY, Collections.singletonList(createPortSchema("testId", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
         validateIssuesNumMatches(1, new ProcessGroupSchema(map, ConfigSchema.TOP_LEVEL_NAME));
     }
 
@@ -59,6 +59,6 @@ public class ProcessGroupSchemaTest {
     private void validateIssuesNumMatches(int expected, ProcessGroupSchema processGroupSchema) {
         int actual = processGroupSchema.getValidationIssues().size();
         String issues = "[" + System.lineSeparator() + processGroupSchema.getValidationIssues().stream().collect(Collectors.joining("," + System.lineSeparator())) + "]";
-        assertEquals("Expected " + expected + " issue(s), got " + actual + ": " + issues, expected, actual);
+        assertEquals(expected, actual, "Expected " + expected + " issue(s), got " + actual + ": " + issues);
     }
 }

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/RemoteProcessGroupSchemaTest.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/RemoteProcessGroupSchemaTest.java
@@ -21,16 +21,16 @@ package org.apache.nifi.minifi.commons.schema;
 
 import org.apache.nifi.minifi.commons.schema.common.BaseSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RemoteProcessGroupSchemaTest {
     @Test
@@ -140,6 +140,6 @@ public class RemoteProcessGroupSchemaTest {
     private void validateIssuesNumMatches(int expected, RemoteProcessGroupSchema remoteProcessGroupSchema) {
         int actual = remoteProcessGroupSchema.getValidationIssues().size();
         String issues = "[" + System.lineSeparator() + remoteProcessGroupSchema.getValidationIssues().stream().collect(Collectors.joining("," + System.lineSeparator())) + "]";
-        assertEquals("Expected " + expected + " issue(s), got " + actual + ": " + issues, expected, actual);
+        assertEquals(expected, actual, "Expected " + expected + " issue(s), got " + actual + ": " + issues);
     }
 }

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/SecurityPropertiesSchemaTest.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/SecurityPropertiesSchemaTest.java
@@ -17,20 +17,20 @@
 
 package org.apache.nifi.minifi.commons.schema;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SecurityPropertiesSchemaTest {
     private SecurityPropertiesSchema securityPropertiesSchema;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        securityPropertiesSchema = new SecurityPropertiesSchema(new HashMap());
+        securityPropertiesSchema = new SecurityPropertiesSchema(new HashMap<>());
     }
 
     @Test

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/serialization/SchemaLoaderTest.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/serialization/SchemaLoaderTest.java
@@ -22,16 +22,16 @@ import org.apache.nifi.minifi.commons.schema.ConnectionSchema;
 import org.apache.nifi.minifi.commons.schema.ProcessorSchema;
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
 import org.apache.nifi.minifi.commons.schema.v1.ConfigSchemaV1;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SchemaLoaderTest {
     @Test
@@ -76,16 +76,12 @@ public class SchemaLoaderTest {
     public void testUnsupportedVersion() throws IOException, SchemaLoaderException {
         Map<String, Object> yamlAsMap = SchemaLoader.loadYamlAsMap(SchemaLoaderTest.class.getClassLoader().getResourceAsStream("config-minimal-v2.yml"));
         yamlAsMap.put(ConfigSchema.VERSION, "9999999");
-        try {
-            SchemaLoader.loadConfigSchemaFromYaml(yamlAsMap);
-            fail();
-        } catch (SchemaLoaderException e) {
-            assertEquals("YAML configuration version 9999999 not supported.  Supported versions: 1, 2, 3", e.getMessage());
-        }
+        final SchemaLoaderException e = assertThrows(SchemaLoaderException.class, () -> SchemaLoader.loadConfigSchemaFromYaml(yamlAsMap));
+        assertEquals("YAML configuration version 9999999 not supported.  Supported versions: 1, 2, 3", e.getMessage());
     }
 
     private void validateMinimalConfigVersion1Parse(ConfigSchema configSchema) {
-        assertTrue(configSchema instanceof ConfigSchema);
+        assertInstanceOf(ConfigSchema.class, configSchema);
 
         List<ConnectionSchema> connections = configSchema.getProcessGroupSchema().getConnections();
         assertNotNull(connections);
@@ -97,6 +93,6 @@ public class SchemaLoaderTest {
         assertEquals(2, processors.size());
         processors.forEach(p -> assertNotNull(p.getId()));
 
-        assertEquals("Expected no errors, got: " + configSchema.getValidationIssues(), 0, configSchema.getValidationIssues().size());
+        assertEquals(0, configSchema.getValidationIssues().size(), "Expected no errors, got: " + configSchema.getValidationIssues());
     }
 }

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v1/ConfigSchemaV1Test.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v1/ConfigSchemaV1Test.java
@@ -26,7 +26,7 @@ import org.apache.nifi.minifi.commons.schema.common.BaseSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
 import org.apache.nifi.minifi.commons.schema.serialization.SchemaLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,8 +37,8 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.NAME_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ConfigSchemaV1Test {
     @Test

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v1/ConnectionSchemaV1Test.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v1/ConnectionSchemaV1Test.java
@@ -22,8 +22,8 @@ package org.apache.nifi.minifi.commons.schema.v1;
 import org.apache.nifi.minifi.commons.schema.ConfigSchema;
 import org.apache.nifi.minifi.commons.schema.ConnectionSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,8 +32,8 @@ import java.util.Map;
 
 import static org.apache.nifi.minifi.commons.schema.ConfigSchemaTest.assertMessageDoesNotExist;
 import static org.apache.nifi.minifi.commons.schema.ConfigSchemaTest.getListWithKeyValues;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ConnectionSchemaV1Test {
     private String testName;
@@ -45,7 +45,7 @@ public class ConnectionSchemaV1Test {
     private String testFlowfileExpiration;
     private String testQueuePrioritizerClass;
 
-    @Before
+    @BeforeEach
     public void setup() {
         testName = "testName";
         testSourceRelationship = "testSourceRelationship";

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v1/ProcessorSchemaV1Test.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v1/ProcessorSchemaV1Test.java
@@ -20,8 +20,8 @@
 package org.apache.nifi.minifi.commons.schema.v1;
 
 import org.apache.nifi.scheduling.SchedulingStrategy;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,8 +45,8 @@ import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.PR
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.SCHEDULING_PERIOD_KEY;
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.SCHEDULING_STRATEGY_KEY;
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.YIELD_PERIOD_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ProcessorSchemaV1Test {
     private String testName;
@@ -66,7 +66,7 @@ public class ProcessorSchemaV1Test {
     private String testValue2;
     private Map<String, Object> testProperties;
 
-    @Before
+    @BeforeEach
     public void setup() {
         testName = "testName";
         testProcessorClass = "testProcessorClass";

--- a/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v2/RemoteProcessGroupSchemaV2Test.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/test/java/org/apache/nifi/minifi/commons/schema/v2/RemoteProcessGroupSchemaV2Test.java
@@ -23,14 +23,14 @@ import org.apache.nifi.minifi.commons.schema.ConfigSchema;
 import org.apache.nifi.minifi.commons.schema.PortSchema;
 import org.apache.nifi.minifi.commons.schema.RemoteProcessGroupSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RemoteProcessGroupSchemaV2Test {
     @Test
@@ -41,7 +41,7 @@ public class RemoteProcessGroupSchemaV2Test {
     @Test
     public void testInputPortsRootGroup() {
         Map<String, Object> map = new HashMap<>();
-        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, Arrays.asList(createPortSchema("f94d2469-39f8-4f07-a0d8-acd9396f639e", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
+        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, Collections.singletonList(createPortSchema("f94d2469-39f8-4f07-a0d8-acd9396f639e", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
         map.put(RemoteProcessGroupSchema.URL_KEY, "http://localhost:8080/nifi");
         map.put(CommonPropertyKeys.ID_KEY, "a58d2fab-7efe-4cb7-8224-12a60bd8003d");
         validateIssuesNumMatches(0, new RemoteProcessGroupSchemaV2(map));
@@ -50,7 +50,7 @@ public class RemoteProcessGroupSchemaV2Test {
     @Test
     public void testTransportProtocol() {
         Map<String, Object> map = new HashMap<>();
-        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, Arrays.asList(createPortSchema("f94d2469-39f8-4f07-a0d8-acd9396f639e", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
+        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, Collections.singletonList(createPortSchema("f94d2469-39f8-4f07-a0d8-acd9396f639e", "testName", ConfigSchema.TOP_LEVEL_NAME).toMap()));
         map.put(RemoteProcessGroupSchema.URL_KEY, "http://localhost:8080/nifi");
         map.put(CommonPropertyKeys.ID_KEY, "a58d2fab-7efe-4cb7-8224-12a60bd8003d");
         map.put(RemoteProcessGroupSchema.TRANSPORT_PROTOCOL_KEY, "not valid");
@@ -77,6 +77,6 @@ public class RemoteProcessGroupSchemaV2Test {
     private void validateIssuesNumMatches(int expected, RemoteProcessGroupSchemaV2 remoteProcessGroupSchema) {
         int actual = remoteProcessGroupSchema.getValidationIssues().size();
         String issues = "[" + System.lineSeparator() + remoteProcessGroupSchema.getValidationIssues().stream().collect(Collectors.joining("," + System.lineSeparator())) + "]";
-        assertEquals("Expected " + expected + " issue(s), got " + actual + ": " + issues, expected, actual);
+        assertEquals(expected, actual, "Expected " + expected + " issue(s), got " + actual + ": " + issues);
     }
 }

--- a/minifi/minifi-commons/minifi-utils/src/test/java/org/apache/nifi/minifi/commons/status/StatusReportTest.java
+++ b/minifi/minifi-commons/minifi-utils/src/test/java/org/apache/nifi/minifi/commons/status/StatusReportTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.nifi.minifi.commons.status;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,7 +33,7 @@ import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.a
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addProcessorStatus;
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addReportingTaskStatus;
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addSystemDiagnosticStatus;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StatusReportTest {
 

--- a/minifi/minifi-integration-tests/pom.xml
+++ b/minifi/minifi-integration-tests/pom.xml
@@ -39,8 +39,8 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>com.palantir.docker.compose</groupId>
-            <artifactId>docker-compose-rule-junit4</artifactId>
-            <version>1.7.0</version>
+            <artifactId>docker-compose-junit-jupiter</artifactId>
+            <version>1.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/standalone/test/StandaloneXmlTest.java
+++ b/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/standalone/test/StandaloneXmlTest.java
@@ -21,33 +21,31 @@ import org.apache.nifi.minifi.commons.schema.ConfigSchema;
 import org.apache.nifi.minifi.commons.schema.serialization.SchemaSaver;
 import org.apache.nifi.minifi.toolkit.configuration.ConfigMain;
 
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class StandaloneXmlTest extends StandaloneYamlTest {
-    public StandaloneXmlTest(String version, String name) throws IOException, JAXBException {
-        super(version, name);
+    public void setDocker(String version, String name) throws Exception {
+        super.setDocker(version, name);
         ConfigSchema configSchema;
         try (InputStream inputStream = StandaloneXmlTest.class.getClassLoader().getResourceAsStream("./standalone/" + version + "/" + name + "/xml/" + name + ".xml")) {
             configSchema = ConfigMain.transformTemplateToSchema(inputStream);
         }
         try (OutputStream outputStream = Files.newOutputStream(Paths.get(StandaloneXmlTest.class.getClassLoader().getResource("docker-compose-v1-standalone.yml").getFile())
-                .getParent().toAbsolutePath().resolve(getConfigYml()))) {
+                .getParent().toAbsolutePath().resolve(getConfigYml(version, name)))) {
             SchemaSaver.saveConfigSchema(configSchema, outputStream);
         }
     }
 
     @Override
-    protected String getConfigYml() {
+    protected String getConfigYml(final String version, final String name) {
         return "./standalone/" + version + "/" + name + "/xml/" + name + ".yml";
     }
 
     @Override
-    protected String getExpectedJson() {
+    protected String getExpectedJson(final String version, final String name) {
         return "standalone/" + version + "/" + name + "/xml/expected.json";
     }
 }

--- a/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
+++ b/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LogUtil {
     private static final Logger logger = LoggerFactory.getLogger(LogUtil.class);

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/status/StatusConfigReporterTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/status/StatusConfigReporterTest.java
@@ -43,8 +43,8 @@ import org.apache.nifi.reporting.Bulletin;
 import org.apache.nifi.reporting.BulletinQuery;
 import org.apache.nifi.reporting.BulletinRepository;
 import org.apache.nifi.reporting.UserAwareEventAccess;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
@@ -65,9 +65,8 @@ import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.a
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addProcessorStatus;
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addReportingTaskStatus;
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addSystemDiagnosticStatus;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +78,7 @@ public class StatusConfigReporterTest {
     private BulletinRepository bulletinRepo;
     private ProcessGroup processGroup;
 
-    @Before
+    @BeforeEach
     public void setup() {
         mockFlowController = mock(FlowController.class);
         mockFlowManager = mock(FlowManager.class);
@@ -105,7 +104,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addProcessorStatus(expected, true, false, false, false, false);
 
@@ -120,7 +119,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addProcessorStatus(expected, true, false, false, false, false);
 
@@ -135,7 +134,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addProcessorStatus(expected, true, true, false, false, false);
 
@@ -150,7 +149,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addProcessorStatus(expected, true, true, true, true, true);
 
@@ -165,7 +164,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport status = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addConnectionStatus(expected, true, false);
 
@@ -181,7 +180,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
         addConnectionStatus(expected, true, true);
 
         assertEquals(expected, actual);
@@ -202,7 +201,7 @@ public class StatusConfigReporterTest {
 
         addProcessorStatus(expected, true, false, false, false, false);
 
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         assertEquals(expected, actual);
     }
@@ -215,7 +214,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
         addReportingTaskStatus(expected, true, false, false, false);
 
         assertEquals(expected, actual);
@@ -230,7 +229,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addReportingTaskStatus(expected, false, false, true, true);
 
@@ -245,7 +244,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addReportingTaskStatus(expected, true, true, true, true);
 
@@ -260,7 +259,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addSystemDiagnosticStatus(expected, true, false, false, false, false);
 
@@ -275,7 +274,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addSystemDiagnosticStatus(expected, false, true, false, false, false);
 
@@ -290,7 +289,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addSystemDiagnosticStatus(expected, false, false, true, false, false);
 
@@ -305,7 +304,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addSystemDiagnosticStatus(expected, false, false, false, true, false);
 
@@ -320,7 +319,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addSystemDiagnosticStatus(expected, false, false, false, false, true);
 
@@ -336,7 +335,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addSystemDiagnosticStatus(expected, true, true, true, true, true);
 
@@ -351,7 +350,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
         addInstanceStatus(expected, true, false, false, false);
 
         assertEquals(expected, actual);
@@ -365,7 +364,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addInstanceStatus(expected, false, false, true, true);
 
@@ -380,7 +379,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addInstanceStatus(expected, false, true, false, false);
 
@@ -395,7 +394,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addInstanceStatus(expected, true, true, true, true);
 
@@ -410,7 +409,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addControllerServiceStatus(expected, true, false, false, false);
 
@@ -425,7 +424,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addControllerServiceStatus(expected, false, false, true, true);
 
@@ -441,7 +440,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addControllerServiceStatus(expected, true, true, true, true);
 
@@ -456,7 +455,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addExpectedRemoteProcessGroupStatus(expected, true, false, false, false, false, false);
 
@@ -471,7 +470,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addExpectedRemoteProcessGroupStatus(expected, false, false, false, false, true, true);
 
@@ -486,7 +485,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addExpectedRemoteProcessGroupStatus(expected, false, true, false, false, false, false);
 
@@ -501,7 +500,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addExpectedRemoteProcessGroupStatus(expected, false, false, true, false, false, false);
 
@@ -516,7 +515,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addExpectedRemoteProcessGroupStatus(expected, false, false, false, true, false, false);
 
@@ -532,7 +531,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addExpectedRemoteProcessGroupStatus(expected, true, true, true, true, true, true);
 
@@ -541,7 +540,7 @@ public class StatusConfigReporterTest {
 
     @Test
     public void statusEverything() throws Exception {
-        when(bulletinRepo.findBulletins(anyObject())).thenReturn(Collections.emptyList());
+        when(bulletinRepo.findBulletins(any())).thenReturn(Collections.emptyList());
 
         populateControllerService(true, false);
         populateInstance(true);
@@ -558,7 +557,7 @@ public class StatusConfigReporterTest {
         FlowStatusReport actual = StatusConfigReporter.getStatus(mockFlowController, statusRequest, LoggerFactory.getLogger(StatusConfigReporterTest.class));
 
         FlowStatusReport expected = new FlowStatusReport();
-        expected.setErrorsGeneratingReport(Collections.EMPTY_LIST);
+        expected.setErrorsGeneratingReport(Collections.emptyList());
 
         addControllerServiceStatus(expected, true, true, true, false);
         addInstanceStatus(expected, true, true, true, true);
@@ -651,7 +650,7 @@ public class StatusConfigReporterTest {
 
             when(reportingTaskNode.getValidationErrors()).thenReturn(validationResultList);
         } else {
-            when(reportingTaskNode.getValidationErrors()).thenReturn(Collections.EMPTY_LIST);
+            when(reportingTaskNode.getValidationErrors()).thenReturn(Collections.emptyList());
         }
     }
 
@@ -718,7 +717,7 @@ public class StatusConfigReporterTest {
 
             when(processorNode.getValidationErrors()).thenReturn(validationResultList);
         } else {
-            when(processorNode.getValidationErrors()).thenReturn(Collections.EMPTY_LIST);
+            when(processorNode.getValidationErrors()).thenReturn(Collections.emptyList());
         }
     }
 
@@ -854,7 +853,7 @@ public class StatusConfigReporterTest {
         bulletinList.add(bulletin);
 
         BulletinQueryAnswer bulletinQueryAnswer = new BulletinQueryAnswer(sourceId, bulletinList);
-        when(bulletinRepo.findBulletins(anyObject())).then(bulletinQueryAnswer);
+        when(bulletinRepo.findBulletins(any())).then(bulletinQueryAnswer);
     }
 
     private void addValidationErrors(ComponentNode connectable) {
@@ -887,7 +886,7 @@ public class StatusConfigReporterTest {
         }
 
         @Override
-        public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+        public Object answer(InvocationOnMock invocationOnMock) {
             BulletinQuery bulletinQuery = (BulletinQuery) invocationOnMock.getArguments()[0];
             if (idToMatch.equals(bulletinQuery.getSourceIdPattern().toString())) {
                 return bulletinList;

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/ConfigMainTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/ConfigMainTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.minifi.toolkit.configuration;
 
-import org.apache.commons.io.Charsets;
 import org.apache.nifi.controller.repository.io.LimitedInputStream;
 import org.apache.nifi.minifi.commons.schema.ConfigSchema;
 import org.apache.nifi.minifi.commons.schema.ConnectionSchema;
@@ -27,12 +26,11 @@ import org.apache.nifi.minifi.commons.schema.RemoteProcessGroupSchema;
 import org.apache.nifi.minifi.commons.schema.common.ConvertableSchema;
 import org.apache.nifi.minifi.commons.schema.serialization.SchemaLoader;
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.xml.bind.JAXBException;
 import java.io.ByteArrayInputStream;
@@ -41,6 +39,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,12 +48,12 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.nifi.minifi.toolkit.configuration.ConfigMain.SUCCESS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ConfigMainTest {
     @Mock
     PathInputStreamFactory pathInputStreamFactory;
@@ -68,7 +67,7 @@ public class ConfigMainTest {
 
     String testOutput;
 
-    @Before
+    @BeforeEach
     public void setup() {
         configMain = new ConfigMain(pathInputStreamFactory, pathOutputStreamFactory);
         testInput = "testInput";
@@ -98,7 +97,7 @@ public class ConfigMainTest {
 
     @Test
     public void testValidateUnableToParseConfig() throws FileNotFoundException {
-        when(pathInputStreamFactory.create(testInput)).thenReturn(new ByteArrayInputStream("!@#$%^&".getBytes(Charsets.UTF_8)));
+        when(pathInputStreamFactory.create(testInput)).thenReturn(new ByteArrayInputStream("!@#$%^&".getBytes(StandardCharsets.UTF_8)));
         assertEquals(ConfigMain.ERR_UNABLE_TO_PARSE_CONFIG, configMain.execute(new String[]{ConfigMain.VALIDATE, testInput}));
     }
 
@@ -144,7 +143,7 @@ public class ConfigMainTest {
 
     @Test
     public void testTransformErrorReadingTemplate() throws FileNotFoundException {
-        when(pathInputStreamFactory.create(testInput)).thenAnswer(invocation -> new ByteArrayInputStream("malformed xml".getBytes(Charsets.UTF_8)));
+        when(pathInputStreamFactory.create(testInput)).thenAnswer(invocation -> new ByteArrayInputStream("malformed xml".getBytes(StandardCharsets.UTF_8)));
         assertEquals(ConfigMain.ERR_UNABLE_TO_READ_TEMPLATE, configMain.execute(new String[]{ConfigMain.TRANSFORM, testInput, testOutput}));
     }
 
@@ -239,22 +238,22 @@ public class ConfigMainTest {
     }
 
     @Test
-    public void testSuccessTransformProcessGroup() throws IOException, JAXBException, SchemaLoaderException {
+    public void testSuccessTransformProcessGroup() throws IOException, JAXBException {
         ConfigMain.transformTemplateToSchema(getClass().getClassLoader().getResourceAsStream("TemplateWithProcessGroup.xml")).toMap();
     }
 
     @Test
-    public void testSuccessTransformInputPort() throws IOException, JAXBException, SchemaLoaderException {
+    public void testSuccessTransformInputPort() throws IOException, JAXBException {
         ConfigMain.transformTemplateToSchema(getClass().getClassLoader().getResourceAsStream("TemplateWithOutputPort.xml")).toMap();
     }
 
     @Test
-    public void testSuccessTransformOutputPort() throws IOException, JAXBException, SchemaLoaderException {
+    public void testSuccessTransformOutputPort() throws IOException, JAXBException {
         ConfigMain.transformTemplateToSchema(getClass().getClassLoader().getResourceAsStream("TemplateWithInputPort.xml")).toMap();
     }
 
     @Test
-    public void testSuccessTransformFunnel() throws IOException, JAXBException, SchemaLoaderException {
+    public void testSuccessTransformFunnel() throws IOException, JAXBException {
         ConfigMain.transformTemplateToSchema(getClass().getClassLoader().getResourceAsStream("TemplateWithFunnel.xml")).toMap();
     }
 
@@ -305,9 +304,9 @@ public class ConfigMainTest {
     }
 
     @Test
-    public void testSuccessTransformDualRPGs() throws IOException, JAXBException, SchemaLoaderException {
+    public void testSuccessTransformDualRPGs() throws IOException, JAXBException {
         ConfigSchema configSchema = ConfigMain.transformTemplateToSchema(getClass().getClassLoader().getResourceAsStream("MINIFI-496/dual_rpgs.xml"));
-        Assert.assertTrue(configSchema.isValid());
+        assertTrue(configSchema.isValid());
     }
 
     private void transformRoundTrip(String name) throws JAXBException, IOException, SchemaLoaderException {

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/BaseSchemaTester.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/BaseSchemaTester.java
@@ -18,13 +18,12 @@
 package org.apache.nifi.minifi.toolkit.configuration.dto;
 
 import org.apache.nifi.minifi.commons.schema.common.WritableSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class BaseSchemaTester<Schema extends WritableSchema, DTO> {
     protected final Function<DTO, Schema> dtoSchemaFunction;
@@ -44,7 +43,7 @@ public abstract class BaseSchemaTester<Schema extends WritableSchema, DTO> {
         assertEquals(dtoSchema.getValidationIssues(), mapSchema.getValidationIssues());
         assertSchemaEquals(dtoSchema, mapSchemaFunction.apply(dtoSchema.toMap()));
         assertSchemaEquals(mapSchema, mapSchemaFunction.apply(mapSchema.toMap()));
-        assertEquals(dtoSchema.getValidationIssues().stream().collect(Collectors.joining(", ")), validationErrors, dtoSchema.getValidationIssues().size());
+        assertEquals(validationErrors, dtoSchema.getValidationIssues().size(), String.join(", ", dtoSchema.getValidationIssues()));
     }
 
     public abstract void assertSchemaEquals(Schema one, Schema two);

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/ConnectionSchemaTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/ConnectionSchemaTest.java
@@ -22,36 +22,36 @@ import org.apache.nifi.minifi.commons.schema.ConnectionSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.web.api.dto.ConnectableDTO;
 import org.apache.nifi.web.api.dto.ConnectionDTO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConnectionSchemaTest extends BaseSchemaTester<ConnectionSchema, ConnectionDTO> {
-    private final String testId = UUID.nameUUIDFromBytes("testId".getBytes(StandardCharsets.UTF_8)).toString();
-    private final String testName = "testName";
-    private final String testSourceId = "testSourceId";
-    private final String testSelectedRelationship = "testSelectedRelationship";
-    private final String testDestinationId = "testDestinationId";
-    private final long testMaxWorkQueueSize = 101L;
-    private final String testMaxWorkQueueDataSize = "120 GB";
-    private final String testFlowfileExpiration = "1 day";
-    private final String testQueuePrioritizerClass = "testQueuePrioritizerClass";
+    private static final String testId = UUID.nameUUIDFromBytes("testId".getBytes(StandardCharsets.UTF_8)).toString();
+    private static final String testName = "testName";
+    private static final String testSourceId = "testSourceId";
+    private static final String testSelectedRelationship = "testSelectedRelationship";
+    private static final String testDestinationId = "testDestinationId";
+    private static final long testMaxWorkQueueSize = 101L;
+    private static final String testMaxWorkQueueDataSize = "120 GB";
+    private static final String testFlowfileExpiration = "1 day";
+    private static final String testQueuePrioritizerClass = "testQueuePrioritizerClass";
 
     public ConnectionSchemaTest() {
         super(new ConnectionSchemaFunction(), ConnectionSchema::new);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         ConnectableDTO source = new ConnectableDTO();
         source.setId(testSourceId);
@@ -63,18 +63,18 @@ public class ConnectionSchemaTest extends BaseSchemaTester<ConnectionSchema, Con
         dto.setId(testId);
         dto.setName(testName);
         dto.setSource(source);
-        dto.setSelectedRelationships(Arrays.asList(testSelectedRelationship).stream().collect(Collectors.toSet()));
+        dto.setSelectedRelationships(Collections.singleton(testSelectedRelationship));
         dto.setDestination(destination);
         dto.setBackPressureObjectThreshold(testMaxWorkQueueSize);
         dto.setBackPressureDataSizeThreshold(testMaxWorkQueueDataSize);
         dto.setFlowFileExpiration(testFlowfileExpiration);
-        dto.setPrioritizers(Arrays.asList(testQueuePrioritizerClass));
+        dto.setPrioritizers(Collections.singletonList(testQueuePrioritizerClass));
 
         map = new HashMap<>();
         map.put(CommonPropertyKeys.ID_KEY, testId);
         map.put(CommonPropertyKeys.NAME_KEY, testName);
         map.put(ConnectionSchema.SOURCE_ID_KEY, testSourceId);
-        map.put(ConnectionSchema.SOURCE_RELATIONSHIP_NAMES_KEY, new ArrayList<>(Arrays.asList(testSelectedRelationship)));
+        map.put(ConnectionSchema.SOURCE_RELATIONSHIP_NAMES_KEY, new ArrayList<>(Collections.singletonList(testSelectedRelationship)));
         map.put(ConnectionSchema.DESTINATION_ID_KEY, testDestinationId);
         map.put(ConnectionSchema.MAX_WORK_QUEUE_SIZE_KEY, testMaxWorkQueueSize);
         map.put(ConnectionSchema.MAX_WORK_QUEUE_DATA_SIZE_KEY, testMaxWorkQueueDataSize);
@@ -106,7 +106,7 @@ public class ConnectionSchemaTest extends BaseSchemaTester<ConnectionSchema, Con
     @Test
     public void testDtoMultipleSourceRelationships() {
         List<String> relationships = Arrays.asList("one", "two");
-        dto.setSelectedRelationships(relationships.stream().collect(Collectors.toSet()));
+        dto.setSelectedRelationships(new LinkedHashSet<>(relationships));
         map.put(ConnectionSchema.SOURCE_RELATIONSHIP_NAMES_KEY, new ArrayList<>(relationships));
         assertDtoAndMapConstructorAreSame(0);
     }

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/FlowControllerSchemaTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/FlowControllerSchemaTest.java
@@ -20,32 +20,32 @@ package org.apache.nifi.minifi.toolkit.configuration.dto;
 import org.apache.nifi.minifi.commons.schema.FlowControllerSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.web.api.dto.TemplateDTO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FlowControllerSchemaTest extends BaseSchemaTester<FlowControllerSchema, TemplateDTO> {
-    private String testName = "testName";
-    private String testComment = "testComment";
+    private static final String TEST_NAME = "testName";
+    private static final String TEST_COMMENT = "testComment";
 
     public FlowControllerSchemaTest() {
         super(new FlowControllerSchemaFunction(), FlowControllerSchema::new);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         dto = new TemplateDTO();
 
-        dto.setName(testName);
-        dto.setDescription(testComment);
+        dto.setName(TEST_NAME);
+        dto.setDescription(TEST_COMMENT);
 
         map = new HashMap<>();
 
-        map.put(CommonPropertyKeys.NAME_KEY, testName);
-        map.put(CommonPropertyKeys.COMMENT_KEY, testComment);
+        map.put(CommonPropertyKeys.NAME_KEY, TEST_NAME);
+        map.put(CommonPropertyKeys.COMMENT_KEY, TEST_COMMENT);
     }
 
     @Test

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/PortSchemaFunctionTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/PortSchemaFunctionTest.java
@@ -21,32 +21,30 @@ package org.apache.nifi.minifi.toolkit.configuration.dto;
 
 import org.apache.nifi.minifi.commons.schema.PortSchema;
 import org.apache.nifi.web.api.dto.PortDTO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PortSchemaFunctionTest {
     private String testId;
     private String testName;
-    private String testWrapperName;
     private PortDTO portDTO;
     private PortSchemaFunction portSchemaFunction;
 
-    @Before
+    @BeforeEach
     public void setup() {
         testId = UUID.nameUUIDFromBytes("testId".getBytes(StandardCharsets.UTF_8)).toString();
         testName = "testName";
-        testWrapperName = "testWrapperName";
         portDTO = new PortDTO();
         portDTO.setId(testId);
         portDTO.setName(testName);
-        portSchemaFunction = new PortSchemaFunction(testWrapperName);
+        portSchemaFunction = new PortSchemaFunction("testWrapperName");
     }
 
     @Test

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/ProcessorSchemaTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/ProcessorSchemaTest.java
@@ -23,8 +23,8 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.RelationshipDTO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -35,7 +35,7 @@ import java.util.UUID;
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.ANNOTATION_DATA_KEY;
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.CLASS_KEY;
 import static org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys.PROPERTIES_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProcessorSchemaTest extends BaseSchemaTester<ProcessorSchema, ProcessorDTO> {
     private final String testName = "testName";
@@ -85,7 +85,7 @@ public class ProcessorSchemaTest extends BaseSchemaTester<ProcessorSchema, Proce
         super(new ProcessorSchemaFunction(), ProcessorSchema::new);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = new ProcessorConfigDTO();
 

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/RemoteInputPortSchemaTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/RemoteInputPortSchemaTest.java
@@ -20,14 +20,14 @@ package org.apache.nifi.minifi.toolkit.configuration.dto;
 import org.apache.nifi.minifi.commons.schema.RemotePortSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupPortDTO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RemoteInputPortSchemaTest extends BaseSchemaTester<RemotePortSchema, RemoteProcessGroupPortDTO> {
 
@@ -41,7 +41,7 @@ public class RemoteInputPortSchemaTest extends BaseSchemaTester<RemotePortSchema
         super(new RemotePortSchemaFunction(), RemotePortSchema::new);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         dto = new RemoteProcessGroupPortDTO();
         dto.setId(testId);

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/RemoteProcessGroupSchemaTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/dto/RemoteProcessGroupSchemaTest.java
@@ -22,19 +22,18 @@ import org.apache.nifi.minifi.commons.schema.RemoteProcessGroupSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupContentsDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class RemoteProcessGroupSchemaTest extends BaseSchemaTester<RemoteProcessGroupSchema, RemoteProcessGroupDTO> {
     private final RemoteInputPortSchemaTest remoteInputPortSchemaTest;
@@ -52,7 +51,7 @@ public class RemoteProcessGroupSchemaTest extends BaseSchemaTester<RemoteProcess
         remoteInputPortSchemaTest = new RemoteInputPortSchemaTest();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         remoteInputPortSchemaTest.setup();
 
@@ -62,7 +61,7 @@ public class RemoteProcessGroupSchemaTest extends BaseSchemaTester<RemoteProcess
         dto.setTargetUri(testUrl);
 
         RemoteProcessGroupContentsDTO contents = new RemoteProcessGroupContentsDTO();
-        contents.setInputPorts(Arrays.asList(remoteInputPortSchemaTest.dto).stream().collect(Collectors.toSet()));
+        contents.setInputPorts(Collections.singleton(remoteInputPortSchemaTest.dto));
         dto.setContents(contents);
 
         dto.setComments(testComment);
@@ -75,7 +74,7 @@ public class RemoteProcessGroupSchemaTest extends BaseSchemaTester<RemoteProcess
         map.put(CommonPropertyKeys.ID_KEY, testId);
         map.put(CommonPropertyKeys.NAME_KEY, testName);
         map.put(RemoteProcessGroupSchema.URL_KEY, testUrl);
-        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, new ArrayList<>(Arrays.asList(remoteInputPortSchemaTest.map)));
+        map.put(CommonPropertyKeys.INPUT_PORTS_KEY, new ArrayList<>(Collections.singletonList(remoteInputPortSchemaTest.map)));
         map.put(CommonPropertyKeys.COMMENT_KEY, testComment);
         map.put(RemoteProcessGroupSchema.TIMEOUT_KEY, testTimeout);
         map.put(CommonPropertyKeys.YIELD_PERIOD_KEY, testYieldPeriod);


### PR DESCRIPTION
# Summary

[NIFI-9999](https://issues.apache.org/jira/browse/NIFI-9999) Refactors MiNiFi test classes to use JUnit 5.

The upgrade includes replacing the `docker-compose-rule-junit4` dependency with `docker-compose-junit-jupiter`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-0000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-0000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
