### PR TITLE
NIFI-9470 Allow creation of Parameter Context without any Inherited Parameter Contexts

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java
@@ -82,9 +82,9 @@ public class StandardParameterContextDAO implements ParameterContextDAO {
 
         final AtomicReference<ParameterContext> parameterContextReference = new AtomicReference<>();
         flowManager.withParameterContextResolution(() -> {
-            final List<String> referencedIds = parameterContextDto.getInheritedParameterContexts().stream()
-                .map(ParameterContextReferenceEntity::getId)
-                .collect(Collectors.toList());
+            final List<String> referencedIds = parameterContextDto.getInheritedParameterContexts() == null
+                    ? new ArrayList<>(0)
+                    : parameterContextDto.getInheritedParameterContexts().stream().map(ParameterContextReferenceEntity::getId).collect(Collectors.toList());
 
             final ParameterContext parameterContext = flowManager.createParameterContext(parameterContextDto.getId(), parameterContextDto.getName(), parameters, referencedIds);
             if (parameterContextDto.getDescription() != null) {


### PR DESCRIPTION
# Summary

[NIFI-9470](https://issues.apache.org/jira/browse/NIFI-9470) allow creation of Parameter Context without any Inherited Parameter Contexts - addition of Parameter Context nesting in 1.15 broke the ability for NiFi Toolkit to `create-param` (also affects 3rd Party clients such as NiPyApi with https://github.com/Chaffelson/nipyapi/issues/305).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
