### PR TITLE
NIFI-10014 Upgrade Registry Test JDBC Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,30 +281,11 @@ If no profile is specified then an H2 DataSource will be used by default and no 
 Assuming Docker is running on the system where the build is running, then the following commands can be run:
 
 | Target Database | Build Command | 
-| --------------- | ------------- |
-| All supported   | `mvn verify -Ptest-all-dbs` |
-| H2 (default)    | `mvn verify` |
-| PostgreSQL 9.x  | `mvn verify -Dspring.profiles.active=postgres` | 
-| PostgreSQL 10.x | `mvn verify -Dspring.profiles.active=postgres-10` | 
-| MySQL 5.6       | `mvn verify -Pcontrib-check -Dspring.profiles.active=mysql-56` |
-| MySQL 5.7       | `mvn verify -Pcontrib-check -Dspring.profiles.active=mysql-57` |
-| MySQL 8         | `mvn verify -Pcontrib-check -Dspring.profiles.active=mysql-8`  |
-      
- When one of the Testcontainer profiles is activated, the test output should show logs that indicate a container has been started, such as the following:
- 
-    2019-05-15 16:14:45.078  INFO 66091 --- [           main] 🐳 [mysql:5.7]                           : Creating container for image: mysql:5.7
-    2019-05-15 16:14:45.145  INFO 66091 --- [           main] o.t.utility.RegistryAuthLocator          : Credentials not found for host (index.docker.io) when using credential helper/store (docker-credential-osxkeychain)
-    2019-05-15 16:14:45.646  INFO 66091 --- [           main] 🐳 [mysql:5.7]                           : Starting container with ID: ca85c8c5a1990d2a898fad04c5897ddcdb3a9405e695cc11259f50f2ebe67c5f
-    2019-05-15 16:14:46.437  INFO 66091 --- [           main] 🐳 [mysql:5.7]                           : Container mysql:5.7 is starting: ca85c8c5a1990d2a898fad04c5897ddcdb3a9405e695cc11259f50f2ebe67c5f
-    2019-05-15 16:14:46.479  INFO 66091 --- [           main] 🐳 [mysql:5.7]                           : Waiting for database connection to become available at jdbc:mysql://localhost:33051/test?useSSL=false&allowPublicKeyRetrieval=true using query 'SELECT 1'
-
-The Flyway connection should also indicate the given database:
-
-    2019-05-15 16:15:02.114  INFO 66091 --- [           main] o.a.n.r.db.CustomFlywayConfiguration     : Determined database type is MYSQL
-    2019-05-15 16:15:02.115  INFO 66091 --- [           main] o.a.n.r.db.CustomFlywayConfiguration     : Setting migration locations to [classpath:db/migration/common, classpath:db/migration/mysql]
-    2019-05-15 16:15:02.373  INFO 66091 --- [           main] o.a.n.r.d.CustomFlywayMigrationStrategy  : First time initializing database...
-    2019-05-15 16:15:02.380  INFO 66091 --- [           main] o.f.c.internal.license.VersionPrinter    : Flyway Community Edition 5.2.1 by Boxfuse
-    2019-05-15 16:15:02.403  INFO 66091 --- [           main] o.f.c.internal.database.DatabaseFactory  : Database: jdbc:mysql://localhost:33051/test (MySQL 5.7)
+| ------------- | ------------- |
+| All supported | `mvn verify -Ptest-all-dbs` |
+| H2 (default)  | `mvn verify` |
+| PostgreSQL 10 | `mvn verify -Dspring.profiles.active=postgres-10` |
+| MySQL 8       | `mvn verify -Pcontrib-check -Dspring.profiles.active=mysql-8`  |
 
 For a full list of the available DataSource factories, consult the `nifi-registry-test` module.
 

--- a/README.md
+++ b/README.md
@@ -280,12 +280,13 @@ If no profile is specified then an H2 DataSource will be used by default and no 
 
 Assuming Docker is running on the system where the build is running, then the following commands can be run:
 
-| Target Database | Build Command | 
-| ------------- | ------------- |
-| All supported | `mvn verify -Ptest-all-dbs` |
-| H2 (default)  | `mvn verify` |
-| PostgreSQL 10 | `mvn verify -Dspring.profiles.active=postgres-10` |
-| MySQL 8       | `mvn verify -Pcontrib-check -Dspring.profiles.active=mysql-8`  |
+| Target Database | Build Command                                                      | 
+|-----------------|--------------------------------------------------------------------|
+| All supported   | `mvn verify -Ptest-all-dbs`                                        |
+| H2 (default)    | `mvn verify`                                                       |
+| MariaDB 10.3    | `mvn verify -Pcontrib-check -Dspring.profiles.active=mariadb-10-3` |
+| MySQL 8         | `mvn verify -Pcontrib-check -Dspring.profiles.active=mysql-8`      |
+| PostgreSQL 10   | `mvn verify -Dspring.profiles.active=postgres-10`                  |
 
 For a full list of the available DataSource factories, consult the `nifi-registry-test` module.
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -57,17 +57,17 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.29</version>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.4.1</version>
+            <version>3.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.19</version>
+            <version>42.3.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/src/main/java/org/apache/nifi/registry/db/MariaDBDataSourceFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/src/main/java/org/apache/nifi/registry/db/MariaDBDataSourceFactory.java
@@ -22,7 +22,6 @@ import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 
 import javax.annotation.PostConstruct;
-import javax.script.ScriptException;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 
@@ -38,7 +37,6 @@ public abstract class MariaDBDataSourceFactory extends TestDataSourceFactory {
             dataSource.setUrl(container.getJdbcUrl());
             dataSource.setUser(container.getUsername());
             dataSource.setPassword(container.getPassword());
-            dataSource.setDatabaseName(container.getDatabaseName());
             return dataSource;
         } catch (SQLException e) {
             throw new RuntimeException("Unable to create MariaDB DataSource", e);
@@ -46,7 +44,7 @@ public abstract class MariaDBDataSourceFactory extends TestDataSourceFactory {
     }
 
     @PostConstruct
-    public void initDatabase() throws SQLException, ScriptException {
+    public void initDatabase() {
         DatabaseDelegate databaseDelegate = new JdbcDatabaseDelegate(mariaDBContainer(), "");
         databaseDelegate.execute("DROP DATABASE test; CREATE DATABASE test;", "", 0, false, true);
     }


### PR DESCRIPTION
# Summary

[NIFI-10014](https://issues.apache.org/jira/browse/NIFI-100014) Upgrades the following JDBC drivers for NiFi Registry database integration tests:

- Upgraded MySQL from 8.0.15 to 8.0.29
- Upgraded MariabDB from 2.4.1 to 3.0.4
- Upgraded PostgreSQL from 42.2.19 to 42.3.5

Additional changes include updating the project README to remove references to unsupported databases. The MariaDB JDBC driver no longer supports the `setDatabaseName()` method, which is not necessary for Data Source configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
