### PR TITLE
NIFI-10019: SendTrapSNMP works without flowfile, upgraded to JUnit5

### DIFF
--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandler.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandler.java
@@ -21,6 +21,7 @@ import org.apache.nifi.snmp.configuration.V1TrapConfiguration;
 import org.apache.nifi.snmp.configuration.V2TrapConfiguration;
 import org.apache.nifi.snmp.factory.trap.V1TrapPDUFactory;
 import org.apache.nifi.snmp.factory.trap.V2TrapPDUFactory;
+import org.apache.nifi.snmp.operations.SNMPResourceHandler;
 import org.apache.nifi.snmp.utils.SNMPUtils;
 import org.snmp4j.PDU;
 import org.snmp4j.Snmp;

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandler.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandler.java
@@ -21,7 +21,6 @@ import org.apache.nifi.snmp.configuration.V1TrapConfiguration;
 import org.apache.nifi.snmp.configuration.V2TrapConfiguration;
 import org.apache.nifi.snmp.factory.trap.V1TrapPDUFactory;
 import org.apache.nifi.snmp.factory.trap.V2TrapPDUFactory;
-import org.apache.nifi.snmp.operations.SNMPResourceHandler;
 import org.apache.nifi.snmp.utils.SNMPUtils;
 import org.snmp4j.PDU;
 import org.snmp4j.Snmp;

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
@@ -121,7 +121,7 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession processSession) {
-        final FlowFile flowFile = Optional.ofNullable(processSession.get()).orElse(processSession.create());
+        final FlowFile flowFile = Optional.ofNullable(processSession.get()).orElseGet(processSession::create);
         final Map<String, String> attributes = new HashMap<>(flowFile.getAttributes());
 
         try {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
@@ -73,7 +73,6 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
             .displayName("SNMP Manager Port")
             .description("The port where the SNMP Manager listens to the incoming traps.")
             .required(true)
-            .defaultValue("0")
             .addValidator(StandardValidators.PORT_VALIDATOR)
             .build();
 
@@ -135,7 +134,12 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
 
                 final String enterpriseOid = context.getProperty(V1TrapProperties.ENTERPRISE_OID).evaluateAttributeExpressions(flowFile).getValue();
                 final String agentAddress = context.getProperty(V1TrapProperties.AGENT_ADDRESS).evaluateAttributeExpressions(flowFile).getValue();
-                final String genericTrapType = context.getProperty(V1TrapProperties.GENERIC_TRAP_TYPE).evaluateAttributeExpressions(flowFile).getValue();
+                String genericTrapType = context.getProperty(V1TrapProperties.GENERIC_TRAP_TYPE).getValue();
+
+                if (genericTrapType.equals(V1TrapProperties.WITH_FLOW_FILE_ATTRIBUTE.getValue()) && flowFile != null) {
+                    genericTrapType = flowFile.getAttribute(V1TrapProperties.GENERIC_TRAP_TYPE_FF_ATTRIBUTE);
+                }
+
                 final String specificTrapType = context.getProperty(V1TrapProperties.SPECIFIC_TRAP_TYPE).evaluateAttributeExpressions(flowFile).getValue();
                 V1TrapConfiguration v1TrapConfiguration = V1TrapConfiguration.builder()
                         .enterpriseOid(enterpriseOid)

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
@@ -41,8 +41,11 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -120,32 +123,53 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession processSession) {
         final FlowFile flowFile = processSession.get();
-        if (flowFile != null) {
-            try {
-                final int snmpVersion = SNMPUtils.getVersion(context.getProperty(BasicProperties.SNMP_VERSION).getValue());
-                if (SnmpConstants.version1 == snmpVersion) {
-                    V1TrapConfiguration v1TrapConfiguration = V1TrapConfiguration.builder()
-                            .enterpriseOid(context.getProperty(V1TrapProperties.ENTERPRISE_OID).evaluateAttributeExpressions(flowFile).getValue())
-                            .agentAddress(context.getProperty(V1TrapProperties.AGENT_ADDRESS).evaluateAttributeExpressions(flowFile).getValue())
-                            .genericTrapType(context.getProperty(V1TrapProperties.GENERIC_TRAP_TYPE).evaluateAttributeExpressions(flowFile).getValue())
-                            .specificTrapType(context.getProperty(V1TrapProperties.SPECIFIC_TRAP_TYPE).evaluateAttributeExpressions(flowFile).getValue())
-                            .build();
-                    snmpHandler.sendTrap(flowFile.getAttributes(), v1TrapConfiguration);
-                } else {
-                    V2TrapConfiguration v2TrapConfiguration = new V2TrapConfiguration(
-                            context.getProperty(V2TrapProperties.TRAP_OID_VALUE).evaluateAttributeExpressions(flowFile).getValue()
-                    );
-                    snmpHandler.sendTrap(flowFile.getAttributes(), v2TrapConfiguration);
-                }
-                processSession.transfer(flowFile, REL_SUCCESS);
-            } catch (IOException e) {
-                getLogger().error("Failed to send request to the agent. Check if the agent supports the used version.", e);
-                processSession.transfer(processSession.penalize(flowFile), REL_FAILURE);
-            } catch (IllegalArgumentException e) {
-                getLogger().error("Invalid trap configuration.", e);
-                processSession.transfer(processSession.penalize(flowFile), REL_FAILURE);
+        final Map<String, String> attributes = new HashMap<>(
+                Optional.ofNullable(flowFile)
+                        .map(FlowFile::getAttributes)
+                        .orElse(Collections.emptyMap())
+        );
+
+        try {
+            final int snmpVersion = SNMPUtils.getVersion(context.getProperty(BasicProperties.SNMP_VERSION).getValue());
+            if (SnmpConstants.version1 == snmpVersion) {
+
+                final String enterpriseOid = context.getProperty(V1TrapProperties.ENTERPRISE_OID).evaluateAttributeExpressions(flowFile).getValue();
+                final String agentAddress = context.getProperty(V1TrapProperties.AGENT_ADDRESS).evaluateAttributeExpressions(flowFile).getValue();
+                final String genericTrapType = context.getProperty(V1TrapProperties.GENERIC_TRAP_TYPE).evaluateAttributeExpressions(flowFile).getValue();
+                final String specificTrapType = context.getProperty(V1TrapProperties.SPECIFIC_TRAP_TYPE).evaluateAttributeExpressions(flowFile).getValue();
+                V1TrapConfiguration v1TrapConfiguration = V1TrapConfiguration.builder()
+                        .enterpriseOid(enterpriseOid)
+                        .agentAddress(agentAddress)
+                        .genericTrapType(genericTrapType)
+                        .specificTrapType(specificTrapType)
+                        .build();
+                attributes.put("agentAddress", agentAddress);
+                attributes.put("enterpriseOid", enterpriseOid);
+                attributes.put("genericTrapType", genericTrapType);
+                attributes.put("specificTrapType", specificTrapType);
+                snmpHandler.sendTrap(attributes, v1TrapConfiguration);
+            } else {
+                final String trapOidValue = context.getProperty(V2TrapProperties.TRAP_OID_VALUE).evaluateAttributeExpressions(flowFile).getValue();
+                V2TrapConfiguration v2TrapConfiguration = new V2TrapConfiguration(trapOidValue);
+                attributes.put("trapOidValue", trapOidValue);
+                snmpHandler.sendTrap(attributes, v2TrapConfiguration);
             }
+            if (flowFile == null) {
+                FlowFile outgoingFlowFile = processSession.create();
+                processSession.putAllAttributes(outgoingFlowFile, attributes);
+                processSession.transfer(outgoingFlowFile, REL_SUCCESS);
+            } else {
+                processSession.putAllAttributes(flowFile, attributes);
+                processSession.transfer(flowFile, REL_SUCCESS);
+            }
+        } catch (IOException e) {
+            getLogger().error("Failed to send request to the agent. Check if the agent supports the used version.", e);
+            processSession.transfer(processSession.penalize(flowFile), REL_FAILURE);
+        } catch (IllegalArgumentException e) {
+            getLogger().error("Invalid trap configuration.", e);
+            processSession.transfer(processSession.penalize(flowFile), REL_FAILURE);
         }
+
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/properties/V1TrapProperties.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/properties/V1TrapProperties.java
@@ -31,9 +31,39 @@ public class V1TrapProperties {
         // Utility class, not needed to instantiate.
     }
 
-    private static final AllowableValue GENERIC_TRAP_TYPE_ENTERPRISE_SPECIFIC = new AllowableValue("6", "Enterprise Specific",
+    static final AllowableValue COLD_START = new AllowableValue("0", "Cold Start",
+            "A coldStart trap signifies that the sending protocol entity is reinitializing itself such that the agent's configuration or the protocol" +
+                    " entity implementation may be altered");
+
+    static final AllowableValue WARM_START = new AllowableValue("1", "Warm Start",
+            "A warmStart trap signifies that the sending protocol entity is reinitializing itself such that neither the agent configuration nor the" +
+                    " protocol entity implementation is altered.");
+
+    static final AllowableValue LINK_DOWN = new AllowableValue("2", "Link Down",
+            "A linkDown trap signifies that the sending protocol entity recognizes a failure in one of the communication links represented in the agent's" +
+                    " configuration.");
+
+    static final AllowableValue LINK_UP = new AllowableValue("3", "Link Up",
+            "A linkUp trap signifies that the sending protocol entity recognizes that one of the communication links represented in the agent's configuration" +
+                    " has come up.");
+
+    static final AllowableValue AUTHENTICATION_FAILURE = new AllowableValue("4", "Authentication Failure",
+            "An authenticationFailure trap signifies that the sending protocol entity is the addressee of a protocol message that is not properly authenticated." +
+                    " While implementations of the SNMP must be capable of generating this trap, they must also be capable of suppressing the emission of such traps via" +
+                    " an implementation- specific mechanism.");
+
+    static final AllowableValue EGP_NEIGHBORLOSS = new AllowableValue("5", "EGP Neighborloss",
+            "An egpNeighborLoss trap signifies that an EGP neighbor for whom the sending protocol entity was an EGP peer has been marked down and the peer relationship" +
+                    " no longer obtains");
+
+    static final AllowableValue ENTERPRISE_SPECIFIC = new AllowableValue("6", "Enterprise Specific",
             "An enterpriseSpecific trap signifies that a particular enterprise-specific trap has occurred which " +
                     "can be defined in the Specific Trap Type field.");
+
+    public static final String GENERIC_TRAP_TYPE_FF_ATTRIBUTE = "generic-trap-type";
+
+    public static final AllowableValue WITH_FLOW_FILE_ATTRIBUTE = new AllowableValue(GENERIC_TRAP_TYPE_FF_ATTRIBUTE, "With \"generic-trap-type\" FlowFile Attribute",
+            "Provide the Generic Trap Type with the \"generic-trap-type\" flowfile attribute.");
 
     public static final PropertyDescriptor ENTERPRISE_OID = new PropertyDescriptor.Builder()
             .name("snmp-trap-enterprise-oid")
@@ -50,7 +80,6 @@ public class V1TrapProperties {
             .displayName("SNMP Trap Agent Address")
             .description("The address where the SNMP Manager sends the trap.")
             .required(true)
-            .defaultValue("0")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .dependsOn(SNMP_VERSION, SNMP_V1)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -60,10 +89,10 @@ public class V1TrapProperties {
             .name("snmp-trap-generic-type")
             .displayName("Generic Trap Type")
             .description("Generic trap type is an integer in the range of 0 to 6. See processor usage for details.")
-            .required(false)
-            .addValidator(StandardValidators.createLongValidator(0, 6, true))
+            .required(true)
             .dependsOn(SNMP_VERSION, SNMP_V1)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .allowableValues(COLD_START, WARM_START, LINK_DOWN, LINK_UP, AUTHENTICATION_FAILURE, EGP_NEIGHBORLOSS,
+                    ENTERPRISE_SPECIFIC, WITH_FLOW_FILE_ATTRIBUTE)
             .build();
 
     public static final PropertyDescriptor SPECIFIC_TRAP_TYPE = new PropertyDescriptor.Builder()
@@ -72,9 +101,10 @@ public class V1TrapProperties {
             .description("Specific trap type is a number that further specifies the nature of the event that generated " +
                     "the trap in the case of traps of generic type 6 (enterpriseSpecific). The interpretation of this " +
                     "code is vendor-specific.")
-            .required(true)
+            .required(false)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .dependsOn(SNMP_VERSION, SNMP_V1)
+            .dependsOn(GENERIC_TRAP_TYPE, ENTERPRISE_SPECIFIC)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/configuration/SNMPConfigurationTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/configuration/SNMPConfigurationTest.java
@@ -17,7 +17,7 @@
 package org.apache.nifi.snmp.configuration;
 
 import org.apache.nifi.remote.io.socket.NetworkUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.mp.SnmpConstants;
 
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.COMMUNITY_STRING;
@@ -28,9 +28,9 @@ import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFact
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PROTOCOL;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_LEVEL;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SNMPConfigurationTest {
+class SNMPConfigurationTest {
 
     private static final int MANAGER_PORT = NetworkUtils.getAvailableUdpPort();
     private static final String TARGET_PORT = "55556";
@@ -39,7 +39,7 @@ public class SNMPConfigurationTest {
     private static final int TIMEOUT_IN_MS = 3000;
 
     @Test
-    public void testMembersAreSetCorrectly() {
+    void testMembersAreSetCorrectly() {
         final SNMPConfiguration snmpConfiguration = SNMPConfiguration.builder()
                 .setManagerPort(MANAGER_PORT)
                 .setTargetHost(LOCALHOST)

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/configuration/V1TrapConfigurationTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/configuration/V1TrapConfigurationTest.java
@@ -16,30 +16,23 @@
  */
 package org.apache.nifi.snmp.configuration;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import static org.apache.nifi.snmp.configuration.V1TrapConfiguration.AGENT_ADDRESS_MUST_BE_SPECIFIED;
-import static org.apache.nifi.snmp.configuration.V1TrapConfiguration.ENTERPRISE_OID_MUST_BE_SPECIFIED;
 import static org.apache.nifi.snmp.configuration.V1TrapConfiguration.GENERIC_TRAP_TYPE_IS_6_ENTERPRISE_SPECIFIC_BUT_SPECIFIC_TRAP_TYPE_IS_NOT_PROVIDED;
 import static org.apache.nifi.snmp.configuration.V1TrapConfiguration.GENERIC_TRAP_TYPE_MUST_BE_BETWEEN_0_AND_6;
 import static org.apache.nifi.snmp.configuration.V1TrapConfiguration.SPECIFIC_TRAP_TYPE_MUST_BE_BETWEEN_0_AND_2147483647;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class V1TrapConfigurationTest {
+class V1TrapConfigurationTest {
 
     private static final String AGENT_ADDRESS = "127.0.0.1";
     private static final String ENTERPRISE_OID = "1.3.6.1.4.1.8072.2.3.0.1";
     private static final int GENERIC_TRAP_TYPE = 6;
     private static final Integer SPECIFIC_TRAP_TYPE = 2;
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
-    public void testMembersAreSetCorrectly() {
+    void testMembersAreSetCorrectly() {
         final V1TrapConfiguration v1TrapConfiguration = V1TrapConfiguration.builder()
                 .enterpriseOid(ENTERPRISE_OID)
                 .agentAddress(AGENT_ADDRESS)
@@ -54,29 +47,32 @@ public class V1TrapConfigurationTest {
     }
 
     @Test
-    public void testRequireNonNullEnterpriseOid() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(ENTERPRISE_OID_MUST_BE_SPECIFIED);
-        V1TrapConfiguration.builder()
-                .agentAddress(AGENT_ADDRESS)
-                .genericTrapType(String.valueOf(GENERIC_TRAP_TYPE))
-                .specificTrapType(String.valueOf(SPECIFIC_TRAP_TYPE))
-                .build();
+    void testRequireNonNullEnterpriseOid() {
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                V1TrapConfiguration.builder()
+                        .agentAddress(AGENT_ADDRESS)
+                        .genericTrapType(String.valueOf(GENERIC_TRAP_TYPE))
+                        .specificTrapType(String.valueOf(SPECIFIC_TRAP_TYPE))
+                        .build()
+        );
+        assertEquals("Enterprise OID must be specified.", exception.getMessage());
     }
 
     @Test
-    public void testRequireNonNullAgentAddress() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(AGENT_ADDRESS_MUST_BE_SPECIFIED);
-        V1TrapConfiguration.builder()
-                .enterpriseOid(ENTERPRISE_OID)
-                .genericTrapType(String.valueOf(GENERIC_TRAP_TYPE))
-                .specificTrapType(String.valueOf(SPECIFIC_TRAP_TYPE))
-                .build();
+    void testRequireNonNullAgentAddress() {
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                        V1TrapConfiguration.builder()
+                                .enterpriseOid(ENTERPRISE_OID)
+                                .genericTrapType(String.valueOf(GENERIC_TRAP_TYPE))
+                                .specificTrapType(String.valueOf(SPECIFIC_TRAP_TYPE))
+                                .build()
+        );
+
+        assertEquals("Agent address must be specified.", exception.getMessage());
     }
 
     @Test
-    public void testGenericTypeIsNegative() {
+    void testGenericTypeIsNegative() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> V1TrapConfiguration.builder()
                 .agentAddress(AGENT_ADDRESS)
                 .enterpriseOid(ENTERPRISE_OID)
@@ -87,7 +83,7 @@ public class V1TrapConfigurationTest {
     }
 
     @Test
-    public void testGenericTypeIsGreaterThan6() {
+    void testGenericTypeIsGreaterThan6() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> V1TrapConfiguration.builder()
                 .agentAddress(AGENT_ADDRESS)
                 .enterpriseOid(ENTERPRISE_OID)
@@ -98,7 +94,7 @@ public class V1TrapConfigurationTest {
     }
 
     @Test
-    public void testGenericTypeIsNotANumber() {
+    void testGenericTypeIsNotANumber() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> V1TrapConfiguration.builder()
                 .agentAddress(AGENT_ADDRESS)
                 .enterpriseOid(ENTERPRISE_OID)
@@ -109,7 +105,7 @@ public class V1TrapConfigurationTest {
     }
 
     @Test
-    public void testSpecificTrapTypeIsNegative() {
+    void testSpecificTrapTypeIsNegative() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> V1TrapConfiguration.builder()
                 .agentAddress(AGENT_ADDRESS)
                 .enterpriseOid(ENTERPRISE_OID)
@@ -121,7 +117,7 @@ public class V1TrapConfigurationTest {
     }
 
     @Test
-    public void testGenericTrapTypeIsEnterpriseSpecificButSpecificTrapTypeIsNotSet() {
+    void testGenericTrapTypeIsEnterpriseSpecificButSpecificTrapTypeIsNotSet() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> V1TrapConfiguration.builder()
                 .agentAddress(AGENT_ADDRESS)
                 .enterpriseOid(ENTERPRISE_OID)

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/dto/SNMPTreeResponseTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/dto/SNMPTreeResponseTest.java
@@ -16,10 +16,8 @@
  */
 package org.apache.nifi.snmp.dto;
 
-import org.apache.nifi.util.LogMessage;
-import org.apache.nifi.util.MockComponentLog;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.Target;
@@ -35,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +59,7 @@ public class SNMPTreeResponseTest {
     @Mock
     private static Target target;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         vbMap = new HashMap<>();
         vbMap.put(SNMP_PREFIX + OID_1 + SNMP_SEPARATOR + VB_SYNTAX, OID_1_VALUE);
@@ -83,7 +81,7 @@ public class SNMPTreeResponseTest {
     }
 
     @Test
-    public void testGetAttributes() {
+    void testGetAttributes() {
         final TreeEvent treeEvent1 = mock(TreeEvent.class);
         when(treeEvent1.getVariableBindings()).thenReturn(vbs1);
         final TreeEvent treeEvent2 = mock(TreeEvent.class);
@@ -102,7 +100,7 @@ public class SNMPTreeResponseTest {
     }
 
     @Test
-    public void testGetAttributesFlattensEmptyVariableBindingArrays() {
+    void testGetAttributesFlattensEmptyVariableBindingArrays() {
         final TreeEvent emptyTreeEvent = mock(TreeEvent.class);
         when(emptyTreeEvent.getVariableBindings()).thenReturn(new VariableBinding[0]);
         final TreeEvent normalTreeEvent = mock(TreeEvent.class);
@@ -119,7 +117,7 @@ public class SNMPTreeResponseTest {
     }
 
     @Test
-    public void testGetAttributesFiltersNullVariableBindings() {
+    void testGetAttributesFiltersNullVariableBindings() {
         final TreeEvent nullTreeEvent = mock(TreeEvent.class);
         when(nullTreeEvent.getVariableBindings()).thenReturn(null);
         final TreeEvent normalTreeEvent = mock(TreeEvent.class);
@@ -136,7 +134,7 @@ public class SNMPTreeResponseTest {
     }
 
     @Test
-    public void testGetTargetAddress() {
+    void testGetTargetAddress() {
         final TreeEvent treeEvent = mock(TreeEvent.class);
         final List<TreeEvent> treeEvents = new ArrayList<>();
         treeEvents.add(treeEvent);
@@ -144,22 +142,5 @@ public class SNMPTreeResponseTest {
         final String actualTargetAddress = snmpTreeResponse.getTargetAddress();
 
         assertEquals(TARGET_ADDRESS, actualTargetAddress);
-    }
-
-    @Test
-    public void testLogErrors() {
-        final MockComponentLog logger = new MockComponentLog("id1", new Object());
-
-
-        final List<TreeEvent> treeEvents = new ArrayList<>();
-        final TreeEvent treeEvent = mock(TreeEvent.class);
-        when(treeEvent.isError()).thenReturn(true);
-        when(treeEvent.getErrorMessage()).thenReturn("ERROR MESSAGE");
-        treeEvents.add(treeEvent);
-        final SNMPTreeResponse snmpTreeResponse = new SNMPTreeResponse(target, treeEvents);
-        snmpTreeResponse.logErrors(logger);
-
-        final List<LogMessage> errorMessages = logger.getErrorMessages();
-        System.out.println("asd");
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPContextTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPContextTest.java
@@ -17,7 +17,7 @@
 package org.apache.nifi.snmp.factory.core;
 
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 
@@ -26,10 +26,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SNMPContextTest {
+class SNMPContextTest {
 
     @Test
-    public void testCreateSNMPContext() {
+    void testCreateSNMPContext() {
         final SNMPContext snmpContext = spy(SNMPContext.class);
         final Snmp mockSnmpManager = mock(Snmp.class);
         final Target mockTarget = mock(Target.class);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPFactoryProviderTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPFactoryProviderTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.nifi.snmp.factory.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.mp.SnmpConstants;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-public class SNMPFactoryProviderTest {
+class SNMPFactoryProviderTest {
 
     @Test
-    public void testCreateFactoryByVersion() {
+    void testCreateFactoryByVersion() {
         final SNMPContext snmpV1V2cFactoryFromVersion1 = SNMPFactoryProvider.getFactory(SnmpConstants.version1);
         final SNMPContext snmpV1V2cFactoryFromVersion2c = SNMPFactoryProvider.getFactory(SnmpConstants.version2c);
         final SNMPContext snmpV3Factory = SNMPFactoryProvider.getFactory(SnmpConstants.version3);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -19,7 +19,7 @@ package org.apache.nifi.snmp.factory.core;
 import org.apache.nifi.remote.io.socket.NetworkUtils;
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
 import org.apache.nifi.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
@@ -30,17 +30,17 @@ import java.util.regex.Pattern;
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class V1V2cSNMPFactoryTest {
+class V1V2cSNMPFactoryTest {
 
     private static final int RETRIES = 3;
 
     @Test
-    public void testFactoryCreatesV1V2Configuration() {
+    void testFactoryCreatesV1V2Configuration() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
         final int managerPort = NetworkUtils.getAvailableUdpPort();
         final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());
@@ -56,7 +56,7 @@ public class V1V2cSNMPFactoryTest {
     }
 
     @Test
-    public void testFactoryCreatesSnmpManager() {
+    void testFactoryCreatesSnmpManager() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
         final int managerPort = NetworkUtils.getAvailableUdpPort();
         final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());
@@ -69,7 +69,7 @@ public class V1V2cSNMPFactoryTest {
     }
 
     @Test
-    public void testFactoryCreatesResourceHandler() {
+    void testFactoryCreatesResourceHandler() {
         final V1V2cSNMPFactory snmpFactory = spy(V1V2cSNMPFactory.class);
         final int managerPort = NetworkUtils.getAvailableUdpPort();
         final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -18,7 +18,7 @@ package org.apache.nifi.snmp.factory.core;
 
 import org.apache.nifi.remote.io.socket.NetworkUtils;
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.UserTarget;
@@ -38,18 +38,18 @@ import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFact
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class V3SNMPFactoryTest {
+class V3SNMPFactoryTest {
 
     private static final int RETRIES = 3;
     private static final int EXPECTED_SECURITY_LEVEL = 3;
 
     @Test
-    public void testFactoryCreatesTarget() {
+    void testFactoryCreatesTarget() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
         final int managerPort = NetworkUtils.getAvailableUdpPort();
         final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());
@@ -65,7 +65,7 @@ public class V3SNMPFactoryTest {
     }
 
     @Test
-    public void testFactoryCreatesSnmpManager() {
+    void testFactoryCreatesSnmpManager() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
         final int managerPort = NetworkUtils.getAvailableUdpPort();
         final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());
@@ -80,7 +80,7 @@ public class V3SNMPFactoryTest {
     }
 
     @Test
-    public void testFactoryCreatesResourceHandler() {
+    void testFactoryCreatesResourceHandler() {
         final V3SNMPFactory snmpFactory = spy(V3SNMPFactory.class);
         final int managerPort = NetworkUtils.getAvailableUdpPort();
         final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/trap/V1TrapPDUFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/trap/V1TrapPDUFactoryTest.java
@@ -17,17 +17,17 @@
 package org.apache.nifi.snmp.factory.trap;
 
 import org.apache.nifi.snmp.configuration.V1TrapConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.PDU;
 import org.snmp4j.PDUv1;
 import org.snmp4j.Target;
 
 import java.time.Instant;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-public class V1TrapPDUFactoryTest {
+class V1TrapPDUFactoryTest {
 
     private static final String AGENT_ADDRESS = "127.0.0.1";
     private static final String ENTERPRISE_OID = "1.3.6.1.4.1.8072.2.3.0.1";
@@ -35,7 +35,7 @@ public class V1TrapPDUFactoryTest {
     private static final int SPECIFIC_TRAP_TYPE = 2;
 
     @Test
-    public void testCreateV1TrapPdu() {
+    void testCreateV1TrapPdu() {
         final Target mockTarget = mock(Target.class);
         final V1TrapConfiguration v1TrapConfiguration = V1TrapConfiguration.builder()
                 .enterpriseOid(ENTERPRISE_OID)

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/trap/V2TrapPDUFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/trap/V2TrapPDUFactoryTest.java
@@ -17,7 +17,7 @@
 package org.apache.nifi.snmp.factory.trap;
 
 import org.apache.nifi.snmp.configuration.V2TrapConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.PDU;
 import org.snmp4j.Target;
 import org.snmp4j.mp.SnmpConstants;
@@ -31,15 +31,15 @@ import java.util.Vector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class V2TrapPDUFactoryTest {
+class V2TrapPDUFactoryTest {
 
     private static final String TRAP_OID = "1.3.6.1.4.1.8072.2.3.0.1";
 
     @Test
-    public void testCreateV2TrapPdu() {
+    void testCreateV2TrapPdu() {
         final Target mockTarget = mock(Target.class);
         final V2TrapConfiguration v2TrapConfiguration = new V2TrapConfiguration(TRAP_OID);
         final V2TrapPDUFactory v2TrapPduFactory = new V2TrapPDUFactory(mockTarget, Instant.now());

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/configurations/SNMPConfigurationFactory.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/configurations/SNMPConfigurationFactory.java
@@ -23,7 +23,7 @@ public interface SNMPConfigurationFactory {
     String LOCALHOST = "127.0.0.1";
     String COMMUNITY_STRING = "public";
 
-    SNMPConfiguration createSnmpGetSetConfiguration(int agentPort);
+    SNMPConfiguration createSnmpGetSetConfiguration(final int agentPort);
 
     SNMPConfiguration createSnmpGetSetConfigWithCustomHost(final String host, final int agentPort);
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/configurations/SNMPV1V2cConfigurationFactory.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/configurations/SNMPV1V2cConfigurationFactory.java
@@ -20,7 +20,7 @@ import org.apache.nifi.snmp.configuration.SNMPConfiguration;
 
 public class SNMPV1V2cConfigurationFactory implements SNMPConfigurationFactory {
 
-    private int snmpVersion;
+    private final int snmpVersion;
 
     public SNMPV1V2cConfigurationFactory(int snmpVersion) {
         this.snmpVersion = snmpVersion;

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/testrunners/SNMPV2cTestRunnerFactory.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/testrunners/SNMPV2cTestRunnerFactory.java
@@ -37,7 +37,7 @@ public class SNMPV2cTestRunnerFactory implements SNMPTestRunnerFactory {
     private static final SNMPConfigurationFactory snmpV2cConfigurationFactory = new SNMPV1V2cConfigurationFactory(SnmpConstants.version2c);
 
     @Override
-    public TestRunner createSnmpGetTestRunner(int agentPort, String oid, String strategy) {
+    public TestRunner createSnmpGetTestRunner(final int agentPort, final String oid, final String strategy) {
         final TestRunner runner = TestRunners.newTestRunner(GetSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV2cConfigurationFactory.createSnmpGetSetConfiguration(agentPort);
         runner.setProperty(GetSNMP.OID, oid);
@@ -50,7 +50,7 @@ public class SNMPV2cTestRunnerFactory implements SNMPTestRunnerFactory {
     }
 
     @Override
-    public TestRunner createSnmpSetTestRunner(int agentPort, String oid, String oidValue) {
+    public TestRunner createSnmpSetTestRunner(int agentPort, final String oid, final String oidValue) {
         final TestRunner runner = TestRunners.newTestRunner(SetSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV2cConfigurationFactory.createSnmpGetSetConfiguration(agentPort);
         runner.setProperty(SetSNMP.AGENT_HOST, snmpConfiguration.getTargetHost());
@@ -63,7 +63,7 @@ public class SNMPV2cTestRunnerFactory implements SNMPTestRunnerFactory {
     }
 
     @Override
-    public TestRunner createSnmpSendTrapTestRunner(int managerPort, final String oid, final String oidValue) {
+    public TestRunner createSnmpSendTrapTestRunner(final int managerPort, final String oid, final String oidValue) {
         final TestRunner runner = TestRunners.newTestRunner(SendTrapSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV2cConfigurationFactory.createSnmpGetSetConfiguration(managerPort);
         final V2TrapConfiguration trapConfiguration = TrapConfigurationFactory.getV2TrapConfiguration();
@@ -78,7 +78,7 @@ public class SNMPV2cTestRunnerFactory implements SNMPTestRunnerFactory {
     }
 
     @Override
-    public TestRunner createSnmpListenTrapTestRunner(int managerPort) {
+    public TestRunner createSnmpListenTrapTestRunner(final int managerPort) {
         final TestRunner runner = TestRunners.newTestRunner(ListenTrapSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV2cConfigurationFactory.createSnmpListenTrapConfig(managerPort);
         runner.setProperty(ListenTrapSNMP.SNMP_MANAGER_PORT, String.valueOf(snmpConfiguration.getManagerPort()));

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/testrunners/SNMPV3TestRunnerFactory.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/testrunners/SNMPV3TestRunnerFactory.java
@@ -38,7 +38,7 @@ public class SNMPV3TestRunnerFactory implements SNMPTestRunnerFactory {
     private static final SNMPConfigurationFactory snmpV3ConfigurationFactory = new SNMPV3ConfigurationFactory();
 
     @Override
-    public TestRunner createSnmpGetTestRunner(int agentPort, String oid, String strategy) {
+    public TestRunner createSnmpGetTestRunner(final int agentPort, final String oid, final String strategy) {
         final TestRunner runner = TestRunners.newTestRunner(GetSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV3ConfigurationFactory.createSnmpGetSetConfiguration(agentPort);
         runner.setProperty(GetSNMP.OID, oid);
@@ -57,7 +57,7 @@ public class SNMPV3TestRunnerFactory implements SNMPTestRunnerFactory {
     }
 
     @Override
-    public TestRunner createSnmpSetTestRunner(int agentPort, String oid, String oidValue) {
+    public TestRunner createSnmpSetTestRunner(final int agentPort, final String oid, final String oidValue) {
         final TestRunner runner = TestRunners.newTestRunner(SetSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV3ConfigurationFactory.createSnmpGetSetConfiguration(agentPort);
         runner.setProperty(SetSNMP.AGENT_HOST, snmpConfiguration.getTargetHost());
@@ -76,7 +76,7 @@ public class SNMPV3TestRunnerFactory implements SNMPTestRunnerFactory {
     }
 
     @Override
-    public TestRunner createSnmpSendTrapTestRunner(int managerPort, final String oid, final String oidValue) {
+    public TestRunner createSnmpSendTrapTestRunner(final int managerPort, final String oid, final String oidValue) {
         final TestRunner runner = TestRunners.newTestRunner(SendTrapSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV3ConfigurationFactory.createSnmpGetSetConfiguration(managerPort);
         final V2TrapConfiguration trapConfiguration = TrapConfigurationFactory.getV2TrapConfiguration();
@@ -100,7 +100,7 @@ public class SNMPV3TestRunnerFactory implements SNMPTestRunnerFactory {
     }
 
     @Override
-    public TestRunner createSnmpListenTrapTestRunner(int managerPort) {
+    public TestRunner createSnmpListenTrapTestRunner(final int managerPort) {
         final TestRunner runner = TestRunners.newTestRunner(ListenTrapSNMP.class);
         final SNMPConfiguration snmpConfiguration = snmpV3ConfigurationFactory.createSnmpListenTrapConfig(managerPort);
         runner.setProperty(ListenTrapSNMP.SNMP_MANAGER_PORT, String.valueOf(snmpConfiguration.getManagerPort()));

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/GetSNMPHandlerTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/GetSNMPHandlerTest.java
@@ -20,9 +20,8 @@ import org.apache.nifi.snmp.dto.SNMPSingleResponse;
 import org.apache.nifi.snmp.dto.SNMPTreeResponse;
 import org.apache.nifi.snmp.exception.RequestTimeoutException;
 import org.apache.nifi.snmp.exception.SNMPWalkException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.snmp4j.PDU;
@@ -44,13 +43,14 @@ import java.util.Optional;
 import static org.apache.nifi.snmp.operations.GetSNMPHandler.EMPTY_SUBTREE_EXCEPTION_MESSAGE;
 import static org.apache.nifi.snmp.operations.GetSNMPHandler.LEAF_ELEMENT_EXCEPTION_MESSAGE;
 import static org.apache.nifi.snmp.operations.GetSNMPHandler.SNMP_ERROR_EXCEPTION_MESSAGE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GetSNMPHandlerTest {
+class GetSNMPHandlerTest {
 
     private static final String OID = "1.3.6.1.4.1.343";
 
@@ -58,7 +58,7 @@ public class GetSNMPHandlerTest {
     private Snmp mockSnmpManager;
     private SNMPResourceHandler snmpResourceHandler;
 
-    @Before
+    @BeforeEach
     public void init() {
         mockTarget = mock(Target.class);
         mockSnmpManager = mock(Snmp.class);
@@ -66,7 +66,7 @@ public class GetSNMPHandlerTest {
     }
 
     @Test
-    public void testGetSnmpWithEmptyFlowFile() throws IOException {
+    void testGetSnmpWithEmptyFlowFile() throws IOException {
         final ResponseEvent mockResponseEvent = mock(ResponseEvent.class);
         final PDU mockPdu = mock(PDU.class);
         when(mockResponseEvent.getResponse()).thenReturn(mockPdu);
@@ -84,7 +84,7 @@ public class GetSNMPHandlerTest {
     }
 
     @Test
-    public void testGetSnmpWithInvalidFlowFile() throws IOException {
+    void testGetSnmpWithInvalidFlowFile() throws IOException {
         final Map<String, String> invalidFlowFileAttributes = new HashMap<>();
         invalidFlowFileAttributes.put("invalid", "flowfile attribute");
 
@@ -100,7 +100,7 @@ public class GetSNMPHandlerTest {
     }
 
     @Test
-    public void testGetSnmpWithValidFlowFile() throws IOException {
+    void testGetSnmpWithValidFlowFile() throws IOException {
         final String flowFileOid = "1.3.6.1.2.1.1.1.0";
         final Map<String, String> flowFileAttributes = new HashMap<>();
         flowFileAttributes.put("snmp$" + flowFileOid, "OID value");
@@ -123,14 +123,14 @@ public class GetSNMPHandlerTest {
     }
 
     @Test
-    public void testGetSnmpWhenTimeout() throws IOException {
+    void testGetSnmpWhenTimeout() throws IOException {
         final ResponseEvent mockResponseEvent = mock(ResponseEvent.class);
         when(mockResponseEvent.getResponse()).thenReturn(null);
         when(mockSnmpManager.get(any(PDU.class), any(Target.class))).thenReturn(mockResponseEvent);
 
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
 
-        final RequestTimeoutException requestTimeoutException = Assert.assertThrows(
+        final RequestTimeoutException requestTimeoutException = assertThrows(
                 RequestTimeoutException.class,
                 () -> getSNMPHandler.get(OID)
         );
@@ -141,7 +141,7 @@ public class GetSNMPHandlerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testWalkSnmpWithEmptyFlowFile() {
+    void testWalkSnmpWithEmptyFlowFile() {
         final TreeUtils mockTreeUtils = mock(TreeUtils.class);
         final TreeEvent mockTreeEvent = mock(TreeEvent.class);
         final List<TreeEvent> mockSubtree = (List<TreeEvent>) mock(List.class);
@@ -163,7 +163,7 @@ public class GetSNMPHandlerTest {
     }
 
     @Test
-    public void testWalkSnmpWithInvalidFlowFile() {
+    void testWalkSnmpWithInvalidFlowFile() {
         final Map<String, String> invalidFlowFileAttributes = new HashMap<>();
         invalidFlowFileAttributes.put("invalid", "flowfile attribute");
 
@@ -175,7 +175,7 @@ public class GetSNMPHandlerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testWalkSnmpWithValidFlowFile() {
+    void testWalkSnmpWithValidFlowFile() {
         final String flowFileOid = "1.3.6.1.2.1.1.1.0";
         final Map<String, String> flowFileAttributes = new HashMap<>();
         flowFileAttributes.put("snmp$" + flowFileOid, "OID value");
@@ -203,7 +203,7 @@ public class GetSNMPHandlerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testWalkSnmpWithEmptySubtreeThrowsException() {
+    void testWalkSnmpWithEmptySubtreeThrowsException() {
         final TreeUtils mockTreeUtils = mock(TreeUtils.class);
         final List<TreeEvent> mockSubtree = (List<TreeEvent>) mock(List.class);
 
@@ -213,7 +213,7 @@ public class GetSNMPHandlerTest {
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
         getSNMPHandler.setTreeUtils(mockTreeUtils);
 
-        final SNMPWalkException snmpWalkException = Assert.assertThrows(
+        final SNMPWalkException snmpWalkException = assertThrows(
                 SNMPWalkException.class,
                 () -> getSNMPHandler.walk(OID)
         );
@@ -223,7 +223,7 @@ public class GetSNMPHandlerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testWalkSnmpWithSubtreeErrorThrowsException() {
+    void testWalkSnmpWithSubtreeErrorThrowsException() {
         final TreeUtils mockTreeUtils = mock(TreeUtils.class);
         final TreeEvent mockTreeEvent = mock(TreeEvent.class);
         final List<TreeEvent> mockSubtree = (List<TreeEvent>) mock(List.class);
@@ -236,7 +236,7 @@ public class GetSNMPHandlerTest {
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
         getSNMPHandler.setTreeUtils(mockTreeUtils);
 
-        final SNMPWalkException snmpWalkException = Assert.assertThrows(
+        final SNMPWalkException snmpWalkException = assertThrows(
                 SNMPWalkException.class,
                 () -> getSNMPHandler.walk(OID)
         );
@@ -246,7 +246,7 @@ public class GetSNMPHandlerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testWalkSnmpWithLeafElementSubtreeThrowsException() {
+    void testWalkSnmpWithLeafElementSubtreeThrowsException() {
         final TreeUtils mockTreeUtils = mock(TreeUtils.class);
         final TreeEvent mockTreeEvent = mock(TreeEvent.class);
         final List<TreeEvent> mockSubtree = (List<TreeEvent>) mock(List.class);
@@ -261,7 +261,7 @@ public class GetSNMPHandlerTest {
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
         getSNMPHandler.setTreeUtils(mockTreeUtils);
 
-        final SNMPWalkException snmpWalkException = Assert.assertThrows(
+        final SNMPWalkException snmpWalkException = assertThrows(
                 SNMPWalkException.class,
                 () -> getSNMPHandler.walk(OID)
         );

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPRequestIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPRequestIT.java
@@ -29,11 +29,10 @@ import org.apache.nifi.snmp.testagents.TestAgent;
 import org.apache.nifi.snmp.testagents.TestSNMPV1Agent;
 import org.apache.nifi.snmp.testagents.TestSNMPV2cAgent;
 import org.apache.nifi.snmp.testagents.TestSNMPV3Agent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.snmp4j.agent.mo.DefaultMOFactory;
 import org.snmp4j.agent.mo.MOAccessImpl;
 import org.snmp4j.mp.SnmpConstants;
@@ -42,7 +41,6 @@ import org.snmp4j.smi.OctetString;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,12 +49,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
-public class SNMPRequestIT {
+class SNMPRequestIT {
 
     private static final String LOCALHOST = "127.0.0.1";
     private static final String INVALID_HOST = "127.0.0.2";
@@ -102,60 +101,69 @@ public class SNMPRequestIT {
         registerManagedObjects(v3TestAgent);
     }
 
-    @Before
-    public void initAgent() throws IOException {
-        agent.start();
-    }
-
-    @After
+    @AfterEach
     public void tearDown() {
-        agent.stop();
-        agent.unregister();
         snmpResourceHandler.close();
     }
 
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {SnmpConstants.version1, snmpV1ConfigurationFactory, v1TestAgent, NO_SUCH_NAME, NO_SUCH_NAME, NO_SUCH_NAME, NO_SUCH_NAME},
-                {SnmpConstants.version2c, snmpv2cConfigurationFactory, v2cTestAgent, NOT_WRITABLE, NO_ACCESS, NO_SUCH_OBJECT, UNABLE_TO_CREATE_OBJECT},
-                {SnmpConstants.version3, snmpv3ConfigurationFactory, v3TestAgent, NOT_WRITABLE, NO_ACCESS, NO_SUCH_OBJECT, UNABLE_TO_CREATE_OBJECT}
-        });
+    private static Stream<Arguments> provideBasicArguments() {
+        return Stream.of(
+                Arguments.of(SnmpConstants.version1, snmpV1ConfigurationFactory, v1TestAgent),
+                Arguments.of(SnmpConstants.version2c, snmpv2cConfigurationFactory, v2cTestAgent),
+                Arguments.of(SnmpConstants.version3, snmpv3ConfigurationFactory, v3TestAgent)
+        );
     }
 
-    private final int version;
-    private final SNMPConfigurationFactory snmpConfigurationFactory;
-    private final TestAgent agent;
-    private final String cannotSetReadOnlyOidStatusMessage;
-    private final String cannotModifyOidStatusMessage;
-    private final String getInvalidOidStatusMessage;
-    private final String setInvalidOidStatusMessage;
-
-    public SNMPRequestIT(final int version, final SNMPConfigurationFactory snmpConfigurationFactory, final TestAgent agent,
-                         final String cannotSetReadOnlyOidStatusMessage, final String cannotModifyOidStatusMessage,
-                         final String getInvalidOidStatusMessage, final String setInvalidOidStatusMessage) {
-        this.version = version;
-        this.snmpConfigurationFactory = snmpConfigurationFactory;
-        this.agent = agent;
-        this.cannotSetReadOnlyOidStatusMessage = cannotSetReadOnlyOidStatusMessage;
-        this.cannotModifyOidStatusMessage = cannotModifyOidStatusMessage;
-        this.getInvalidOidStatusMessage = getInvalidOidStatusMessage;
-        this.setInvalidOidStatusMessage = setInvalidOidStatusMessage;
+    private static Stream<Arguments> provideCannotSetReadOnlyOidArguments() {
+        return Stream.of(
+                Arguments.of(SnmpConstants.version1, snmpV1ConfigurationFactory, v1TestAgent, NO_SUCH_NAME),
+                Arguments.of(SnmpConstants.version2c, snmpv2cConfigurationFactory, v2cTestAgent, NOT_WRITABLE),
+                Arguments.of(SnmpConstants.version3, snmpv3ConfigurationFactory, v3TestAgent, NOT_WRITABLE)
+        );
     }
 
-    @Test
-    public void testSuccessfulSnmpGet() throws IOException {
+    private static Stream<Arguments> provideCannotModifyOidStatusMessageArguments() {
+        return Stream.of(
+                Arguments.of(SnmpConstants.version1, snmpV1ConfigurationFactory, v1TestAgent, NO_SUCH_NAME),
+                Arguments.of(SnmpConstants.version2c, snmpv2cConfigurationFactory, v2cTestAgent, NO_ACCESS),
+                Arguments.of(SnmpConstants.version3, snmpv3ConfigurationFactory, v3TestAgent, NO_ACCESS)
+        );
+    }
+
+    private static Stream<Arguments> provideGetInvalidOidStatusMessageArguments() {
+        return Stream.of(
+                Arguments.of(SnmpConstants.version1, snmpV1ConfigurationFactory, v1TestAgent, NO_SUCH_NAME),
+                Arguments.of(SnmpConstants.version2c, snmpv2cConfigurationFactory, v2cTestAgent, NO_SUCH_OBJECT),
+                Arguments.of(SnmpConstants.version3, snmpv3ConfigurationFactory, v3TestAgent, NO_SUCH_OBJECT)
+        );
+    }
+
+    private static Stream<Arguments> provideSetInvalidOidStatusMessageArguments() {
+        return Stream.of(
+                Arguments.of(SnmpConstants.version1, snmpV1ConfigurationFactory, v1TestAgent, NO_SUCH_NAME),
+                Arguments.of(SnmpConstants.version2c, snmpv2cConfigurationFactory, v2cTestAgent, UNABLE_TO_CREATE_OBJECT),
+                Arguments.of(SnmpConstants.version3, snmpv3ConfigurationFactory, v3TestAgent, UNABLE_TO_CREATE_OBJECT)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBasicArguments")
+    void testSuccessfulSnmpGet(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
         final SNMPSingleResponse response = getSNMPHandler.get(READ_ONLY_OID_1);
         assertEquals(READ_ONLY_OID_VALUE_1, response.getVariableBindings().get(0).getVariable());
         assertEquals(SUCCESS, response.getErrorStatusText());
-
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testSuccessfulSnmpGetWithFlowFileInput() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideBasicArguments")
+    void testSuccessfulSnmpGetWithFlowFileInput(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
@@ -169,29 +177,44 @@ public class SNMPRequestIT {
         } else {
             fail("Response is not present.");
         }
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testSuccessfulSnmpWalk() {
+
+    @ParameterizedTest
+    @MethodSource("provideBasicArguments")
+    void testSuccessfulSnmpWalk(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
         final SNMPTreeResponse response = getSNMPHandler.walk(WALK_OID);
 
         assertSubTreeContainsOids(response);
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test(expected = RequestTimeoutException.class)
-    public void testSnmpGetTimeoutReturnsNull() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideBasicArguments")
+    void testSnmpGetTimeoutReturnsNull(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfigWithCustomHost(INVALID_HOST, agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
 
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        getSNMPHandler.get(READ_ONLY_OID_1);
+        assertThrows(RequestTimeoutException.class, () ->
+                getSNMPHandler.get(READ_ONLY_OID_1)
+        );
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testSnmpGetInvalidOidWithFlowFileInput() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideBasicArguments")
+    void testSnmpGetInvalidOidWithFlowFileInput(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
@@ -210,12 +233,15 @@ public class SNMPRequestIT {
         } else {
             fail("Response is not present.");
         }
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testSuccessfulSnmpSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideBasicArguments")
+    void testSuccessfulSnmpSet(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
+        agent.start();
         final Map<String, String> flowFileAttributes = getFlowFileAttributes(WRITE_ONLY_OID);
-
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
@@ -227,12 +253,16 @@ public class SNMPRequestIT {
         } else {
             fail("Response is not present.");
         }
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testCannotSetReadOnlyObject() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideCannotSetReadOnlyOidArguments")
+    void testCannotSetReadOnlyObject(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
+                                     String cannotSetReadOnlyOidStatusMessage) throws IOException {
+        agent.start();
         final Map<String, String> flowFileAttributes = getFlowFileAttributes(READ_ONLY_OID_1);
-
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
@@ -243,20 +273,30 @@ public class SNMPRequestIT {
         } else {
             fail("Response is not present.");
         }
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testCannotGetWriteOnlyObject() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideCannotModifyOidStatusMessageArguments")
+    void testCannotGetWriteOnlyObject(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
+                                      String cannotModifyOidStatusMessage) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
         final SNMPSingleResponse response = getSNMPHandler.get(WRITE_ONLY_OID);
 
         assertEquals(cannotModifyOidStatusMessage, response.getErrorStatusText());
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testCannotGetInvalidOid() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideGetInvalidOidStatusMessageArguments")
+    void testCannotGetInvalidOid(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
+                                 String getInvalidOidStatusMessage) throws IOException {
+        agent.start();
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
         final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
@@ -267,10 +307,15 @@ public class SNMPRequestIT {
             assertEquals(getInvalidOidStatusMessage, response.getVariableBindings().get(0).getVariable());
             assertEquals(SUCCESS, response.getErrorStatusText());
         }
+        agent.stop();
+        agent.unregister();
     }
 
-    @Test
-    public void testCannotSetInvalidOid() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideSetInvalidOidStatusMessageArguments")
+    void testCannotSetInvalidOid(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
+                                 String setInvalidOidStatusMessage) throws IOException {
+        agent.start();
         final Map<String, String> flowFileAttributes = getFlowFileAttributes(INVALID_OID);
         final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
         snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
@@ -282,6 +327,8 @@ public class SNMPRequestIT {
         } else {
             fail("Response is not present.");
         }
+        agent.stop();
+        agent.unregister();
     }
 
     private Map<String, String> getFlowFileAttributes(String oid) {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPRequestIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPRequestIT.java
@@ -157,7 +157,8 @@ class SNMPRequestIT {
             final SNMPSingleResponse response = getSNMPHandler.get(READ_ONLY_OID_1);
             assertEquals(READ_ONLY_OID_VALUE_1, response.getVariableBindings().get(0).getVariable());
             assertEquals(SUCCESS, response.getErrorStatusText());
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -182,7 +183,8 @@ class SNMPRequestIT {
             } else {
                 fail("Response is not present.");
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -201,7 +203,8 @@ class SNMPRequestIT {
             final SNMPTreeResponse response = getSNMPHandler.walk(WALK_OID);
 
             assertSubTreeContainsOids(response);
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -220,7 +223,8 @@ class SNMPRequestIT {
             assertThrows(RequestTimeoutException.class, () ->
                     getSNMPHandler.get(READ_ONLY_OID_1)
             );
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -250,7 +254,8 @@ class SNMPRequestIT {
             } else {
                 fail("Response is not present.");
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -274,7 +279,8 @@ class SNMPRequestIT {
             } else {
                 fail("Response is not present.");
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -298,7 +304,8 @@ class SNMPRequestIT {
             } else {
                 fail("Response is not present.");
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -317,7 +324,8 @@ class SNMPRequestIT {
             final SNMPSingleResponse response = getSNMPHandler.get(WRITE_ONLY_OID);
 
             assertEquals(cannotModifyOidStatusMessage, response.getErrorStatusText());
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -340,7 +348,8 @@ class SNMPRequestIT {
                 assertEquals(getInvalidOidStatusMessage, response.getVariableBindings().get(0).getVariable());
                 assertEquals(SUCCESS, response.getErrorStatusText());
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();
@@ -364,7 +373,8 @@ class SNMPRequestIT {
             } else {
                 fail("Response is not present.");
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             agent.stop();
             agent.unregister();

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPRequestIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPRequestIT.java
@@ -150,35 +150,43 @@ class SNMPRequestIT {
     @MethodSource("provideBasicArguments")
     void testSuccessfulSnmpGet(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        final SNMPSingleResponse response = getSNMPHandler.get(READ_ONLY_OID_1);
-        assertEquals(READ_ONLY_OID_VALUE_1, response.getVariableBindings().get(0).getVariable());
-        assertEquals(SUCCESS, response.getErrorStatusText());
-        agent.stop();
-        agent.unregister();
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            final SNMPSingleResponse response = getSNMPHandler.get(READ_ONLY_OID_1);
+            assertEquals(READ_ONLY_OID_VALUE_1, response.getVariableBindings().get(0).getVariable());
+            assertEquals(SUCCESS, response.getErrorStatusText());
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
+        }
     }
 
     @ParameterizedTest
     @MethodSource("provideBasicArguments")
     void testSuccessfulSnmpGetWithFlowFileInput(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        final Optional<SNMPSingleResponse> optionalResponse = getSNMPHandler.get(getFlowFileAttributesForSnmpGet(READ_ONLY_OID_1, READ_ONLY_OID_2));
-        if (optionalResponse.isPresent()) {
-            final SNMPSingleResponse response = optionalResponse.get();
-            Set<String> expectedVariables = new HashSet<>(Arrays.asList(READ_ONLY_OID_VALUE_1, READ_ONLY_OID_VALUE_2));
-            Set<String> actualVariables = response.getVariableBindings().stream().map(SNMPValue::getVariable).collect(Collectors.toSet());
-            assertEquals(expectedVariables, actualVariables);
-            assertEquals(SUCCESS, response.getErrorStatusText());
-        } else {
-            fail("Response is not present.");
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            final Optional<SNMPSingleResponse> optionalResponse = getSNMPHandler.get(getFlowFileAttributesForSnmpGet(READ_ONLY_OID_1, READ_ONLY_OID_2));
+            if (optionalResponse.isPresent()) {
+                final SNMPSingleResponse response = optionalResponse.get();
+                Set<String> expectedVariables = new HashSet<>(Arrays.asList(READ_ONLY_OID_VALUE_1, READ_ONLY_OID_VALUE_2));
+                Set<String> actualVariables = response.getVariableBindings().stream().map(SNMPValue::getVariable).collect(Collectors.toSet());
+                assertEquals(expectedVariables, actualVariables);
+                assertEquals(SUCCESS, response.getErrorStatusText());
+            } else {
+                fail("Response is not present.");
+            }
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
         }
-        agent.stop();
-        agent.unregister();
     }
 
 
@@ -186,75 +194,91 @@ class SNMPRequestIT {
     @MethodSource("provideBasicArguments")
     void testSuccessfulSnmpWalk(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        final SNMPTreeResponse response = getSNMPHandler.walk(WALK_OID);
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            final SNMPTreeResponse response = getSNMPHandler.walk(WALK_OID);
 
-        assertSubTreeContainsOids(response);
-        agent.stop();
-        agent.unregister();
+            assertSubTreeContainsOids(response);
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
+        }
     }
 
     @ParameterizedTest
     @MethodSource("provideBasicArguments")
     void testSnmpGetTimeoutReturnsNull(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfigWithCustomHost(INVALID_HOST, agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfigWithCustomHost(INVALID_HOST, agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
 
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        assertThrows(RequestTimeoutException.class, () ->
-                getSNMPHandler.get(READ_ONLY_OID_1)
-        );
-        agent.stop();
-        agent.unregister();
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            assertThrows(RequestTimeoutException.class, () ->
+                    getSNMPHandler.get(READ_ONLY_OID_1)
+            );
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
+        }
     }
 
     @ParameterizedTest
     @MethodSource("provideBasicArguments")
     void testSnmpGetInvalidOidWithFlowFileInput(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        final Optional<SNMPSingleResponse> optionalResponse = getSNMPHandler.get(getFlowFileAttributesForSnmpGet(INVALID_OID, READ_ONLY_OID_2));
-        if (optionalResponse.isPresent()) {
-            final SNMPSingleResponse response = optionalResponse.get();
-            if (version == SnmpConstants.version1) {
-                assertEquals("Null", response.getVariableBindings().get(1).getVariable());
-                assertEquals(READ_ONLY_OID_VALUE_2, response.getVariableBindings().get(0).getVariable());
-                assertEquals(NO_SUCH_NAME, response.getErrorStatusText());
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            final Optional<SNMPSingleResponse> optionalResponse = getSNMPHandler.get(getFlowFileAttributesForSnmpGet(INVALID_OID, READ_ONLY_OID_2));
+            if (optionalResponse.isPresent()) {
+                final SNMPSingleResponse response = optionalResponse.get();
+                if (version == SnmpConstants.version1) {
+                    assertEquals("Null", response.getVariableBindings().get(1).getVariable());
+                    assertEquals(READ_ONLY_OID_VALUE_2, response.getVariableBindings().get(0).getVariable());
+                    assertEquals(NO_SUCH_NAME, response.getErrorStatusText());
+                } else {
+                    assertEquals(NO_SUCH_OBJECT, response.getVariableBindings().get(1).getVariable());
+                    assertEquals(READ_ONLY_OID_VALUE_2, response.getVariableBindings().get(0).getVariable());
+                    assertEquals(SUCCESS, response.getErrorStatusText());
+                }
             } else {
-                assertEquals(NO_SUCH_OBJECT, response.getVariableBindings().get(1).getVariable());
-                assertEquals(READ_ONLY_OID_VALUE_2, response.getVariableBindings().get(0).getVariable());
-                assertEquals(SUCCESS, response.getErrorStatusText());
+                fail("Response is not present.");
             }
-        } else {
-            fail("Response is not present.");
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
         }
-        agent.stop();
-        agent.unregister();
     }
 
     @ParameterizedTest
     @MethodSource("provideBasicArguments")
     void testSuccessfulSnmpSet(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent) throws IOException {
         agent.start();
-        final Map<String, String> flowFileAttributes = getFlowFileAttributes(WRITE_ONLY_OID);
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
-        final Optional<SNMPSingleResponse> optionalResponse = setSNMPHandler.set(flowFileAttributes);
-        if (optionalResponse.isPresent()) {
-            final SNMPSingleResponse response = optionalResponse.get();
-            assertEquals(TEST_OID_VALUE, response.getVariableBindings().get(0).getVariable());
-            assertEquals(SUCCESS, response.getErrorStatusText());
-        } else {
-            fail("Response is not present.");
+        try {
+            final Map<String, String> flowFileAttributes = getFlowFileAttributes(WRITE_ONLY_OID);
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
+            final Optional<SNMPSingleResponse> optionalResponse = setSNMPHandler.set(flowFileAttributes);
+            if (optionalResponse.isPresent()) {
+                final SNMPSingleResponse response = optionalResponse.get();
+                assertEquals(TEST_OID_VALUE, response.getVariableBindings().get(0).getVariable());
+                assertEquals(SUCCESS, response.getErrorStatusText());
+            } else {
+                fail("Response is not present.");
+            }
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
         }
-        agent.stop();
-        agent.unregister();
     }
 
     @ParameterizedTest
@@ -262,19 +286,23 @@ class SNMPRequestIT {
     void testCannotSetReadOnlyObject(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
                                      String cannotSetReadOnlyOidStatusMessage) throws IOException {
         agent.start();
-        final Map<String, String> flowFileAttributes = getFlowFileAttributes(READ_ONLY_OID_1);
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
-        final Optional<SNMPSingleResponse> optionalResponse = setSNMPHandler.set(flowFileAttributes);
-        if (optionalResponse.isPresent()) {
-            final SNMPSingleResponse response = optionalResponse.get();
-            assertEquals(cannotSetReadOnlyOidStatusMessage, response.getErrorStatusText());
-        } else {
-            fail("Response is not present.");
+        try {
+            final Map<String, String> flowFileAttributes = getFlowFileAttributes(READ_ONLY_OID_1);
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
+            final Optional<SNMPSingleResponse> optionalResponse = setSNMPHandler.set(flowFileAttributes);
+            if (optionalResponse.isPresent()) {
+                final SNMPSingleResponse response = optionalResponse.get();
+                assertEquals(cannotSetReadOnlyOidStatusMessage, response.getErrorStatusText());
+            } else {
+                fail("Response is not present.");
+            }
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
         }
-        agent.stop();
-        agent.unregister();
     }
 
     @ParameterizedTest
@@ -282,14 +310,18 @@ class SNMPRequestIT {
     void testCannotGetWriteOnlyObject(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
                                       String cannotModifyOidStatusMessage) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        final SNMPSingleResponse response = getSNMPHandler.get(WRITE_ONLY_OID);
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            final SNMPSingleResponse response = getSNMPHandler.get(WRITE_ONLY_OID);
 
-        assertEquals(cannotModifyOidStatusMessage, response.getErrorStatusText());
-        agent.stop();
-        agent.unregister();
+            assertEquals(cannotModifyOidStatusMessage, response.getErrorStatusText());
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
+        }
     }
 
     @ParameterizedTest
@@ -297,18 +329,22 @@ class SNMPRequestIT {
     void testCannotGetInvalidOid(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
                                  String getInvalidOidStatusMessage) throws IOException {
         agent.start();
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
-        final SNMPSingleResponse response = getSNMPHandler.get(INVALID_OID);
-        if (version == SnmpConstants.version1) {
-            assertEquals(getInvalidOidStatusMessage, response.getErrorStatusText());
-        } else {
-            assertEquals(getInvalidOidStatusMessage, response.getVariableBindings().get(0).getVariable());
-            assertEquals(SUCCESS, response.getErrorStatusText());
+        try {
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final GetSNMPHandler getSNMPHandler = new GetSNMPHandler(snmpResourceHandler);
+            final SNMPSingleResponse response = getSNMPHandler.get(INVALID_OID);
+            if (version == SnmpConstants.version1) {
+                assertEquals(getInvalidOidStatusMessage, response.getErrorStatusText());
+            } else {
+                assertEquals(getInvalidOidStatusMessage, response.getVariableBindings().get(0).getVariable());
+                assertEquals(SUCCESS, response.getErrorStatusText());
+            }
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
         }
-        agent.stop();
-        agent.unregister();
     }
 
     @ParameterizedTest
@@ -316,19 +352,23 @@ class SNMPRequestIT {
     void testCannotSetInvalidOid(int version, SNMPConfigurationFactory snmpConfigurationFactory, TestAgent agent,
                                  String setInvalidOidStatusMessage) throws IOException {
         agent.start();
-        final Map<String, String> flowFileAttributes = getFlowFileAttributes(INVALID_OID);
-        final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
-        snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
-        final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
-        final Optional<SNMPSingleResponse> optionalResponse = setSNMPHandler.set(flowFileAttributes);
-        if (optionalResponse.isPresent()) {
-            final SNMPSingleResponse response = optionalResponse.get();
-            assertEquals(setInvalidOidStatusMessage, response.getErrorStatusText());
-        } else {
-            fail("Response is not present.");
+        try {
+            final Map<String, String> flowFileAttributes = getFlowFileAttributes(INVALID_OID);
+            final SNMPConfiguration snmpConfiguration = snmpConfigurationFactory.createSnmpGetSetConfiguration(agent.getPort());
+            snmpResourceHandler = SNMPFactoryProvider.getFactory(version).createSNMPResourceHandler(snmpConfiguration);
+            final SetSNMPHandler setSNMPHandler = new SetSNMPHandler(snmpResourceHandler);
+            final Optional<SNMPSingleResponse> optionalResponse = setSNMPHandler.set(flowFileAttributes);
+            if (optionalResponse.isPresent()) {
+                final SNMPSingleResponse response = optionalResponse.get();
+                assertEquals(setInvalidOidStatusMessage, response.getErrorStatusText());
+            } else {
+                fail("Response is not present.");
+            }
+        } catch (Exception ignored) {
+        } finally {
+            agent.stop();
+            agent.unregister();
         }
-        agent.stop();
-        agent.unregister();
     }
 
     private Map<String, String> getFlowFileAttributes(String oid) {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverHandlerTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverHandlerTest.java
@@ -21,7 +21,7 @@ import org.apache.nifi.remote.io.socket.NetworkUtils;
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
 import org.apache.nifi.snmp.utils.JsonFileUsmReader;
 import org.apache.nifi.util.MockComponentLog;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.snmp4j.Snmp;
 import org.snmp4j.mp.SnmpConstants;
@@ -31,9 +31,9 @@ import org.snmp4j.security.UsmUser;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -41,12 +41,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SNMPTrapReceiverHandlerTest {
+class SNMPTrapReceiverHandlerTest {
 
     public static final String USERS_JSON = "src/test/resources/users.json";
 
     @Test
-    public void testTrapReceiverCreatesCommandResponder() {
+    void testTrapReceiverCreatesCommandResponder() {
         final SNMPConfiguration snmpConfiguration = mock(SNMPConfiguration.class);
         final ProcessSessionFactory mockProcessSessionFactory = mock(ProcessSessionFactory.class);
         final MockComponentLog mockComponentLog = new MockComponentLog("componentId", new Object());
@@ -65,7 +65,7 @@ public class SNMPTrapReceiverHandlerTest {
     }
 
     @Test
-    public void testCloseTrapReceiverCleansUpResources() throws IOException {
+    void testCloseTrapReceiverCleansUpResources() throws IOException {
         final SNMPConfiguration snmpConfiguration = mock(SNMPConfiguration.class);
         final ProcessSessionFactory mockProcessSessionFactory = mock(ProcessSessionFactory.class);
         final MockComponentLog mockComponentLog = new MockComponentLog("componentId", new Object());
@@ -88,7 +88,7 @@ public class SNMPTrapReceiverHandlerTest {
     }
 
     @Test
-    public void testAddUsmUsers() {
+    void testAddUsmUsers() {
         final List<UsmUser> usmUsers = new JsonFileUsmReader(USERS_JSON).readUsm();
 
         final SNMPConfiguration snmpConfiguration = SNMPConfiguration.builder()

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -24,8 +24,8 @@ import org.apache.nifi.util.MockComponentLog;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessSession;
 import org.apache.nifi.util.SharedSessionState;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.CommandResponderEvent;
 import org.snmp4j.PDU;
 import org.snmp4j.PDUv1;
@@ -36,13 +36,13 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SNMPTrapReceiverTest {
+class SNMPTrapReceiverTest {
 
     private static final Object MOCK_COMPONENT_ID = new Object();
 
@@ -53,7 +53,7 @@ public class SNMPTrapReceiverTest {
     private SNMPTrapReceiver snmpTrapReceiver;
 
 
-    @Before
+    @BeforeEach
     public void init() {
         mockProcessSessionFactory = mock(ProcessSessionFactory.class);
         mockComponentLog = new MockComponentLog("componentId", MOCK_COMPONENT_ID);
@@ -64,7 +64,7 @@ public class SNMPTrapReceiverTest {
     }
 
     @Test
-    public void testReceiveTrapWithNullPduLogsError() {
+    void testReceiveTrapWithNullPduLogsError() {
         CommandResponderEvent mockEvent = mock(CommandResponderEvent.class);
 
         snmpTrapReceiver.processPdu(mockEvent);
@@ -75,7 +75,7 @@ public class SNMPTrapReceiverTest {
     }
 
     @Test
-    public void testReceiveTrapWithInvalidPduTypeLogsError() {
+    void testReceiveTrapWithInvalidPduTypeLogsError() {
         final CommandResponderEvent mockEvent = mock(CommandResponderEvent.class);
 
         when(mockPdu.getType()).thenReturn(PDU.REPORT);
@@ -88,7 +88,7 @@ public class SNMPTrapReceiverTest {
     }
 
     @Test
-    public void testTrapReceiverCreatesTrapPduV1FlowFile() {
+    void testTrapReceiverCreatesTrapPduV1FlowFile() {
         final CommandResponderEvent mockEvent = mock(CommandResponderEvent.class);
         final PDUv1 mockV1Pdu = mock(PDUv1.class);
 
@@ -110,7 +110,7 @@ public class SNMPTrapReceiverTest {
     }
 
     @Test
-    public void testTrapReceiverCreatesTrapPduV2FlowFile() {
+    void testTrapReceiverCreatesTrapPduV2FlowFile() {
         final CommandResponderEvent mockEvent = mock(CommandResponderEvent.class);
 
         when(mockPdu.getType()).thenReturn(PDU.TRAP);
@@ -131,7 +131,7 @@ public class SNMPTrapReceiverTest {
     }
 
     @Test
-    public void testReceiveTrapWithErrorGetsTransferredToFailure() {
+    void testReceiveTrapWithErrorGetsTransferredToFailure() {
         final CommandResponderEvent mockEvent = mock(CommandResponderEvent.class);
 
         when(mockPdu.getType()).thenReturn(PDU.TRAP);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandlerTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandlerTest.java
@@ -21,9 +21,9 @@ import org.apache.nifi.snmp.configuration.V2TrapConfiguration;
 import org.apache.nifi.snmp.factory.trap.V1TrapPDUFactory;
 import org.apache.nifi.snmp.factory.trap.V2TrapPDUFactory;
 import org.apache.nifi.util.MockComponentLog;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.PDU;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
@@ -33,12 +33,12 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SendTrapSNMPHandlerTest {
+class SendTrapSNMPHandlerTest {
 
     private Target mockTarget;
     private Snmp mockSnmpManager;
@@ -50,7 +50,7 @@ public class SendTrapSNMPHandlerTest {
     private SNMPResourceHandler snmpResourceHandler;
     private SendTrapSNMPHandler sendTrapSNMPHandler;
 
-    @Before
+    @BeforeEach
     public void init() throws IOException {
         mockTarget = mock(Target.class);
         mockSnmpManager = mock(Snmp.class);
@@ -81,13 +81,13 @@ public class SendTrapSNMPHandlerTest {
         };
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         snmpResourceHandler.close();
     }
 
     @Test
-    public void testSendV1TrapWithValidFlowfile() throws IOException {
+    void testSendV1TrapWithValidFlowfile() throws IOException {
         final String flowFileOid = "1.3.6.1.2.1.1.1.0";
         sendTrapSNMPHandler.sendTrap(Collections.singletonMap("snmp$" + flowFileOid, "OID value"), mockV1TrapConfiguration);
 
@@ -95,7 +95,7 @@ public class SendTrapSNMPHandlerTest {
     }
 
     @Test
-    public void testSendV2TrapWithValidFlowfile() throws IOException {
+    void testSendV2TrapWithValidFlowfile() throws IOException {
         final String flowFileOid = "1.3.6.1.2.1.1.1.0";
         sendTrapSNMPHandler.sendTrap(Collections.singletonMap("snmp$" + flowFileOid, "OID value"), mockV2TrapConfiguration);
 
@@ -103,7 +103,7 @@ public class SendTrapSNMPHandlerTest {
     }
 
     @Test
-    public void testSendV1TrapWithFlowfileWithoutOptionalSnmpAttributes() throws IOException {
+    void testSendV1TrapWithFlowfileWithoutOptionalSnmpAttributes() throws IOException {
         sendTrapSNMPHandler.sendTrap(Collections.singletonMap("invalid key", "invalid value"), mockV1TrapConfiguration);
 
         verify(mockSnmpManager).send(mockPdu, mockTarget);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SetSNMPHandlerTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SetSNMPHandlerTest.java
@@ -18,10 +18,9 @@ package org.apache.nifi.snmp.operations;
 
 import org.apache.nifi.snmp.dto.SNMPSingleResponse;
 import org.apache.nifi.snmp.exception.RequestTimeoutException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.PDU;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
@@ -35,14 +34,15 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.nifi.snmp.operations.SNMPResourceHandler.REQUEST_TIMEOUT_EXCEPTION_TEMPLATE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SetSNMPHandlerTest {
+class SetSNMPHandlerTest {
 
     private static final PDUFactory defaultSetPduFactory = new DefaultPDUFactory(PDU.SET);
 
@@ -54,7 +54,7 @@ public class SetSNMPHandlerTest {
 
     private SetSNMPHandler setSNMPHandler;
 
-    @Before
+    @BeforeEach
     public void init() {
         mockTarget = mock(Target.class);
         mockSnmpManager = mock(Snmp.class);
@@ -70,13 +70,13 @@ public class SetSNMPHandlerTest {
         SetSNMPHandler.setSetPduFactory(mockPduFactory);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         SetSNMPHandler.setSetPduFactory(defaultSetPduFactory);
     }
 
     @Test
-    public void testSetSnmpValidResponse() throws IOException {
+    void testSetSnmpValidResponse() throws IOException {
         final String flowFileOid = "1.3.6.1.2.1.1.1.0";
         final Map<String, String> flowFileAttributes = new HashMap<>();
         flowFileAttributes.put("snmp$" + flowFileOid, "OID value");
@@ -90,14 +90,14 @@ public class SetSNMPHandlerTest {
     }
 
     @Test
-    public void testSetSnmpTimeoutThrowsException() throws IOException {
+    void testSetSnmpTimeoutThrowsException() throws IOException {
         final String flowFileOid = "1.3.6.1.2.1.1.1.0";
         final Map<String, String> flowFileAttributes = new HashMap<>();
         flowFileAttributes.put("snmp$" + flowFileOid, "OID value");
 
         when(mockSnmpManager.set(any(PDU.class), any(Target.class))).thenReturn(mockResponseEvent);
 
-        final RequestTimeoutException requestTimeoutException = Assert.assertThrows(
+        final RequestTimeoutException requestTimeoutException = assertThrows(
                 RequestTimeoutException.class,
                 () -> setSNMPHandler.set(flowFileAttributes)
         );
@@ -106,7 +106,7 @@ public class SetSNMPHandlerTest {
     }
 
     @Test
-    public void testSetSnmpWithInvalidPduThrowsException() throws IOException {
+    void testSetSnmpWithInvalidPduThrowsException() throws IOException {
         final Map<String, String> flowFileAttributes = new HashMap<>();
         flowFileAttributes.put("invalid key", "invalid value");
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/AbstractSNMPProcessorTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/AbstractSNMPProcessorTest.java
@@ -25,8 +25,8 @@ import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.MockProcessSession;
 import org.apache.nifi.util.SharedSessionState;
 import org.apache.nifi.util.TestRunner;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.mp.SnmpConstants;
 
 import java.util.Collections;
@@ -34,12 +34,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AbstractSNMPProcessorTest {
+class AbstractSNMPProcessorTest {
 
     private static final String TEST_OID = "1.3.6.1.4.1.32437.1.5.1.4.2.0";
     private static final String UNSUPPORTED_SECURITY_LEVEL = "1.3.6.1.6.3.15.1.1.1";
@@ -51,7 +51,7 @@ public class AbstractSNMPProcessorTest {
     private SNMPSingleResponse mockResponse;
     private TestRunner getTestRunner;
 
-    @Before
+    @BeforeEach
     public void init() {
         getTestRunner = new SNMPV1TestRunnerFactory().createSnmpGetTestRunner(NetworkUtils.getAvailableUdpPort(), TEST_OID, "GET");
         getSNMP = (GetSNMP) getTestRunner.getProcessor();
@@ -62,7 +62,7 @@ public class AbstractSNMPProcessorTest {
     }
 
     @Test
-    public void testProcessResponseWithInvalidResponseThrowsException() {
+    void testProcessResponseWithInvalidResponseThrowsException() {
         final String errorStatus = "Test error status text";
         when(mockResponse.getErrorStatusText()).thenReturn(errorStatus);
 
@@ -75,7 +75,7 @@ public class AbstractSNMPProcessorTest {
     }
 
     @Test
-    public void testProcessResponseWithNoSuchObjectThrowsException() {
+    void testProcessResponseWithNoSuchObjectThrowsException() {
         when(mockResponse.isValid()).thenReturn(true);
         when(mockResponse.getVersion()).thenReturn(SnmpConstants.version2c);
 
@@ -92,7 +92,7 @@ public class AbstractSNMPProcessorTest {
     }
 
     @Test
-    public void testValidProcessResponseWithoutVariableBindingThrowsException() {
+    void testValidProcessResponseWithoutVariableBindingThrowsException() {
         when(mockResponse.isValid()).thenReturn(true);
         when(mockResponse.getVersion()).thenReturn(SnmpConstants.version2c);
 
@@ -107,7 +107,7 @@ public class AbstractSNMPProcessorTest {
     }
 
     @Test
-    public void testValidProcessResponse() {
+    void testValidProcessResponse() {
         when(mockResponse.isValid()).thenReturn(true);
         when(mockResponse.getVersion()).thenReturn(SnmpConstants.version2c);
 
@@ -124,7 +124,7 @@ public class AbstractSNMPProcessorTest {
     }
 
     @Test
-    public void testProcessResponseWithReportPduWithoutErrorMessage() {
+    void testProcessResponseWithReportPduWithoutErrorMessage() {
         when(mockResponse.isValid()).thenReturn(true);
         when(mockResponse.isReportPdu()).thenReturn(true);
 
@@ -143,7 +143,7 @@ public class AbstractSNMPProcessorTest {
     }
 
     @Test
-    public void testProcessResponseWithReportPdu() {
+    void testProcessResponseWithReportPdu() {
         when(mockResponse.isValid()).thenReturn(true);
         when(mockResponse.isReportPdu()).thenReturn(true);
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
@@ -81,54 +81,66 @@ class GetSNMPIT {
     @MethodSource("provideArguments")
     void testSnmpGet(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
         testAgent.start();
-        final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), READ_ONLY_OID_1, GET);
-        runner.run();
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
+        try {
+            final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), READ_ONLY_OID_1, GET);
+            runner.run();
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
 
-        assertNotNull(successFF);
-        assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        testAgent.stop();
-        testAgent.unregister();
+            assertNotNull(successFF);
+            assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+        } catch (Exception ignored) {
+        } finally {
+            testAgent.stop();
+            testAgent.unregister();
+        }
     }
 
     @ParameterizedTest
     @MethodSource("provideArguments")
     void testSnmpWalk(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
         testAgent.start();
-        final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), WALK_OID, WALK);
-        runner.run();
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
-        assertNotNull(successFF);
+        try {
+            final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), WALK_OID, WALK);
+            runner.run();
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
+            assertNotNull(successFF);
 
-        assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        assertEquals(READ_ONLY_OID_VALUE_2, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_2 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        testAgent.stop();
-        testAgent.unregister();
+            assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+            assertEquals(READ_ONLY_OID_VALUE_2, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_2 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+        } catch (Exception ignored) {
+        } finally {
+            testAgent.stop();
+            testAgent.unregister();
+        }
     }
 
     @ParameterizedTest
     @MethodSource("provideArguments")
     void testSnmpGetWithEmptyResponse(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
         testAgent.start();
-        final MockFlowFile mockFlowFile = new MockFlowFile(0L);
-        mockFlowFile.putAttributes(Collections.singletonMap("snmp$" + NOT_FOUND_OID, StringUtils.EMPTY));
-        final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), NOT_FOUND_OID, GET);
-        runner.enqueue(mockFlowFile);
-        runner.run();
+        try {
+            final MockFlowFile mockFlowFile = new MockFlowFile(0L);
+            mockFlowFile.putAttributes(Collections.singletonMap("snmp$" + NOT_FOUND_OID, StringUtils.EMPTY));
+            final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), NOT_FOUND_OID, GET);
+            runner.enqueue(mockFlowFile);
+            runner.run();
 
-        if (testAgent == v1TestAgent) {
-            final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
-            assertNotNull(failureFF);
-            assertEquals(StringUtils.EMPTY, failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID));
-            assertEquals("No such name", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
-        } else {
-            final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
-            assertNotNull(failureFF);
-            assertEquals("noSuchObject", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID + SNMPUtils.SNMP_PROP_DELIMITER + "128"));
-            assertEquals("Success", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
+            if (testAgent == v1TestAgent) {
+                final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
+                assertNotNull(failureFF);
+                assertEquals(StringUtils.EMPTY, failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID));
+                assertEquals("No such name", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
+            } else {
+                final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
+                assertNotNull(failureFF);
+                assertEquals("noSuchObject", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID + SNMPUtils.SNMP_PROP_DELIMITER + "128"));
+                assertEquals("Success", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
+            }
+        } catch (Exception ignored) {
+        } finally {
+            testAgent.stop();
+            testAgent.unregister();
         }
-        testAgent.stop();
-        testAgent.unregister();
     }
 
     private static void registerManagedObjects(final TestAgent agent) {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
@@ -28,26 +28,22 @@ import org.apache.nifi.snmp.testagents.TestSNMPV3Agent;
 import org.apache.nifi.snmp.utils.SNMPUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.snmp4j.agent.mo.DefaultMOFactory;
 import org.snmp4j.agent.mo.MOAccessImpl;
 import org.snmp4j.smi.OID;
 import org.snmp4j.smi.OctetString;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(Parameterized.class)
-public class GetSNMPIT {
+class GetSNMPIT {
 
     private static final String LOCALHOST = "127.0.0.1";
     private static final String READ_ONLY_OID_1 = "1.3.6.1.4.1.32437.1.5.1.4.2.0";
@@ -73,47 +69,32 @@ public class GetSNMPIT {
         registerManagedObjects(v3TestAgent);
     }
 
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {v1TestAgent, v1TestRunnerFactory},
-                {v2cTestAgent, v2cTestRunnerFactory},
-                {v3TestAgent, v3TestRunnerFactory}
-        });
+    private static Stream<Arguments> provideArguments() {
+        return Stream.of(
+                Arguments.of(v1TestAgent, v1TestRunnerFactory),
+                Arguments.of(v2cTestAgent, v2cTestRunnerFactory),
+                Arguments.of(v3TestAgent, v3TestRunnerFactory)
+        );
     }
 
-    private final TestAgent testAgent;
-    private final SNMPTestRunnerFactory testRunnerFactory;
-
-    public GetSNMPIT(final TestAgent testAgent, final SNMPTestRunnerFactory testRunnerFactory) {
-        this.testAgent = testAgent;
-        this.testRunnerFactory = testRunnerFactory;
-    }
-
-    @Before
-    public void setUp() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    void testSnmpGet(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
         testAgent.start();
-    }
-
-    @After
-    public void tearDown() {
-        testAgent.stop();
-        testAgent.unregister();
-    }
-
-    @Test
-    public void testSnmpGet() {
-
         final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), READ_ONLY_OID_1, GET);
         runner.run();
         final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
 
         assertNotNull(successFF);
         assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+        testAgent.stop();
+        testAgent.unregister();
     }
 
-    @Test
-    public void testSnmpWalk() {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    void testSnmpWalk(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
+        testAgent.start();
         final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), WALK_OID, WALK);
         runner.run();
         final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
@@ -121,10 +102,14 @@ public class GetSNMPIT {
 
         assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
         assertEquals(READ_ONLY_OID_VALUE_2, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_2 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+        testAgent.stop();
+        testAgent.unregister();
     }
 
-    @Test
-    public void testSnmpGetWithEmptyResponse() {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    void testSnmpGetWithEmptyResponse(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
+        testAgent.start();
         final MockFlowFile mockFlowFile = new MockFlowFile(0L);
         mockFlowFile.putAttributes(Collections.singletonMap("snmp$" + NOT_FOUND_OID, StringUtils.EMPTY));
         final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), NOT_FOUND_OID, GET);
@@ -139,16 +124,17 @@ public class GetSNMPIT {
         } else {
             final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
             assertNotNull(failureFF);
-             assertEquals("noSuchObject", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID + SNMPUtils.SNMP_PROP_DELIMITER + "128"));
+            assertEquals("noSuchObject", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID + SNMPUtils.SNMP_PROP_DELIMITER + "128"));
             assertEquals("Success", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
         }
-
+        testAgent.stop();
+        testAgent.unregister();
     }
 
     private static void registerManagedObjects(final TestAgent agent) {
         agent.registerManagedObjects(
                 DefaultMOFactory.getInstance().createScalar(new OID(READ_ONLY_OID_1), MOAccessImpl.ACCESS_READ_ONLY, new OctetString(READ_ONLY_OID_VALUE_1)),
                 DefaultMOFactory.getInstance().createScalar(new OID(READ_ONLY_OID_2), MOAccessImpl.ACCESS_READ_ONLY, new OctetString(READ_ONLY_OID_VALUE_2))
-                );
+        );
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class GetSNMPIT {
 
@@ -88,7 +89,8 @@ class GetSNMPIT {
 
             assertNotNull(successFF);
             assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             testAgent.stop();
             testAgent.unregister();
@@ -107,7 +109,8 @@ class GetSNMPIT {
 
             assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
             assertEquals(READ_ONLY_OID_VALUE_2, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_2 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             testAgent.stop();
             testAgent.unregister();
@@ -136,7 +139,8 @@ class GetSNMPIT {
                 assertEquals("noSuchObject", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID + SNMPUtils.SNMP_PROP_DELIMITER + "128"));
                 assertEquals("Success", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             testAgent.stop();
             testAgent.unregister();

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPTest.java
@@ -30,12 +30,12 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class GetSNMPTest {
+class GetSNMPTest {
 
     private static final String OID = "1.3.6.1.4.1.32437.1.5.1.4.2.0";
 
     @Test
-    public void testOnTriggerWithGetStrategyPerformsSnmpGet() {
+    void testOnTriggerWithGetStrategyPerformsSnmpGet() {
         final TestRunner getSnmpTestRunner = new SNMPV1TestRunnerFactory().createSnmpGetTestRunner(NetworkUtils.getAvailableUdpPort(), OID, "GET");
         final GetSNMP spyGetSNMP = spy((GetSNMP) getSnmpTestRunner.getProcessor());
         final MockProcessSession mockProcessSession = new MockProcessSession(new SharedSessionState(spyGetSNMP, new AtomicLong(0L)), spyGetSNMP);
@@ -48,7 +48,7 @@ public class GetSNMPTest {
     }
 
     @Test
-    public void testOnTriggerWithWalkStrategyPerformsSnmpWalk() {
+    void testOnTriggerWithWalkStrategyPerformsSnmpWalk() {
         final TestRunner getSnmpTestRunner = new SNMPV1TestRunnerFactory().createSnmpGetTestRunner(NetworkUtils.getAvailableUdpPort(), OID, "WALK");
         final GetSNMP spyGetSNMP = spy((GetSNMP) getSnmpTestRunner.getProcessor());
         final MockProcessSession mockProcessSession = new MockProcessSession(new SharedSessionState(spyGetSNMP, new AtomicLong(0L)), spyGetSNMP);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class SetSNMPIT {
 
@@ -80,7 +81,8 @@ class SetSNMPIT {
 
             assertNotNull(successFF);
             assertEquals(TEST_OID_VALUE, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + TEST_OID + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            fail(e);
         } finally {
             testAgent.stop();
             testAgent.unregister();

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
@@ -73,14 +73,18 @@ class SetSNMPIT {
     @MethodSource("provideArguments")
     void testSnmpSet(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
         testAgent.start();
-        final TestRunner runner = testRunnerFactory.createSnmpSetTestRunner(testAgent.getPort(), TEST_OID, TEST_OID_VALUE);
-        runner.run();
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(SetSNMP.REL_SUCCESS).get(0);
+        try {
+            final TestRunner runner = testRunnerFactory.createSnmpSetTestRunner(testAgent.getPort(), TEST_OID, TEST_OID_VALUE);
+            runner.run();
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(SetSNMP.REL_SUCCESS).get(0);
 
-        assertNotNull(successFF);
-        assertEquals(TEST_OID_VALUE, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + TEST_OID + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
-        testAgent.stop();
-        testAgent.unregister();
+            assertNotNull(successFF);
+            assertEquals(TEST_OID_VALUE, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + TEST_OID + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+        } catch (Exception ignored) {
+        } finally {
+            testAgent.stop();
+            testAgent.unregister();
+        }
     }
 
     private static void registerManagedObjects(final TestAgent agent) {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
@@ -27,25 +27,21 @@ import org.apache.nifi.snmp.testagents.TestSNMPV3Agent;
 import org.apache.nifi.snmp.utils.SNMPUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.snmp4j.agent.mo.DefaultMOFactory;
 import org.snmp4j.agent.mo.MOAccessImpl;
 import org.snmp4j.smi.OID;
 import org.snmp4j.smi.OctetString;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(Parameterized.class)
-public class SetSNMPIT {
+class SetSNMPIT {
 
     private static final String LOCALHOST = "127.0.0.1";
     private static final String TEST_OID = "1.3.6.1.4.1.32437.1.5.1.4.2.0";
@@ -65,43 +61,26 @@ public class SetSNMPIT {
         registerManagedObjects(v3TestAgent);
     }
 
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {v1TestAgent, v1TestRunnerFactory},
-                {v2cTestAgent, v2cTestRunnerFactory},
-                {v3TestAgent, v3TestRunnerFactory}
-        });
+    private static Stream<Arguments> provideArguments() {
+        return Stream.of(
+                Arguments.of(v1TestAgent, v1TestRunnerFactory),
+                Arguments.of(v2cTestAgent, v2cTestRunnerFactory),
+                Arguments.of(v3TestAgent, v3TestRunnerFactory)
+        );
     }
 
-    private final TestAgent testAgent;
-    private final SNMPTestRunnerFactory testRunnerFactory;
-
-    public SetSNMPIT(final TestAgent testAgent, final SNMPTestRunnerFactory testRunnerFactory) {
-        this.testAgent = testAgent;
-        this.testRunnerFactory = testRunnerFactory;
-    }
-
-    @Before
-    public void setUp() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    void testSnmpSet(TestAgent testAgent, SNMPTestRunnerFactory testRunnerFactory) throws IOException {
         testAgent.start();
-    }
-
-    @After
-    public void tearDown() {
-        testAgent.stop();
-        testAgent.unregister();
-    }
-
-
-    @Test
-    public void testSnmpSet() {
         final TestRunner runner = testRunnerFactory.createSnmpSetTestRunner(testAgent.getPort(), TEST_OID, TEST_OID_VALUE);
         runner.run();
         final MockFlowFile successFF = runner.getFlowFilesForRelationship(SetSNMP.REL_SUCCESS).get(0);
 
         assertNotNull(successFF);
         assertEquals(TEST_OID_VALUE, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + TEST_OID + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
+        testAgent.stop();
+        testAgent.unregister();
     }
 
     private static void registerManagedObjects(final TestAgent agent) {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/TrapSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/TrapSNMPIT.java
@@ -33,13 +33,13 @@ import org.snmp4j.mp.SnmpConstants;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class TrapSNMPIT {
+class TrapSNMPIT {
 
     protected static final String SYSTEM_DESCRIPTION_OID = "1.3.6.1.2.1.1.1.0";
     protected static final String SYSTEM_DESCRIPTION_OID_VALUE = "optionalTrapOidTestValue";
 
     @Test
-    public void testSendReceiveV1Trap() throws InterruptedException {
+    void testSendReceiveV1Trap() throws InterruptedException {
         final int listenPort = NetworkUtils.getAvailableUdpPort();
 
         final V1TrapConfiguration v1TrapConfiguration = TrapConfigurationFactory.getV1TrapConfiguration();

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/TrapSNMPIT.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/TrapSNMPIT.java
@@ -26,12 +26,12 @@ import org.apache.nifi.snmp.helper.testrunners.SNMPV2cTestRunnerFactory;
 import org.apache.nifi.snmp.utils.SNMPUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.snmp4j.mp.SnmpConstants;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TrapSNMPIT {
 
@@ -71,7 +71,7 @@ public class TrapSNMPIT {
     }
 
     @Test
-    public void testSendReceiveV2Trap() throws InterruptedException {
+    void testSendReceiveV2Trap() throws InterruptedException {
         final int listenPort = NetworkUtils.getAvailableUdpPort();
 
         final V2TrapConfiguration v2TrapConfiguration = TrapConfigurationFactory.getV2TrapConfiguration();
@@ -99,10 +99,10 @@ public class TrapSNMPIT {
         listenTrapTestRunner.shutdown();
     }
 
-    @Ignore("The ListenTrapSNMP and SendTrapSNMP processors use the same SecurityProtocols instance" +
+    @Disabled("The ListenTrapSNMP and SendTrapSNMP processors use the same SecurityProtocols instance" +
             " and same USM (the USM is stored in a map by version), hence this case shall be manually tested." +
             " Check assertByVersion() to see what the trap payload must contain.")
     @Test
-    public void testReceiveV3Trap() {
+    void testReceiveV3Trap() {
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/utils/SNMPUtilsTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/utils/SNMPUtilsTest.java
@@ -26,13 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test class for {@link SNMPUtils}.
  */
-public class SNMPUtilsTest {
+class SNMPUtilsTest {
 
     /**
      * Test for updating attributes of flow files with {@link PDU}
      */
     @Test
-    public void validateUpdateFlowFileAttributes() {
+    void validateUpdateFlowFileAttributes() {
         final PDU pdu = new PDU();
         pdu.setErrorIndex(0);
         pdu.setErrorStatus(0);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

- SendTrapSNMP fix to work without flowfile as well
- Upgraded tests from JUnit4 to JUnit5

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10019) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
