### PR TITLE
NIFI-3869 Add HTTP/2 support to ListenHTTP and HandleHttpRequest

### DIFF
--- a/nifi-commons/nifi-jetty-configuration/pom.xml
+++ b/nifi-commons/nifi-jetty-configuration/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-commons</artifactId>
+        <version>1.17.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>nifi-jetty-configuration</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/ApplicationLayerProtocol.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/ApplicationLayerProtocol.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jetty.configuration.connector;
+
+/**
+ * Application Layer Protocols supported for Server Connectors
+ */
+public enum ApplicationLayerProtocol {
+    HTTP_1_1("http/1.1"),
+
+    H2("h2");
+
+    private String protocol;
+
+    ApplicationLayerProtocol(final String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+}

--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/ServerConnectorFactory.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/ServerConnectorFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jetty.configuration.connector;
+
+import org.eclipse.jetty.server.ServerConnector;
+
+/**
+ * Jetty Server Connector Factory
+ */
+public interface ServerConnectorFactory {
+    /**
+     * Get Server Connector
+     *
+     * @return Configured Server Connector
+     */
+    ServerConnector getServerConnector();
+}

--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jetty.configuration.connector;
+
+import org.apache.nifi.jetty.configuration.connector.alpn.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http2.HTTP2Cipher;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import javax.net.ssl.SSLContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Standard implementation of Server Connector Factory supporting HTTP/2 and HTTP/1.1 with TLS or simple HTTP/1.1
+ */
+public class StandardServerConnectorFactory implements ServerConnectorFactory {
+    private static final boolean SEND_SERVER_VERSION = false;
+
+    private static final String[] INCLUDE_ALL_SECURITY_PROTOCOLS = new String[0];
+
+    private static final Set<ApplicationLayerProtocol> DEFAULT_APPLICATION_LAYER_PROTOCOLS = Collections.singleton(ApplicationLayerProtocol.HTTP_1_1);
+
+    private final Server server;
+
+    private final int port;
+
+    private Set<ApplicationLayerProtocol> applicationLayerProtocols = DEFAULT_APPLICATION_LAYER_PROTOCOLS;
+
+    private SSLContext sslContext;
+
+    private boolean needClientAuth;
+
+    private boolean wantClientAuth;
+
+    private String[] includeSecurityProtocols = INCLUDE_ALL_SECURITY_PROTOCOLS;
+
+    /**
+     * Standard Server Connector Factory Constructor with required properties
+     *
+     * @param server Jetty Server
+     * @param port Secure Port Number
+     */
+    public StandardServerConnectorFactory(
+            final Server server,
+            final int port
+    ) {
+        this.server = Objects.requireNonNull(server, "Server required");
+        this.port = port;
+    }
+
+    /**
+     * Get Server Connector configured with HTTP/2 and ALPN as well as fallback to HTTP/1.1 with TLS
+     *
+     * @return Secure Server Connector
+     */
+    @Override
+    public ServerConnector getServerConnector() {
+        final HttpConfiguration httpConfiguration = getHttpConfiguration();
+        final HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfiguration);
+
+        final ServerConnector serverConnector;
+        if (sslContext == null) {
+            serverConnector = new ServerConnector(server, httpConnectionFactory);
+        } else {
+            final List<ConnectionFactory> connectionFactories = new ArrayList<>();
+            if (applicationLayerProtocols.contains(ApplicationLayerProtocol.H2)) {
+                final ALPNServerConnectionFactory alpnServerConnectionFactory = new ALPNServerConnectionFactory();
+                final HTTP2ServerConnectionFactory http2ServerConnectionFactory = new HTTP2ServerConnectionFactory(httpConfiguration);
+
+                connectionFactories.add(alpnServerConnectionFactory);
+                connectionFactories.add(http2ServerConnectionFactory);
+            }
+            // Add HTTP/1.1 Connection Factory after HTTP/2
+            if (applicationLayerProtocols.contains(ApplicationLayerProtocol.HTTP_1_1)) {
+                connectionFactories.add(httpConnectionFactory);
+            }
+
+            // SslConnectionFactory must be first and must indicate the next protocol
+            final String nextProtocol = connectionFactories.get(0).getProtocol();
+            final SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(getSslContextFactory(), nextProtocol);
+            connectionFactories.add(0, sslConnectionFactory);
+
+            final ConnectionFactory[] factories = connectionFactories.toArray(new ConnectionFactory[0]);
+            serverConnector = new ServerConnector(server, factories);
+        }
+
+        serverConnector.setPort(port);
+        return serverConnector;
+    }
+
+    /**
+     * Set SSL Context enables TLS communication
+     *
+     * @param sslContext SSL Context
+     */
+    public void setSslContext(final SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
+    /**
+     * Set Need Client Authentication requires clients to provide certificates for mutual TLS
+     *
+     * @param needClientAuth Need Client Authentication status
+     */
+    public void setNeedClientAuth(final boolean needClientAuth) {
+        this.needClientAuth = needClientAuth;
+    }
+
+    /**
+     * Set Want Client Authentication requests clients to provide certificates for mutual TLS but does not require certificates
+     *
+     * @param wantClientAuth Want Client Authentication status
+     */
+    public void setWantClientAuth(final boolean wantClientAuth) {
+        this.wantClientAuth = wantClientAuth;
+    }
+
+    /**
+     * Set Include Security Protocols limits enabled TLS Protocols to the values provided
+     *
+     * @param includeSecurityProtocols Security Protocols with null or empty enabling all standard TLS protocol versions
+     */
+    public void setIncludeSecurityProtocols(final String[] includeSecurityProtocols) {
+        this.includeSecurityProtocols = includeSecurityProtocols == null ? INCLUDE_ALL_SECURITY_PROTOCOLS : includeSecurityProtocols;
+    }
+
+    /**
+     * Set Application Layer Protocols applicable when TLS is enabled
+     *
+     * @param applicationLayerProtocols Protocols requires at one Application Layer Protocol
+     */
+    public void setApplicationLayerProtocols(final Set<ApplicationLayerProtocol> applicationLayerProtocols) {
+        if (Objects.requireNonNull(applicationLayerProtocols, "Application Layer Protocols required").isEmpty()) {
+            throw new IllegalArgumentException("Application Layer Protocols not specified");
+        }
+        this.applicationLayerProtocols = applicationLayerProtocols;
+    }
+
+    private HttpConfiguration getHttpConfiguration() {
+        final HttpConfiguration httpConfiguration = new HttpConfiguration();
+
+        if (sslContext != null) {
+            httpConfiguration.setSecurePort(port);
+            httpConfiguration.setSecureScheme(HttpScheme.HTTPS.asString());
+            httpConfiguration.setSendServerVersion(SEND_SERVER_VERSION);
+
+            final SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+            httpConfiguration.addCustomizer(secureRequestCustomizer);
+        }
+
+        return httpConfiguration;
+    }
+
+    private SslContextFactory.Server getSslContextFactory() {
+        final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setSslContext(sslContext);
+        sslContextFactory.setNeedClientAuth(needClientAuth);
+        sslContextFactory.setWantClientAuth(wantClientAuth);
+        sslContextFactory.setIncludeProtocols(includeSecurityProtocols);
+
+        if (applicationLayerProtocols.contains(ApplicationLayerProtocol.H2)) {
+            sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
+        }
+
+        return sslContextFactory;
+    }
+}

--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/alpn/ALPNServerConnectionFactory.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/alpn/ALPNServerConnectionFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jetty.configuration.connector.alpn;
+
+import org.eclipse.jetty.alpn.server.ALPNServerConnection;
+import org.eclipse.jetty.io.AbstractConnection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.ssl.ALPNProcessor;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.NegotiatingServerConnectionFactory;
+
+import javax.net.ssl.SSLEngine;
+import java.util.List;
+
+/**
+ * ALPN Server Connection Factory with standard ALPN Processor implementation
+ */
+public class ALPNServerConnectionFactory extends NegotiatingServerConnectionFactory {
+    private static final String ALPN_PROTOCOL = "alpn";
+
+    private final ALPNProcessor.Server processor;
+
+    public ALPNServerConnectionFactory() {
+        super(ALPN_PROTOCOL);
+        processor = new StandardALPNProcessor();
+    }
+
+    /**
+     * Create new Server Connection and configure the connection using ALPN Processor
+     *
+     * @param connector Connector for the Connection
+     * @param endPoint End Point for the Connection
+     * @param sslEngine SSL Engine for the Connection
+     * @param protocols Application Protocols
+     * @param defaultProtocol Default Application Protocol
+     * @return ALPN Server Connection
+     */
+    @Override
+    protected AbstractConnection newServerConnection(
+            final Connector connector,
+            final EndPoint endPoint,
+            final SSLEngine sslEngine,
+            final List<String> protocols,
+            final String defaultProtocol
+    ) {
+        final ALPNServerConnection connection = new ALPNServerConnection(connector, endPoint, sslEngine, protocols, defaultProtocol);
+        processor.configure(sslEngine, connection);
+        return connection;
+    }
+}

--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/alpn/StandardALPNProcessor.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/alpn/StandardALPNProcessor.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jetty.configuration.connector.alpn;
+
+import org.eclipse.jetty.alpn.server.ALPNServerConnection;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.ssl.ALPNProcessor;
+import org.eclipse.jetty.io.ssl.SslConnection;
+import org.eclipse.jetty.io.ssl.SslHandshakeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * Standard ALPN Processor supporting JDK 1.8.0-251 and higher based on Jetty JDK9ServerALPNProcessor
+ */
+public class StandardALPNProcessor implements ALPNProcessor.Server, SslHandshakeListener {
+    private static final Logger logger = LoggerFactory.getLogger(StandardALPNProcessor.class);
+
+    /**
+     * Applies to SSL Engine instances regardless of implementation
+     *
+     * @param sslEngine SSL Engine to be evaluated
+     * @return Applicable Status
+     */
+    @Override
+    public boolean appliesTo(final SSLEngine sslEngine) {
+        return true;
+    }
+
+    /**
+     * Configure ALPN negotiation for Connection
+     *
+     * @param sslEngine SSL Engine to be configured
+     * @param connection Connection to be configured
+     */
+    @Override
+    public void configure(final SSLEngine sslEngine, final Connection connection) {
+        logger.debug("Configuring Connection Remote Address [{}]", connection.getEndPoint().getRemoteAddress());
+        final ALPNServerConnection serverConnection = (ALPNServerConnection) connection;
+        final ProtocolSelector protocolSelector = new ProtocolSelector(serverConnection);
+        sslEngine.setHandshakeApplicationProtocolSelector(protocolSelector);
+
+        final SslConnection.DecryptedEndPoint endPoint = (SslConnection.DecryptedEndPoint) serverConnection.getEndPoint();
+        endPoint.getSslConnection().addHandshakeListener(protocolSelector);
+    }
+
+    private static final class ProtocolSelector implements BiFunction<SSLEngine, List<String>, String>, SslHandshakeListener {
+        private final ALPNServerConnection serverConnection;
+
+        private ProtocolSelector(final ALPNServerConnection connection) {
+            serverConnection = connection;
+        }
+
+        /**
+         * Select supported Application Layer Protocol based on requested protocols
+         *
+         * @param sslEngine SSL Engine
+         * @param protocols Protocols requested
+         * @return Protocol selected or null when no supported protocol found
+         */
+        @Override
+        public String apply(final SSLEngine sslEngine, final List<String> protocols) {
+            String protocol = null;
+            try {
+                serverConnection.select(protocols);
+                protocol = serverConnection.getProtocol();
+                logger.debug("Connection Remote Address [{}] Application Layer Protocol [{}] selected", serverConnection.getEndPoint().getRemoteAddress(), protocol);
+            } catch (final Throwable e) {
+                logger.debug("Connection Remote Address [{}] Application Layer Protocols {} not supported", serverConnection.getEndPoint().getRemoteAddress(), protocols);
+            }
+            return protocol;
+        }
+
+        /**
+         * Handler for successful handshake checks for selected Application Layer Protocol
+         *
+         * @param event Event is not used
+         */
+        @Override
+        public void handshakeSucceeded(final Event event) {
+            final InetSocketAddress remoteAddress = serverConnection.getEndPoint().getRemoteAddress();
+            final SSLSession session = event.getSSLEngine().getSession();
+            logger.debug("Connection Remote Address [{}] Handshake Succeeded [{}] Cipher Suite [{}]", remoteAddress, session.getProtocol(), session.getCipherSuite());
+
+            final String protocol = serverConnection.getProtocol();
+            if (protocol == null) {
+                logger.debug("Connection Remote Address [{}] Application Layer Protocol not supported", remoteAddress);
+                serverConnection.unsupported();
+            }
+        }
+
+        /**
+         * Handle for failed handshake logs status
+         *
+         * @param event Event is not used
+         * @param failure Failure cause to be logged
+         */
+        @Override
+        public void handshakeFailed(final Event event, final Throwable failure) {
+            logger.warn("Connection Remote Address [{}] Handshake Failed", serverConnection.getEndPoint().getRemoteAddress(), failure);
+        }
+    }
+}

--- a/nifi-commons/nifi-jetty-configuration/src/test/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactoryTest.java
+++ b/nifi-commons/nifi-jetty-configuration/src/test/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactoryTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jetty.configuration.connector;
+
+import org.apache.nifi.jetty.configuration.connector.alpn.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardServerConnectorFactoryTest {
+    private static final int HTTP_PORT = 8080;
+
+    private static final int HTTPS_PORT = 8443;
+
+    private static final String[] INCLUDE_PROTOCOLS = new String[]{ "TLSv1.2" };
+
+    @Test
+    void testGetServerConnector() {
+        final Server server = new Server();
+        final StandardServerConnectorFactory factory = new StandardServerConnectorFactory(server, HTTP_PORT);
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        assertHttpConnectionFactoryFound(serverConnector);
+    }
+
+    @Test
+    void testGetServerConnectorSecured() throws NoSuchAlgorithmException {
+        final StandardServerConnectorFactory factory = createSecuredStandardServerConnectorFactory();
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        assertHttpConnectionFactoryFound(serverConnector);
+        final SslConnectionFactory sslConnectionFactory = assertSslConnectionFactoryFound(serverConnector);
+
+        final HttpConnectionFactory httpConnectionFactory = assertHttpConnectionFactoryFound(serverConnector);
+        assertHttpConnectionFactorySecured(httpConnectionFactory);
+
+        final SslContextFactory.Server sslContextFactory = (SslContextFactory.Server) sslConnectionFactory.getSslContextFactory();
+        assertFalse(sslContextFactory.getNeedClientAuth());
+        assertFalse(sslContextFactory.getWantClientAuth());
+        assertNotNull(sslContextFactory.getIncludeProtocols());
+
+        final HTTP2ServerConnectionFactory http2ConnectionFactory = serverConnector.getConnectionFactory(HTTP2ServerConnectionFactory.class);
+        assertNull(http2ConnectionFactory);
+    }
+
+    @Test
+    void testGetServerConnectorSecuredNeedClientAuthentication() throws NoSuchAlgorithmException {
+        final StandardServerConnectorFactory factory = createSecuredStandardServerConnectorFactory();
+        factory.setNeedClientAuth(true);
+        factory.setIncludeSecurityProtocols(INCLUDE_PROTOCOLS);
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        assertHttpConnectionFactoryFound(serverConnector);
+        final SslConnectionFactory sslConnectionFactory = assertSslConnectionFactoryFound(serverConnector);
+
+        final HttpConnectionFactory httpConnectionFactory = assertHttpConnectionFactoryFound(serverConnector);
+        assertHttpConnectionFactorySecured(httpConnectionFactory);
+
+        final SslContextFactory.Server sslContextFactory = (SslContextFactory.Server) sslConnectionFactory.getSslContextFactory();
+        assertTrue(sslContextFactory.getNeedClientAuth());
+        assertArrayEquals(INCLUDE_PROTOCOLS, sslContextFactory.getIncludeProtocols());
+    }
+
+    @Test
+    void testGetServerConnectorSecuredHttp2AndHttp1() throws NoSuchAlgorithmException {
+        final StandardServerConnectorFactory factory = createSecuredStandardServerConnectorFactory();
+        factory.setApplicationLayerProtocols(new LinkedHashSet<>(Arrays.asList(ApplicationLayerProtocol.H2, ApplicationLayerProtocol.HTTP_1_1)));
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        final HttpConnectionFactory httpConnectionFactory = assertHttpConnectionFactoryFound(serverConnector);
+        assertHttpConnectionFactorySecured(httpConnectionFactory);
+
+        final SslConnectionFactory sslConnectionFactory = assertSslConnectionFactoryFound(serverConnector);
+        final SslContextFactory.Server sslContextFactory = (SslContextFactory.Server) sslConnectionFactory.getSslContextFactory();
+        assertFalse(sslContextFactory.getNeedClientAuth());
+
+        assertHttp2ConnectionFactoriesFound(serverConnector);
+    }
+
+    @Test
+    void testGetServerConnectorSecuredHttp2() throws NoSuchAlgorithmException {
+        final StandardServerConnectorFactory factory = createSecuredStandardServerConnectorFactory();
+        factory.setApplicationLayerProtocols(Collections.singleton(ApplicationLayerProtocol.H2));
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        final HttpConnectionFactory connectionFactory = serverConnector.getConnectionFactory(HttpConnectionFactory.class);
+        assertNull(connectionFactory);
+
+        final SslConnectionFactory sslConnectionFactory = assertSslConnectionFactoryFound(serverConnector);
+        final SslContextFactory.Server sslContextFactory = (SslContextFactory.Server) sslConnectionFactory.getSslContextFactory();
+        assertFalse(sslContextFactory.getNeedClientAuth());
+
+        assertHttp2ConnectionFactoriesFound(serverConnector);
+    }
+
+    private StandardServerConnectorFactory createSecuredStandardServerConnectorFactory() throws NoSuchAlgorithmException {
+        final Server server = new Server();
+        final StandardServerConnectorFactory factory = new StandardServerConnectorFactory(server, HTTPS_PORT);
+        final SSLContext sslContext = SSLContext.getDefault();
+        factory.setSslContext(sslContext);
+        return factory;
+    }
+
+    private HttpConnectionFactory assertHttpConnectionFactoryFound(final ServerConnector serverConnector) {
+        assertNotNull(serverConnector);
+        final HttpConnectionFactory connectionFactory = serverConnector.getConnectionFactory(HttpConnectionFactory.class);
+        assertNotNull(connectionFactory);
+        return connectionFactory;
+    }
+
+    private void assertHttp2ConnectionFactoriesFound(final ServerConnector serverConnector) {
+        final HTTP2ServerConnectionFactory http2ConnectionFactory = serverConnector.getConnectionFactory(HTTP2ServerConnectionFactory.class);
+        assertNotNull(http2ConnectionFactory);
+
+        final ALPNServerConnectionFactory alpnServerConnectionFactory = serverConnector.getConnectionFactory(ALPNServerConnectionFactory.class);
+        assertNotNull(alpnServerConnectionFactory);
+    }
+
+    private SslConnectionFactory assertSslConnectionFactoryFound(final ServerConnector serverConnector) {
+        final SslConnectionFactory sslConnectionFactory = serverConnector.getConnectionFactory(SslConnectionFactory.class);
+        assertNotNull(sslConnectionFactory);
+        return sslConnectionFactory;
+    }
+
+    private void assertHttpConnectionFactorySecured(final HttpConnectionFactory httpConnectionFactory) {
+        final HttpConfiguration configuration = httpConnectionFactory.getHttpConfiguration();
+        assertEquals(HTTPS_PORT, configuration.getSecurePort());
+        assertEquals(HttpScheme.HTTPS.asString(), configuration.getSecureScheme());
+        final SecureRequestCustomizer secureRequestCustomizer = configuration.getCustomizer(SecureRequestCustomizer.class);
+        assertNotNull(secureRequestCustomizer);
+    }
+}

--- a/nifi-commons/pom.xml
+++ b/nifi-commons/pom.xml
@@ -32,6 +32,7 @@
         <module>nifi-flow-encryptor</module>
         <module>nifi-hl7-query-language</module>
         <module>nifi-json-utils</module>
+        <module>nifi-jetty-configuration</module>
         <module>nifi-logging-utils</module>
         <module>nifi-metrics</module>
         <module>nifi-parameter</module>

--- a/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
@@ -78,5 +78,15 @@
             <artifactId>apache-jstl</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -94,6 +94,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-jetty-configuration</artifactId>
+            <version>1.17.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-distributed-cache-client-service-api</artifactId>
         </dependency>
         <dependency>
@@ -179,6 +184,14 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
@@ -188,7 +188,6 @@ public class HandleHttpResponse extends AbstractProcessor {
 
         try {
             session.exportTo(flowFile, response.getOutputStream());
-            response.flushBuffer();
         } catch (final ProcessException e) {
             getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, e});
             try {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/HttpProtocolStrategy.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/HttpProtocolStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.http;
+
+import org.apache.nifi.components.DescribedValue;
+import org.apache.nifi.jetty.configuration.connector.ApplicationLayerProtocol;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+
+/**
+ * HTTP protocol configuration strategy
+ */
+public enum HttpProtocolStrategy implements DescribedValue {
+    HTTP_1_1("http/1.1", "HTTP/1.1", singleton(ApplicationLayerProtocol.HTTP_1_1)),
+
+    H2_HTTP_1_1("h2 http/1.1", "HTTP/2 and HTTP/1.1 negotiated based on requested protocols", new LinkedHashSet<>(asList(ApplicationLayerProtocol.HTTP_1_1, ApplicationLayerProtocol.H2))),
+
+    H2("h2", "HTTP/2", singleton(ApplicationLayerProtocol.H2));
+
+    private final String displayName;
+
+    private final String description;
+
+    private final Set<ApplicationLayerProtocol> applicationLayerProtocols;
+
+    HttpProtocolStrategy(final String displayName, final String description, final Set<ApplicationLayerProtocol> applicationLayerProtocols) {
+        this.displayName = displayName;
+        this.description = description;
+        this.applicationLayerProtocols = applicationLayerProtocols;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    public Set<ApplicationLayerProtocol> getApplicationLayerProtocols() {
+        return applicationLayerProtocols;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,19 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-server</artifactId>
+                <version>${jetty.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-server</artifactId>
+                <version>${jetty.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-alpn-client</artifactId>
                 <version>${jetty.version}</version>
             </dependency>


### PR DESCRIPTION
# Summary

[NIFI-3869](https://issues.apache.org/jira/browse/NIFI-3869) Adds configurable support the HTTP/2 protocol in the `ListenHTTP` and `HandleHttpRequest` Processors.

The implementation includes a new `nifi-jetty-configuration` module under `nifi-commons` containing a reusable `ServerConnectorFactory` and standard implementation. The configuration module includes a custom Application Layer Protocol Negotiation (ALPN) Processor that supports Java 8 Update 251 and later, which aligns with the current minimum required Java version for NiFi. The Jetty `http2-server` and `jetty-alpn-server` libraries are now included in the `nifi-jetty-bundle` along with all other required Jetty libraries.

Both `ListenHTTP` and `HandleHttpRequest` include a new `HTTP Protocols` property that depends on the `SSL Context Service` property. Enabling HTTP/2 requires enabling TLS, and both components default to HTTP/1.1 for both standard and TLS configurations in order to avoid unexpected changes when upgrading. The HTTP/2 protocol supports negotiating support based on client requests using ALPN, but maintaining HTTP/1.1 as the default property setting allows administrators to enable HTTP/2 support if desired. The `HTTP Protocols` property supports the following configuration options:

- `http/1.1`
- `h2 http/1.1`
- `h2`

The property values correspond to the values defined in [RFC 7540 Section 3.1](https://www.rfc-editor.org/rfc/rfc7540.html#section-3.1) and also align with the approach used for configuring HTTP Protocols in [Apache HTTP Server](https://httpd.apache.org/docs/2.4/mod/core.html#protocols). The value of `h2 http/1.1` enables the server and client to negotiate the supported version, while selecting `h2` or `http/1.1` requires the client to support the selected version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files