### PR TITLE
NIFI-8233 ListenHTTP - Add ability to filter incoming flowfile attributes

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -201,6 +201,14 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
         .required(false)
         .build();
+    public static final PropertyDescriptor FLOWFILE_ATTRIBUTES_REGEX = new PropertyDescriptor.Builder()
+            .name("FlowFile Attributes to receive as Attributes (Regex)")
+            .description("Specifies the Regular Expression that determines the names of incoming flowFile attributes to be passed along.  "
+                    + "Applies only when incoming data is a FlowFile.")
+            .defaultValue(".*")
+            .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
+            .required(false)
+            .build();
     public static final PropertyDescriptor RETURN_CODE = new PropertyDescriptor.Builder()
         .name("Return Code")
         .description("The HTTP return code returned after every HTTP call")
@@ -281,6 +289,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             AUTHORIZED_ISSUER_DN_PATTERN,
             MAX_UNCONFIRMED_TIME,
             HEADERS_AS_ATTRIBUTES_REGEX,
+            FLOWFILE_ATTRIBUTES_REGEX,
             RETURN_CODE,
             MULTIPART_REQUEST_MAX_SIZE,
             MULTIPART_READ_BUFFER_SIZE,
@@ -300,6 +309,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
     public static final String CONTEXT_ATTRIBUTE_AUTHORITY_PATTERN = "authorityPattern";
     public static final String CONTEXT_ATTRIBUTE_AUTHORITY_ISSUER_PATTERN = "authorityIssuerPattern";
     public static final String CONTEXT_ATTRIBUTE_HEADER_PATTERN = "headerPattern";
+    public static final String CONTEXT_ATTRIBUTE_ATTRIBUTE_PATTERN = "attributePattern";
     public static final String CONTEXT_ATTRIBUTE_FLOWFILE_MAP = "flowFileMap";
     public static final String CONTEXT_ATTRIBUTE_STREAM_THROTTLER = "streamThrottler";
     public static final String CONTEXT_ATTRIBUTE_BASE_PATH = "basePath";
@@ -459,6 +469,11 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
         if (context.getProperty(HEADERS_AS_ATTRIBUTES_REGEX).isSet()) {
             contextHandler.setAttribute(CONTEXT_ATTRIBUTE_HEADER_PATTERN, Pattern.compile(context.getProperty(HEADERS_AS_ATTRIBUTES_REGEX).getValue()));
         }
+
+        if (context.getProperty(FLOWFILE_ATTRIBUTES_REGEX).isSet()) {
+            contextHandler.setAttribute(CONTEXT_ATTRIBUTE_ATTRIBUTE_PATTERN, Pattern.compile(context.getProperty(FLOWFILE_ATTRIBUTES_REGEX).getValue()));
+        }
+
         try {
             server.start();
         } catch (Exception e) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -111,6 +111,7 @@ public class ListenHTTPServlet extends HttpServlet {
     private Pattern authorizedPattern;
     private Pattern authorizedIssuerPattern;
     private Pattern headerPattern;
+    private Pattern attributePattern;
     private ConcurrentMap<String, FlowFileEntryTimeWrapper> flowFileMap;
     private StreamThrottler streamThrottler;
     private String basePath;
@@ -131,6 +132,7 @@ public class ListenHTTPServlet extends HttpServlet {
         this.authorizedPattern = (Pattern) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_AUTHORITY_PATTERN);
         this.authorizedIssuerPattern = (Pattern) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_AUTHORITY_ISSUER_PATTERN);
         this.headerPattern = (Pattern) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_HEADER_PATTERN);
+        this.attributePattern = (Pattern) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_ATTRIBUTE_PATTERN);
         this.flowFileMap = (ConcurrentMap<String, FlowFileEntryTimeWrapper>) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_FLOWFILE_MAP);
         this.streamThrottler = (StreamThrottler) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_STREAM_THROTTLER);
         this.basePath = (String) context.getAttribute(ListenHTTP.CONTEXT_ATTRIBUTE_BASE_PATH);
@@ -333,6 +335,10 @@ public class ListenHTTPServlet extends HttpServlet {
                         logger.debug("Record processing will not be utilized while processing with unpackager. Request URI: {}", request.getRequestURI());
                     }
                     attributes.putAll(unpackager.unpackageFlowFile(in, bos));
+
+                    if (attributePattern != null) {
+                        attributes.keySet().removeIf(attribute -> !attributePattern.matcher(attribute).matches());
+                    }
 
                     if (destinationIsLegacyNiFi) {
                         if (attributes.containsKey("nf.file.name")) {


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-8233](https://issues.apache.org/jira/browse/NIFI-8233)

This gives ListenHTTP the ability to control its attributes when incoming data is a flowfile.

Currently, ListenHTTP doesn't control attributes it gets when the file it receives is a flowfile.  They are automatically passed along.

So for instance, if ListenHttp receives a file in flowfile format (sent by the PostHTTP processor). the attributes it had when leaving PostHTTP will remain with the flowfile passing through ListenHTTP as well..

This allows users to control that with new property:
`FlowFile Attributes to receive as Attributes (Regex)`

Default value is set to `.*` to maintain backward compatiblity

Similar functionality already exists with the current
`HTTP Headers to receive as Attributes (Regex)` attribute
but this doesn't cover the use case where incoming data is in flowfile format.
so this will now cover that as well.
 
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
