### PR TITLE
NIFI-7535 add detailed error message when .nar file is not readable

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarUnpacker.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarUnpacker.java
@@ -122,6 +122,10 @@ public final class NarUnpacker {
                 final long startTime = System.nanoTime();
                 logger.info("Expanding " + narFiles.size() + " NAR files with all processors...");
                 for (File narFile : narFiles) {
+                    if (!narFile.canRead()) {
+                        throw new IllegalStateException("Unable to read NAR file: " + narFile.getAbsolutePath());
+                    }
+
                     logger.debug("Expanding NAR file: " + narFile.getAbsolutePath());
 
                     // get the manifest for this nar


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-7535](https://issues.apache.org/jira/browse/NIFI-7535)
When NiFi hasn't got read permission to a nar file, different error message appears based on the scenario it wanted to read it. In case of autoload we get a FileNotFoundException with permission denied message, but during startup there is no check for that and we get a NullPointerException in the DocGenerator where NiFi attempts to use it for the first time.

It would be better to throw IOException, but those exceptions are caught which is undesirable in this situation. It can be changed later, based on the result of the below mentioned topic.

During this task it came up that in which cases NiFi should recover during startup when it is unable to load nars to any reason. After a brief analysis it shouldn't, but it definitely needs more discussion so I've opened a new issue for it: [NIFI-10035](https://issues.apache.org/jira/browse/NIFI-10035)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
