### PR TITLE
NIFI-9958 Add Framework Support for Sensitive Dynamic Properties

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/SupportsSensitiveDynamicProperties.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/SupportsSensitiveDynamicProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.annotation.behavior;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Component annotation indicating support for dynamic properties that can be designated as sensitive for the purpose of
+ * persistence and framework processing
+ */
+@Documented
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface SupportsSensitiveDynamicProperties {
+
+}

--- a/nifi-api/src/main/java/org/apache/nifi/documentation/AbstractDocumentationWriter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/documentation/AbstractDocumentationWriter.java
@@ -28,6 +28,7 @@ import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.Stateful;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.TriggerSerially;
 import org.apache.nifi.annotation.behavior.TriggerWhenAnyDestinationAvailable;
@@ -141,6 +142,7 @@ public abstract class AbstractDocumentationWriter implements ExtensionDocumentat
             writeTriggerWhenEmpty(processor.getClass().getAnnotation(TriggerWhenEmpty.class));
             writeTriggerWhenAnyDestinationAvailable(processor.getClass().getAnnotation(TriggerWhenAnyDestinationAvailable.class));
             writeSupportsBatching(processor.getClass().getAnnotation(SupportsBatching.class));
+            writeSupportsSensitiveDynamicProperties(processor.getClass().getAnnotation(SupportsSensitiveDynamicProperties.class));
             writeEventDriven(processor.getClass().getAnnotation(EventDriven.class));
             writePrimaryNodeOnly(processor.getClass().getAnnotation(PrimaryNodeOnly.class));
             writeSideEffectFree(processor.getClass().getAnnotation(SideEffectFree.class));
@@ -301,6 +303,8 @@ public abstract class AbstractDocumentationWriter implements ExtensionDocumentat
     protected abstract void writeTriggerWhenAnyDestinationAvailable(TriggerWhenAnyDestinationAvailable triggerWhenAnyDestinationAvailable) throws IOException;
 
     protected abstract void writeSupportsBatching(SupportsBatching supportsBatching) throws IOException;
+
+    protected abstract void writeSupportsSensitiveDynamicProperties(SupportsSensitiveDynamicProperties supportsSensitiveDynamicProperties) throws IOException;
 
     protected abstract void writeEventDriven(EventDriven eventDriven) throws IOException;
 

--- a/nifi-api/src/main/java/org/apache/nifi/documentation/AbstractDocumentationWriter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/documentation/AbstractDocumentationWriter.java
@@ -129,6 +129,7 @@ public abstract class AbstractDocumentationWriter implements ExtensionDocumentat
         writeTags(getTags(component));
         writeProperties(component.getPropertyDescriptors(), propertyServices);
         writeDynamicProperties(getDynamicProperties(component));
+        writeSupportsSensitiveDynamicProperties(component.getClass().getAnnotation(SupportsSensitiveDynamicProperties.class));
 
         if (component instanceof Processor) {
             final Processor processor = (Processor) component;
@@ -142,7 +143,6 @@ public abstract class AbstractDocumentationWriter implements ExtensionDocumentat
             writeTriggerWhenEmpty(processor.getClass().getAnnotation(TriggerWhenEmpty.class));
             writeTriggerWhenAnyDestinationAvailable(processor.getClass().getAnnotation(TriggerWhenAnyDestinationAvailable.class));
             writeSupportsBatching(processor.getClass().getAnnotation(SupportsBatching.class));
-            writeSupportsSensitiveDynamicProperties(processor.getClass().getAnnotation(SupportsSensitiveDynamicProperties.class));
             writeEventDriven(processor.getClass().getAnnotation(EventDriven.class));
             writePrimaryNodeOnly(processor.getClass().getAnnotation(PrimaryNodeOnly.class));
             writeSideEffectFree(processor.getClass().getAnnotation(SideEffectFree.class));

--- a/nifi-api/src/main/java/org/apache/nifi/documentation/xml/XmlDocumentationWriter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/documentation/xml/XmlDocumentationWriter.java
@@ -27,6 +27,7 @@ import org.apache.nifi.annotation.behavior.Restriction;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.Stateful;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.TriggerSerially;
 import org.apache.nifi.annotation.behavior.TriggerWhenAnyDestinationAvailable;
@@ -460,6 +461,14 @@ public class XmlDocumentationWriter extends AbstractDocumentationWriter {
             return;
         }
         writeBooleanElement("supportsBatching", true);
+    }
+
+    @Override
+    protected void writeSupportsSensitiveDynamicProperties(final SupportsSensitiveDynamicProperties supportsSensitiveDynamicProperties) throws IOException {
+        if (supportsSensitiveDynamicProperties == null) {
+            return;
+        }
+        writeBooleanElement("supportsSensitiveDynamicProperties", true);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
@@ -45,9 +45,11 @@ public class ControllerServiceDTO extends ComponentDTO {
     private Boolean deprecated;
     private Boolean isExtensionMissing;
     private Boolean multipleVersionsAvailable;
+    private Boolean supportsSensitiveDynamicProperties;
 
     private Map<String, String> properties;
     private Map<String, PropertyDescriptorDTO> descriptors;
+    private Set<String> sensitiveDynamicPropertyNames;
 
     private String customUiUrl;
     private String annotationData;
@@ -202,6 +204,20 @@ public class ControllerServiceDTO extends ComponentDTO {
     }
 
     /**
+     * @return whether this controller service supports sensitive dynamic properties
+     */
+    @ApiModelProperty(
+            value = "Whether the controller service supports sensitive dynamic properties."
+    )
+    public Boolean getSupportsSensitiveDynamicProperties() {
+        return supportsSensitiveDynamicProperties;
+    }
+
+    public void setSupportsSensitiveDynamicProperties(final Boolean supportsSensitiveDynamicProperties) {
+        this.supportsSensitiveDynamicProperties = supportsSensitiveDynamicProperties;
+    }
+
+    /**
      * @return The state of this controller service. Possible values are ENABLED, ENABLING, DISABLED, DISABLING
      */
     @ApiModelProperty(
@@ -242,6 +258,20 @@ public class ControllerServiceDTO extends ComponentDTO {
 
     public void setDescriptors(Map<String, PropertyDescriptorDTO> descriptors) {
         this.descriptors = descriptors;
+    }
+
+    /**
+     * @return Set of sensitive dynamic property names
+     */
+    @ApiModelProperty(
+            value = "Set of sensitive dynamic property names"
+    )
+    public Set<String> getSensitiveDynamicPropertyNames() {
+        return sensitiveDynamicPropertyNames;
+    }
+
+    public void setSensitiveDynamicPropertyNames(final Set<String> sensitiveDynamicPropertyNames) {
+        this.sensitiveDynamicPropertyNames = sensitiveDynamicPropertyNames;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorConfigDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorConfigDTO.java
@@ -30,6 +30,7 @@ public class ProcessorConfigDTO {
 
     private Map<String, String> properties;
     private Map<String, PropertyDescriptorDTO> descriptors;
+    private Set<String> sensitiveDynamicPropertyNames;
 
     // settings
     private String schedulingPeriod;
@@ -224,6 +225,20 @@ public class ProcessorConfigDTO {
 
     public void setDescriptors(Map<String, PropertyDescriptorDTO> descriptors) {
         this.descriptors = descriptors;
+    }
+
+    /**
+     * @return Set of sensitive dynamic property names
+     */
+    @ApiModelProperty(
+            value = "Set of sensitive dynamic property names"
+    )
+    public Set<String> getSensitiveDynamicPropertyNames() {
+        return sensitiveDynamicPropertyNames;
+    }
+
+    public void setSensitiveDynamicPropertyNames(final Set<String> sensitiveDynamicPropertyNames) {
+        this.sensitiveDynamicPropertyNames = sensitiveDynamicPropertyNames;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
@@ -42,6 +42,7 @@ public class ProcessorDTO extends ComponentDTO {
     private Boolean supportsParallelProcessing;
     private Boolean supportsEventDriven;
     private Boolean supportsBatching;
+    private Boolean supportsSensitiveDynamicProperties;
     private Boolean persistsState;
     private Boolean restricted;
     private Boolean deprecated;
@@ -148,6 +149,20 @@ public class ProcessorDTO extends ComponentDTO {
 
     public void setSupportsParallelProcessing(Boolean supportsParallelProcessing) {
         this.supportsParallelProcessing = supportsParallelProcessing;
+    }
+
+    /**
+     * @return whether this processor supports sensitive dynamic properties
+     */
+    @ApiModelProperty(
+            value = "Whether the processor supports sensitive dynamic properties."
+    )
+    public Boolean getSupportsSensitiveDynamicProperties() {
+        return supportsSensitiveDynamicProperties;
+    }
+
+    public void setSupportsSensitiveDynamicProperties(final Boolean supportsSensitiveDynamicProperties) {
+        this.supportsSensitiveDynamicProperties = supportsSensitiveDynamicProperties;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.xml.bind.annotation.XmlType;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Component that is capable of reporting internal NiFi state to an external service
@@ -41,6 +42,7 @@ public class ReportingTaskDTO extends ComponentDTO {
     private Boolean deprecated;
     private Boolean isExtensionMissing;
     private Boolean multipleVersionsAvailable;
+    private Boolean supportsSensitiveDynamicProperties;
 
     private String schedulingPeriod;
     private String schedulingStrategy;
@@ -48,6 +50,7 @@ public class ReportingTaskDTO extends ComponentDTO {
 
     private Map<String, String> properties;
     private Map<String, PropertyDescriptorDTO> descriptors;
+    private Set<String> sensitiveDynamicPropertyNames;
 
     private String customUiUrl;
     private String annotationData;
@@ -201,6 +204,20 @@ public class ReportingTaskDTO extends ComponentDTO {
     }
 
     /**
+     * @return whether this reporting task supports sensitive dynamic properties
+     */
+    @ApiModelProperty(
+            value = "Whether the reporting task supports sensitive dynamic properties."
+    )
+    public Boolean getSupportsSensitiveDynamicProperties() {
+        return supportsSensitiveDynamicProperties;
+    }
+
+    public void setSupportsSensitiveDynamicProperties(final Boolean supportsSensitiveDynamicProperties) {
+        this.supportsSensitiveDynamicProperties = supportsSensitiveDynamicProperties;
+    }
+
+    /**
      * @return current scheduling state of the reporting task
      */
     @ApiModelProperty(
@@ -255,6 +272,20 @@ public class ReportingTaskDTO extends ComponentDTO {
 
     public void setDescriptors(Map<String, PropertyDescriptorDTO> descriptors) {
         this.descriptors = descriptors;
+    }
+
+    /**
+     * @return Set of sensitive dynamic property names
+     */
+    @ApiModelProperty(
+            value = "Set of sensitive dynamic property names"
+    )
+    public Set<String> getSensitiveDynamicPropertyNames() {
+        return sensitiveDynamicPropertyNames;
+    }
+
+    public void setSensitiveDynamicPropertyNames(final Set<String> sensitiveDynamicPropertyNames) {
+        this.sensitiveDynamicPropertyNames = sensitiveDynamicPropertyNames;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingContext.java
@@ -27,6 +27,7 @@ import org.apache.nifi.components.resource.StandardResourceContext;
 import org.apache.nifi.components.resource.StandardResourceReferenceFactory;
 import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
 import org.apache.nifi.events.BulletinFactory;
@@ -44,7 +45,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public abstract class AbstractReportingContext implements ReportingContext {
-    private final ReportingTask reportingTask;
+    private final ReportingTaskNode reportingTaskNode;
     private final BulletinRepository bulletinRepository;
     private final ControllerServiceProvider serviceProvider;
     private final Map<PropertyDescriptor, String> properties;
@@ -52,14 +53,14 @@ public abstract class AbstractReportingContext implements ReportingContext {
     private final ParameterLookup parameterLookup;
     private final VariableRegistry variableRegistry;
 
-    public AbstractReportingContext(final ReportingTask reportingTask, final BulletinRepository bulletinRepository,
+    public AbstractReportingContext(final ReportingTaskNode reportingTaskNode, final BulletinRepository bulletinRepository,
                                     final Map<PropertyDescriptor, String> properties, final ControllerServiceProvider controllerServiceProvider,
                                     final ParameterLookup parameterLookup, final VariableRegistry variableRegistry) {
 
         this.bulletinRepository = bulletinRepository;
         this.properties = Collections.unmodifiableMap(properties);
         this.serviceProvider = controllerServiceProvider;
-        this.reportingTask = reportingTask;
+        this.reportingTaskNode = reportingTaskNode;
         this.parameterLookup = parameterLookup;
         this.variableRegistry = variableRegistry;
         this.preparedQueries = new HashMap<>();
@@ -77,7 +78,7 @@ public abstract class AbstractReportingContext implements ReportingContext {
     }
 
     protected ReportingTask getReportingTask() {
-        return reportingTask;
+        return reportingTaskNode.getReportingTask();
     }
 
     @Override
@@ -101,7 +102,7 @@ public abstract class AbstractReportingContext implements ReportingContext {
 
     @Override
     public PropertyValue getProperty(final PropertyDescriptor property) {
-        final PropertyDescriptor descriptor = reportingTask.getPropertyDescriptor(property.getName());
+        final PropertyDescriptor descriptor = reportingTaskNode.getPropertyDescriptor(property.getName());
         if (descriptor == null) {
             return null;
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -217,8 +217,8 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
     }
 
     @Override
-    public void setProperties(final Map<String, String> properties, final boolean allowRemovalOfRequiredProperties) {
-        super.setProperties(properties, allowRemovalOfRequiredProperties);
+    public void setProperties(final Map<String, String> properties, final boolean allowRemovalOfRequiredProperties, final Set<String> sensitiveDynamicPropertyNames) {
+        super.setProperties(properties, allowRemovalOfRequiredProperties, sensitiveDynamicPropertyNames);
 
         // It's possible that changing the properties of this Controller Service could alter the Classloader Isolation Key of a referencing
         // component so reload any referencing component as necessary.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -1195,8 +1195,9 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             service.setComments(proposed.getComments());
             service.setName(proposed.getName());
 
+            final Set<String> sensitiveDynamicPropertyNames = getSensitiveDynamicPropertyNames(service, proposed.getProperties());
             final Map<String, String> properties = populatePropertiesMap(service, proposed.getProperties(), service.getProcessGroup());
-            service.setProperties(properties, true);
+            service.setProperties(properties, true, sensitiveDynamicPropertyNames);
 
             if (!isEqual(service.getBundleCoordinate(), proposed.getBundle())) {
                 final BundleCoordinate newBundleCoordinate = toCoordinate(proposed.getBundle());
@@ -1207,6 +1208,18 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
         } finally {
             service.resumeValidationTrigger();
         }
+    }
+
+    private Set<String> getSensitiveDynamicPropertyNames(final ComponentNode componentNode, final Map<String, String> proposedProperties) {
+        // Find Encrypted Property values and find associated dynamic Property Descriptor names
+        return proposedProperties.entrySet()
+                .stream()
+                .filter(entry -> isValueEncrypted(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .map(componentNode::getPropertyDescriptor)
+                .filter(PropertyDescriptor::isDynamic)
+                .map(PropertyDescriptor::getName)
+                .collect(Collectors.toSet());
     }
 
     private Map<String, String> populatePropertiesMap(final ComponentNode componentNode, final Map<String, String> proposedProperties, final ProcessGroup group) {
@@ -1237,16 +1250,13 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     // of an existing service that is outside the current processor group, and if it is we want to leave
                     // the property set to that value
                     String existingExternalServiceId = null;
-                    final PropertyDescriptor componentDescriptor = componentNode.getPropertyDescriptor(propertyName);
-                    if (componentDescriptor != null) {
-                        final String componentDescriptorValue = componentNode.getEffectivePropertyValue(componentDescriptor);
-                        if (componentDescriptorValue != null) {
-                            final ProcessGroup parentGroup = group.getParent();
-                            if (parentGroup != null) {
-                                final ControllerServiceNode serviceNode = parentGroup.findControllerService(componentDescriptorValue, false, true);
-                                if (serviceNode != null) {
-                                    existingExternalServiceId = componentDescriptorValue;
-                                }
+                    final String componentDescriptorValue = componentNode.getEffectivePropertyValue(descriptor);
+                    if (componentDescriptorValue != null) {
+                        final ProcessGroup parentGroup = group.getParent();
+                        if (parentGroup != null) {
+                            final ControllerServiceNode serviceNode = parentGroup.findControllerService(componentDescriptorValue, false, true);
+                            if (serviceNode != null) {
+                                existingExternalServiceId = componentDescriptorValue;
                             }
                         }
                     }
@@ -1270,9 +1280,8 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                 // populated value. The exception to this rule is if the currently configured value is a Parameter Reference and the Versioned Flow is empty. In this case, it implies
                 // that the Versioned Flow has changed from a Parameter Reference to an explicit value. In this case, we do in fact want to change the value of the Sensitive Property from
                 // the current parameter reference to an unset value.
-                final boolean sensitive = componentNode.getPropertyDescriptor(propertyName).isSensitive();
-                if (sensitive && value == null) {
-                    final PropertyConfiguration propertyConfiguration = componentNode.getProperty(componentNode.getPropertyDescriptor(propertyName));
+                if (descriptor.isSensitive() && value == null) {
+                    final PropertyConfiguration propertyConfiguration = componentNode.getProperty(descriptor);
                     if (propertyConfiguration == null) {
                         continue;
                     }
@@ -1295,23 +1304,21 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
     }
 
     private static String decrypt(final String value, final PropertyDecryptor decryptor) {
-        if (value == null) {
-            return null;
-        }
-        if (!value.startsWith(ENC_PREFIX)) {
+        if (isValueEncrypted(value)) {
+            try {
+                return decryptor.decrypt(value.substring(ENC_PREFIX.length(), value.length() - ENC_SUFFIX.length()));
+            } catch (EncryptionException e) {
+                final String moreDescriptiveMessage = "There was a problem decrypting a sensitive flow configuration value. " +
+                        "Check that the nifi.sensitive.props.key value in nifi.properties matches the value used to encrypt the flow.xml.gz file";
+                throw new EncryptionException(moreDescriptiveMessage, e);
+            }
+        } else {
             return value;
         }
-        if (!value.endsWith(ENC_SUFFIX)) {
-            return value;
-        }
+    }
 
-        try {
-            return decryptor.decrypt(value.substring(ENC_PREFIX.length(), value.length() - ENC_SUFFIX.length()));
-        } catch (EncryptionException e) {
-            final String moreDescriptiveMessage = "There was a problem decrypting a sensitive flow configuration value. " +
-                "Check that the nifi.sensitive.props.key value in nifi.properties matches the value used to encrypt the flow.xml.gz file";
-            throw new EncryptionException(moreDescriptiveMessage, e);
-        }
+    private static boolean isValueEncrypted(final String value) {
+        return value != null && value.startsWith(ENC_PREFIX) && value.endsWith(ENC_SUFFIX);
     }
 
     private void verifyCanSynchronize(final ParameterContext parameterContext, final VersionedParameterContext proposed) throws FlowSynchronizationException {
@@ -2490,8 +2497,9 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             processor.setName(proposed.getName());
             processor.setPenalizationPeriod(proposed.getPenaltyDuration());
 
+            final Set<String> sensitiveDynamicPropertyNames = getSensitiveDynamicPropertyNames(processor, proposed.getProperties());
             final Map<String, String> properties = populatePropertiesMap(processor, proposed.getProperties(), processor.getProcessGroup());
-            processor.setProperties(properties, true);
+            processor.setProperties(properties, true, sensitiveDynamicPropertyNames);
             processor.setRunDuration(proposed.getRunDurationMillis(), TimeUnit.MILLISECONDS);
             processor.setSchedulingStrategy(SchedulingStrategy.valueOf(proposed.getSchedulingStrategy()));
             processor.setScheduldingPeriod(proposed.getSchedulingPeriod());
@@ -3178,7 +3186,8 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             reportingTask.setSchedulingStrategy(SchedulingStrategy.valueOf(proposed.getSchedulingStrategy()));
 
             reportingTask.setAnnotationData(proposed.getAnnotationData());
-            reportingTask.setProperties(proposed.getProperties());
+            final Set<String> sensitiveDynamicPropertyNames = getSensitiveDynamicPropertyNames(reportingTask, proposed.getProperties());
+            reportingTask.setProperties(proposed.getProperties(), false, sensitiveDynamicPropertyNames);
 
             // enable/disable/start according to the ScheduledState
             switch (proposed.getScheduledState()) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
@@ -146,7 +146,7 @@ public class StandardProcessContext implements ProcessContext, ControllerService
         }
 
         // Get the "canonical" Property Descriptor from the Processor
-        final PropertyDescriptor canonicalDescriptor = procNode.getProcessor().getPropertyDescriptor(descriptor.getName());
+        final PropertyDescriptor canonicalDescriptor = procNode.getPropertyDescriptor(descriptor.getName());
         final String defaultValue = canonicalDescriptor.getDefaultValue();
 
         return new StandardPropertyValue(resourceContext, defaultValue, this, procNode.getParameterLookup(), preparedQueries.get(descriptor), procNode.getVariableRegistry());
@@ -160,8 +160,7 @@ public class StandardProcessContext implements ProcessContext, ControllerService
     @Override
     public PropertyValue getProperty(final String propertyName) {
         verifyTaskActive();
-        final Processor processor = procNode.getProcessor();
-        final PropertyDescriptor descriptor = processor.getPropertyDescriptor(propertyName);
+        final PropertyDescriptor descriptor = procNode.getPropertyDescriptor(propertyName);
         if (descriptor == null) {
             return null;
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
@@ -302,7 +302,7 @@ public class StandardVersionedComponentSynchronizerTest {
         synchronizer.synchronize(processorA, versionedProcessor, group, synchronizationOptions);
 
         // Ensure that the processor was updated as expected.
-        verify(processorA).setProperties(versionedProcessor.getProperties(), true);
+        verify(processorA).setProperties(versionedProcessor.getProperties(), true, Collections.emptySet());
         verify(processorA).setName(versionedProcessor.getName());
         verify(componentScheduler, times(0)).startComponent(any(Connectable.class));
     }
@@ -327,7 +327,7 @@ public class StandardVersionedComponentSynchronizerTest {
         synchronizer.synchronize(processorA, versionedProcessor, group, synchronizationOptions);
 
         verify(group, times(1)).stopProcessor(processorA);
-        verify(processorA).setProperties(versionedProcessor.getProperties(), true);
+        verify(processorA).setProperties(versionedProcessor.getProperties(), true, Collections.emptySet());
         verify(componentScheduler, atLeast(1)).startComponent(any(Connectable.class));
     }
 
@@ -346,7 +346,7 @@ public class StandardVersionedComponentSynchronizerTest {
         verifyStopped(processorA);
         verifyNotRestarted(processorA);
         verify(processorA, times(0)).terminate();
-        verify(processorA, times(0)).setProperties(versionedProcessor.getProperties());
+        verify(processorA, times(0)).setProperties(eq(versionedProcessor.getProperties()), anyBoolean(), anySet());
         verify(processorA, times(0)).setName(versionedProcessor.getName());
     }
 
@@ -362,7 +362,7 @@ public class StandardVersionedComponentSynchronizerTest {
         verifyStopped(processorA);
         verifyRestarted(processorA);
         verify(processorA, times(1)).terminate();
-        verify(processorA, times(1)).setProperties(versionedProcessor.getProperties(), true);
+        verify(processorA, times(1)).setProperties(versionedProcessor.getProperties(), true, Collections.emptySet());
         verify(processorA, times(1)).setName(versionedProcessor.getName());
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.controller;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.attribute.expression.language.Query;
 import org.apache.nifi.attribute.expression.language.StandardPropertyValue;
 import org.apache.nifi.attribute.expression.language.VariableImpact;
@@ -105,6 +106,7 @@ public abstract class AbstractComponentNode implements ComponentNode {
 
     private final Lock lock = new ReentrantLock();
     private final ConcurrentMap<PropertyDescriptor, PropertyConfiguration> properties = new ConcurrentHashMap<>();
+    private final AtomicReference<Set<String>> sensitiveDynamicPropertyNames = new AtomicReference<>(new HashSet<>());
     private volatile String additionalResourcesFingerprint;
     private final AtomicReference<ValidationState> validationState = new AtomicReference<>(new ValidationState(ValidationStatus.VALIDATING, Collections.emptyList()));
     private final ValidationTrigger validationTrigger;
@@ -144,6 +146,11 @@ public abstract class AbstractComponentNode implements ComponentNode {
     @Override
     public boolean isExtensionMissing() {
         return isExtensionMissing.get();
+    }
+
+    @Override
+    public boolean isSupportsSensitiveDynamicProperties() {
+        return getComponentClass().isAnnotationPresent(SupportsSensitiveDynamicProperties.class);
     }
 
     @Override
@@ -228,14 +235,24 @@ public abstract class AbstractComponentNode implements ComponentNode {
         return false;
     }
 
+    /**
+     * Set Properties updates internal Map of Property Descriptors and values along with current definition of Sensitive Dynamic Property Names
+     *
+     * @param properties Property Names and Values to be updated
+     * @param allowRemovalOfRequiredProperties Allow Removal of Required Properties
+     * @param updatedSensitiveDynamicPropertyNames Requested Sensitive Dynamic Property Names replaces current configuration
+     */
     @Override
-    public void setProperties(final Map<String, String> properties, final boolean allowRemovalOfRequiredProperties) {
+    public void setProperties(final Map<String, String> properties, final boolean allowRemovalOfRequiredProperties, final Set<String> updatedSensitiveDynamicPropertyNames) {
         if (properties == null) {
             return;
         }
 
         lock.lock();
         try {
+            Objects.requireNonNull(updatedSensitiveDynamicPropertyNames, "Sensitive Dynamic Property Names required");
+            sensitiveDynamicPropertyNames.getAndSet(updatedSensitiveDynamicPropertyNames);
+
             verifyCanUpdateProperties(properties);
 
             // Determine the Classloader Isolation Key, if applicable, so we can determine whether or not the key changes by setting properties.
@@ -247,8 +264,15 @@ public abstract class AbstractComponentNode implements ComponentNode {
             try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(extensionManager, getComponent().getClass(), id)) {
                 boolean classpathChanged = false;
                 for (final Map.Entry<String, String> entry : properties.entrySet()) {
+                    final String propertyName = entry.getKey();
+
+                    // Set sensitive status on dynamic properties after getting canonical representation of Property Descriptor
+                    final PropertyDescriptor componentDescriptor = getComponent().getPropertyDescriptor(propertyName);
+                    final PropertyDescriptor descriptor = componentDescriptor.isDynamic() && updatedSensitiveDynamicPropertyNames.contains(propertyName)
+                            ? new PropertyDescriptor.Builder().fromPropertyDescriptor(componentDescriptor).sensitive(true).build()
+                            : componentDescriptor;
+
                     // determine if any of the property changes require resetting the InstanceClassLoader
-                    final PropertyDescriptor descriptor = getComponent().getPropertyDescriptor(entry.getKey());
                     if (descriptor.isDynamicClasspathModifier()) {
                         classpathChanged = true;
                     }
@@ -260,21 +284,21 @@ public abstract class AbstractComponentNode implements ComponentNode {
                         }
                     }
 
-                    if (entry.getKey() != null && entry.getValue() == null) {
-                        removeProperty(entry.getKey(), allowRemovalOfRequiredProperties);
-                    } else if (entry.getKey() != null) {
+                    if (propertyName != null && entry.getValue() == null) {
+                        removeProperty(propertyName, allowRemovalOfRequiredProperties);
+                    } else if (propertyName != null) {
                         // Use the EL-Agnostic Parameter Parser to gather the list of referenced Parameters. We do this because we want to to keep track of which parameters
                         // are referenced, regardless of whether or not they are referenced from within an EL Expression. However, we also will need to derive a different ParameterTokenList
                         // that we can provide to the PropertyConfiguration, so that when compiling the Expression Language Expressions, we are able to keep the Parameter Reference within
                         // the Expression's text.
-                        final PropertyConfiguration propertyConfiguration = configurationMap.get(entry.getKey());
+                        final PropertyConfiguration propertyConfiguration = configurationMap.get(propertyName);
                         final List<ParameterReference> parameterReferences = propertyConfiguration.getParameterReferences();
                         for (final ParameterReference reference : parameterReferences) {
                             // increment count in map for this parameter
                             parameterReferenceCounts.merge(reference.getParameterName(), 1, (a, b) -> a == -1 ? null : a + b);
                         }
 
-                        setProperty(entry.getKey(), propertyConfiguration, this.properties::get);
+                        setProperty(descriptor, propertyConfiguration, this.properties::get);
                     }
                 }
 
@@ -383,7 +407,7 @@ public abstract class AbstractComponentNode implements ComponentNode {
                     results.add(new ConfigVerificationResult.Builder()
                         .verificationStepName(PERFORM_VALIDATION_STEP_NAME)
                         .outcome(Outcome.FAILED)
-                        .explanation("Component is invalid: " + result.toString())
+                        .explanation("Component is invalid: " + result)
                         .build());
                 }
 
@@ -442,12 +466,10 @@ public abstract class AbstractComponentNode implements ComponentNode {
     }
 
     // Keep setProperty/removeProperty private so that all calls go through setProperties
-    private void setProperty(final String name, final PropertyConfiguration propertyConfiguration, final Function<PropertyDescriptor, PropertyConfiguration> valueToCompareFunction) {
-        if (name == null || propertyConfiguration == null || propertyConfiguration.getRawValue() == null) {
-            throw new IllegalArgumentException("Name or Value can not be null");
-        }
+    private void setProperty(final PropertyDescriptor descriptor, final PropertyConfiguration propertyConfiguration, final Function<PropertyDescriptor, PropertyConfiguration> valueToCompareFunction) {
+        // Remove current PropertyDescriptor to force updated instance references
+        properties.remove(descriptor);
 
-        final PropertyDescriptor descriptor = getComponent().getPropertyDescriptor(name);
         final PropertyConfiguration propertyModComparisonValue = valueToCompareFunction.apply(descriptor);
         final PropertyConfiguration oldConfiguration = properties.put(descriptor, propertyConfiguration);
         final String effectiveValue = propertyConfiguration.getEffectiveValue(getParameterContext());
@@ -603,11 +625,11 @@ public abstract class AbstractComponentNode implements ComponentNode {
                 continue;
             }
 
-            setProperty(propertyDescriptor.getName(), configuration, descriptor -> createPropertyConfiguration(descriptor.getDefaultValue(), descriptor.isExpressionLanguageSupported()));
+            setProperty(propertyDescriptor, configuration, descriptor -> createPropertyConfiguration(descriptor.getDefaultValue()));
         }
     }
 
-    private PropertyConfiguration createPropertyConfiguration(final String value, final boolean supportsEL) {
+    private PropertyConfiguration createPropertyConfiguration(final String value) {
         final ParameterParser parser = new ExpressionLanguageAwareParameterParser();
         final ParameterTokenList references = parser.parseTokens(value);
         final VariableImpact variableImpact = Query.prepare(value).getVariableImpact();
@@ -725,6 +747,16 @@ public abstract class AbstractComponentNode implements ComponentNode {
     protected Collection<ValidationResult> computeValidationErrors(final ValidationContext validationContext) {
         Throwable failureCause = null;
         try {
+            if (!sensitiveDynamicPropertyNames.get().isEmpty() && !isSupportsSensitiveDynamicProperties()) {
+                return Collections.singletonList(
+                        new ValidationResult.Builder()
+                                .subject("Component")
+                                .valid(false)
+                                .explanation(String.format("Sensitive Dynamic Properties %s configured but not supported", sensitiveDynamicPropertyNames))
+                                .build()
+                );
+            }
+
             final List<ValidationResult> invalidParameterResults = validateParameterReferences(validationContext);
             if (!invalidParameterResults.isEmpty()) {
                 // At this point, we are not able to properly resolve all property values, so we will not attempt to perform
@@ -971,7 +1003,12 @@ public abstract class AbstractComponentNode implements ComponentNode {
     @Override
     public PropertyDescriptor getPropertyDescriptor(final String name) {
         try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(extensionManager, getComponent().getClass(), getComponent().getIdentifier())) {
-            return getComponent().getPropertyDescriptor(name);
+            final PropertyDescriptor propertyDescriptor = getComponent().getPropertyDescriptor(name);
+            if (propertyDescriptor.isDynamic() && sensitiveDynamicPropertyNames.get().contains(name)) {
+                return new PropertyDescriptor.Builder().fromPropertyDescriptor(propertyDescriptor).sensitive(true).build();
+            } else {
+                return propertyDescriptor;
+            }
         }
     }
 
@@ -1311,5 +1348,4 @@ public abstract class AbstractComponentNode implements ComponentNode {
     }
 
     protected abstract ParameterContext getParameterContext();
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.controller;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.attribute.expression.language.Query;
 import org.apache.nifi.attribute.expression.language.StandardPropertyValue;
 import org.apache.nifi.attribute.expression.language.VariableImpact;
@@ -146,11 +145,6 @@ public abstract class AbstractComponentNode implements ComponentNode {
     @Override
     public boolean isExtensionMissing() {
         return isExtensionMissing.get();
-    }
-
-    @Override
-    public boolean isSupportsSensitiveDynamicProperties() {
-        return getComponentClass().isAnnotationPresent(SupportsSensitiveDynamicProperties.class);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -552,10 +552,12 @@ public abstract class AbstractComponentNode implements ComponentNode {
                 final Map<PropertyDescriptor, PropertyConfiguration> props = new LinkedHashMap<>();
 
                 for (final PropertyDescriptor descriptor : supported) {
-                    props.put(descriptor, null);
+                    // Get Canonical Property Descriptor
+                    props.put(getPropertyDescriptor(descriptor.getName()), null);
                 }
 
-                props.putAll(properties);
+                // Get Canonical Property Descriptor for returned Map of properties
+                properties.forEach((descriptor, config) -> props.put(getPropertyDescriptor(descriptor.getName()), config));
                 return props;
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.controller;
 
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.authorization.AccessDeniedException;
 import org.apache.nifi.authorization.AuthorizationResult;
 import org.apache.nifi.authorization.AuthorizationResult.Result;
@@ -197,7 +198,7 @@ public interface ComponentNode extends ComponentAuthorizable {
      * @return Support status for Sensitive Dynamic Properties
      */
     default boolean isSupportsSensitiveDynamicProperties() {
-        return false;
+        return getComponent().getClass().isAnnotationPresent(SupportsSensitiveDynamicProperties.class);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
@@ -41,6 +41,7 @@ import org.apache.nifi.registry.ComponentVariableRegistry;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,21 +49,21 @@ import java.util.concurrent.TimeUnit;
 
 public interface ComponentNode extends ComponentAuthorizable {
     @Override
-    public String getIdentifier();
+    String getIdentifier();
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public String getAnnotationData();
+    String getAnnotationData();
 
-    public void setAnnotationData(String data);
+    void setAnnotationData(String data);
 
-    public default void setProperties(Map<String, String> properties) {
-        setProperties(properties, false);
+    default void setProperties(Map<String, String> properties) {
+        setProperties(properties, false, Collections.emptySet());
     }
 
-    public void setProperties(Map<String, String> properties, boolean allowRemovalOfRequiredProperties);
+    void setProperties(Map<String, String> properties, boolean allowRemovalOfRequiresProperties, Set<String> sensitiveDynamicPropertyNames);
 
     void verifyCanUpdateProperties(final Map<String, String> properties);
 
@@ -191,6 +192,15 @@ public interface ComponentNode extends ComponentAuthorizable {
     boolean isValidationNecessary();
 
     /**
+     * Indicates whether the Component supports sensitive dynamic properties
+     *
+     * @return Support status for Sensitive Dynamic Properties
+     */
+    default boolean isSupportsSensitiveDynamicProperties() {
+        return false;
+    }
+
+    /**
      * @return the variable registry for this component
      */
     ComponentVariableRegistry getVariableRegistry();
@@ -200,7 +210,7 @@ public interface ComponentNode extends ComponentAuthorizable {
      *
      * @return the processor's current Validation Status
      */
-    public abstract ValidationStatus getValidationStatus();
+    ValidationStatus getValidationStatus();
 
     /**
      * Returns the processor's Validation Status, waiting up to the given amount of time for the Validation to complete
@@ -212,7 +222,7 @@ public interface ComponentNode extends ComponentAuthorizable {
      * @param unit the time unit
      * @return the ValidationStatus
      */
-    public abstract ValidationStatus getValidationStatus(long timeout, TimeUnit unit);
+    ValidationStatus getValidationStatus(long timeout, TimeUnit unit);
 
     /**
      * Validates the component against the current configuration

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowSnippet.java
@@ -251,7 +251,8 @@ public class StandardFlowSnippet implements FlowSnippet {
             for (final ControllerServiceDTO controllerServiceDTO : dto.getControllerServices()) {
                 final String serviceId = controllerServiceDTO.getId();
                 final ControllerServiceNode serviceNode = flowManager.getControllerServiceNode(serviceId);
-                serviceNode.setProperties(controllerServiceDTO.getProperties());
+                final Set<String> sensitiveDynamicPropertyNames = controllerServiceDTO.getSensitiveDynamicPropertyNames();
+                serviceNode.setProperties(controllerServiceDTO.getProperties(), false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
             }
         } finally {
             serviceNodes.forEach(ControllerServiceNode::resumeValidationTrigger);
@@ -420,7 +421,8 @@ public class StandardFlowSnippet implements FlowSnippet {
                 group.addProcessor(procNode);
 
                 if (config.getProperties() != null) {
-                    procNode.setProperties(config.getProperties());
+                    final Set<String> sensitiveDynamicPropertyNames = config.getSensitiveDynamicPropertyNames();
+                    procNode.setProperties(config.getProperties(), false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
                 }
 
                 // Notify the processor node that the configuration (properties, e.g.) has been restored

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/TemplateUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/TemplateUtils.java
@@ -257,6 +257,7 @@ public class TemplateUtils {
             processorDTO.setSupportsBatching(null);
             processorDTO.setSupportsEventDriven(null);
             processorDTO.setSupportsParallelProcessing(null);
+            processorDTO.setSupportsSensitiveDynamicProperties(null);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/XmlFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/XmlFlowSynchronizer.java
@@ -726,7 +726,8 @@ public class XmlFlowSynchronizer implements FlowSynchronizer {
             reportingTask.setSchedulingStrategy(SchedulingStrategy.valueOf(dto.getSchedulingStrategy()));
 
             reportingTask.setAnnotationData(dto.getAnnotationData());
-            reportingTask.setProperties(dto.getProperties());
+            final Set<String> sensitiveDynamicPropertyNames = dto.getSensitiveDynamicPropertyNames();
+            reportingTask.setProperties(dto.getProperties(), false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
             return reportingTask;
         } else {
             // otherwise return the existing reporting task node
@@ -1269,7 +1270,8 @@ public class XmlFlowSynchronizer implements FlowSynchronizer {
                 procNode.setAutoTerminatedRelationships(relationships);
             }
 
-            procNode.setProperties(config.getProperties());
+            final Set<String> sensitiveDynamicPropertyNames = config.getSensitiveDynamicPropertyNames();
+            procNode.setProperties(config.getProperties(), false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
 
             final ScheduledState scheduledState = ScheduledState.valueOf(processorDTO.getState());
             if (ScheduledState.RUNNING.equals(scheduledState)) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingContext.java
@@ -20,13 +20,13 @@ import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.state.StateManager;
 import org.apache.nifi.controller.FlowController;
+import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.parameter.ParameterLookup;
 import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.reporting.BulletinRepository;
 import org.apache.nifi.reporting.EventAccess;
 import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.reporting.ReportingTask;
 
 import java.util.Map;
 
@@ -37,9 +37,9 @@ public class StandardReportingContext extends AbstractReportingContext implement
     private final boolean analyticsEnabled;
 
     public StandardReportingContext(final FlowController flowController, final BulletinRepository bulletinRepository,
-                                    final Map<PropertyDescriptor, String> properties, final ReportingTask reportingTask,
+                                    final Map<PropertyDescriptor, String> properties, final ReportingTaskNode reportingTaskNode,
                                     final VariableRegistry variableRegistry, final ParameterLookup parameterLookup) {
-        super(reportingTask, bulletinRepository, properties, flowController.getControllerServiceProvider(), parameterLookup, variableRegistry);
+        super(reportingTaskNode, bulletinRepository, properties, flowController.getControllerServiceProvider(), parameterLookup, variableRegistry);
         this.flowController = flowController;
         this.eventAccess = flowController.getEventAccess();
         this.analyticsEnabled = flowController.getStatusAnalyticsEngine() != null;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingTaskNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/reporting/StandardReportingTaskNode.java
@@ -74,7 +74,7 @@ public class StandardReportingTaskNode extends AbstractReportingTaskNode impleme
 
     @Override
     public Class<?> getComponentClass() {
-        return getReportingContext().getClass();
+        return getReportingTask().getClass();
     }
 
     @Override
@@ -84,7 +84,7 @@ public class StandardReportingTaskNode extends AbstractReportingTaskNode impleme
 
     @Override
     public ReportingContext getReportingContext() {
-        return new StandardReportingContext(flowController, flowController.getBulletinRepository(), getEffectivePropertyValues(), getReportingTask(), getVariableRegistry(), ParameterLookup.EMPTY);
+        return new StandardReportingContext(flowController, flowController.getBulletinRepository(), getEffectivePropertyValues(), this, getVariableRegistry(), ParameterLookup.EMPTY);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ControllerServiceLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ControllerServiceLoader.java
@@ -216,7 +216,8 @@ public class ControllerServiceLoader {
         node.pauseValidationTrigger();
         try {
             node.setAnnotationData(dto.getAnnotationData());
-            node.setProperties(dto.getProperties());
+            final Set<String> sensitiveDynamicPropertyNames = dto.getSensitiveDynamicPropertyNames();
+            node.setProperties(dto.getProperties(), false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
         } finally {
             node.resumeValidationTrigger();
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerServiceAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerServiceAuditor.java
@@ -149,6 +149,7 @@ public class ControllerServiceAuditor extends NiFiAuditor {
                 if (operation != null) {
                     // clear the value if this property is sensitive
                     final PropertyDescriptor propertyDescriptor = controllerService.getPropertyDescriptor(property);
+                    // Evaluate both Property Descriptor status and whether the client requested a new Sensitive Dynamic Property
                     if (propertyDescriptor != null && (propertyDescriptor.isSensitive() || sensitiveDynamicPropertyNames.contains(property))) {
                         if (newValue != null) {
                             newValue = SENSITIVE_VALUE_PLACEHOLDER;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerServiceAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerServiceAuditor.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -119,6 +120,9 @@ public class ControllerServiceAuditor extends NiFiAuditor {
 
         // ensure the user was found
         if (user != null) {
+            final Set<String> sensitiveDynamicPropertyNames = controllerServiceDTO.getSensitiveDynamicPropertyNames() == null
+                    ? Collections.emptySet() : controllerServiceDTO.getSensitiveDynamicPropertyNames();
+
             // determine the updated values
             Map<String, String> updatedValues = extractConfiguredPropertyValues(controllerService, controllerServiceDTO);
 
@@ -144,13 +148,13 @@ public class ControllerServiceAuditor extends NiFiAuditor {
                 // create a configuration action accordingly
                 if (operation != null) {
                     // clear the value if this property is sensitive
-                    final PropertyDescriptor propertyDescriptor = controllerService.getControllerServiceImplementation().getPropertyDescriptor(property);
-                    if (propertyDescriptor != null && propertyDescriptor.isSensitive()) {
+                    final PropertyDescriptor propertyDescriptor = controllerService.getPropertyDescriptor(property);
+                    if (propertyDescriptor != null && (propertyDescriptor.isSensitive() || sensitiveDynamicPropertyNames.contains(property))) {
                         if (newValue != null) {
-                            newValue = "********";
+                            newValue = SENSITIVE_VALUE_PLACEHOLDER;
                         }
                         if (oldValue != null) {
-                            oldValue = "********";
+                            oldValue = SENSITIVE_VALUE_PLACEHOLDER;
                         }
                     } else if (ANNOTATION_DATA.equals(property)) {
                         if (newValue != null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/NiFiAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/NiFiAuditor.java
@@ -35,6 +35,8 @@ import java.util.Collection;
  */
 public abstract class NiFiAuditor {
 
+    protected static final String SENSITIVE_VALUE_PLACEHOLDER = "********";
+
     private AuditService auditService;
     private NiFiServiceFacade serviceFacade;
     private ProcessGroupDAO processGroupDAO;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
@@ -170,6 +170,7 @@ public class ProcessorAuditor extends NiFiAuditor {
                 if (operation != null) {
                     // clear the value if this property is sensitive
                     final PropertyDescriptor propertyDescriptor = processor.getPropertyDescriptor(property);
+                    // Evaluate both Property Descriptor status and whether the client requested a new Sensitive Dynamic Property
                     if (propertyDescriptor != null && (propertyDescriptor.isSensitive() || sensitiveDynamicPropertyNames.contains(property))) {
                         if (newValue != null) {
                             newValue = SENSITIVE_VALUE_PLACEHOLDER;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ReportingTaskAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ReportingTaskAuditor.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -113,6 +114,9 @@ public class ReportingTaskAuditor extends NiFiAuditor {
 
         // ensure the user was found
         if (user != null) {
+            final Set<String> sensitiveDynamicPropertyNames = reportingTaskDTO.getSensitiveDynamicPropertyNames() == null
+                    ? Collections.emptySet() : reportingTaskDTO.getSensitiveDynamicPropertyNames();
+
             // determine the updated values
             Map<String, String> updatedValues = extractConfiguredPropertyValues(reportingTask, reportingTaskDTO);
 
@@ -138,13 +142,13 @@ public class ReportingTaskAuditor extends NiFiAuditor {
                 // create a configuration action accordingly
                 if (operation != null) {
                     // clear the value if this property is sensitive
-                    final PropertyDescriptor propertyDescriptor = reportingTask.getReportingTask().getPropertyDescriptor(property);
-                    if (propertyDescriptor != null && propertyDescriptor.isSensitive()) {
+                    final PropertyDescriptor propertyDescriptor = reportingTask.getPropertyDescriptor(property);
+                    if (propertyDescriptor != null && (propertyDescriptor.isSensitive() || sensitiveDynamicPropertyNames.contains(property))) {
                         if (newValue != null) {
-                            newValue = "********";
+                            newValue = SENSITIVE_VALUE_PLACEHOLDER;
                         }
                         if (oldValue != null) {
-                            oldValue = "********";
+                            oldValue = SENSITIVE_VALUE_PLACEHOLDER;
                         }
                     } else if (ANNOTATION_DATA.equals(property)) {
                         if (newValue != null) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ReportingTaskAuditor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ReportingTaskAuditor.java
@@ -143,6 +143,7 @@ public class ReportingTaskAuditor extends NiFiAuditor {
                 if (operation != null) {
                     // clear the value if this property is sensitive
                     final PropertyDescriptor propertyDescriptor = reportingTask.getPropertyDescriptor(property);
+                    // Evaluate both Property Descriptor status and whether the client requested a new Sensitive Dynamic Property
                     if (propertyDescriptor != null && (propertyDescriptor.isSensitive() || sensitiveDynamicPropertyNames.contains(property))) {
                         if (newValue != null) {
                             newValue = SENSITIVE_VALUE_PLACEHOLDER;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -616,9 +616,10 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
+     * @param sensitive Sensitive Status
      * @return descriptor
      */
-    PropertyDescriptorDTO getProcessorPropertyDescriptor(String id, String property);
+    PropertyDescriptorDTO getProcessorPropertyDescriptor(String id, String property, boolean sensitive);
 
     /**
      * Gets all the Processor transfer objects for this controller.
@@ -2046,9 +2047,10 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
+     * @param sensitive Requested Sensitive Status
      * @return property
      */
-    PropertyDescriptorDTO getControllerServicePropertyDescriptor(String id, String property);
+    PropertyDescriptorDTO getControllerServicePropertyDescriptor(String id, String property, boolean sensitive);
 
     /**
      * Gets the references for specified controller service.
@@ -2168,9 +2170,10 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
+     * @param sensitive Requested sensitive status
      * @return descriptor
      */
-    PropertyDescriptorDTO getReportingTaskPropertyDescriptor(String id, String property);
+    PropertyDescriptorDTO getReportingTaskPropertyDescriptor(String id, String property, boolean sensitive);
 
     /**
      * Updates the specified reporting task.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -616,10 +616,9 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
-     * @param sensitive Sensitive Status
      * @return descriptor
      */
-    PropertyDescriptorDTO getProcessorPropertyDescriptor(String id, String property, boolean sensitive);
+    PropertyDescriptorDTO getProcessorPropertyDescriptor(String id, String property);
 
     /**
      * Gets all the Processor transfer objects for this controller.
@@ -2047,10 +2046,9 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
-     * @param sensitive Requested Sensitive Status
      * @return property
      */
-    PropertyDescriptorDTO getControllerServicePropertyDescriptor(String id, String property, boolean sensitive);
+    PropertyDescriptorDTO getControllerServicePropertyDescriptor(String id, String property);
 
     /**
      * Gets the references for specified controller service.
@@ -2170,10 +2168,9 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
-     * @param sensitive Requested sensitive status
      * @return descriptor
      */
-    PropertyDescriptorDTO getReportingTaskPropertyDescriptor(String id, String property, boolean sensitive);
+    PropertyDescriptorDTO getReportingTaskPropertyDescriptor(String id, String property);
 
     /**
      * Updates the specified reporting task.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -3642,13 +3642,15 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public PropertyDescriptorDTO getProcessorPropertyDescriptor(final String id, final String property) {
+    public PropertyDescriptorDTO getProcessorPropertyDescriptor(final String id, final String property, final boolean sensitive) {
         final ProcessorNode processor = processorDAO.getProcessor(id);
         PropertyDescriptor descriptor = processor.getPropertyDescriptor(property);
 
         // return an invalid descriptor if the processor doesn't support this property
         if (descriptor == null) {
             descriptor = new PropertyDescriptor.Builder().name(property).addValidator(Validator.INVALID).dynamic(true).build();
+        } else if (descriptor.isDynamic() && sensitive) {
+            descriptor = new PropertyDescriptor.Builder().fromPropertyDescriptor(descriptor).sensitive(true).build();
         }
 
         return dtoFactory.createPropertyDescriptorDto(descriptor, processor.getProcessGroup().getIdentifier());
@@ -4511,13 +4513,15 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public PropertyDescriptorDTO getControllerServicePropertyDescriptor(final String id, final String property) {
+    public PropertyDescriptorDTO getControllerServicePropertyDescriptor(final String id, final String property, final boolean sensitive) {
         final ControllerServiceNode controllerService = controllerServiceDAO.getControllerService(id);
-        PropertyDescriptor descriptor = controllerService.getControllerServiceImplementation().getPropertyDescriptor(property);
+        PropertyDescriptor descriptor = controllerService.getPropertyDescriptor(property);
 
         // return an invalid descriptor if the controller service doesn't support this property
         if (descriptor == null) {
             descriptor = new PropertyDescriptor.Builder().name(property).addValidator(Validator.INVALID).dynamic(true).build();
+        } else if (descriptor.isDynamic() && sensitive) {
+            descriptor = new PropertyDescriptor.Builder().fromPropertyDescriptor(descriptor).sensitive(true).build();
         }
 
         final String groupId = controllerService.getProcessGroup() == null ? null : controllerService.getProcessGroup().getIdentifier();
@@ -4555,13 +4559,15 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public PropertyDescriptorDTO getReportingTaskPropertyDescriptor(final String id, final String property) {
+    public PropertyDescriptorDTO getReportingTaskPropertyDescriptor(final String id, final String property, final boolean sensitive) {
         final ReportingTaskNode reportingTask = reportingTaskDAO.getReportingTask(id);
-        PropertyDescriptor descriptor = reportingTask.getReportingTask().getPropertyDescriptor(property);
+        PropertyDescriptor descriptor = reportingTask.getPropertyDescriptor(property);
 
         // return an invalid descriptor if the reporting task doesn't support this property
         if (descriptor == null) {
             descriptor = new PropertyDescriptor.Builder().name(property).addValidator(Validator.INVALID).dynamic(true).build();
+        } else if (descriptor.isDynamic() && sensitive) {
+            descriptor = new PropertyDescriptor.Builder().fromPropertyDescriptor(descriptor).sensitive(true).build();
         }
 
         return dtoFactory.createPropertyDescriptorDto(descriptor, null);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -3642,15 +3642,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public PropertyDescriptorDTO getProcessorPropertyDescriptor(final String id, final String property, final boolean sensitive) {
+    public PropertyDescriptorDTO getProcessorPropertyDescriptor(final String id, final String property) {
         final ProcessorNode processor = processorDAO.getProcessor(id);
         PropertyDescriptor descriptor = processor.getPropertyDescriptor(property);
 
         // return an invalid descriptor if the processor doesn't support this property
         if (descriptor == null) {
             descriptor = new PropertyDescriptor.Builder().name(property).addValidator(Validator.INVALID).dynamic(true).build();
-        } else if (descriptor.isDynamic() && sensitive) {
-            descriptor = new PropertyDescriptor.Builder().fromPropertyDescriptor(descriptor).sensitive(true).build();
         }
 
         return dtoFactory.createPropertyDescriptorDto(descriptor, processor.getProcessGroup().getIdentifier());
@@ -4513,15 +4511,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public PropertyDescriptorDTO getControllerServicePropertyDescriptor(final String id, final String property, final boolean sensitive) {
+    public PropertyDescriptorDTO getControllerServicePropertyDescriptor(final String id, final String property) {
         final ControllerServiceNode controllerService = controllerServiceDAO.getControllerService(id);
         PropertyDescriptor descriptor = controllerService.getPropertyDescriptor(property);
 
         // return an invalid descriptor if the controller service doesn't support this property
         if (descriptor == null) {
             descriptor = new PropertyDescriptor.Builder().name(property).addValidator(Validator.INVALID).dynamic(true).build();
-        } else if (descriptor.isDynamic() && sensitive) {
-            descriptor = new PropertyDescriptor.Builder().fromPropertyDescriptor(descriptor).sensitive(true).build();
         }
 
         final String groupId = controllerService.getProcessGroup() == null ? null : controllerService.getProcessGroup().getIdentifier();
@@ -4559,15 +4555,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public PropertyDescriptorDTO getReportingTaskPropertyDescriptor(final String id, final String property, final boolean sensitive) {
+    public PropertyDescriptorDTO getReportingTaskPropertyDescriptor(final String id, final String property) {
         final ReportingTaskNode reportingTask = reportingTaskDAO.getReportingTask(id);
         PropertyDescriptor descriptor = reportingTask.getPropertyDescriptor(property);
 
         // return an invalid descriptor if the reporting task doesn't support this property
         if (descriptor == null) {
             descriptor = new PropertyDescriptor.Builder().name(property).addValidator(Validator.INVALID).dynamic(true).build();
-        } else if (descriptor.isDynamic() && sensitive) {
-            descriptor = new PropertyDescriptor.Builder().fromPropertyDescriptor(descriptor).sensitive(true).build();
         }
 
         return dtoFactory.createPropertyDescriptorDto(descriptor, null);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
@@ -281,7 +281,12 @@ public class ControllerServiceResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName, sensitive);
+        final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName);
+
+        // Adjust sensitive status for dynamic properties based on requested status
+        if (descriptor.isDynamic()) {
+            descriptor.setSensitive(sensitive);
+        }
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
@@ -283,9 +283,9 @@ public class ControllerServiceResource extends ApplicationResource {
         // get the property descriptor
         final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName);
 
-        // Adjust sensitive status for dynamic properties based on requested status
-        if (descriptor.isDynamic()) {
-            descriptor.setSensitive(sensitive);
+        // Adjust sensitive status for dynamic properties when sensitive status enabled
+        if (descriptor.isDynamic() && sensitive) {
+            descriptor.setSensitive(true);
         }
 
         // generate the response entity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
@@ -257,7 +257,13 @@ public class ControllerServiceResource extends ApplicationResource {
                     value = "The property name to return the descriptor for.",
                     required = true
             )
-            @QueryParam("propertyName") final String propertyName) {
+            @QueryParam("propertyName") final String propertyName,
+            @ApiParam(
+                    value = "Property Descriptor requested sensitive status",
+                    defaultValue = "false"
+            )
+            @QueryParam("sensitive") final boolean sensitive
+    ) {
 
         // ensure the property name is specified
         if (propertyName == null) {
@@ -275,7 +281,7 @@ public class ControllerServiceResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName);
+        final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName, sensitive);
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
@@ -429,9 +429,9 @@ public class ProcessorResource extends ApplicationResource {
         // get the property descriptor
         final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName);
 
-        // Adjust sensitive status for dynamic properties based on requested status
-        if (descriptor.isDynamic()) {
-            descriptor.setSensitive(sensitive);
+        // Adjust sensitive status for dynamic properties when sensitive status enabled
+        if (descriptor.isDynamic() && sensitive) {
+            descriptor.setSensitive(true);
         }
 
         // generate the response entity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
@@ -403,7 +403,13 @@ public class ProcessorResource extends ApplicationResource {
                     value = "The property name.",
                     required = true
             )
-            @QueryParam("propertyName") final String propertyName) throws InterruptedException {
+            @QueryParam("propertyName") final String propertyName,
+            @ApiParam(
+                    value = "Property Descriptor requested sensitive status",
+                    defaultValue = "false"
+            )
+            @QueryParam("sensitive") final boolean sensitive
+    ) throws InterruptedException {
 
         // ensure the property name is specified
         if (propertyName == null) {
@@ -421,7 +427,7 @@ public class ProcessorResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName);
+        final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName, sensitive);
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
@@ -427,7 +427,12 @@ public class ProcessorResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName, sensitive);
+        final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName);
+
+        // Adjust sensitive status for dynamic properties based on requested status
+        if (descriptor.isDynamic()) {
+            descriptor.setSensitive(sensitive);
+        }
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
@@ -243,7 +243,13 @@ public class ReportingTaskResource extends ApplicationResource {
                     value = "The property name.",
                     required = true
             )
-            @QueryParam("propertyName") final String propertyName) {
+            @QueryParam("propertyName") final String propertyName,
+            @ApiParam(
+                    value = "Property Descriptor requested sensitive status",
+                    defaultValue = "false"
+            )
+            @QueryParam("sensitive") final boolean sensitive
+    ) {
 
         // ensure the property name is specified
         if (propertyName == null) {
@@ -261,7 +267,7 @@ public class ReportingTaskResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName);
+        final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName, sensitive);
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
@@ -267,7 +267,12 @@ public class ReportingTaskResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName, sensitive);
+        final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName);
+
+        // Adjust sensitive status for dynamic properties based on requested status
+        if (descriptor.isDynamic()) {
+            descriptor.setSensitive(sensitive);
+        }
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
@@ -269,9 +269,9 @@ public class ReportingTaskResource extends ApplicationResource {
         // get the property descriptor
         final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName);
 
-        // Adjust sensitive status for dynamic properties based on requested status
-        if (descriptor.isDynamic()) {
-            descriptor.setSensitive(sensitive);
+        // Adjust sensitive status for dynamic properties when sensitive status enabled
+        if (descriptor.isDynamic() && sensitive) {
+            descriptor.setSensitive(true);
         }
 
         // generate the response entity

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -4129,6 +4129,7 @@ public final class DtoFactory {
         copy.setParentGroupId(original.getParentGroupId());
         copy.setName(original.getName());
         copy.setProperties(copy(original.getProperties()));
+        copy.setSensitiveDynamicPropertyNames(copy(original.getSensitiveDynamicPropertyNames()));
         copy.setReferencingComponents(copy(original.getReferencingComponents()));
         copy.setState(original.getState());
         copy.setType(original.getType());
@@ -4235,6 +4236,7 @@ public final class DtoFactory {
         copy.setCustomUiUrl(original.getCustomUiUrl());
         copy.setDescriptors(copy(original.getDescriptors()));
         copy.setProperties(copy(original.getProperties()));
+        copy.setSensitiveDynamicPropertyNames(copy(original.getSensitiveDynamicPropertyNames()));
         copy.setSchedulingPeriod(original.getSchedulingPeriod());
         copy.setPenaltyDuration(original.getPenaltyDuration());
         copy.setYieldDuration(original.getYieldDuration());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -1533,6 +1533,8 @@ public final class DtoFactory {
             return bundleCoordinate.getGroup().equals(coordinate.getGroup()) && bundleCoordinate.getId().equals(coordinate.getId());
         }).collect(Collectors.toList());
 
+        final Class<? extends ReportingTask> reportingTaskClass = reportingTaskNode.getReportingTask().getClass();
+
         final ReportingTaskDTO dto = new ReportingTaskDTO();
         dto.setId(reportingTaskNode.getIdentifier());
         dto.setName(reportingTaskNode.getName());
@@ -1544,7 +1546,8 @@ public final class DtoFactory {
         dto.setActiveThreadCount(reportingTaskNode.getActiveThreadCount());
         dto.setAnnotationData(reportingTaskNode.getAnnotationData());
         dto.setComments(reportingTaskNode.getComments());
-        dto.setPersistsState(reportingTaskNode.getReportingTask().getClass().isAnnotationPresent(Stateful.class));
+        dto.setPersistsState(reportingTaskClass.isAnnotationPresent(Stateful.class));
+        dto.setSupportsSensitiveDynamicProperties(reportingTaskNode.isSupportsSensitiveDynamicProperties());
         dto.setRestricted(reportingTaskNode.isRestricted());
         dto.setDeprecated(reportingTaskNode.isDeprecated());
         dto.setExtensionMissing(reportingTaskNode.isExtensionMissing());
@@ -1620,17 +1623,20 @@ public final class DtoFactory {
             return bundleCoordinate.getGroup().equals(coordinate.getGroup()) && bundleCoordinate.getId().equals(coordinate.getId());
         }).collect(Collectors.toList());
 
+        final Class<? extends ControllerService> controllerServiceClass = controllerServiceNode.getControllerServiceImplementation().getClass();
+
         final ControllerServiceDTO dto = new ControllerServiceDTO();
         dto.setId(controllerServiceNode.getIdentifier());
         dto.setParentGroupId(controllerServiceNode.getProcessGroup() == null ? null : controllerServiceNode.getProcessGroup().getIdentifier());
         dto.setName(controllerServiceNode.getName());
         dto.setType(controllerServiceNode.getCanonicalClassName());
         dto.setBundle(createBundleDto(bundleCoordinate));
-        dto.setControllerServiceApis(createControllerServiceApiDto(controllerServiceNode.getControllerServiceImplementation().getClass()));
+        dto.setControllerServiceApis(createControllerServiceApiDto(controllerServiceClass));
         dto.setState(controllerServiceNode.getState().name());
         dto.setAnnotationData(controllerServiceNode.getAnnotationData());
         dto.setComments(controllerServiceNode.getComments());
-        dto.setPersistsState(controllerServiceNode.getControllerServiceImplementation().getClass().isAnnotationPresent(Stateful.class));
+        dto.setPersistsState(controllerServiceClass.isAnnotationPresent(Stateful.class));
+        dto.setSupportsSensitiveDynamicProperties(controllerServiceNode.isSupportsSensitiveDynamicProperties());
         dto.setRestricted(controllerServiceNode.isRestricted());
         dto.setDeprecated(controllerServiceNode.isDeprecated());
         dto.setExtensionMissing(controllerServiceNode.isExtensionMissing());
@@ -3131,13 +3137,16 @@ public final class DtoFactory {
             }
         }
 
+        final Class<? extends Processor> processorClass = node.getProcessor().getClass();
+
         final ProcessorDTO dto = new ProcessorDTO();
         dto.setId(node.getIdentifier());
         dto.setPosition(createPositionDto(node.getPosition()));
         dto.setStyle(node.getStyle());
         dto.setParentGroupId(node.getProcessGroup().getIdentifier());
         dto.setInputRequirement(node.getInputRequirement().name());
-        dto.setPersistsState(node.getProcessor().getClass().isAnnotationPresent(Stateful.class));
+        dto.setPersistsState(processorClass.isAnnotationPresent(Stateful.class));
+        dto.setSupportsSensitiveDynamicProperties(node.isSupportsSensitiveDynamicProperties());
         dto.setRestricted(node.isRestricted());
         dto.setDeprecated(node.isDeprecated());
         dto.setExecutionNodeRestricted(node.isExecutionNodeRestricted());
@@ -4203,6 +4212,7 @@ public final class DtoFactory {
         copy.setSupportsParallelProcessing(original.getSupportsParallelProcessing());
         copy.setSupportsEventDriven(original.getSupportsEventDriven());
         copy.setSupportsBatching(original.getSupportsBatching());
+        copy.setSupportsSensitiveDynamicProperties(original.getSupportsSensitiveDynamicProperties());
         copy.setPersistsState(original.getPersistsState());
         copy.setExecutionNodeRestricted(original.isExecutionNodeRestricted());
         copy.setExtensionMissing(original.getExtensionMissing());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardControllerServiceDAO.java
@@ -369,7 +369,8 @@ public class StandardControllerServiceDAO extends ComponentDAO implements Contro
                 controllerService.setComments(comments);
             }
             if (isNotNull(properties)) {
-                controllerService.setProperties(properties);
+                final Set<String> sensitiveDynamicPropertyNames = controllerServiceDTO.getSensitiveDynamicPropertyNames();
+                controllerService.setProperties(properties, false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
             }
         } finally {
             controllerService.resumeValidationTrigger();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -61,6 +61,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -198,7 +199,8 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                     processor.setLossTolerant(config.isLossTolerant());
                 }
                 if (isNotNull(configProperties)) {
-                    processor.setProperties(configProperties);
+                    final Set<String> sensitiveDynamicPropertyNames = config.getSensitiveDynamicPropertyNames();
+                    processor.setProperties(configProperties, false,sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
                 }
 
                 if (isNotNull(retryCount)) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardReportingTaskDAO.java
@@ -53,6 +53,7 @@ import org.quartz.CronExpression;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -384,7 +385,8 @@ public class StandardReportingTaskDAO extends ComponentDAO implements ReportingT
                 reportingTask.setComments(comments);
             }
             if (isNotNull(properties)) {
-                reportingTask.setProperties(properties);
+                final Set<String> sensitiveDynamicPropertyNames = reportingTaskDTO.getSensitiveDynamicPropertyNames();
+                reportingTask.setProperties(properties, false,sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
             }
         } finally {
             reportingTask.resumeValidationTrigger();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -80,6 +80,7 @@ import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
@@ -116,6 +117,7 @@ import org.apache.nifi.stream.io.StreamUtils;
 
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
+@SupportsSensitiveDynamicProperties
 @SupportsBatching
 @Tags({"http", "https", "rest", "client"})
 @InputRequirement(Requirement.INPUT_ALLOWED)

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/DifferenceType.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/DifferenceType.java
@@ -129,6 +129,11 @@ public enum DifferenceType {
     PROPERTY_REMOVED("Property Removed"),
 
     /**
+     * The sensitive status of the property changed
+     */
+    PROPERTY_SENSITIVITY_CHANGED("Property Sensitivity Changed"),
+
+    /**
      * Property is unset or set to an explicit value in Flow A but set to (exactly) a parameter reference in Flow B. Note that if Flow A
      * has a property set to "#{param1} abc" and it is changed to "#{param1} abc #{param2}" this would indicate a Difference Type of @{link #PROPERTY_CHANGED}, not
      * PROPERTY_PARAMETERIZED

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -291,9 +291,12 @@ public class StandardFlowComparator implements FlowComparator {
             final String valueB = decrypt(rawValueB, descriptorsB.get(key));
             final String valueA = decrypt(rawValueA, descriptorsA.get(key));
 
-            VersionedPropertyDescriptor descriptor = descriptorsA.get(key);
+            final VersionedPropertyDescriptor descriptorA = descriptorsA.get(key);
+            final VersionedPropertyDescriptor descriptorB = descriptorsB.get(key);
+
+            VersionedPropertyDescriptor descriptor = descriptorA;
             if (descriptor == null) {
-                descriptor = descriptorsB.get(key);
+                descriptor = descriptorB;
             }
 
             final String displayName;
@@ -301,6 +304,12 @@ public class StandardFlowComparator implements FlowComparator {
                 displayName = key;
             } else {
                 displayName = descriptor.getDisplayName() == null ? descriptor.getName() : descriptor.getDisplayName();
+            }
+
+            if (descriptorA != null && descriptorB != null) {
+                if (descriptorA.isSensitive() != descriptorB.isSensitive()) {
+                    differences.add(difference(DifferenceType.PROPERTY_SENSITIVITY_CHANGED, componentA, componentB, key, displayName, descriptorA.isSensitive(), descriptorB.isSensitive()));
+                }
             }
 
             if (valueA == null && valueB != null) {

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StaticDifferenceDescriptor.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StaticDifferenceDescriptor.java
@@ -53,6 +53,9 @@ public class StaticDifferenceDescriptor implements DifferenceDescriptor {
             case PROPERTY_CHANGED:
                 description = String.format("Property '%s' for %s with ID %s is different", fieldName, componentA.getComponentType().getTypeName(), getId(componentA));
                 break;
+            case PROPERTY_SENSITIVITY_CHANGED:
+                description = String.format("Property '%s' for %s with ID %s has a different sensitive status", fieldName, componentA.getComponentType().getTypeName(), componentA.getIdentifier());
+                break;
             case PROPERTY_PARAMETERIZED:
                 description = String.format("Property '%s' is a parameter reference in %s but not in %s", fieldName, flowAName, flowBName);
                 break;

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/controller/reporting/StatelessReportingContext.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/controller/reporting/StatelessReportingContext.java
@@ -19,12 +19,12 @@ package org.apache.nifi.controller.reporting;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.state.StateManager;
+import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.parameter.ParameterLookup;
 import org.apache.nifi.registry.VariableRegistry;
 import org.apache.nifi.reporting.EventAccess;
 import org.apache.nifi.reporting.ReportingContext;
-import org.apache.nifi.reporting.ReportingTask;
 import org.apache.nifi.stateless.engine.StatelessEngine;
 
 import java.util.Map;
@@ -34,9 +34,9 @@ public class StatelessReportingContext extends AbstractReportingContext implemen
     private final FlowManager flowManager;
 
     public StatelessReportingContext(final StatelessEngine statelessEngine, final FlowManager flowManager,
-                                     final Map<PropertyDescriptor, String> properties, final ReportingTask reportingTask,
+                                     final Map<PropertyDescriptor, String> properties, final ReportingTaskNode reportingTaskNode,
                                      final VariableRegistry variableRegistry, final ParameterLookup parameterLookup) {
-        super(reportingTask, statelessEngine.getBulletinRepository(), properties, statelessEngine.getControllerServiceProvider(), parameterLookup, variableRegistry);
+        super(reportingTaskNode, statelessEngine.getBulletinRepository(), properties, statelessEngine.getControllerServiceProvider(), parameterLookup, variableRegistry);
         this.statelessEngine = statelessEngine;
         this.flowManager = flowManager;
     }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/controller/reporting/StatelessReportingTaskNode.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/controller/reporting/StatelessReportingTaskNode.java
@@ -53,7 +53,7 @@ public class StatelessReportingTaskNode extends AbstractReportingTaskNode implem
 
     @Override
     public ReportingContext getReportingContext() {
-        return new StatelessReportingContext(statelessEngine, flowManager, getEffectivePropertyValues(), getReportingTask(), getVariableRegistry(), getParameterLookup());
+        return new StatelessReportingContext(statelessEngine, flowManager, getEffectivePropertyValues(), this, getVariableRegistry(), getParameterLookup());
     }
 
     @Override

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/cs/tests/system/SensitiveDynamicPropertiesService.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/cs/tests/system/SensitiveDynamicPropertiesService.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cs.tests.system;
+
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.controller.AbstractControllerService;
+
+@SupportsSensitiveDynamicProperties
+public class SensitiveDynamicPropertiesService extends AbstractControllerService {
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyName) {
+        return new PropertyDescriptor.Builder().name(propertyName).addValidator(Validator.VALID).dynamic(true).build();
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/SensitiveDynamicPropertiesProcessor.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/SensitiveDynamicPropertiesProcessor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.tests.system;
+
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@SupportsSensitiveDynamicProperties
+public class SensitiveDynamicPropertiesProcessor extends AbstractProcessor {
+    private List<PropertyDescriptor> properties;
+    private Set<Relationship> relationships;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> properties = new ArrayList<>();
+        this.properties = Collections.unmodifiableList(properties);
+
+        final Set<Relationship> relationships = new HashSet<>();
+        this.relationships = Collections.unmodifiableSet(relationships);
+
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .required(false)
+                .addValidator(Validator.VALID)
+                .dynamic(true)
+                .build();
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/reporting/SensitiveDynamicPropertiesReportingTask.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/reporting/SensitiveDynamicPropertiesReportingTask.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.reporting;
+
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+
+@SupportsSensitiveDynamicProperties
+public class SensitiveDynamicPropertiesReportingTask extends AbstractReportingTask {
+
+    @Override
+    public void onTrigger(final ReportingContext context) {
+
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyName) {
+        return new PropertyDescriptor.Builder().name(propertyName).addValidator(Validator.VALID).dynamic(true).build();
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -15,5 +15,6 @@
 
 org.apache.nifi.cs.tests.system.EnsureControllerServiceConfigurationCorrect
 org.apache.nifi.cs.tests.system.FakeControllerService1
+org.apache.nifi.cs.tests.system.SensitiveDynamicPropertiesService
 org.apache.nifi.cs.tests.system.StandardCountService
 org.apache.nifi.cs.tests.system.StandardSleepService

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -33,6 +33,7 @@ org.apache.nifi.processors.tests.system.PassThroughRequiresInstanceClassLoading
 org.apache.nifi.processors.tests.system.ReplaceWithFile
 org.apache.nifi.processors.tests.system.ReverseContents
 org.apache.nifi.processors.tests.system.RoundRobinFlowFiles
+org.apache.nifi.processors.tests.system.SensitiveDynamicPropertiesProcessor
 org.apache.nifi.processors.tests.system.SetAttribute
 org.apache.nifi.processors.tests.system.Sleep
 org.apache.nifi.processors.tests.system.SplitByLine

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.reporting.ReportingTask
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.reporting.ReportingTask
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 org.apache.nifi.reporting.EnsureReportingTaskConfigurationCorrect
+org.apache.nifi.reporting.SensitiveDynamicPropertiesReportingTask
 org.apache.nifi.reporting.WriteToFileReportingTask

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -533,24 +533,8 @@ public class NiFiClientUtil {
         }
     }
 
-    public void waitForReportingTaskValid(final String reportingTaskId) throws NiFiClientException, IOException, InterruptedException {
+    public void waitForReportingTaskValid(final String reportingTaskId) throws NiFiClientException, IOException {
         waitForReportingTaskValidationStatus(reportingTaskId, "Valid");
-    }
-
-    public void waitForReportingTaskValidationStatus(final String reportingTaskId, final String expectedStatus) throws NiFiClientException, IOException, InterruptedException {
-        while (true) {
-            final ReportingTaskEntity entity = nifiClient.getReportingTasksClient().getReportingTask(reportingTaskId);
-            final String validationStatus = entity.getComponent().getValidationStatus();
-            if (expectedStatus.equalsIgnoreCase(validationStatus)) {
-                return;
-            }
-
-            if ("Invalid".equalsIgnoreCase(validationStatus)) {
-                logger.info("Reporting Task with ID {} is currently invalid due to: {}", reportingTaskId, entity.getComponent().getValidationErrors());
-            }
-
-            Thread.sleep(100L);
-        }
     }
 
     public ControllerServiceEntity updateControllerService(final ControllerServiceEntity currentEntity, final Map<String, String> properties) throws NiFiClientException, IOException {
@@ -759,6 +743,48 @@ public class NiFiClientUtil {
             final ControllerServiceEntity entity = nonDisabledServices.get(0);
             logger.info("Controller Service ID [{}] Type [{}] State [{}] waiting for State [{}]: sleeping for 500 ms before retrying", entity.getId(),
                     entity.getComponent().getType(), entity.getComponent().getState(), desiredState);
+
+            try {
+                Thread.sleep(500L);
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void waitForControllerServiceValidationStatus(final String controllerServiceId, final String validationStatus) throws NiFiClientException, IOException {
+        while (true) {
+            final ControllerServiceEntity controllerServiceEntity = nifiClient.getControllerServicesClient().getControllerService(controllerServiceId);
+            final String currentValidationStatus = controllerServiceEntity.getStatus().getValidationStatus();
+            if (validationStatus.contentEquals(currentValidationStatus)) {
+                logger.info("Controller Service ID [{}] Type [{}] Validation Status [{}] matched", controllerServiceId,
+                        controllerServiceEntity.getComponent().getType(), validationStatus);
+                return;
+            }
+
+            logger.info("Controller Service ID [{}] Type [{}] Validation Status [{}] waiting for [{}]: sleeping for 500 ms before retrying", controllerServiceId,
+                    controllerServiceEntity.getComponent().getType(), currentValidationStatus, validationStatus);
+
+            try {
+                Thread.sleep(500L);
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void waitForReportingTaskValidationStatus(final String reportingTaskId, final String validationStatus) throws NiFiClientException, IOException {
+        while (true) {
+            final ReportingTaskEntity reportingTaskEntity = nifiClient.getReportingTasksClient().getReportingTask(reportingTaskId);
+            final String currentValidationStatus = reportingTaskEntity.getStatus().getValidationStatus();
+            if (validationStatus.equalsIgnoreCase(currentValidationStatus)) {
+                logger.info("Reporting Task ID [{}] Type [{}] Validation Status [{}] matched", reportingTaskId,
+                        reportingTaskEntity.getComponent().getType(), validationStatus);
+                return;
+            }
+
+            logger.info("Reporting Task ID [{}] Type [{}] Validation Status [{}] waiting for [{}]: sleeping for 500 ms before retrying", reportingTaskEntity,
+                    reportingTaskEntity.getComponent().getType(), currentValidationStatus, validationStatus);
 
             try {
                 Thread.sleep(500L);

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -756,7 +756,7 @@ public class NiFiClientUtil {
         while (true) {
             final ControllerServiceEntity controllerServiceEntity = nifiClient.getControllerServicesClient().getControllerService(controllerServiceId);
             final String currentValidationStatus = controllerServiceEntity.getStatus().getValidationStatus();
-            if (validationStatus.contentEquals(currentValidationStatus)) {
+            if (validationStatus.equals(currentValidationStatus)) {
                 logger.info("Controller Service ID [{}] Type [{}] Validation Status [{}] matched", controllerServiceId,
                         controllerServiceEntity.getComponent().getType(), validationStatus);
                 return;

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/controllerservice/ControllerServiceApiValidationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/controllerservice/ControllerServiceApiValidationIT.java
@@ -17,34 +17,18 @@
 package org.apache.nifi.tests.system.controllerservice;
 
 import org.apache.nifi.tests.system.NiFiSystemIT;
-import org.apache.nifi.toolkit.cli.impl.client.nifi.ControllerServicesClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
-import org.apache.nifi.web.api.dto.ControllerServiceDTO;
-import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceRunStatusEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
-import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ControllerServiceApiValidationIT extends NiFiSystemIT {
-
-    private static final String SENSITIVE_PROPERTY_NAME = "Credentials";
-
-    private static final String SENSITIVE_PROPERTY_VALUE = "Token";
-
-    private static final Set<String> SENSITIVE_DYNAMIC_PROPERTY_NAMES = Collections.singleton(SENSITIVE_PROPERTY_NAME);
 
     @Test
     public void testMatchingControllerService() throws NiFiClientException, IOException {
@@ -166,60 +150,5 @@ public class ControllerServiceApiValidationIT extends NiFiSystemIT {
 
         assertEquals("ENABLED", controllerStatus);
         assertEquals("Stopped", processorStatus);
-    }
-
-    @Test
-    void testGetPropertyDescriptor() throws NiFiClientException, IOException {
-        final ControllerServiceEntity controllerServiceEntity = getClientUtil().createControllerService("SensitiveDynamicPropertiesService");
-
-        final ControllerServicesClient servicesClient = getNifiClient().getControllerServicesClient();
-        final PropertyDescriptorEntity propertyDescriptorEntity = servicesClient.getPropertyDescriptor(controllerServiceEntity.getId(), SENSITIVE_PROPERTY_NAME, null);
-        final PropertyDescriptorDTO propertyDescriptor = propertyDescriptorEntity.getPropertyDescriptor();
-        assertFalse(propertyDescriptor.isSensitive());
-        assertTrue(propertyDescriptor.isDynamic());
-
-        final PropertyDescriptorEntity sensitivePropertyDescriptorEntity = servicesClient.getPropertyDescriptor(controllerServiceEntity.getId(), SENSITIVE_PROPERTY_NAME, true);
-        final PropertyDescriptorDTO sensitivePropertyDescriptor = sensitivePropertyDescriptorEntity.getPropertyDescriptor();
-        assertTrue(sensitivePropertyDescriptor.isSensitive());
-        assertTrue(sensitivePropertyDescriptor.isDynamic());
-    }
-
-    @Test
-    public void testSensitiveDynamicPropertiesNotSupported() throws NiFiClientException, IOException {
-        final ControllerServiceEntity controllerServiceEntity = getClientUtil().createControllerService("StandardCountService");
-        final ControllerServiceDTO component = controllerServiceEntity.getComponent();
-        assertFalse(component.getSupportsSensitiveDynamicProperties());
-
-        component.setSensitiveDynamicPropertyNames(SENSITIVE_DYNAMIC_PROPERTY_NAMES);
-
-        getClientUtil().updateControllerService(controllerServiceEntity, Collections.singletonMap(SENSITIVE_PROPERTY_NAME, SENSITIVE_PROPERTY_VALUE));
-
-        getClientUtil().waitForControllerServiceValidationStatus(controllerServiceEntity.getId(), ControllerServiceDTO.INVALID);
-    }
-
-    @Test
-    public void testSensitiveDynamicPropertiesSupportedConfigured() throws NiFiClientException, IOException {
-        final ControllerServiceEntity controllerServiceEntity = getClientUtil().createControllerService("SensitiveDynamicPropertiesService");
-        final ControllerServiceDTO component = controllerServiceEntity.getComponent();
-        assertTrue(component.getSupportsSensitiveDynamicProperties());
-
-        component.setSensitiveDynamicPropertyNames(SENSITIVE_DYNAMIC_PROPERTY_NAMES);
-        component.setProperties(Collections.singletonMap(SENSITIVE_PROPERTY_NAME, SENSITIVE_PROPERTY_VALUE));
-
-        getNifiClient().getControllerServicesClient().updateControllerService(controllerServiceEntity);
-
-        final ControllerServiceEntity updatedControllerServiceEntity = getNifiClient().getControllerServicesClient().getControllerService(controllerServiceEntity.getId());
-        final ControllerServiceDTO updatedComponent = updatedControllerServiceEntity.getComponent();
-
-        final Map<String, String> properties = updatedComponent.getProperties();
-        assertNotSame(SENSITIVE_PROPERTY_VALUE, properties.get(SENSITIVE_PROPERTY_NAME));
-
-        final Map<String, PropertyDescriptorDTO> descriptors = updatedComponent.getDescriptors();
-        final PropertyDescriptorDTO descriptor = descriptors.get(SENSITIVE_PROPERTY_NAME);
-        assertNotNull(descriptor);
-        assertTrue(descriptor.isSensitive());
-        assertTrue(descriptor.isDynamic());
-
-        getClientUtil().waitForControllerServiceValidationStatus(controllerServiceEntity.getId(), ControllerServiceDTO.VALID);
     }
 }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/controllerservice/ControllerServiceDynamicPropertiesIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/controllerservice/ControllerServiceDynamicPropertiesIT.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.tests.system.controllerservice;
+
+import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ControllerServicesClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.web.api.dto.ControllerServiceDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
+import org.apache.nifi.web.api.entity.ControllerServiceEntity;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ControllerServiceDynamicPropertiesIT extends NiFiSystemIT {
+
+    private static final String SENSITIVE_PROPERTY_NAME = "Credentials";
+
+    private static final String SENSITIVE_PROPERTY_VALUE = "Token";
+
+    private static final Set<String> SENSITIVE_DYNAMIC_PROPERTY_NAMES = Collections.singleton(SENSITIVE_PROPERTY_NAME);
+
+    @Test
+    void testGetPropertyDescriptor() throws NiFiClientException, IOException {
+        final ControllerServiceEntity controllerServiceEntity = getClientUtil().createControllerService("SensitiveDynamicPropertiesService");
+
+        final ControllerServicesClient servicesClient = getNifiClient().getControllerServicesClient();
+        final PropertyDescriptorEntity propertyDescriptorEntity = servicesClient.getPropertyDescriptor(controllerServiceEntity.getId(), SENSITIVE_PROPERTY_NAME, null);
+        final PropertyDescriptorDTO propertyDescriptor = propertyDescriptorEntity.getPropertyDescriptor();
+        assertFalse(propertyDescriptor.isSensitive());
+        assertTrue(propertyDescriptor.isDynamic());
+
+        final PropertyDescriptorEntity sensitivePropertyDescriptorEntity = servicesClient.getPropertyDescriptor(controllerServiceEntity.getId(), SENSITIVE_PROPERTY_NAME, true);
+        final PropertyDescriptorDTO sensitivePropertyDescriptor = sensitivePropertyDescriptorEntity.getPropertyDescriptor();
+        assertTrue(sensitivePropertyDescriptor.isSensitive());
+        assertTrue(sensitivePropertyDescriptor.isDynamic());
+    }
+
+    @Test
+    public void testSensitiveDynamicPropertiesNotSupported() throws NiFiClientException, IOException {
+        final ControllerServiceEntity controllerServiceEntity = getClientUtil().createControllerService("StandardCountService");
+        final ControllerServiceDTO component = controllerServiceEntity.getComponent();
+        assertFalse(component.getSupportsSensitiveDynamicProperties());
+
+        component.setSensitiveDynamicPropertyNames(SENSITIVE_DYNAMIC_PROPERTY_NAMES);
+
+        getClientUtil().updateControllerService(controllerServiceEntity, Collections.singletonMap(SENSITIVE_PROPERTY_NAME, SENSITIVE_PROPERTY_VALUE));
+
+        getClientUtil().waitForControllerServiceValidationStatus(controllerServiceEntity.getId(), ControllerServiceDTO.INVALID);
+    }
+
+    @Test
+    public void testSensitiveDynamicPropertiesSupportedConfigured() throws NiFiClientException, IOException {
+        final ControllerServiceEntity controllerServiceEntity = getClientUtil().createControllerService("SensitiveDynamicPropertiesService");
+        final ControllerServiceDTO component = controllerServiceEntity.getComponent();
+        assertTrue(component.getSupportsSensitiveDynamicProperties());
+
+        component.setSensitiveDynamicPropertyNames(SENSITIVE_DYNAMIC_PROPERTY_NAMES);
+        component.setProperties(Collections.singletonMap(SENSITIVE_PROPERTY_NAME, SENSITIVE_PROPERTY_VALUE));
+
+        getNifiClient().getControllerServicesClient().updateControllerService(controllerServiceEntity);
+
+        final ControllerServiceEntity updatedControllerServiceEntity = getNifiClient().getControllerServicesClient().getControllerService(controllerServiceEntity.getId());
+        final ControllerServiceDTO updatedComponent = updatedControllerServiceEntity.getComponent();
+
+        final Map<String, String> properties = updatedComponent.getProperties();
+        assertNotSame(SENSITIVE_PROPERTY_VALUE, properties.get(SENSITIVE_PROPERTY_NAME));
+
+        final Map<String, PropertyDescriptorDTO> descriptors = updatedComponent.getDescriptors();
+        final PropertyDescriptorDTO descriptor = descriptors.get(SENSITIVE_PROPERTY_NAME);
+        assertNotNull(descriptor);
+        assertTrue(descriptor.isSensitive());
+        assertTrue(descriptor.isDynamic());
+
+        getClientUtil().waitForControllerServiceValidationStatus(controllerServiceEntity.getId(), ControllerServiceDTO.VALID);
+    }
+}

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/ProcessorDynamicPropertiesIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/ProcessorDynamicPropertiesIT.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.tests.system.processor;
+
+import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
+import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
+import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProcessorDynamicPropertiesIT extends NiFiSystemIT {
+    private static final String SENSITIVE_PROPERTY_NAME = "Credentials";
+
+    private static final String SENSITIVE_PROPERTY_VALUE = "Token";
+
+    private static final Set<String> SENSITIVE_DYNAMIC_PROPERTY_NAMES = Collections.singleton(SENSITIVE_PROPERTY_NAME);
+
+    @Test
+    void testGetPropertyDescriptor() throws NiFiClientException, IOException {
+        final ProcessorEntity processorEntity = getClientUtil().createProcessor("SensitiveDynamicPropertiesProcessor");
+
+        final PropertyDescriptorEntity propertyDescriptorEntity = getNifiClient().getProcessorClient().getPropertyDescriptor(processorEntity.getId(), SENSITIVE_PROPERTY_NAME, null);
+        final PropertyDescriptorDTO propertyDescriptor = propertyDescriptorEntity.getPropertyDescriptor();
+        assertFalse(propertyDescriptor.isSensitive());
+        assertTrue(propertyDescriptor.isDynamic());
+
+        final PropertyDescriptorEntity sensitivePropertyDescriptorEntity = getNifiClient().getProcessorClient().getPropertyDescriptor(processorEntity.getId(), SENSITIVE_PROPERTY_NAME, true);
+        final PropertyDescriptorDTO sensitivePropertyDescriptor = sensitivePropertyDescriptorEntity.getPropertyDescriptor();
+        assertTrue(sensitivePropertyDescriptor.isSensitive());
+        assertTrue(sensitivePropertyDescriptor.isDynamic());
+    }
+
+    @Test
+    void testSensitiveDynamicPropertiesNotSupported() throws NiFiClientException, IOException, InterruptedException {
+        final ProcessorEntity processorEntity = getClientUtil().createProcessor("FakeDynamicPropertiesProcessor");
+        final ProcessorDTO component = processorEntity.getComponent();
+        assertFalse(component.getSupportsSensitiveDynamicProperties());
+
+        final ProcessorConfigDTO config = component.getConfig();
+        config.setSensitiveDynamicPropertyNames(SENSITIVE_DYNAMIC_PROPERTY_NAMES);
+        config.setProperties(Collections.singletonMap(SENSITIVE_PROPERTY_NAME, SENSITIVE_PROPERTY_VALUE));
+
+        getClientUtil().updateProcessorConfig(processorEntity, config);
+
+        getClientUtil().waitForInvalidProcessor(processorEntity.getId());
+    }
+
+    @Test
+    void testSensitiveDynamicPropertiesSupportedConfigured() throws NiFiClientException, IOException, InterruptedException {
+        final ProcessorEntity processorEntity = getClientUtil().createProcessor("SensitiveDynamicPropertiesProcessor");
+        final ProcessorDTO component = processorEntity.getComponent();
+        assertTrue(component.getSupportsSensitiveDynamicProperties());
+
+        final ProcessorConfigDTO config = component.getConfig();
+        config.setSensitiveDynamicPropertyNames(SENSITIVE_DYNAMIC_PROPERTY_NAMES);
+        config.setProperties(Collections.singletonMap(SENSITIVE_PROPERTY_NAME, SENSITIVE_PROPERTY_VALUE));
+
+        getClientUtil().updateProcessorConfig(processorEntity, config);
+
+        getClientUtil().waitForValidProcessor(processorEntity.getId());
+
+        final ProcessorEntity updatedProcessorEntity = getNifiClient().getProcessorClient().getProcessor(processorEntity.getId());
+        final ProcessorDTO updatedComponent = updatedProcessorEntity.getComponent();
+        final ProcessorConfigDTO updatedConfig = updatedComponent.getConfig();
+
+        final Map<String, String> properties = updatedConfig.getProperties();
+        assertNotSame(SENSITIVE_PROPERTY_VALUE, properties.get(SENSITIVE_PROPERTY_NAME));
+
+        final Map<String, PropertyDescriptorDTO> descriptors = updatedConfig.getDescriptors();
+        final PropertyDescriptorDTO descriptor = descriptors.get(SENSITIVE_PROPERTY_NAME);
+        assertNotNull(descriptor);
+        assertTrue(descriptor.isSensitive());
+        assertTrue(descriptor.isDynamic());
+    }
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ControllerServicesClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ControllerServicesClient.java
@@ -19,6 +19,7 @@ package org.apache.nifi.toolkit.cli.impl.client.nifi;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceReferencingComponentsEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceRunStatusEntity;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.UpdateControllerServiceReferenceRequestEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
 
@@ -49,4 +50,5 @@ public interface ControllerServicesClient {
 
     VerifyConfigRequestEntity deleteConfigVerificationRequest(String serviceId, String verificationRequestId) throws NiFiClientException, IOException;
 
+    PropertyDescriptorEntity getPropertyDescriptor(String serviceId, String propertyName, Boolean sensitive) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessorClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessorClient.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.toolkit.cli.impl.client.nifi;
 
 import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
 
 import java.io.IOException;
@@ -53,6 +54,8 @@ public interface ProcessorClient {
     VerifyConfigRequestEntity getConfigVerificationRequest(String processorId, String verificationRequestId) throws NiFiClientException, IOException;
 
     VerifyConfigRequestEntity deleteConfigVerificationRequest(String processorId, String verificationRequestId) throws NiFiClientException, IOException;
+
+    PropertyDescriptorEntity getPropertyDescriptor(String processorId, String propertyName, Boolean sensitive) throws NiFiClientException, IOException;
 
     /**
      * Indicates that mutable requests should indicate that the client has acknowledged that the node is disconnected.

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ReportingTasksClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ReportingTasksClient.java
@@ -17,6 +17,7 @@
  */
 package org.apache.nifi.toolkit.cli.impl.client.nifi;
 
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskRunStatusEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
@@ -42,4 +43,5 @@ public interface ReportingTasksClient {
 
     ReportingTaskEntity deleteReportingTask(ReportingTaskEntity reportingTask) throws NiFiClientException, IOException;
 
+    PropertyDescriptorEntity getPropertyDescriptor(String taskId, String propertyName, Boolean sensitive) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyControllerServicesClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyControllerServicesClient.java
@@ -24,6 +24,7 @@ import org.apache.nifi.web.api.dto.RevisionDTO;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceReferencingComponentsEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceRunStatusEntity;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.UpdateControllerServiceReferenceRequestEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
 
@@ -31,6 +32,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Jersey implementation of ControllerServicersClient.
@@ -238,6 +240,22 @@ public class JerseyControllerServicesClient extends AbstractJerseyClient impleme
                 .resolveTemplate("requestId", verificationRequestId);
 
             return getRequestBuilder(target).delete(VerifyConfigRequestEntity.class);
+        });
+    }
+
+    @Override
+    public PropertyDescriptorEntity getPropertyDescriptor(final String serviceId, final String propertyName, final Boolean sensitive) throws NiFiClientException, IOException {
+        Objects.requireNonNull(serviceId, "Service ID required");
+        Objects.requireNonNull(propertyName, "Property Name required");
+
+        return executeAction("Error retrieving Property Descriptor", () -> {
+            final WebTarget target = controllerServicesTarget
+                    .path("{id}/descriptors")
+                    .resolveTemplate("id", serviceId)
+                    .queryParam("propertyName", propertyName)
+                    .queryParam("sensitive", sensitive);
+
+            return getRequestBuilder(target).get(PropertyDescriptorEntity.class);
         });
     }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessorClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessorClient.java
@@ -23,12 +23,14 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.RequestConfig;
 import org.apache.nifi.web.api.dto.RevisionDTO;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.apache.nifi.web.api.entity.ProcessorRunStatusEntity;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.Objects;
 
 public class JerseyProcessorClient extends AbstractJerseyClient implements ProcessorClient {
     private volatile WebTarget processGroupTarget;
@@ -255,6 +257,22 @@ public class JerseyProcessorClient extends AbstractJerseyClient implements Proce
                 .resolveTemplate("requestId", verificationRequestId);
 
             return getRequestBuilder(target).delete(VerifyConfigRequestEntity.class);
+        });
+    }
+
+    @Override
+    public PropertyDescriptorEntity getPropertyDescriptor(final String processorId, final String propertyName, final Boolean sensitive) throws NiFiClientException, IOException {
+        Objects.requireNonNull(processorId, "Processor ID required");
+        Objects.requireNonNull(propertyName, "Property Name required");
+
+        return executeAction("Error retrieving Property Descriptor", () -> {
+            final WebTarget target = processorTarget
+                    .path("/descriptors")
+                    .resolveTemplate("id", processorId)
+                    .queryParam("propertyName", propertyName)
+                    .queryParam("sensitive", sensitive);
+
+            return getRequestBuilder(target).get(PropertyDescriptorEntity.class);
         });
     }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyReportingTasksClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyReportingTasksClient.java
@@ -22,6 +22,7 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.ReportingTasksClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.RequestConfig;
 import org.apache.nifi.web.api.dto.RevisionDTO;
+import org.apache.nifi.web.api.entity.PropertyDescriptorEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskRunStatusEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
@@ -30,6 +31,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Jersey implementation of ReportingTasksClient.
@@ -183,4 +185,19 @@ public class JerseyReportingTasksClient extends AbstractJerseyClient implements 
         });
     }
 
+    @Override
+    public PropertyDescriptorEntity getPropertyDescriptor(final String componentId, final String propertyName, final Boolean sensitive) throws NiFiClientException, IOException {
+        Objects.requireNonNull(componentId, "Component ID required");
+        Objects.requireNonNull(propertyName, "Property Name required");
+
+        return executeAction("Error retrieving Property Descriptor", () -> {
+            final WebTarget target = reportingTasksTarget
+                    .path("{id}/descriptors")
+                    .resolveTemplate("id", componentId)
+                    .queryParam("propertyName", propertyName)
+                    .queryParam("sensitive", sensitive);
+
+            return getRequestBuilder(target).get(PropertyDescriptorEntity.class);
+        });
+    }
 }


### PR DESCRIPTION
# Summary

[NIFI-9958](https://issues.apache.org/jira/browse/NIFI-9958) Adds framework support for Sensitive Dynamic Properties in Processors, Controller Services and Reporting Tasks.

The implementation adds a `SupportsSensitiveDynamicProperties` behavior annotation, which must be applied to component classes to indicate support for Sensitive Dynamic Properties. No other changes are necessary at the component implementation level.

Changes include updates to REST Resource methods and models to indicate component support for sensitive dynamic properties, as well as the ability for a client to indicate names of dynamic properties that should be marked sensitive. The Property Descriptor REST Resource methods for components include an new optional `sensitive` query parameter to support subsequent user interface integration.

New system tests include basic component creation and updating with sensitive dynamic property names and values. Component auditor changes ensure the Flow Configuration History masks sensitive dynamic property values.

The flow persistence approach infers sensitive property value status based on whether the property value matches the standard encrypted pattern. This strategy avoids the need to introduce structural changes to the flow.xml.gz or flow.json.gz files.

This implementation provides the basic capabilities, and adds the `SupportsSensitiveDynamicProperties` annotation to `InvokeHTTP` for the purpose of testing REST Resource methods. Subsequent pull requests will incorporate user interface and documentation updates.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
