### PR TITLE
NIFI-10036: Making Elasticsearch requests consistently lead with a /

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -320,7 +320,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             final HttpEntity entity = new NStringEntity(payload.toString(), ContentType.APPLICATION_JSON);
             final StopWatch watch = new StopWatch();
             watch.start();
-            final Response response = performRequest("POST", "_bulk", requestParameters, entity);
+            final Response response = performRequest("POST", "/_bulk", requestParameters, entity);
             watch.stop();
 
             final String rawResponse = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -360,7 +360,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             final HttpEntity entity = new NStringEntity(sb.toString(), ContentType.APPLICATION_JSON);
             final StopWatch watch = new StopWatch();
             watch.start();
-            final Response response = performRequest("POST", "_bulk", requestParameters, entity);
+            final Response response = performRequest("POST", "/_bulk", requestParameters, entity);
             watch.stop();
 
             if (getLogger().isDebugEnabled()) {
@@ -406,7 +406,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         try {
             final StringBuilder endpoint = new StringBuilder();
             if (StringUtils.isNotBlank(index) && !"/".equals(index)) {
-                endpoint.append(index);
+                endpoint.append("/").append(index);
             }
             endpoint.append("/_refresh");
             final Response response = performRequest("POST", endpoint.toString(), requestParameters, null);
@@ -421,7 +421,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
     public Map<String, Object> get(final String index, final String type, final String id, final Map<String, String> requestParameters) {
         try {
             final StringBuilder endpoint = new StringBuilder();
-            endpoint.append(index);
+            endpoint.append("/").append(index);
             if (StringUtils.isNotBlank(type)) {
                 endpoint.append("/").append(type);
             } else {
@@ -482,7 +482,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
                     put("keep_alive", keepAlive);
                 }
             }};
-            final Response response = performRequest("POST", index + "/_pit", params, null);
+            final Response response = performRequest("POST", "/" + index + "/_pit", params, null);
             final String body = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             parseResponseWarningHeaders(response);
 


### PR DESCRIPTION
# Summary

[NIFI-10036](https://issues.apache.org/jira/browse/NIFI-10036)

This changes `ElasticSearchClientServiceImpl` to submit all requests with a leading slash (/).

The simplest test is to use `PutElasticsearchRecord`, which uses the `'_bulk'` API, which will now POST to `'/_bulk'` instead.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
