### PR TITLE
NIFI-10038 Add Java 17 to system-tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -21,9 +21,11 @@ on:
     - cron: "0 0 * * *"
   push:
     paths:
+      - '.github/workflows/system-tests.yml'
       - 'nifi-system-tests/**'
   pull_request:
     paths:
+      - '.github/workflows/system-tests.yml'
       - 'nifi-system-tests/**'
 
 env:
@@ -51,6 +53,46 @@ env:
     -pl nifi-system-tests/nifi-stateless-system-test-suite
 
 jobs:
+  ubuntu-17:
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    name: Ubuntu Java 17
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Set up Java 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: 'maven'
+      - name: Build Dependencies
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_BUILD_ARGUMENTS }}
+          ${{ env.MAVEN_PROJECTS }}
+      - name: Run Tests
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_RUN_ARGUMENTS }}
+          ${{ env.MAVEN_PROJECTS }}
+      - name: Upload Troubleshooting Logs
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ubuntu-17-troubleshooting-logs
+          path: |
+            nifi-system-tests/nifi-system-test-suite/target/failsafe-reports/**/*.txt
+            nifi-system-tests/nifi-system-test-suite/target/surefire-reports/**/*.txt
+            nifi-system-tests/nifi-system-test-suite/target/troubleshooting/**/*
+          retention-days: 7
+
   ubuntu:
     timeout-minutes: 120
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

[NIFI-10038](https://issues.apache.org/jira/browse/NIFI-10038) Adds Ubuntu Java 17 as an additional platform to the GitHub system-tests workflow.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
