### PR TITLE
NIFIDEVS-5378: prevent duplicate keys with different values in nifi.p…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/java/org/apache/nifi/properties/NiFiPropertiesLoaderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/java/org/apache/nifi/properties/NiFiPropertiesLoaderTest.java
@@ -25,23 +25,43 @@ import java.net.URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NiFiPropertiesLoaderTest {
     private static final String NULL_PATH = null;
 
     private static final String EMPTY_PATH = "/properties/conf/empty.nifi.properties";
-
     private static final String FLOW_PATH = "/properties/conf/flow.nifi.properties";
-
     private static final String PROTECTED_PATH = "/properties/conf/protected.nifi.properties";
+    private static final String DUPLICATE_PROPERTIES_PATH = "/properties/conf/duplicates.nifi.properties";
 
     private static final String HEXADECIMAL_KEY = "12345678123456788765432187654321";
-
     private static final String EXPECTED_PASSWORD = "propertyValue";
 
     @AfterEach
     void clearSystemProperty() {
         System.clearProperty(NiFiProperties.PROPERTIES_FILE_PATH);
+    }
+
+    @Test
+    void testDuplicateProperties() {
+        final URL resource = NiFiPropertiesLoaderTest.class.getResource(DUPLICATE_PROPERTIES_PATH);
+        assertNotNull(resource);
+
+        final String path = resource.getPath();
+
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, path);
+
+        final NiFiPropertiesLoader loader = NiFiPropertiesLoader.withKey(String.class.getSimpleName());
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            final NiFiProperties properties = loader.get();
+        });
+
+        String expectedMessage = "Duplicate keys were detected in the properties file. See previous errors.";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/properties/conf/duplicates.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/test/resources/properties/conf/duplicates.nifi.properties
@@ -14,7 +14,4 @@
 # limitations under the License.
 
 nifi.flow.configuration.file=./conf/flow.xml.gz
-nifi.flow.configuration.json.file=./conf/flow.json.gz
-# duplicate with the same value intentionally added to verify this is valid
-# while bad form, it is not considered a duplicate
-nifi.flow.configuration.json.file=./conf/flow.json.gz
+nifi.flow.configuration.file=./conf/flow.json.gz


### PR DESCRIPTION
…roperties

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
When loading nifi.properties file, first check for duplicate key/value entries. Duplicate keys are allowed if their values are the same. If the same key has different values, an error with key/value details is written to nifi-app.log and NiFi will not start.

[NIFI-4278](https://issues.apache.org/jira/browse/NIFI-5378)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification
Installed NiFi and attempted to start with various combinations of key/value duplicates. 
Duplicate keys with unique values
Duplicate keys with same values
All unique keys

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
