### PR TITLE
NIFI-10043 fix ElasticsearchClient integration tests following JUnit5 upgrade

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.6.3</version>
+            <version>3.8.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -210,8 +210,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-failsafe-plugin</artifactId>
-                            <!-- use 3.0.0-M3 due to a classpath/class loader issue in -M5, expected to be fixed in M6+ -->
-                            <version>3.0.0-M3</version>
+                            <version>3.0.0-M6</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>
@@ -251,7 +250,7 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <es.int.version>7.17.1</es.int.version>
+                <es.int.version>7.17.3</es.int.version>
                 <es.int.script.name>setup-7.script</es.int.script.name>
                 <es.int.type.name />
                 <es.int.path.conf />
@@ -264,7 +263,7 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <es.int.version>8.0.1</es.int.version>
+                <es.int.version>8.2.0</es.int.version>
                 <!-- elasticsearch-maven-plugin version 6.20+ required for Elasticsearch 8.x+ -->
                 <alexcojocaru.plugin.version>6.22</alexcojocaru.plugin.version>
                 <es.int.script.name>setup-8.script</es.int.script.name>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/pom.xml
@@ -93,7 +93,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Summary

[NIFI-10043](https://issues.apache.org/jira/browse/NIFI-10043) fix ElasticsearchClient integration tests following JUnit5 upgrade.

Update Elasticsearch and json-path dependency versions

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
