### PR TITLE
NIFI-10044: Add content viewer support for YAML

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
@@ -79,5 +79,10 @@
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.30</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
@@ -30,6 +30,8 @@ import org.apache.nifi.xml.processing.transform.StandardTransformProvider;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -57,6 +59,13 @@ public class StandardContentViewerController extends HttpServlet {
         supportedMimeTypes.add("application/avro-binary");
         supportedMimeTypes.add("avro/binary");
         supportedMimeTypes.add("application/avro+binary");
+        supportedMimeTypes.add("text/x-yaml");
+        supportedMimeTypes.add("text/yaml");
+        supportedMimeTypes.add("text/yml");
+        supportedMimeTypes.add("application/x-yaml");
+        supportedMimeTypes.add("application/x-yml");
+        supportedMimeTypes.add("application/yaml");
+        supportedMimeTypes.add("application/yml");
     }
 
     /**
@@ -150,6 +159,20 @@ public class StandardContentViewerController extends HttpServlet {
                     formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectJson);
 
                     contentType = "application/json";
+                } else if ("text/x-yaml".equals(contentType) || "text/yaml".equals(contentType) || "text/yml".equals(contentType)
+                        || "application/x-yaml".equals(contentType) || "application/x-yml".equals(contentType)
+                        || "application/yaml".equals(contentType) || "application/yml".equals(contentType)) {
+                    Yaml yaml = new Yaml();
+                    // Parse the YAML file
+                    final Object yamlObject = yaml.load(content.getContentStream());
+                    DumperOptions options = new DumperOptions();
+                    options.setIndent(2);
+                    options.setPrettyFlow(true);
+                    // Fix below - additional configuration
+                    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+                    Yaml output = new Yaml(options);
+                    formatted = output.dump(yamlObject);
+
                 } else {
                     // leave plain text alone when formatting
                     formatted = content.getContent();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/resources/META-INF/NOTICE
@@ -35,3 +35,7 @@ The following binary components are provided under the Apache Software License v
       This library containd statically linked libstdc++. This inclusion is allowed by
       "GCC RUntime Library Exception"
       http://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
+
+  (ASLv2) SnakeYAML
+      The following NOTICE information applies:
+        Copyright (c) 2008, https://www.snakeyaml.org

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/webapp/META-INF/nifi-content-viewer
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/webapp/META-INF/nifi-content-viewer
@@ -20,3 +20,10 @@ text/csv
 avro/binary
 application/avro-binary
 application/avro+binary
+text/x-yaml
+text/yaml
+text/yml
+application/x-yaml
+application/x-yml
+application/yaml
+application/yml


### PR DESCRIPTION
# Summary

[NIFI-10044](https://issues.apache.org/jira/browse/NIFI-10044) This PR adds support for viewing YAML content (original and formatted) to NiFi 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
