### PR TITLE
NIFI-10027: Add support for WEBP images to the image viewer

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer/src/main/java/org/apache/nifi/web/ImageViewerController.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer/src/main/java/org/apache/nifi/web/ImageViewerController.java
@@ -38,7 +38,8 @@ public class ImageViewerController extends HttpServlet {
         final ViewableContent content = (ViewableContent) request.getAttribute(ViewableContent.CONTENT_REQUEST_ATTRIBUTE);
 
         // handle images
-        if ("image/png".equals(content.getContentType()) || "image/jpeg".equals(content.getContentType()) || "image/gif".equals(content.getContentType())) {
+        if ("image/png".equals(content.getContentType()) || "image/jpeg".equals(content.getContentType())
+                || "image/gif".equals(content.getContentType()) || "image/webp".equals(content.getContentType())) {
             // defer to the jsp
             request.getRequestDispatcher("/WEB-INF/jsp/image.jsp").include(request, response);
         } else {

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer/src/main/webapp/META-INF/nifi-content-viewer
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer/src/main/webapp/META-INF/nifi-content-viewer
@@ -15,3 +15,4 @@
 image/png
 image/jpeg
 image/gif
+image/webp


### PR DESCRIPTION
# Summary

[NIFI-10027](https://issues.apache.org/jira/browse/NIFI-10027) This PR adds support for [WebP](https://developers.google.com/speed/webp) images to the image viewer in the NiFi UI. Note that the image is only rendered if the browser NiFi is in supports the WebP format. I tested on Chrome and Firefox (both of which showed the image) and Safari (which did not show the image).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
