### PR TITLE
NIFI-9959 Add UI Support for Sensitive Dynamic Properties

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -997,6 +997,12 @@ public abstract class AbstractComponentNode implements ComponentNode {
     }
 
     @Override
+    public boolean isSensitiveDynamicProperty(final String name) {
+        Objects.requireNonNull(name, "Property Name required");
+        return sensitiveDynamicPropertyNames.get().contains(name);
+    }
+
+    @Override
     public PropertyDescriptor getPropertyDescriptor(final String name) {
         try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(extensionManager, getComponent().getClass(), getComponent().getIdentifier())) {
             final PropertyDescriptor propertyDescriptor = getComponent().getPropertyDescriptor(name);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
@@ -261,6 +261,11 @@ public interface ComponentNode extends ComponentAuthorizable {
      */
     PropertyDescriptor getPropertyDescriptor(String name);
 
+    /**
+     * @param name Property Name
+     * @return Sensitive Dynamic Property status
+     */
+    boolean isSensitiveDynamicProperty(String name);
 
     @Override
     default AuthorizationResult checkAuthorization(Authorizer authorizer, RequestAction action, NiFiUser user, Map<String, String> resourceContext) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -616,9 +616,10 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
+     * @param sensitive requested sensitive status
      * @return descriptor
      */
-    PropertyDescriptorDTO getProcessorPropertyDescriptor(String id, String property);
+    PropertyDescriptorDTO getProcessorPropertyDescriptor(String id, String property, boolean sensitive);
 
     /**
      * Gets all the Processor transfer objects for this controller.
@@ -2046,9 +2047,10 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
+     * @param sensitive requested sensitive status
      * @return property
      */
-    PropertyDescriptorDTO getControllerServicePropertyDescriptor(String id, String property);
+    PropertyDescriptorDTO getControllerServicePropertyDescriptor(String id, String property, boolean sensitive);
 
     /**
      * Gets the references for specified controller service.
@@ -2168,9 +2170,10 @@ public interface NiFiServiceFacade {
      *
      * @param id id
      * @param property property
+     * @param sensitive requested sensitive status
      * @return descriptor
      */
-    PropertyDescriptorDTO getReportingTaskPropertyDescriptor(String id, String property);
+    PropertyDescriptorDTO getReportingTaskPropertyDescriptor(String id, String property, boolean sensitive);
 
     /**
      * Updates the specified reporting task.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerServiceResource.java
@@ -281,12 +281,7 @@ public class ControllerServiceResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName);
-
-        // Adjust sensitive status for dynamic properties when sensitive status enabled
-        if (descriptor.isDynamic() && sensitive) {
-            descriptor.setSensitive(true);
-        }
+        final PropertyDescriptorDTO descriptor = serviceFacade.getControllerServicePropertyDescriptor(id, propertyName, sensitive);
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessorResource.java
@@ -427,12 +427,7 @@ public class ProcessorResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName);
-
-        // Adjust sensitive status for dynamic properties when sensitive status enabled
-        if (descriptor.isDynamic() && sensitive) {
-            descriptor.setSensitive(true);
-        }
+        final PropertyDescriptorDTO descriptor = serviceFacade.getProcessorPropertyDescriptor(id, propertyName, sensitive);
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ReportingTaskResource.java
@@ -267,12 +267,7 @@ public class ReportingTaskResource extends ApplicationResource {
         });
 
         // get the property descriptor
-        final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName);
-
-        // Adjust sensitive status for dynamic properties when sensitive status enabled
-        if (descriptor.isDynamic() && sensitive) {
-            descriptor.setSensitive(true);
-        }
+        final PropertyDescriptorDTO descriptor = serviceFacade.getReportingTaskPropertyDescriptor(id, propertyName, sensitive);
 
         // generate the response entity
         final PropertyDescriptorEntity entity = new PropertyDescriptorEntity();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/modal/jquery.modal.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/modal/jquery.modal.css
@@ -103,10 +103,6 @@
     word-wrap: break-word;
 }
 
-.dialog-content-overflow-disabled {
-    overflow: hidden;
-}
-
 .dialog-buttons {
     position: absolute;
     bottom: 0;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/modal/jquery.modal.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/modal/jquery.modal.css
@@ -103,6 +103,10 @@
     word-wrap: break-word;
 }
 
+.dialog-content-overflow-disabled {
+    overflow: hidden;
+}
+
 .dialog-buttons {
     position: absolute;
     bottom: 0;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1212,7 +1212,8 @@
                         contentType: 'application/json'
                     }).done(function (response) {
                         // load the descriptor and update the property
-                        configurationOptions.descriptorDeferred(item.property).done(function (descriptorResponse) {
+                        // Controller Service dynamic property descriptors will not be marked as sensitive
+                        configurationOptions.descriptorDeferred(item.property, false).done(function (descriptorResponse) {
                             var descriptor = descriptorResponse.propertyDescriptor;
 
                             // store the descriptor for use later

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -2044,7 +2044,7 @@
                         // build the new property dialog
                         var newPropertyDialogMarkup =
                             '<div id="new-property-dialog" class="dialog cancellable small-dialog hidden">' +
-                                '<div class="dialog-content dialog-content-overflow-disabled">' +
+                                '<div class="dialog-content">' +
                                     '<div class="setting">' +
                                         '<div class="setting-name">Property name</div>' +
                                         '<div class="setting-field new-property-name-container">' +
@@ -2052,14 +2052,14 @@
                                         '</div>' +
                                     '</div>' +
                                     '<div class="setting">' +
-                                        '<div class="setting-field new-property-sensitive-value-container">' +
-                                            '<div class="setting-name">Sensitive Value ' +
-                                                '<span class="fa fa-question-circle" alt="Info"' +
-                                                    ' title="Components must declare support for Sensitive Dynamic Properties to enable selection of Sensitive Value status.' +
-                                                    ' Components that flag dynamic properties as sensitive do not allow Sensitive Value status to be changed."' +
-                                                '>' +
-                                                '</span>' +
-                                            '</div>' +
+                                        '<div class="setting-name">Sensitive Value ' +
+                                            '<span class="fa fa-question-circle" alt="Info"' +
+                                                ' title="Components must declare support for Sensitive Dynamic Properties to enable selection of Sensitive Value status.' +
+                                                ' Components that flag dynamic properties as sensitive do not allow Sensitive Value status to be changed."' +
+                                            '>' +
+                                            '</span>' +
+                                        '</div>' +
+                                        '<div class="setting-field">' +
                                             '<input id="value-sensitive-radio-button" type="radio" name="sensitive" value="sensitive" /> Yes' +
                                             '<input id="value-not-sensitive-radio-button" type="radio" name="sensitive" value="plain" style="margin-left: 20px;"/> No' +
                                         '</div>' +

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -2044,7 +2044,7 @@
                         // build the new property dialog
                         var newPropertyDialogMarkup =
                             '<div id="new-property-dialog" class="dialog cancellable small-dialog hidden">' +
-                                '<div class="dialog-content">' +
+                                '<div class="dialog-content dialog-content-overflow-disabled">' +
                                     '<div class="setting">' +
                                         '<div class="setting-name">Property name</div>' +
                                         '<div class="setting-field new-property-name-container">' +
@@ -2054,11 +2054,11 @@
                                     '<div class="setting">' +
                                         '<div class="setting-field new-property-sensitive-value-container">' +
                                             '<div class="setting-name">Sensitive Value ' +
-                                                '<div class="fa fa-question-circle" alt="Info"' +
+                                                '<span class="fa fa-question-circle" alt="Info"' +
                                                     ' title="Components must declare support for Sensitive Dynamic Properties to enable selection of Sensitive Value status.' +
                                                     ' Components that flag dynamic properties as sensitive do not allow Sensitive Value status to be changed."' +
                                                 '>' +
-                                                '</div>' +
+                                                '</span>' +
                                             '</div>' +
                                             '<input id="value-sensitive-radio-button" type="radio" name="sensitive" value="sensitive" /> Yes' +
                                             '<input id="value-not-sensitive-radio-button" type="radio" name="sensitive" value="plain" style="margin-left: 20px;"/> No' +
@@ -2074,7 +2074,6 @@
 
                         newPropertyDialog.modal({
                             headerText: 'Add Property',
-                            scrollableContentStyle: 'scrollable',
                             buttons: [{
                                 buttonText: 'Ok',
                                 color: {
@@ -2120,38 +2119,38 @@
                                     }
                                 });
 
-                                // load the descriptor with requested sensitive status
-                                var sensitive = valueSensitiveField.prop('checked');
-                                options.descriptorDeferred(propertyName, sensitive).done(function (response) {
-                                    var descriptor = response.propertyDescriptor;
+                                if (existingItem === null || existingItem.hidden === true) {
+                                    // load the descriptor with requested sensitive status
+                                    var sensitive = valueSensitiveField.prop('checked');
+                                    options.descriptorDeferred(propertyName, sensitive).done(function (response) {
+                                        var descriptor = response.propertyDescriptor;
 
-                                    // store the descriptor for use later
-                                    var descriptors = table.data('descriptors');
-                                    if (!nfCommon.isUndefined(descriptors)) {
-                                        descriptors[descriptor.name] = descriptor;
-                                    }
+                                        // store the descriptor for use later
+                                        var descriptors = table.data('descriptors');
+                                        if (!nfCommon.isUndefined(descriptors)) {
+                                            descriptors[descriptor.name] = descriptor;
+                                        }
 
-                                    // add the property when existing item not found
-                                    if (existingItem === null) {
-                                        // add a row for the new property
-                                        var id = propertyData.getItems().length;
-                                        propertyData.addItem({
-                                            id: id,
-                                            hidden: false,
-                                            property: propertyName,
-                                            displayName: propertyName,
-                                            previousValue: null,
-                                            value: null,
-                                            type: 'userDefined'
-                                        });
+                                        // add the property when existing item not found
+                                        if (existingItem === null) {
+                                            // add a row for the new property
+                                            var id = propertyData.getItems().length;
+                                            propertyData.addItem({
+                                                id: id,
+                                                hidden: false,
+                                                property: propertyName,
+                                                displayName: propertyName,
+                                                previousValue: null,
+                                                value: null,
+                                                type: 'userDefined'
+                                            });
 
-                                        // select the new properties row
-                                        var row = propertyData.getRowById(id);
-                                        propertyGrid.setActiveCell(row, propertyGrid.getColumnIndex('value'));
-                                        propertyGrid.editActiveCell();
-                                    } else {
-                                        // if this row is currently hidden, clear the value and show it
-                                        if (existingItem.hidden === true) {
+                                            // select the new properties row
+                                            var row = propertyData.getRowById(id);
+                                            propertyGrid.setActiveCell(row, propertyGrid.getColumnIndex('value'));
+                                            propertyGrid.editActiveCell();
+                                        } else {
+                                            // if this row is currently hidden, clear the value and show it
                                             propertyData.updateItem(existingItem.id, $.extend(existingItem, {
                                                 hidden: false,
                                                 previousValue: null,
@@ -2164,21 +2163,18 @@
                                             propertyGrid.render();
                                             propertyGrid.setActiveCell(row, propertyGrid.getColumnIndex('value'));
                                             propertyGrid.editActiveCell();
-                                        } else {
-                                            nfDialog.showOkDialog({
-                                                headerText: 'Property Exists',
-                                                dialogContent: 'A property with this name already exists.'
-                                            });
-
-                                            // select the existing properties row
-                                            var row = propertyData.getRowById(existingItem.id);
-                                            propertyGrid.invalidateRow(row);
-                                            propertyGrid.render();
-                                            propertyGrid.setSelectedRows([row]);
-                                            propertyGrid.scrollRowIntoView(row);
                                         }
-                                    }
-                                });
+                                    });
+                                } else {
+                                    nfDialog.showOkDialog({
+                                        headerText: 'Property Exists',
+                                        dialogContent: 'A property with this name already exists.'
+                                    });
+                                    // select the existing properties row
+                                    var row = propertyData.getRowById(existingItem.id);
+                                    propertyGrid.setSelectedRows([row]);
+                                    propertyGrid.scrollRowIntoView(row);
+                                }
                             } else {
                                 nfDialog.showOkDialog({
                                     headerText: 'Property Name',

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -2053,7 +2053,13 @@
                                     '</div>' +
                                     '<div class="setting">' +
                                         '<div class="setting-field new-property-sensitive-value-container">' +
-                                            '<div class="setting-name">Sensitive Value</div>' +
+                                            '<div class="setting-name">Sensitive Value ' +
+                                                '<div class="fa fa-question-circle" alt="Info"' +
+                                                    ' title="Components must declare support for Sensitive Dynamic Properties to enable selection of Sensitive Value status.' +
+                                                    ' Components that flag dynamic properties as sensitive do not allow Sensitive Value status to be changed."' +
+                                                '>' +
+                                                '</div>' +
+                                            '</div>' +
                                             '<input id="value-sensitive-radio-button" type="radio" name="sensitive" value="sensitive" /> Yes' +
                                             '<input id="value-not-sensitive-radio-button" type="radio" name="sensitive" value="plain" style="margin-left: 20px;"/> No' +
                                         '</div>' +
@@ -2154,10 +2160,10 @@
 
                                             // select the new properties row
                                             var row = propertyData.getRowById(existingItem.id);
-                                            propertyGrid.setActiveCell(row, propertyGrid.getColumnIndex('value'));
-                                            propertyGrid.editActiveCell();
                                             propertyGrid.invalidateRow(row);
                                             propertyGrid.render();
+                                            propertyGrid.setActiveCell(row, propertyGrid.getColumnIndex('value'));
+                                            propertyGrid.editActiveCell();
                                         } else {
                                             nfDialog.showOkDialog({
                                                 headerText: 'Property Exists',
@@ -2166,10 +2172,10 @@
 
                                             // select the existing properties row
                                             var row = propertyData.getRowById(existingItem.id);
-                                            propertyGrid.setSelectedRows([row]);
-                                            propertyGrid.scrollRowIntoView(row);
                                             propertyGrid.invalidateRow(row);
                                             propertyGrid.render();
+                                            propertyGrid.setSelectedRows([row]);
+                                            propertyGrid.scrollRowIntoView(row);
                                         }
                                     }
                                 });

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
@@ -120,6 +120,7 @@
         if ($.isEmptyObject(properties) === false) {
             controllerServiceDto['properties'] = properties;
         }
+        controllerServiceDto['sensitiveDynamicPropertyNames'] = $('#controller-service-properties').propertytable('getSensitiveDynamicPropertyNames');
 
         // create the controller service entity
         var controllerServiceEntity = {};
@@ -1518,14 +1519,16 @@
      * Gets a property descriptor for the controller service currently being configured.
      *
      * @param {type} propertyName
+     * @param {type} sensitive Requested sensitive status
      */
-    var getControllerServicePropertyDescriptor = function (propertyName) {
+    var getControllerServicePropertyDescriptor = function (propertyName, sensitive) {
         var controllerServiceEntity = $('#controller-service-configuration').data('controllerServiceDetails');
         return $.ajax({
             type: 'GET',
             url: controllerServiceEntity.uri + '/descriptors',
             data: {
-                propertyName: propertyName
+                propertyName: propertyName,
+                sensitive: sensitive
             },
             dataType: 'json'
         }).fail(nfErrorHandler.handleAjaxError);
@@ -2113,6 +2116,7 @@
                 // load the property table
                 $('#controller-service-properties')
                     .propertytable('setGroupId', controllerService.parentGroupId)
+                    .propertytable('setSupportsSensitiveDynamicProperties', controllerService.supportsSensitiveDynamicProperties)
                     .propertytable('loadProperties', controllerService.properties, controllerService.descriptors, controllerServiceHistory.propertyHistory)
                     .propertytable('setPropertyVerificationCallback', function (proposedProperties) {
                         nfVerify.verify(controllerService['id'], controllerServiceEntity['uri'], proposedProperties, referencedAttributes, handleVerificationResults, $('#controller-service-properties-verification-results-listing'));
@@ -2257,6 +2261,7 @@
                 // load the property table
                 $('#controller-service-properties')
                     .propertytable('setGroupId', controllerService.parentGroupId)
+                    .propertytable('setSupportsSensitiveDynamicProperties', controllerService.supportsSensitiveDynamicProperties)
                     .propertytable('loadProperties', controllerService.properties, controllerService.descriptors, controllerServiceHistory.propertyHistory);
 
                 // show the details

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -387,6 +387,10 @@
             processorConfigDto['properties'] = properties;
         }
 
+        if (processor.supportsSensitiveDynamicProperties === true) {
+            processorConfigDto['sensitiveDynamicPropertyNames'] = $('#processor-properties').propertytable('getSensitiveDynamicPropertyNames');
+        }
+
         // create the processor dto
         var processorDto = {};
         processorDto['id'] = $('#processor-id').text();
@@ -697,14 +701,15 @@
                 readOnly: false,
                 supportsGoTo: true,
                 dialogContainer: '#new-processor-property-container',
-                descriptorDeferred: function (propertyName) {
+                descriptorDeferred: function (propertyName, sensitive) {
                     var processor = $('#processor-configuration').data('processorDetails');
                     var d = nfProcessor.get(processor.id);
                     return $.ajax({
                         type: 'GET',
                         url: d.uri + '/descriptors',
                         data: {
-                            propertyName: propertyName
+                            propertyName: propertyName,
+                            sensitive: sensitive
                         },
                         dataType: 'json'
                     }).fail(nfErrorHandler.handleAjaxError);
@@ -1094,6 +1099,7 @@
                     // load the property table
                     $('#processor-properties')
                         .propertytable('setGroupId', processor.parentGroupId)
+                        .propertytable('setSupportsSensitiveDynamicProperties', processor.supportsSensitiveDynamicProperties)
                         .propertytable('loadProperties', processor.config.properties, processor.config.descriptors, processorHistory.propertyHistory)
                         .propertytable('setPropertyVerificationCallback', function (proposedProperties) {
                             nfVerify.verify(processor['id'], processorResponse['uri'], proposedProperties, referencedAttributes, handleVerificationResults, $('#processor-properties-verification-results-listing'));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
@@ -168,6 +168,7 @@
         if ($.isEmptyObject(properties) === false) {
             reportingTaskDto['properties'] = properties;
         }
+        reportingTaskDto['sensitiveDynamicPropertyNames'] = $('#reporting-task-properties').propertytable('getSensitiveDynamicPropertyNames');
 
         // create the reporting task entity
         var reportingTaskEntity = {};
@@ -313,14 +314,16 @@
      * Gets a property descriptor for the controller service currently being configured.
      *
      * @param {type} propertyName
+     * @param {type} sensitive Requested sensitive status
      */
-    var getReportingTaskPropertyDescriptor = function (propertyName) {
+    var getReportingTaskPropertyDescriptor = function (propertyName, sensitive) {
         var details = $('#reporting-task-configuration').data('reportingTaskDetails');
         return $.ajax({
             type: 'GET',
             url: details.uri + '/descriptors',
             data: {
-                propertyName: propertyName
+                propertyName: propertyName,
+                sensitive: sensitive
             },
             dataType: 'json'
         }).fail(nfErrorHandler.handleAjaxError);
@@ -643,6 +646,7 @@
                 // load the property table
                 $('#reporting-task-properties')
                     .propertytable('setGroupId', null)
+                    .propertytable('setSupportsSensitiveDynamicProperties', reportingTask.supportsSensitiveDynamicProperties)
                     .propertytable('loadProperties', reportingTask.properties, reportingTask.descriptors, reportingTaskHistory.propertyHistory)
                     .propertytable('setPropertyVerificationCallback', function (proposedProperties) {
                         nfVerify.verify(reportingTask['id'], reportingTaskEntity['uri'], proposedProperties, referencedAttributes, handleVerificationResults, $('#reporting-task-properties-verification-results-listing'));
@@ -767,6 +771,7 @@
                 // load the property table
                 $('#reporting-task-properties')
                     .propertytable('setGroupId', null)
+                    .propertytable('setSupportsSensitiveDynamicProperties', reportingTask.supportsSensitiveDynamicProperties)
                     .propertytable('loadProperties', reportingTask.properties, reportingTask.descriptors, reportingTaskHistory.propertyHistory);
 
                 // show the details

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/reporting/script/ScriptedReportingTask.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/reporting/script/ScriptedReportingTask.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.behavior.Restriction;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -54,6 +55,7 @@ import java.util.Map;
 /**
  * A Reporting task whose body is provided by a script (via supported JSR-223 script engines)
  */
+@SupportsSensitiveDynamicProperties
 @Tags({"reporting", "script", "execute", "groovy", "python", "jython", "jruby", "ruby", "javascript", "js", "lua", "luaj"})
 @CapabilityDescription("Provides reporting and status information to a script. ReportingContext, ComponentLog, and VirtualMachineMetrics objects are made available "
         + "as variables (context, log, and vmMetrics, respectively) to the script for further processing. The context makes various information available such "

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
@@ -22,6 +22,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.nifi.annotation.behavior.DynamicProperties;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
@@ -70,6 +71,7 @@ import static org.apache.nifi.components.ConfigVerificationResult.Outcome.SUCCES
  * Implementation of for Database Connection Pooling Service. Apache DBCP is used for connection pooling functionality.
  *
  */
+@SupportsSensitiveDynamicProperties
 @Tags({ "dbcp", "jdbc", "database", "connection", "pooling", "store" })
 @CapabilityDescription("Provides Database Connection Pooling Service. Connections can be asked from pool and returned after usage.")
 @DynamicProperties({


### PR DESCRIPTION
# Summary

[NIFI-9959](https://issues.apache.org/jira/browse/NIFI-9959) Adds web user interface support for Sensitive Dynamic Properties in Processors, Controller Services, and Reporting Tasks based on framework support implemented in #6057 for NIFI-9958.

The implementation applies the `SupportsSensitiveDynamicProperties` annotation to `DBCPConnectionPool` and `ScriptedReportingTask` to enable evaluation of component types in addition to `InvokeHTTP`.

The UI implementation adds a new `Sensitive Value` field to the New Property dialog with radio button selections for `Yes` and `No`. The implementation follows the same approach as the `Sensitive Value` field in Parameter definitions. The internal processing collects sensitive dynamic property names for sending to the REST API on each invocation.

Components that do not support sensitive dynamic properties will show the `No` value selected, and the radio buttons will be disabled.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
