### PR TITLE
NIFI-10057: Add support for SQL Server's DATETIMEOFFSET type to ExecuteSQL processors

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -526,6 +526,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             case Types.TIMESTAMP_WITH_TIMEZONE:
             case -101: // Oracle's TIMESTAMP WITH TIME ZONE
             case -102: // Oracle's TIMESTAMP WITH LOCAL TIME ZONE
+            case -155: // SQL Server's DATETIMEOFFSET
                 return getRecordFieldType(TIMESTAMP, useLogicalTypes);
         }
 

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -635,6 +635,7 @@ public class JdbcCommon {
                 case TIMESTAMP_WITH_TIMEZONE:
                 case -101: // Oracle's TIMESTAMP WITH TIME ZONE
                 case -102: // Oracle's TIMESTAMP WITH LOCAL TIME ZONE
+                case -155: // SQL Server's DATETIMEOFFSET
                     addNullableField(builder, columnName,
                             u -> options.useLogicalTypes
                                     ? u.type(LogicalTypes.timestampMillis().addToSchema(SchemaBuilder.builder().longType()))


### PR DESCRIPTION

# Summary

[NIFI-10057](https://issues.apache.org/jira/browse/NIFI-10057) This PR adds support for MSSQL's DATETIMEOFFSET type by treating it as a timestamp so the driver can do the conversion to a standard Timestamp object.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
