### PR TITLE
NIFI-10054: Improve SendTrapSNMP error handling

### DIFF
--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandlerTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SendTrapSNMPHandlerTest.java
@@ -18,6 +18,7 @@ package org.apache.nifi.snmp.operations;
 
 import org.apache.nifi.snmp.configuration.V1TrapConfiguration;
 import org.apache.nifi.snmp.configuration.V2TrapConfiguration;
+import org.apache.nifi.snmp.exception.SNMPException;
 import org.apache.nifi.snmp.factory.trap.V1TrapPDUFactory;
 import org.apache.nifi.snmp.factory.trap.V2TrapPDUFactory;
 import org.apache.nifi.util.MockComponentLog;
@@ -27,12 +28,16 @@ import org.junit.Test;
 import org.snmp4j.PDU;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
+import org.snmp4j.event.ResponseEvent;
+import org.snmp4j.smi.TransportIpAddress;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,6 +47,7 @@ public class SendTrapSNMPHandlerTest {
     private Target mockTarget;
     private Snmp mockSnmpManager;
     private PDU mockPdu;
+    private ResponseEvent mockResponseEvent;
     private MockComponentLog mockComponentLog;
     private V1TrapConfiguration mockV1TrapConfiguration;
     private V2TrapConfiguration mockV2TrapConfiguration;
@@ -49,10 +55,11 @@ public class SendTrapSNMPHandlerTest {
     private SendTrapSNMPHandler sendTrapSNMPHandler;
 
     @Before
-    public void init() {
+    public void init() throws IOException {
         mockTarget = mock(Target.class);
         mockSnmpManager = mock(Snmp.class);
         mockPdu = mock(PDU.class);
+        mockResponseEvent = mock(ResponseEvent.class);
         mockComponentLog = new MockComponentLog("id", new Object());
         mockV1TrapConfiguration = mock(V1TrapConfiguration.class);
         mockV2TrapConfiguration = mock(V2TrapConfiguration.class);
@@ -60,6 +67,8 @@ public class SendTrapSNMPHandlerTest {
         when(mockV1TrapPDUFactory.get(mockV1TrapConfiguration)).thenReturn(mockPdu);
         V2TrapPDUFactory mockV2TrapPDUFactory = mock(V2TrapPDUFactory.class);
         when(mockV2TrapPDUFactory.get(mockV2TrapConfiguration)).thenReturn(mockPdu);
+
+        when(mockSnmpManager.send(mockPdu, mockTarget)).thenReturn(mockResponseEvent);
 
         snmpResourceHandler = new SNMPResourceHandler(mockSnmpManager, mockTarget);
 
@@ -105,5 +114,35 @@ public class SendTrapSNMPHandlerTest {
 
         final String expectedDebugLog = "{} No optional SNMP specific variables found in flowfile.";
         assertEquals(expectedDebugLog, mockComponentLog.getDebugMessages().get(0).getMsg());
+    }
+
+    @Test
+    public void testSendTrapToInvalidPort() throws IOException {
+        when(mockSnmpManager.send(mockPdu, mockTarget)).thenReturn(null);
+        final TransportIpAddress mockAddress = mock(TransportIpAddress.class);
+        final int port = 55555;
+        when(mockAddress.getPort()).thenReturn(port);
+        when(mockTarget.getAddress()).thenReturn(mockAddress);
+
+        final String flowFileOid = "1.3.6.1.2.1.1.1.0";
+        Exception e = assertThrows(IOException.class,
+                () -> sendTrapSNMPHandler.sendTrap(Collections.singletonMap("snmp$" + flowFileOid, "OID value"), mockV2TrapConfiguration)
+        );
+
+        assertTrue(e.getMessage().contains(String.valueOf(port)));
+    }
+
+    @Test
+    public void testSendTrapInvalidResponse() throws IOException {
+        final String trapSnmpError = "Test Trap SNMP Error";
+        when(mockResponseEvent.getError()).thenReturn(new SNMPException(trapSnmpError));
+        when(mockSnmpManager.send(mockPdu, mockTarget)).thenReturn(mockResponseEvent);
+
+        final String flowFileOid = "1.3.6.1.2.1.1.1.0";
+        Exception e = assertThrows(IOException.class,
+                () -> sendTrapSNMPHandler.sendTrap(Collections.singletonMap("snmp$" + flowFileOid, "OID value"), mockV2TrapConfiguration)
+        );
+
+        assertTrue(e.getCause().getMessage().contains(trapSnmpError));
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

SendTrapSNMP handles when sends trap to invalid port and when SNMP specific errors occur.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10054) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
