### PR TITLE
NIFI-10071: Adding support for HashiCorp Vault K/V version 2 Secrets …

### DIFF
--- a/nifi-commons/nifi-vault-utils/src/main/java/org/apache/nifi/vault/hashicorp/HashiCorpVaultCommunicationService.java
+++ b/nifi-commons/nifi-vault-utils/src/main/java/org/apache/nifi/vault/hashicorp/HashiCorpVaultCommunicationService.java
@@ -46,39 +46,39 @@ public interface HashiCorpVaultCommunicationService {
     byte[] decrypt(String transitPath, String cipherText);
 
     /**
-     * Writes a single secret value using Vault's unversioned Key/Value Secrets Engine.
+     * Writes a single secret value using Vault's Key/Value Secrets Engine.
      *
-     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv/kv-v1">https://www.vaultproject.io/api-docs/secret/kv/kv-v1</a>
-     * @param keyValuePath The Vault path to use for the configured Key/Value v1 Secrets Engine
+     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv">https://www.vaultproject.io/api-docs/secret/kv</a>
+     * @param keyValuePath The Vault path to use for the configured Key/Value Secrets Engine
      * @param secretKey The secret key
      * @param value The secret value
      */
     void writeKeyValueSecret(String keyValuePath, String secretKey, String value);
 
     /**
-     * Reads a single secret value from Vault's unversioned Key/Value Secrets Engine.
+     * Reads a single secret value from Vault's Key/Value Secrets Engine.
      *
-     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv/kv-v1">https://www.vaultproject.io/api-docs/secret/kv/kv-v1</a>
-     * @param keyValuePath The Vault path to use for the configured Key/Value v1 Secrets Engine
+     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv">https://www.vaultproject.io/api-docs/secret/kv</a>
+     * @param keyValuePath The Vault path to use for the configured Key/Value Secrets Engine
      * @param secretKey The secret key
      * @return The secret value, or empty if not found
      */
     Optional<String> readKeyValueSecret(String keyValuePath, String secretKey);
 
     /**
-     * Writes a secret with multiple key/value pairs using Vault's unversioned Key/Value Secrets Engine.
+     * Writes a secret with multiple key/value pairs using Vault's Key/Value Secrets Engine.
      *
-     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv/kv-v1">https://www.vaultproject.io/api-docs/secret/kv/kv-v1</a>
-     * @param keyValuePath The Vault path to use for the configured Key/Value v1 Secrets Engine
+     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv">https://www.vaultproject.io/api-docs/secret/kv</a>
+     * @param keyValuePath The Vault path to use for the configured Key/Value Secrets Engine
      * @param keyValues A map from key to value for keys/values that should be stored in the secret
      */
     void writeKeyValueSecretMap(String keyValuePath, String secretKey, Map<String, String> keyValues);
 
     /**
-     * Reads a secret with multiple key/value pairs from Vault's unversioned Key/Value Secrets Engine.
+     * Reads a secret with multiple key/value pairs from Vault's Key/Value Secrets Engine.
      *
-     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv/kv-v1">https://www.vaultproject.io/api-docs/secret/kv/kv-v1</a>
-     * @param keyValuePath The Vault path to use for the configured Key/Value v1 Secrets Engine
+     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv">https://www.vaultproject.io/api-docs/secret/kv</a>
+     * @param keyValuePath The Vault path to use for the configured Key/Value Secrets Engine
      * @param secretKey The secret key
      * @return A map from key to value from the secret key/values, or an empty map if not found
      */

--- a/nifi-commons/nifi-vault-utils/src/main/java/org/apache/nifi/vault/hashicorp/config/lookup/BeanPropertyLookup.java
+++ b/nifi-commons/nifi-vault-utils/src/main/java/org/apache/nifi/vault/hashicorp/config/lookup/BeanPropertyLookup.java
@@ -44,9 +44,14 @@ public class BeanPropertyLookup extends PropertyLookup {
                 .filter(pd -> pd.getReadMethod().getAnnotation(HashiCorpVaultProperty.class) != null)
                 .collect(Collectors.toMap(
                         pd -> getPropertyKey(prefix, pd),
-                        pd -> pd.getReadMethod().getReturnType().equals(String.class) ? new ValuePropertyLookup(pd)
+                        pd -> isValueProperty(pd) ? new ValuePropertyLookup(pd)
                                 : new BeanPropertyLookup(getPropertyKey(prefix, pd), pd.getReadMethod().getReturnType(), pd)
                 ));
+    }
+
+    private boolean isValueProperty(final PropertyDescriptor propertyDescriptor) {
+        final Class<?> returnType = propertyDescriptor.getReadMethod().getReturnType();
+        return returnType.equals(String.class) || returnType.isPrimitive();
     }
 
     private static String getPropertyKey(final String prefix, final PropertyDescriptor propertyDescriptor) {

--- a/nifi-commons/nifi-vault-utils/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultConfiguration.java
+++ b/nifi-commons/nifi-vault-utils/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultConfiguration.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultKeyValueOperationsSupport;
 import org.springframework.vault.support.SslConfiguration;
 
 import java.io.File;
@@ -132,6 +133,29 @@ public class TestHashiCorpVaultConfiguration {
     @Test
     public void testBasicProperties() {
         this.runTest("http");
+    }
+
+    @Test
+    public void testKvVersion() {
+        config = new HashiCorpVaultConfiguration(new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+        assertEquals(VaultKeyValueOperationsSupport.KeyValueBackend.KV_1, config.getKeyValueBackend());
+
+        propertiesBuilder.setKvVersion(2);
+        config = new HashiCorpVaultConfiguration(new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+        assertEquals(VaultKeyValueOperationsSupport.KeyValueBackend.KV_2, config.getKeyValueBackend());
+
+        propertiesBuilder.setKvVersion(1);
+        config = new HashiCorpVaultConfiguration(new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+        assertEquals(VaultKeyValueOperationsSupport.KeyValueBackend.KV_1, config.getKeyValueBackend());
+    }
+
+    @Test
+    public void testKvVersionInvalid() {
+        propertiesBuilder.setKvVersion(0);
+        assertThrows(HashiCorpVaultConfigurationException.class, () -> new HashiCorpVaultConfiguration(new HashiCorpVaultPropertySource(propertiesBuilder.build())));
+
+        propertiesBuilder.setKvVersion(3);
+        assertThrows(HashiCorpVaultConfigurationException.class, () -> new HashiCorpVaultConfiguration(new HashiCorpVaultPropertySource(propertiesBuilder.build())));
     }
 
     @Test

--- a/nifi-commons/nifi-vault-utils/src/test/java/org/apache/nifi/vault/hashicorp/TestStandardHashiCorpVaultCommunicationService.java
+++ b/nifi-commons/nifi-vault-utils/src/test/java/org/apache/nifi/vault/hashicorp/TestStandardHashiCorpVaultCommunicationService.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.mockito.Mockito.when;
+
 public class TestStandardHashiCorpVaultCommunicationService {
     public static final String URI_VALUE = "http://127.0.0.1:8200";
     public static final String CIPHER_SUITE_VALUE = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384";
@@ -47,9 +49,10 @@ public class TestStandardHashiCorpVaultCommunicationService {
         properties = Mockito.mock(HashiCorpVaultProperties.class);
         sslProperties = Mockito.mock(HashiCorpVaultSslProperties.class);
 
-        Mockito.when(properties.getUri()).thenReturn(URI_VALUE);
-        Mockito.when(properties.getAuthPropertiesFilename()).thenReturn(authProps.getAbsolutePath());
-        Mockito.when(properties.getSsl()).thenReturn(sslProperties);
+        when(properties.getUri()).thenReturn(URI_VALUE);
+        when(properties.getAuthPropertiesFilename()).thenReturn(authProps.getAbsolutePath());
+        when(properties.getSsl()).thenReturn(sslProperties);
+        when(properties.getKvVersion()).thenReturn(1);
     }
 
     @AfterEach
@@ -88,8 +91,8 @@ public class TestStandardHashiCorpVaultCommunicationService {
 
     @Test
     public void testTimeouts() {
-        Mockito.when(properties.getConnectionTimeout()).thenReturn(Optional.of("20 secs"));
-        Mockito.when(properties.getReadTimeout()).thenReturn(Optional.of("40 secs"));
+        when(properties.getConnectionTimeout()).thenReturn(Optional.of("20 secs"));
+        when(properties.getReadTimeout()).thenReturn(Optional.of("40 secs"));
         this.configureService();
     }
 
@@ -97,17 +100,17 @@ public class TestStandardHashiCorpVaultCommunicationService {
     public void testTLS() {
         TlsConfiguration tlsConfiguration = new TemporaryKeyStoreBuilder().build();
 
-        Mockito.when(sslProperties.getKeyStore()).thenReturn(tlsConfiguration.getKeystorePath());
-        Mockito.when(sslProperties.getKeyStorePassword()).thenReturn(tlsConfiguration.getKeystorePassword());
-        Mockito.when(sslProperties.getKeyStoreType()).thenReturn(tlsConfiguration.getKeystoreType().getType());
-        Mockito.when(sslProperties.getTrustStore()).thenReturn(tlsConfiguration.getTruststorePath());
-        Mockito.when(sslProperties.getTrustStorePassword()).thenReturn(tlsConfiguration.getTruststorePassword());
-        Mockito.when(sslProperties.getTrustStoreType()).thenReturn(tlsConfiguration.getTruststoreType().getType());
-        Mockito.when(sslProperties.getEnabledProtocols()).thenReturn(Arrays.stream(tlsConfiguration.getEnabledProtocols())
+        when(sslProperties.getKeyStore()).thenReturn(tlsConfiguration.getKeystorePath());
+        when(sslProperties.getKeyStorePassword()).thenReturn(tlsConfiguration.getKeystorePassword());
+        when(sslProperties.getKeyStoreType()).thenReturn(tlsConfiguration.getKeystoreType().getType());
+        when(sslProperties.getTrustStore()).thenReturn(tlsConfiguration.getTruststorePath());
+        when(sslProperties.getTrustStorePassword()).thenReturn(tlsConfiguration.getTruststorePassword());
+        when(sslProperties.getTrustStoreType()).thenReturn(tlsConfiguration.getTruststoreType().getType());
+        when(sslProperties.getEnabledProtocols()).thenReturn(Arrays.stream(tlsConfiguration.getEnabledProtocols())
                 .collect(Collectors.joining(",")));
-        Mockito.when(sslProperties.getEnabledCipherSuites()).thenReturn(CIPHER_SUITE_VALUE);
+        when(sslProperties.getEnabledCipherSuites()).thenReturn(CIPHER_SUITE_VALUE);
 
-        Mockito.when(properties.getUri()).thenReturn(URI_VALUE.replace("http", "https"));
+        when(properties.getUri()).thenReturn(URI_VALUE.replace("http", "https"));
         this.configureService();
 
         this.ensureTlsPropertiesAccessed(1);

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -1852,6 +1852,7 @@ Following are the configuration properties available inside the `bootstrap-hashi
 [options="header,footer"]
 |===
 |Property Name|Description|Default
+|`vault.kv.version`|The Key/Value Secrets Engine version: `1` for unversioned, and `2` for versioned.  This must match the versioned enabled in Vault.|`1`
 |`vault.connection.timeout`|The connection timeout of the Vault client|`5 secs`
 |`vault.read.timeout`|The read timeout of the Vault client|`15 secs`
 |`vault.ssl.enabledCipherSuites`|A comma-separated list of the enabled TLS cipher suites|_none_

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap-hashicorp-vault.conf
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap-hashicorp-vault.conf
@@ -23,6 +23,8 @@ vault.transit.path=
 
 # Key/Value Path is required to enable the Sensitive Properties Provider Protection Scheme 'hashicorp/vault/kv/{path}'
 vault.kv.path=
+# Key/Value Secrets Engine version may be 1 or 2, and defaults to 1
+# vault.kv.version=1
 
 # Token Authentication example properties
 # vault.authentication=TOKEN

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/bootstrap-hashicorp-vault.conf
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/bootstrap-hashicorp-vault.conf
@@ -23,6 +23,8 @@ vault.transit.path=
 
 # Key/Value Path is required to enable the Sensitive Properties Provider Protection Scheme 'hashicorp/vault/kv/{path}'
 vault.kv.path=
+# Key/Value Secrets Engine version may be 1 or 2, and defaults to 1
+# vault.kv.version=1
 
 # Token Authentication example properties
 # vault.authentication=TOKEN


### PR DESCRIPTION
…Engine

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10071](https://issues.apache.org/jira/browse/NIFI-10071) Currently, only K/V version 1 is supported in the `StandardHashiCorpVaultCommunicationService`.  This PR will allow K/V version 2 Secrets Engine to be used in Vault when configured with a new `vault.kv.version` property.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
