### PR TITLE
NIFI-6943 Set DataDogReportingTask API Key Property as Sensitive

### DIFF
--- a/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
+++ b/nifi-nar-bundles/nifi-datadog-bundle/nifi-datadog-reporting-task/src/test/java/org/apache/nifi/reporting/datadog/TestDataDogReportingTask.java
@@ -16,12 +16,12 @@
  */
 package org.apache.nifi.reporting.datadog;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.status.ProcessGroupStatus;
 import org.apache.nifi.controller.status.ProcessorStatus;
 import org.apache.nifi.metrics.jvm.JmxJvmMetrics;
+import org.apache.nifi.mock.MockComponentLogger;
 import org.apache.nifi.reporting.EventAccess;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.reporting.ReportingContext;
@@ -30,21 +30,20 @@ import org.apache.nifi.reporting.datadog.metrics.MetricsService;
 import org.apache.nifi.util.MockPropertyValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 public class TestDataDogReportingTask {
 
@@ -53,13 +52,10 @@ public class TestDataDogReportingTask {
     private ConcurrentHashMap<String, Double> metricsMap;
     private MetricRegistry metricRegistry;
     private MetricsService metricsService;
-    private String env = "dev";
-    private String prefix = "nifi";
     private ReportingContext context;
     private ReportingInitializationContext initContext;
     private ConfigurationContext configurationContext;
     private volatile JmxJvmMetrics virtualMachineMetrics;
-    private Logger logger;
 
     @BeforeEach
     public void setup() {
@@ -68,49 +64,43 @@ public class TestDataDogReportingTask {
         initContexts();
     }
 
-    //init all contexts
     private void initContexts() {
-        configurationContext = Mockito.mock(ConfigurationContext.class);
-        context = Mockito.mock(ReportingContext.class);
-        Mockito.when(context.getProperty(DataDogReportingTask.ENVIRONMENT))
-                .thenReturn(new MockPropertyValue(env, null));
-        Mockito.when(context.getProperty(DataDogReportingTask.METRICS_PREFIX))
-                .thenReturn(new MockPropertyValue(prefix, null));
-        Mockito.when(context.getProperty(DataDogReportingTask.API_KEY))
+        configurationContext = mock(ConfigurationContext.class);
+        context = mock(ReportingContext.class);
+        when(context.getProperty(DataDogReportingTask.ENVIRONMENT))
+                .thenReturn(new MockPropertyValue("dev", null));
+        when(context.getProperty(DataDogReportingTask.METRICS_PREFIX))
+                .thenReturn(new MockPropertyValue("nifi", null));
+        when(context.getProperty(DataDogReportingTask.API_KEY))
                 .thenReturn(new MockPropertyValue("agent", null));
-        Mockito.when(context.getProperty(DataDogReportingTask.DATADOG_TRANSPORT))
+        when(context.getProperty(DataDogReportingTask.DATADOG_TRANSPORT))
                 .thenReturn(new MockPropertyValue("DataDog Agent", null));
-        EventAccess eventAccess = Mockito.mock(EventAccess.class);
-        Mockito.when(eventAccess.getControllerStatus()).thenReturn(status);
-        Mockito.when(context.getEventAccess()).thenReturn(eventAccess);
+        EventAccess eventAccess = mock(EventAccess.class);
+        when(eventAccess.getControllerStatus()).thenReturn(status);
+        when(context.getEventAccess()).thenReturn(eventAccess);
 
-        logger = Mockito.mock(Logger.class);
-        initContext = Mockito.mock(ReportingInitializationContext.class);
-        Mockito.when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
-        //Mockito.when(initContext.getLogger()).thenReturn(logger);
+        initContext = mock(ReportingInitializationContext.class);
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(initContext.getLogger()).thenReturn(new MockComponentLogger());
         metricsMap = new ConcurrentHashMap<>();
-        metricRegistry = Mockito.mock(MetricRegistry.class);
+        metricRegistry = mock(MetricRegistry.class);
         virtualMachineMetrics = JmxJvmMetrics.getInstance();
-        metricsService = Mockito.mock(MetricsService.class);
-
+        metricsService = mock(MetricsService.class);
     }
 
-    //test onTrigger method
     @Test
-    public void testOnTrigger() throws InitializationException, IOException {
+    public void testOnTrigger() throws InitializationException {
         DataDogReportingTask dataDogReportingTask = new TestableDataDogReportingTask();
         dataDogReportingTask.initialize(initContext);
         dataDogReportingTask.setup(configurationContext);
         dataDogReportingTask.onTrigger(context);
 
-        verify(metricsService, atLeast(1)).getProcessorMetrics(Mockito.<ProcessorStatus>any());
-        verify(metricsService, atLeast(1)).getJVMMetrics(Mockito.<JmxJvmMetrics>any());
+        verify(metricsService, atLeast(1)).getProcessorMetrics(any());
+        verify(metricsService, atLeast(1)).getJVMMetrics(any());
     }
 
-
-    //test updating metrics of processors
     @Test
-    public void testUpdateMetricsProcessor() throws InitializationException, IOException {
+    public void testUpdateMetricsProcessor() throws InitializationException {
         MetricsService ms = new MetricsService();
         Map<String, Double> processorMetrics = ms.getProcessorMetrics(procStatus);
         Map<String, String> tagsMap = Collections.singletonMap("env", "test");
@@ -119,16 +109,15 @@ public class TestDataDogReportingTask {
         dataDogReportingTask.setup(configurationContext);
         dataDogReportingTask.updateMetrics(processorMetrics, tagsMap);
 
-        verify(metricRegistry).register(eq("nifi.FlowFilesReceivedLast5Minutes"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.ActiveThreads"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.BytesWrittenLast5Minutes"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.BytesReadLast5Minutes"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.FlowFilesSentLast5Minutes"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.FlowFilesReceivedLast5Minutes"), any());
+        verify(metricRegistry).register(eq("nifi.ActiveThreads"), any());
+        verify(metricRegistry).register(eq("nifi.BytesWrittenLast5Minutes"), any());
+        verify(metricRegistry).register(eq("nifi.BytesReadLast5Minutes"), any());
+        verify(metricRegistry).register(eq("nifi.FlowFilesSentLast5Minutes"), any());
     }
 
-    //test updating JMV metrics
     @Test
-    public void testUpdateMetricsJVM() throws InitializationException, IOException {
+    public void testUpdateMetricsJVM() throws InitializationException {
         MetricsService ms = new MetricsService();
         Map<String, Double> processorMetrics = ms.getJVMMetrics(virtualMachineMetrics);
         Map<String, String> tagsMap = Collections.singletonMap("env", "test");
@@ -138,18 +127,17 @@ public class TestDataDogReportingTask {
         dataDogReportingTask.setup(configurationContext);
 
         dataDogReportingTask.updateMetrics(processorMetrics, tagsMap);
-        verify(metricRegistry).register(eq("nifi.jvm.heap_usage"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.thread_count"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.thread_states.terminated"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.heap_used"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.thread_states.runnable"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.thread_states.timed_waiting"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.uptime"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.daemon_thread_count"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.file_descriptor_usage"), Mockito.<Gauge>any());
-        verify(metricRegistry).register(eq("nifi.jvm.thread_states.blocked"), Mockito.<Gauge>any());
+        verify(metricRegistry).register(eq("nifi.jvm.heap_usage"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_count"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.terminated"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.heap_used"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.runnable"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.timed_waiting"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.uptime"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.daemon_thread_count"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.file_descriptor_usage"), any());
+        verify(metricRegistry).register(eq("nifi.jvm.thread_states.blocked"), any());
     }
-
 
     private void initProcessGroupStatus() {
         status = new ProcessGroupStatus();
@@ -209,5 +197,4 @@ public class TestDataDogReportingTask {
         }
 
     }
-
 }


### PR DESCRIPTION
# Summary

[NIFI-6943](https://issues.apache.org/jira/browse/NIFI-6943) Sets the `API Key` property in `DataDogReportingTask` as sensitive, corrects logger handling, and improves unit test methods.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
