### PR TITLE
NIFI-10086 Upgrade Spring Framework from 5.3.19 to 5.3.20

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <jax.rs.api.version>2.1</jax.rs.api.version>
-        <spring.boot.version>2.6.7</spring.boot.version>
+        <spring.boot.version>2.7.0</spring.boot.version>
         <flyway.version>8.4.2</flyway.version>
         <flyway.tests.version>7.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,8 @@
         <mockito.version>3.11.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <netty.4.version>4.1.77.Final</netty.4.version>
-        <spring.version>5.3.19</spring.version>
-        <spring.security.version>5.6.3</spring.security.version>
+        <spring.version>5.3.20</spring.version>
+        <spring.security.version>5.7.1</spring.security.version>
         <h2.version>2.1.210</h2.version>
     </properties>
 


### PR DESCRIPTION
# Summary

[NIFI-10086](https://issues.apache.org/jira/browse/NIFI-10086) Upgrades Spring Framework dependencies from 5.3.19 to [5.3.20](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.20) and upgrades Spring Security from 5.6.3 to [5.7.1](https://github.com/spring-projects/spring-security/releases/tag/5.7.1). Changes also include upgrading Spring Boot from 2.6.7 to [2.7.0](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.0) for NiFi Registry.

These upgrades include several fixes that resolve associated vulnerabilities which do not appear to impact NiFi directly.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
