### PR TITLE
NIFI-10079 Upgrade ZooKeeper from 3.5.9 to 3.8.0

### DIFF
--- a/nifi-external/nifi-spark-receiver/pom.xml
+++ b/nifi-external/nifi-spark-receiver/pom.xml
@@ -22,9 +22,6 @@
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-spark-receiver</artifactId>
-    <properties>
-        <zookeeper.version>3.5.9</zookeeper.version>
-    </properties>
     <dependencyManagement>
         <dependencies>
             <!-- Override commons-compress -->

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -175,6 +175,16 @@
             <artifactId>nifi-flowfile-repo-serialization</artifactId>
             <version>1.17.0-SNAPSHOT</version>
         </dependency>
+        <!-- metrics-core required for ZooKeeper Server -->
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <!-- snappy-java required for ZooKeeper Server -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/server/ZooKeeperStateServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/server/ZooKeeperStateServer.java
@@ -118,7 +118,8 @@ public class ZooKeeperStateServer extends ZooKeeperServerMain {
             embeddedZkServer.setMaxSessionTimeout(config.getMaxSessionTimeout());
 
             connectionFactory = ServerCnxnFactory.createFactory();
-            connectionFactory.configure(getAvailableSocketAddress(config), config.getMaxClientCnxns(), quorumPeerConfig.isSslQuorum());
+            final int listenBacklog = quorumPeerConfig.getClientPortListenBacklog();
+            connectionFactory.configure(getAvailableSocketAddress(config), config.getMaxClientCnxns(), listenBacklog, quorumPeerConfig.isSslQuorum());
             connectionFactory.startup(embeddedZkServer);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -136,7 +137,8 @@ public class ZooKeeperStateServer extends ZooKeeperServerMain {
         try {
             transactionLog = new FileTxnSnapLog(quorumPeerConfig.getDataLogDir(), quorumPeerConfig.getDataDir());
             connectionFactory = ServerCnxnFactory.createFactory();
-            connectionFactory.configure(getAvailableSocketAddress(quorumPeerConfig), quorumPeerConfig.getMaxClientCnxns(), quorumPeerConfig.isSslQuorum());
+            final int listenBacklog = quorumPeerConfig.getClientPortListenBacklog();
+            connectionFactory.configure(getAvailableSocketAddress(quorumPeerConfig), quorumPeerConfig.getMaxClientCnxns(), listenBacklog, quorumPeerConfig.isSslQuorum());
 
             quorumPeer = new QuorumPeer();
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/leader/election/ITSecureClientZooKeeperFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/leader/election/ITSecureClientZooKeeperFactory.java
@@ -194,7 +194,7 @@ public class ITSecureClientZooKeeperFactory {
 
         ZooKeeperServer zkServer = new ZooKeeperServer(dataDir.toFile(), dataDir.toFile(), 2000);
         ServerCnxnFactory secureConnectionFactory = ServerCnxnFactory.createFactory(clientPort, -1);
-        secureConnectionFactory.configure(new InetSocketAddress(clientPort), -1, true);
+        secureConnectionFactory.configure(new InetSocketAddress(clientPort), -1, -1, true);
         secureConnectionFactory.startup(zkServer);
 
         return secureConnectionFactory;

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -24,7 +24,6 @@
     <description>NiFi: Framework Bundle</description>
     <properties>
         <curator.version>5.2.1</curator.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
     </properties>
     <modules>
         <module>nifi-framework</module>
@@ -534,6 +533,12 @@
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>3.3.0</version>
+            </dependency>
+            <!-- metrics-core marked as provided in zookeeper -->
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>4.1.12.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -109,7 +109,6 @@
         <hive.version>${hive3.version}</hive.version>
         <calcite.version>1.27.0</calcite.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
     </properties>
 
     <build>

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-ranger-bundle</artifactId>
     <packaging>pom</packaging>
 
-    <properties>
-        <zookeeper.version>3.5.9</zookeeper.version>
-    </properties>
-
     <modules>
         <module>nifi-ranger-plugin</module>
         <module>nifi-ranger-nar</module>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -23,10 +23,6 @@
     <artifactId>nifi-spark-bundle</artifactId>
     <packaging>pom</packaging>
 
-    <properties>
-        <zookeeper.version>3.5.9</zookeeper.version>
-    </properties>
-
     <modules>
         <module>nifi-livy-nar</module>
         <module>nifi-livy-controller-service-api-nar</module>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
@@ -24,7 +24,6 @@
     <packaging>pom</packaging>
     <properties>
         <hadoop.version>2.7.3</hadoop.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
     </properties>
     <modules>
         <module>nifi-hbase_1_1_2-client-service</module>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -26,7 +26,6 @@
 
     <properties>
         <hbase.version>2.2.2</hbase.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
     </properties>
 
     <modules>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
@@ -24,10 +24,6 @@
     <artifactId>nifi-registry-ranger</artifactId>
     <packaging>pom</packaging>
 
-    <properties>
-        <zookeeper.version>3.5.9</zookeeper.version>
-    </properties>
-
     <modules>
         <module>nifi-registry-ranger-assembly</module>
         <module>nifi-registry-ranger-jersey-bundle</module>

--- a/nifi-toolkit/nifi-toolkit-zookeeper-migrator/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-zookeeper-migrator/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <properties>
         <curator.version>5.2.1</curator.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <spring.version>5.3.19</spring.version>
         <spring.security.version>5.6.3</spring.security.version>
         <h2.version>2.1.210</h2.version>
+        <zookeeper.version>3.8.0</zookeeper.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
# Summary

[NIFI-10079](https://issues.apache.org/jira/browse/NIFI-10079) Upgrades ZooKeeper from 3.5.9 to 3.8.0 for framework and extension components.

ZooKeeper 3.5.9 is no longer supported as of 2022-06-01 according to [Apache ZooKeeper Releases](https://zookeeper.apache.org/releases.html) documentation. The documentation also indicates compatibility between 3.8.0 clients and servers running 3.5 or higher:

> ZooKeeper clients from 3.5.x onwards are fully compatible with 3.8.x servers.
ZooKeeper 3.8.x clients are compatible with 3.5.x, 3.6.x and 3.7.x servers as long as you are not using new APIs not present these versions.

Upgrading to ZooKeeper 3.8.0 required adjustments to the maintain support for the embedded ZooKeeper Server, with the addition of a required connection backlog argument to `ServerCnxnFactory.configure()`. The embedded ZooKeeper 3.8.0 Server also requires `metrics-core` and `snappy-java` dependencies, which are marked as `provided` in the `zookeeper` Maven configuration, requiring direct dependency additions to `nifi-framework-core`. Previous versions included these dependencies without the `provided` scope, and existing LICENSE and NOTICE files list these dependencies.

Running the `nifi-system-test-suite` confirmed successful cluster operation with the embedded ZooKeeper 3.8.0 server. Initial testing with an external ZooKeeper 3.5.9 cluster also worked as expected.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
