### PR TITLE
NIFI-10088 Set SSH Transport Timeout using SFTP Data Timeout

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientProvider.java
@@ -20,6 +20,7 @@ import net.schmizz.keepalive.KeepAlive;
 import net.schmizz.sshj.Config;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.connection.Connection;
+import net.schmizz.sshj.transport.Transport;
 import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 import net.schmizz.sshj.userauth.keyprovider.KeyFormat;
@@ -145,6 +146,12 @@ public class StandardSSHClientProvider implements SSHClientProvider {
 
         final int dataTimeout = context.getProperty(DATA_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
         client.setTimeout(dataTimeout);
+
+        // Set Transport and Connection timeouts using Socket Data Timeout property
+        final Transport transport = client.getTransport();
+        transport.setTimeoutMs(dataTimeout);
+        final Connection connection = client.getConnection();
+        connection.setTimeoutMs(dataTimeout);
 
         final boolean strictHostKeyChecking = context.getProperty(STRICT_HOST_KEY_CHECKING).asBoolean();
         final String hostKeyFilePath = context.getProperty(HOST_KEY_FILE).getValue();


### PR DESCRIPTION
# Summary

[NIFI-10088](https://issues.apache.org/jira/browse/NIFI-10088) Updates the Standard SSH Client Provider to set the SSH Client Transport Timeout using the value of the `Data Timeout` property specified in SFTP Processors. Setting the Transport Timeout overrides the internal SSHJ default timeout of 30 seconds. The default value of the `Data Timeout` property is also 30 seconds, so this change allows more customization of the SFTP connection without impacting default behavior.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
