### PR TITLE
NIFI-10092 Update OWASP dependency-check suppressions

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -29,4 +29,34 @@
         <packageUrl regex="true">^pkg:maven/org\.testcontainers/mysql@.*$</packageUrl>
         <cpe>cpe:/a:mysql:mysql</cpe>
     </suppress>
+    <suppress>
+        <notes>StumbleUpon Async is incorrectly identified as the JavaScript Async library</notes>
+        <packageUrl regex="true">^pkg:maven/com\.stumbleupon/async@.*$</packageUrl>
+        <cve>CVE-2021-43138</cve>
+    </suppress>
+    <suppress>
+        <notes>HBase Async is incorrectly identified as the JavaScript Async library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.hbase/asynchbase@.*$</packageUrl>
+        <cve>CVE-2021-43138</cve>
+    </suppress>
+    <suppress>
+        <notes>Jetty SSLEngine is incorrectly identified with Jetty Server</notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jetty/jetty\-sslengine@.*$</packageUrl>
+        <cpe regex="true">^cpe:.*$</cpe>
+    </suppress>
+    <suppress>
+        <notes>MySQL Binary Log Connector is incorrectly identified as MySQL server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.github\.shyiko/mysql\-binlog\-connector\-java@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress>
+        <notes>Testcontainers MariaDB is incorrectly identified with MariaDB server</notes>
+        <packageUrl regex="true">^pkg:maven/org\.testcontainers/mariadb@.*$</packageUrl>
+        <cpe>cpe:/a:mariadb:mariadb</cpe>
+    </suppress>
+    <suppress>
+        <notes>Twill ZooKeeper is incorrectly identified with ZooKeeper server</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill\-zookeeper@.*$</packageUrl>
+        <cpe>cpe:/a:apache:zookeeper</cpe>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1237,12 +1237,9 @@
             </properties>
         </profile>
         <profile>
-            <!-- Run "mvn clean verify -P owasp" to generate dependency-check-report.html in the target directory -->
+            <!-- Run "mvn validate -P dependency-check" to generate dependency-check-report.html in the target directory -->
             <!-- Report results require detailed analysis to determine whether the vulnerability impacts the application -->
-            <id>owasp</id>
-            <properties>
-                <skipTests>true</skipTests>
-            </properties>
+            <id>dependency-check</id>
             <build>
                 <plugins>
                     <plugin>
@@ -1252,6 +1249,7 @@
                         <executions>
                             <execution>
                                 <inherited>false</inherited>
+                                <phase>validate</phase>
                                 <goals>
                                     <goal>aggregate</goal>
                                 </goals>


### PR DESCRIPTION
# Summary

[NIFI-10092](https://issues.apache.org/jira/browse/NIFI-10092) Updates the OWASP Dependency Check plugin configuration to suppress false positives related to the following dependencies:

- MariaDB test containers
- Jetty SSLEngine
- StumbleUpon and HBase Async
- MySQL binary log connector
- Twill ZooKeeper

Additional changes include changing the plugin lifecycle phase to execute during the Maven `validate` phase to support streamlined execution using the following command:

```
mvn validate -P dependency-check
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
