### PR TITLE
NIFI-10093 Set timeout to 5 seconds on SocketProtocolListenerTest

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/JaxbProtocolContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/JaxbProtocolContext.java
@@ -46,7 +46,7 @@ import java.nio.ByteBuffer;
  * @param <T> The type of protocol message.
  *
  */
-public class JaxbProtocolContext<T> implements ProtocolContext {
+public class JaxbProtocolContext<T> implements ProtocolContext<T> {
 
     private static final int BUF_SIZE = (int) Math.pow(2, 10);  // 1k
 


### PR DESCRIPTION
# Summary

[NIFI-10093](https://issues.apache.org/jira/browse/NIFI-10093) Updates `SocketProtocolListenerTest` to use 5 seconds instead of 1 second for socket timeout configuration. This change should make test methods more reliable in resource-constrained automated build environments. Additional changes include upgrading the test to JUnit 5 and including the missing generic type on `JaxbProtocolContext`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
