### PR TITLE
NIFI-10095 Use Allowable Value Display Name for Default Value when found

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/html/HtmlDocumentationWriter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/html/HtmlDocumentationWriter.java
@@ -516,7 +516,7 @@ public class HtmlDocumentationWriter implements DocumentationWriter {
                 }
 
                 xmlStreamWriter.writeEndElement();
-                writeSimpleElement(xmlStreamWriter, "td", property.getDefaultValue(), false, "default-value");
+                writeSimpleElement(xmlStreamWriter, "td", getDefaultValue(property), false, "default-value");
                 xmlStreamWriter.writeStartElement("td");
                 xmlStreamWriter.writeAttribute("id", "allowable-values");
                 writeValidValues(xmlStreamWriter, property);
@@ -672,6 +672,25 @@ public class HtmlDocumentationWriter implements DocumentationWriter {
         } else {
             writeSimpleElement(xmlStreamWriter, "p", "This component has no required or optional properties.");
         }
+    }
+
+    private String getDefaultValue(final PropertyDescriptor propertyDescriptor) {
+        final String defaultValue;
+
+        final String descriptorDefaultValue = propertyDescriptor.getDefaultValue();
+
+        final List<AllowableValue> allowableValues = propertyDescriptor.getAllowableValues();
+        if (allowableValues != null) {
+            defaultValue = allowableValues.stream()
+                    .filter(allowableValue -> allowableValue.getValue().equals(descriptorDefaultValue))
+                    .findFirst()
+                    .map(AllowableValue::getDisplayName)
+                    .orElse(descriptorDefaultValue);
+        } else {
+            defaultValue = descriptorDefaultValue;
+        }
+
+        return defaultValue;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/java/org/apache/nifi/documentation/example/FullyDocumentedProcessor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/java/org/apache/nifi/documentation/example/FullyDocumentedProcessor.java
@@ -89,8 +89,8 @@ public class FullyDocumentedProcessor extends AbstractProcessor {
             .description("Indicates whether or not to pull files from subdirectories")
             .required(true)
             .allowableValues(
-                    new AllowableValue("true", "true", "Should pull from sub directories"),
-                    new AllowableValue("false", "false", "Should not pull from sub directories")
+                    new AllowableValue("true", "Enabled", "Should pull from sub directories"),
+                    new AllowableValue("false", "Disabled", "Should not pull from sub directories")
             )
             .defaultValue("true")
             .build();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/java/org/apache/nifi/documentation/html/ProcessorDocumentationWriterTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/src/test/java/org/apache/nifi/documentation/html/ProcessorDocumentationWriterTest.java
@@ -94,6 +94,10 @@ public class ProcessorDocumentationWriterTest {
         assertContains(results, "Supports Expression Language: true (will be evaluated using variable registry only)");
         assertContains(results, "Supports Expression Language: true (undefined scope)");
 
+        // Check Property Values
+        assertContains(results, "Enabled");
+        assertContains(results, "0 sec");
+
         // verify dynamic properties
         assertContains(results, "Routes FlowFiles to relationships based on XPath");
 


### PR DESCRIPTION
# Summary

[NIFI-10095](https://issues.apache.org/jira/browse/NIFI-10095) Updates generated component documentation to use the `Display Name` of an Allowable Value when finding a match for the Property Descriptor `Default Value`. This maintains compatibility with existing default value settings and renders a Default Value that matches one of the Allowable Values listed in components such as `ListSFTP`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
