### PR TITLE
NIFI-9996 - ListFile does not list root directory when Recurse Subdir…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -692,21 +692,16 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 return false;
             }
 
-            final Path relativePath = basePath.relativize(path).getParent();
-            final String relativeDir = relativePath == null ? "" : relativePath.toString();
+            final Path relativePath = basePath.relativize(path);
+            final Path relativePathParent = relativePath.getParent();
+            final String relativeDir = relativePathParent == null ? "" : relativePathParent.toString();
             final String filename = path.getFileName().toString();
             final TimingInfo timingInfo = performanceTracker.getTimingInfo(relativeDir, filename);
 
             final File file = path.toFile();
 
-            if (pathPattern != null) {
-                if (relativePath == null || relativePath.toString().isEmpty()) {
-                    return false;
-                }
-
-                if (!pathPattern.matcher(relativePath.toString()).matches()) {
-                    return false;
-                }
+            if ((pathPattern != null) && (!pathPattern.matcher(relativeDir).matches())) {
+                return false;
             }
 
             final boolean matchesFilter = filePattern.matcher(filename).matches();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
@@ -695,6 +695,40 @@ public class TestListFile {
     }
 
     @Test
+    public void testFilterPathPatternNegative() throws Exception {
+        final long now = getTestModifiedTime();
+
+        final File subdirA = new File(TESTDIR + "/AAA");
+        assertTrue(subdirA.mkdirs());
+
+        final File subdirL = new File(TESTDIR + "/LOG");
+        assertTrue(subdirL.mkdirs());
+
+        final File file1 = new File(TESTDIR + "/file1.txt");
+        assertTrue(file1.createNewFile());
+        assertTrue(file1.setLastModified(now));
+
+        final File file2 = new File(TESTDIR + "/AAA/file2.txt");
+        assertTrue(file2.createNewFile());
+        assertTrue(file2.setLastModified(now));
+
+        final File file3 = new File(TESTDIR + "/LOG/file3.txt");
+        assertTrue(file3.createNewFile());
+        assertTrue(file3.setLastModified(now));
+
+        runner.setProperty(ListFile.DIRECTORY, testDir.getAbsolutePath());
+        runner.setProperty(ListFile.FILE_FILTER, ListFile.FILE_FILTER.getDefaultValue());
+        runner.setProperty(ListFile.PATH_FILTER, "^((?!LOG).)*$");
+        runner.setProperty(ListFile.RECURSE, "true");
+        assertVerificationOutcome(Outcome.SUCCESSFUL, "Successfully listed .* Found 3 objects.  Of those, 2 match the filter.");
+        runNext();
+
+        runner.assertAllFlowFilesTransferred(ListFile.REL_SUCCESS);
+        final List<MockFlowFile> successFiles1 = runner.getFlowFilesForRelationship(ListFile.REL_SUCCESS);
+        assertEquals(2, successFiles1.size());
+    }
+
+    @Test
     public void testRecurse() throws Exception {
         final long now = getTestModifiedTime();
 


### PR DESCRIPTION
…ectories is active and Path Filter is specified

# Summary

[NIFI-9996](https://issues.apache.org/jira/browse/NIFI-9996)

Handle case where a negative path pattern is specified in the processor config.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
