### PR TITLE
NIFI-10109 Preserve Field Order in JsonTreeReader

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -346,7 +346,7 @@ public class MapRecord implements Record {
 
     public Map<String, Object> toMap(boolean convertSubRecords) {
         if (convertSubRecords) {
-            Map<String, Object> newMap = new HashMap<>();
+            Map<String, Object> newMap = new LinkedHashMap<>();
             values.forEach((key, value) -> {
                 Object valueToAdd;
 
@@ -362,7 +362,7 @@ public class MapRecord implements Record {
                     }
                     valueToAdd = maps;
                 } else if (value instanceof List) {
-                    List valueList = (List) value;
+                    List<?> valueList = (List<?>) value;
                     if (!valueList.isEmpty() && valueList.get(0) instanceof MapRecord) {
                         List<Map<String, Object>> newRecords = new ArrayList<>();
                         for (Object o : valueList) {
@@ -495,7 +495,7 @@ public class MapRecord implements Record {
 
         Object mapObject = values.get(recordField.getFieldName());
         if (mapObject == null) {
-            mapObject = new HashMap<String, Object>();
+            mapObject = new LinkedHashMap<String, Object>();
         }
         if (!(mapObject instanceof Map)) {
             return;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
@@ -37,7 +37,7 @@ import org.apache.nifi.serialization.record.util.DataTypeUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +92,7 @@ public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
     private Record convertJsonNodeToRecord(final JsonNode jsonNode, final RecordSchema schema, final String fieldNamePrefix,
             final boolean coerceTypes, final boolean dropUnknown) throws IOException, MalformedRecordException {
 
-        final Map<String, Object> values = new HashMap<>(schema.getFieldCount() * 2);
+        final Map<String, Object> values = new LinkedHashMap<>(schema.getFieldCount() * 2);
 
         if (dropUnknown) {
             for (final RecordField recordField : schema.getFields()) {
@@ -167,7 +167,7 @@ public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
             case MAP: {
                 final DataType valueType = ((MapDataType) desiredType).getValueType();
 
-                final Map<String, Object> map = new HashMap<>();
+                final Map<String, Object> map = new LinkedHashMap<>();
                 final Iterator<String> fieldNameItr = fieldNode.fieldNames();
                 while (fieldNameItr.hasNext()) {
                     final String childName = fieldNameItr.next();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -415,6 +416,25 @@ class TestJsonTreeRowRecordReader {
         }
     }
 
+    @Test
+    void testReadRawRecordFieldOrderPreserved() throws IOException, MalformedRecordException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("id", RecordFieldType.INT.getDataType()));
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final String expectedMap = "{id=1, name=John Doe, address=123 My Street, city=My City, state=MS, zipCode=11111, country=USA, account=MapRecord[{balance=4750.89, id=42}]}";
+        final String expectedRecord = String.format("MapRecord[%s]", expectedMap);
+        try (final InputStream in = new FileInputStream("src/test/resources/json/single-element-nested.json");
+             final JsonTreeRowRecordReader reader = new JsonTreeRowRecordReader(in, mock(ComponentLog.class), schema, dateFormat, timeFormat, timestampFormat)) {
+
+            final Record rawRecord = reader.nextRecord(false, false);
+
+            assertEquals(expectedRecord, rawRecord.toString());
+
+            final Map<String, Object> map = rawRecord.toMap();
+            assertEquals(expectedMap, map.toString());
+        }
+    }
 
     @Test
     void testReadRawRecordTypeCoercion() throws IOException, MalformedRecordException {


### PR DESCRIPTION
# Summary

[NIFI-10109](https://issues.apache.org/jira/browse/NIFI-10109) Replaces usage of `HashMap` with `LinkedHashMap` in `JsonTreeRowRecordReader` and `MapRecord` to preserve input field order read from input JSON Objects nodes. This approach maintains a deterministic internal representation of objects.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
