### PR TITLE
NIFI-10101 Move nifi-hive-nar to optional include-hive profile

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -625,18 +625,6 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hive-services-api-nar</artifactId>
-            <version>1.17.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hive-nar</artifactId>
-            <version>1.17.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-site-to-site-reporting-nar</artifactId>
             <version>1.17.0-SNAPSHOT</version>
             <type>nar</type>
@@ -936,6 +924,26 @@ language governing permissions and limitations under the License. -->
             </dependencies>
         </profile>
         <profile>
+            <id>include-hive</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hive-nar</artifactId>
+                    <version>1.17.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hive-services-api-nar</artifactId>
+                    <version>1.17.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>include-hive1_1</id>
             <!-- This profile handles the inclusion of Hive 1.1.x artifacts. The NAR
             is quite large and makes the resultant binary distribution significantly
@@ -947,6 +955,12 @@ language governing permissions and limitations under the License. -->
                 <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-hive_1_1-nar</artifactId>
+                    <version>1.17.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hive-services-api-nar</artifactId>
                     <version>1.17.0-SNAPSHOT</version>
                     <type>nar</type>
                 </dependency>
@@ -964,6 +978,12 @@ language governing permissions and limitations under the License. -->
                 <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-hive3-nar</artifactId>
+                    <version>1.17.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hive-services-api-nar</artifactId>
                     <version>1.17.0-SNAPSHOT</version>
                     <type>nar</type>
                 </dependency>


### PR DESCRIPTION
# Summary

[NIFI-10101](https://issues.apache.org/jira/browse/NIFI-10101) Moves the `nifi-hive-nar` out of the standard `nifi-assembly` binary build to an optional profile named `include-hive`. This approach aligns Hive 1.2 components with other Hive 1.1 and Hive 3 components which are already mapped to the optional `include-hive1_1` and `include-hive3` profiles. 

Removing the inclusion of Hive 1.2 components in the default binary build reduces the standard size by 100 MB and also encourages selection of the appropriate version when downloading extension NAR files. All Hive components require the `nifi-hive-services-api-nar`, which will be included when building any of the optional profiles.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
