### PR TITLE
NIFI-10116: Add new command to delete report tasks

### DIFF
--- a/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
@@ -110,6 +110,7 @@ The following are available commands:
  nifi get-reporting-task
  nifi get-reporting-tasks
  nifi create-reporting-task
+ nifi delete-reporting-task
  nifi set-param
  nifi delete-param
  nifi list-param-contexts
@@ -293,7 +294,7 @@ Typing "nifi " and then a tab will show the sub-commands for NiFi:
  delete-param            get-service             pg-get-param-context    update-reg-client
  delete-param-context    get-services            pg-get-services         update-user-group
  disable-services        import-param-context    pg-get-vars             upload-template
- disconnect-node         list-param-contexts     pg-get-version
+ disconnect-node         list-param-contexts     pg-get-version          delete-reporting-task
  download-template       list-reg-clients        pg-import
 
 Arguments that represent a path to a file, such as `-p` or when setting a properties file in the session, will auto-complete the path being typed:

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
@@ -74,6 +74,7 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.CreateRegistryClie
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.GetRegistryClientId;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.ListRegistryClients;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.UpdateRegistryClient;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.reporting.DeleteReportingTask;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.templates.DownloadTemplate;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.templates.ListTemplates;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.templates.UploadTemplate;
@@ -140,6 +141,7 @@ public class NiFiCommandGroup extends AbstractCommandGroup {
         commands.add(new GetReportingTasks());
         commands.add(new GetReportingTask());
         commands.add(new CreateReportingTask());
+        commands.add(new DeleteReportingTask());
         commands.add(new StartReportingTasks());
         commands.add(new StopReportingTasks());
         commands.add(new ListUsers());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/reporting/DeleteReportingTask.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/reporting/DeleteReportingTask.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.reporting;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.CommandException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ReportingTasksClient;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.nifi.ReportingTaskResult;
+import org.apache.nifi.web.api.entity.ReportingTaskEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Command for creating a reporting task.
+ */
+public class DeleteReportingTask extends AbstractNiFiCommand<ReportingTaskResult> {
+
+    public DeleteReportingTask() {
+        super("delete-reporting-task", ReportingTaskResult.class);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Delete a reporting task.";
+    }
+
+    @Override
+    public void doInitialize(final Context context) {
+        addOption(CommandOption.RT_ID.createOption());
+    }
+
+    @Override
+    public ReportingTaskResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException, CommandException {
+
+        final String reportingTaskId = getRequiredArg(properties, CommandOption.RT_ID);
+
+        final ReportingTasksClient reportingTasksClient = client.getReportingTasksClient();
+        ReportingTaskEntity reportingTask = reportingTasksClient.getReportingTask(reportingTaskId);
+        final ReportingTaskEntity deletedReportingTaskEntity = reportingTasksClient.deleteReportingTask(reportingTask);
+
+        return new ReportingTaskResult(getResultType(properties), deletedReportingTaskEntity);
+    }
+
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10116](https://issues.apache.org/jira/browse/NIFI-10116)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
