### PR TITLE
NIFI-10118 Upgrade OWASP Dependency Check from 7.1.0 to 7.1.1

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -59,4 +59,39 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill\-zookeeper@.*$</packageUrl>
         <cpe>cpe:/a:apache:zookeeper</cpe>
     </suppress>
+    <suppress>
+        <notes>H2 1.4.200 is shaded and repackaged without vulnerable components in nifi-h2-database for migration</notes>
+        <packageUrl>pkg:maven/com.h2database/h2@1.4.200</packageUrl>
+        <vulnerabilityName regex="true">^CVE.*$</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>H2 2 is not vulnerable to CVE-2018-14335</notes>
+        <packageUrl regex="true">^pkg:maven/com\.h2database/h2@2.*$</packageUrl>
+        <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Jetty apache-jsp is not part of Apache Tomcat server</notes>
+        <packageUrl>pkg:maven/org.mortbay.jasper/apache-jsp@8.5.70</packageUrl>
+        <cpe>cpe:/a:apache:tomcat</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2016-1000027 does not apply to Spring Web 5.3.20 and later</notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-5408 does not apply to Spring Security Crypto 5.7.1 and later</notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Spring Security Kerberos Core is an extension of the Spring Security project</notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security\.kerberos/spring\-security\-kerberos.*$</packageUrl>
+        <cpe>cpe:/a:vmware:spring_security</cpe>
+    </suppress>
+    <suppress>
+        <notes>Servlet API 2.5 does not include Jetty Server vulnerabilities</notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jetty/servlet\-api@.*$</packageUrl>
+        <cpe regex="true">^cpe:.*$</cpe>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1245,7 +1245,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.1.0</version>
+                        <version>7.1.1</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-10118](https://issues.apache.org/jira/browse/NIFI-10118) Upgrades to OWASP Dependency Check Plugin from 7.1.0 to [7.1.1](https://github.com/jeremylong/DependencyCheck/milestone/45?closed=1) in order to resolve a number of false positives. Additional changes include updating the suppression configuration to address the following false positives:

- H2 1.4.200 in nifi-h2-database used as the source for a shaded dependency
- H2 2 is not vulnerable to CVE-2018-14335
- Jetty apache-jsp is not part of Apache Tomcat server or subject to associated vulnerabilities in version 8.5.70
- Spring Web 5.3.20 is not vulnerable to CVE-2016-1000027 as used
- Spring Security Crypto 5.7.1 is not vulnerable to CVE-2020-5408
- Spring Security Kerberos Core is not part of Spring Security or subject to associated vulnerabilities
- Servlet API 2.5 is not subject to vulnerabilities associated with Jetty Server

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
