### PR TITLE
NIFI-10117: Allowing remote group ports to be synchronized from Stand…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -2749,15 +2749,9 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             if (proposedPort != null) {
                 if (proposedPort.getBatchSize() != null) {
                     final BatchSize batchSize = proposedPort.getBatchSize();
-                    if (batchSize.getSize() != null) {
-                        port.setBatchSize(batchSize.getSize());
-                    }
-                    if (batchSize.getCount() != null) {
-                        port.setBatchCount(batchSize.getCount());
-                    }
-                    if (batchSize.getDuration() != null) {
-                        port.setBatchDuration(batchSize.getDuration());
-                    }
+                    port.setBatchSize(batchSize.getSize());
+                    port.setBatchCount(batchSize.getCount());
+                    port.setBatchDuration(batchSize.getDuration());
                 }
                 if (proposedPort.isUseCompression() != null) {
                     port.setUseCompression(proposedPort.isUseCompression());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -2704,6 +2704,9 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
         rpg.setInputPorts(proposed.getInputPorts() == null ? Collections.emptySet() : proposed.getInputPorts().stream()
             .map(port -> createPortDescriptor(port, componentIdGenerator, rpg.getIdentifier()))
             .collect(Collectors.toSet()), false);
+
+        synchronizeRemoteGroupPorts(rpg.getInputPorts(), proposed.getInputPorts());
+        synchronizeRemoteGroupPorts(rpg.getOutputPorts(), proposed.getOutputPorts());
         rpg.setName(proposed.getName());
         rpg.setNetworkInterface(proposed.getLocalNetworkInterface());
         rpg.setOutputPorts(proposed.getOutputPorts() == null ? Collections.emptySet() : proposed.getOutputPorts().stream()
@@ -2737,6 +2740,41 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                 }
             }
         }
+    }
+
+    private void synchronizeRemoteGroupPorts(final Set<RemoteGroupPort> remoteGroupPorts, final Set<VersionedRemoteGroupPort> proposedPorts) {
+        final Map<String, VersionedRemoteGroupPort> inputPortsByTargetId = mapRemoteGroupPortsByTargetId(proposedPorts);
+        remoteGroupPorts.forEach(port -> {
+            final VersionedRemoteGroupPort proposedPort = inputPortsByTargetId.get(port.getTargetIdentifier());
+            if (proposedPort != null) {
+                if (proposedPort.getBatchSize() != null) {
+                    final BatchSize batchSize = proposedPort.getBatchSize();
+                    if (batchSize.getSize() != null) {
+                        port.setBatchSize(batchSize.getSize());
+                    }
+                    if (batchSize.getCount() != null) {
+                        port.setBatchCount(batchSize.getCount());
+                    }
+                    if (batchSize.getDuration() != null) {
+                        port.setBatchDuration(batchSize.getDuration());
+                    }
+                }
+                if (proposedPort.isUseCompression() != null) {
+                    port.setUseCompression(proposedPort.isUseCompression());
+                }
+                if (proposedPort.getConcurrentlySchedulableTaskCount() != null) {
+                    port.setMaxConcurrentTasks(proposedPort.getConcurrentlySchedulableTaskCount());
+                }
+            }
+        });
+    }
+
+    private Map<String, VersionedRemoteGroupPort> mapRemoteGroupPortsByTargetId(final Set<VersionedRemoteGroupPort> remoteGroupPorts) {
+        return remoteGroupPorts == null ? Collections.emptyMap() : remoteGroupPorts.stream()
+                .collect(Collectors.toMap(
+                        VersionedRemoteGroupPort::getTargetId,
+                        Function.identity()
+                ));
     }
 
     private RemoteGroupPort getRpgInputPort(final VersionedRemoteGroupPort port, final RemoteProcessGroup rpg, final ComponentIdGenerator componentIdGenerator) {
@@ -3003,7 +3041,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
 
         final Connectable source = getConnectable(destinationGroup, proposed.getSource());
         if (source == null) {
-            throw new IllegalArgumentException("Connection has a source with identifier " + proposed.getIdentifier()
+            throw new IllegalArgumentException("Connection has a source with identifier " + proposed.getSource().getId()
                 + " but no component could be found in the Process Group with a corresponding identifier");
         }
 


### PR DESCRIPTION
…ardVersionedComponentSynchronizer

# Summary
This allows the StandardVersionedComponentSynchronizer to update RemoteGroupPorts from VersionedRemoteGroupPorts, including fields like batchSize, useCompression, and maxConcurrentTasks.

[NIFI-10117](https://issues.apache.org/jira/browse/NIFI-10117)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
