### PR TITLE
NIFI-10122 Upgrade Spark Streaming to 3.3.0

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -94,4 +94,9 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jetty/servlet\-api@.*$</packageUrl>
         <cpe regex="true">^cpe:.*$</cpe>
     </suppress>
+    <suppress>
+        <notes>Spark 2.13 used in nifi-spark-receiver is not impacted by Spark Server vulnerabilities</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.spark/spark\-.+?_2\.13@.*$</packageUrl>
+        <cpe>cpe:/a:apache:spark</cpe>
+    </suppress>
 </suppressions>

--- a/nifi-external/nifi-spark-receiver/pom.xml
+++ b/nifi-external/nifi-spark-receiver/pom.xml
@@ -22,47 +22,20 @@
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-spark-receiver</artifactId>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.21</version>
-            </dependency>
-            <!-- Override commons-beanutils -->
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
-            </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>${netty.3.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_2.10</artifactId>
+            <artifactId>spark-streaming_2.13</artifactId>
             <scope>provided</scope>
-            <version>1.6.0</version>
+            <version>3.3.0</version>
             <exclusions>
                 <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -71,18 +44,13 @@
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-site-to-site-client</artifactId>
             <version>1.17.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-server</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-10122](https://issues.apache.org/jira/browse/NIFI-10122) Upgrades the provided Spark Streaming dependency in `nifi-spark-receiver` to 3.3.0. The upgrade maintains API compatibility with the existing receiver implementation while resolving a number of vulnerabilities associated with compiling against the older version. Additional changes include updating the dependency check suppression configuration to avoid false positives associated with Spark Server that do not impact the streaming library.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
