### PR TITLE
NIFI-10137 Change nifi-toolkit-api to use Jersey 2 and Jackson

### DIFF
--- a/nifi-toolkit/nifi-toolkit-api/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-api/pom.xml
@@ -20,10 +20,6 @@ language governing permissions and limitations under the License. -->
 
     <artifactId>nifi-toolkit-api</artifactId>
 
-    <properties>
-        <okhttp2.version>2.7.5</okhttp2.version>
-    </properties>
-
     <dependencies>
         <!-- to get swagger definitions -->
         <dependency>
@@ -42,23 +38,28 @@ language governing permissions and limitations under the License. -->
             <version>1.6.0</version>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp2.version}</version>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
-            <artifactId>logging-interceptor</artifactId>
-            <version>${okhttp2.version}</version>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.8.2</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
     </dependencies>
 
@@ -83,7 +84,7 @@ language governing permissions and limitations under the License. -->
             <plugin>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>2.2.2</version>
+                <version>2.4.27</version>
                 <executions>
                     <execution>
                         <goals>
@@ -100,6 +101,8 @@ language governing permissions and limitations under the License. -->
                                 <apiPackage>org.apache.nifi.api.toolkit.api</apiPackage>
                                 <modelPackage>org.apache.nifi.api.toolkit.model</modelPackage>
                                 <httpUserAgent>apache-nifi-api-toolkit-agent</httpUserAgent>
+                                <library>jersey2</library>
+                                <dateLibrary>java8</dateLibrary>
                             </configOptions>
                         </configuration>
                     </execution>


### PR DESCRIPTION
# Summary

[NIFI-10137](https://issues.apache.org/jira/browse/NIFI-10137) Changes the `nifi-toolkit-api` Swagger Codegen configuration to use Jersey 2 with Jackson instead of OkHttp 2 and Gson with Joda Time for generated classes. Swagger Codegen does not support OkHttp 3 or 4, and OkHttp 2 is deprecated.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
