### PR TITLE
NIFI-10130 AzureGraphUserGroupProvider handles nested group

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-graph-authorizer/src/main/java/org/apache/nifi/authorization/azure/AzureGraphUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-graph-authorizer/src/main/java/org/apache/nifi/authorization/azure/AzureGraphUserGroupProvider.java
@@ -339,7 +339,6 @@ public class AzureGraphUserGroupProvider implements UserGroupProvider {
 
         if (currentPage != null && currentPage.size() > 0) {
             final com.microsoft.graph.models.extensions.Group graphGroup = results.getCurrentPage().get(0);
-            //logger.info("calling with "+ graphGroup.id);
             final Group.Builder groupBuilder =
                 new Group.Builder()
                     .identifier(graphGroup.id)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-graph-authorizer/src/main/java/org/apache/nifi/authorization/azure/AzureGraphUserGroupProvider.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-graph-authorizer/src/main/java/org/apache/nifi/authorization/azure/AzureGraphUserGroupProvider.java
@@ -32,17 +32,16 @@ import java.util.stream.Collectors;
 
 import com.google.gson.JsonObject;
 import com.microsoft.graph.core.ClientException;
-import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.IGraphServiceClient;
 import com.microsoft.graph.options.Option;
 import com.microsoft.graph.options.QueryOption;
 import com.microsoft.graph.requests.extensions.GraphServiceClient;
-import com.microsoft.graph.requests.extensions.IDirectoryObjectCollectionWithReferencesPage;
-import com.microsoft.graph.requests.extensions.IDirectoryObjectCollectionWithReferencesRequest;
-import com.microsoft.graph.requests.extensions.IDirectoryObjectCollectionWithReferencesRequestBuilder;
 import com.microsoft.graph.requests.extensions.IGroupCollectionPage;
 import com.microsoft.graph.requests.extensions.IGroupCollectionRequest;
 import com.microsoft.graph.requests.extensions.IGroupCollectionRequestBuilder;
+import com.microsoft.graph.requests.extensions.IUserCollectionWithReferencesPage;
+import com.microsoft.graph.requests.extensions.IUserCollectionWithReferencesRequest;
+import com.microsoft.graph.requests.extensions.IUserCollectionWithReferencesRequestBuilder;
 
 import org.apache.nifi.authorization.AuthorizerConfigurationContext;
 import org.apache.nifi.authorization.Group;
@@ -340,28 +339,22 @@ public class AzureGraphUserGroupProvider implements UserGroupProvider {
 
         if (currentPage != null && currentPage.size() > 0) {
             final com.microsoft.graph.models.extensions.Group graphGroup = results.getCurrentPage().get(0);
+            //logger.info("calling with "+ graphGroup.id);
             final Group.Builder groupBuilder =
                 new Group.Builder()
                     .identifier(graphGroup.id)
                     .name(graphGroup.displayName);
 
-            IDirectoryObjectCollectionWithReferencesRequest uRequest =
+            IUserCollectionWithReferencesRequest uRequest =
                 graphClient.groups(graphGroup.id)
-                    .members()
+                    .transitiveMembersAsUser()
                     .buildRequest()
                     .select("id, displayName, mail, userPrincipalName");
 
-            if (pageSize > 0) {
-                uRequest = uRequest.top(pageSize);
-            }
-            IDirectoryObjectCollectionWithReferencesPage userpage =
-                graphClient.groups(graphGroup.id)
-                    .members()
-                    .buildRequest()
-                    .select("id, displayName, mail, userPrincipalName").get();
+            IUserCollectionWithReferencesPage userpage = uRequest.get();
 
-            while (userpage.getCurrentPage() != null) {
-                for (DirectoryObject userDO : userpage.getCurrentPage()) {
+            while (userpage != null && userpage.getCurrentPage() != null) {
+                for (com.microsoft.graph.models.extensions.User userDO : userpage.getCurrentPage()) {
                     JsonObject jsonUser = userDO.getRawObject();
                     final String idUser;
                     if (!jsonUser.get("id").isJsonNull()) {
@@ -386,7 +379,7 @@ public class AzureGraphUserGroupProvider implements UserGroupProvider {
                     users.add(user);
                     groupBuilder.addUser(idUser);
                 }
-                IDirectoryObjectCollectionWithReferencesRequestBuilder nextPageRequest = userpage.getNextPage();
+                IUserCollectionWithReferencesRequestBuilder nextPageRequest = userpage.getNextPage();
 
                 if (nextPageRequest != null) {
                     userpage = nextPageRequest.buildRequest().get();


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10130](https://issues.apache.org/jira/browse/NIFI-10130) This bug fix will retrieves all users under sub groups thru transitivemembers MS graph api.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
