### PR TITLE
NIFI-10139: Adding fields to RemoteProcessGroupStatus

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/ProcessGroupStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/ProcessGroupStatus.java
@@ -20,6 +20,7 @@ import org.apache.nifi.registry.flow.VersionedFlowState;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -586,6 +587,13 @@ public class ProcessGroupStatus implements Cloneable {
             merged.setSentContentSize(merged.getSentContentSize() + statusToMerge.getSentContentSize());
             merged.setSentCount(merged.getSentCount() + statusToMerge.getSentCount());
             merged.setActiveThreadCount(merged.getActiveThreadCount() + statusToMerge.getActiveThreadCount());
+
+            // Take the earliest last refresh time
+            final Date mergedLastRefreshTime = merged.getLastRefreshTime();
+            final Date toMergeLastRefreshTime = statusToMerge.getLastRefreshTime();
+            if (mergedLastRefreshTime == null || (toMergeLastRefreshTime != null && toMergeLastRefreshTime.before(mergedLastRefreshTime))) {
+                merged.setLastRefreshTime(toMergeLastRefreshTime);
+            }
         }
 
         target.setRemoteProcessGroupStatus(mergedRemoteGroupMap.values());

--- a/nifi-api/src/main/java/org/apache/nifi/controller/status/RemoteProcessGroupStatus.java
+++ b/nifi-api/src/main/java/org/apache/nifi/controller/status/RemoteProcessGroupStatus.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.controller.status;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -28,6 +29,9 @@ public class RemoteProcessGroupStatus implements Cloneable {
     private TransmissionStatus transmissionStatus;
     private String uri;
     private String name;
+    private String comments;
+    private String authorizationIssue;
+    private Date lastRefreshTime;
     private Integer activeThreadCount;
     private int sentCount;
     private long sentContentSize;
@@ -68,6 +72,30 @@ public class RemoteProcessGroupStatus implements Cloneable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    public String getAuthorizationIssue() {
+        return authorizationIssue;
+    }
+
+    public void setAuthorizationIssue(String authorizationIssue) {
+        this.authorizationIssue = authorizationIssue;
+    }
+
+    public Date getLastRefreshTime() {
+        return lastRefreshTime;
+    }
+
+    public void setLastRefreshTime(Date lastRefreshTime) {
+        this.lastRefreshTime = lastRefreshTime;
     }
 
     public String getId() {
@@ -156,6 +184,9 @@ public class RemoteProcessGroupStatus implements Cloneable {
         clonedObj.id = id;
         clonedObj.groupId = groupId;
         clonedObj.name = name;
+        clonedObj.comments = comments;
+        clonedObj.authorizationIssue = authorizationIssue;
+        clonedObj.lastRefreshTime = lastRefreshTime;
         clonedObj.uri = uri;
         clonedObj.activeThreadCount = activeThreadCount;
         clonedObj.transmissionStatus = transmissionStatus;
@@ -178,6 +209,12 @@ public class RemoteProcessGroupStatus implements Cloneable {
         builder.append(groupId);
         builder.append(", name=");
         builder.append(name);
+        builder.append(", comments=");
+        builder.append(comments);
+        builder.append(", authorizationIssue=");
+        builder.append(authorizationIssue);
+        builder.append(", lastRefreshTime=");
+        builder.append(lastRefreshTime);
         builder.append(", uri=");
         builder.append(uri);
         builder.append(", activeThreadCount=");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/reporting/AbstractEventAccess.java
@@ -510,6 +510,9 @@ public abstract class AbstractEventAccess implements EventAccess {
         final RemoteProcessGroupStatus status = new RemoteProcessGroupStatus();
         status.setGroupId(remoteGroup.getProcessGroup().getIdentifier());
         status.setName(isRemoteProcessGroupAuthorized ? remoteGroup.getName() : remoteGroup.getIdentifier());
+        status.setComments(isRemoteProcessGroupAuthorized ? remoteGroup.getComments() : null);
+        status.setAuthorizationIssue(remoteGroup.getAuthorizationIssue());
+        status.setLastRefreshTime(remoteGroup.getLastRefreshTime());
         status.setTargetUri(isRemoteProcessGroupAuthorized ? remoteGroup.getTargetUri() : null);
 
         long lineageMillis = 0L;


### PR DESCRIPTION

# Summary

[NIFI-10139](https://issues.apache.org/jira/browse/NIFI-10139) adds some fields to `RemoteProcessGroupStatus`, which can benefit consumers of this API.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
