### PR TITLE
NIFI-10146 Upgrade Apache Tika from 2.4.0 to 2.4.1

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -238,7 +238,7 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>2.4.0</tika.version>
+        <tika.version>2.4.1</tika.version>
     </properties>
 
     <dependencies>
@@ -44,11 +44,6 @@
             <artifactId>nifi-mock</artifactId>
             <version>1.17.0-SNAPSHOT</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.drewnoakes</groupId>
-            <artifactId>metadata-extractor</artifactId>
-            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.1</version>
             </dependency>
             <dependency>
                 <groupId>io.github.rburgst</groupId>


### PR DESCRIPTION
# Summary

[NIFI-10146](https://issues.apache.org/jira/browse/NIFI-10146) Upgrades Apache Tika dependencies from 2.4.0 to 2.4.1 and removes the direct dependency on `metadata-extractor` to inherit a newer transitive version, which resolves CVE-2022-24613 and CVE-2022-24613 related to processing crafted JPEG files.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
