### PR TITLE
NIFI-10141: Fix WriteJsonResult logging to show writer's schema

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -218,7 +218,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
 
             endTask.apply(generator);
         } catch (final Exception e) {
-            logger.error("Failed to write {} with schema {} as a JSON Object due to {}", record, writeSchema, e.toString(), e);
+            logger.error("Failed to write {} with reader schema {} and writer schema {} as a JSON Object due to {}", record, record.getSchema(), writeSchema, e.toString(), e);
             throw e;
         }
     }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -218,7 +218,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
 
             endTask.apply(generator);
         } catch (final Exception e) {
-            logger.error("Failed to write {} with schema {} as a JSON Object due to {}", new Object[] {record, record.getSchema(), e.toString(), e});
+            logger.error("Failed to write {} with schema {} as a JSON Object due to {}", record, writeSchema, e.toString(), e);
             throw e;
         }
     }


### PR DESCRIPTION
# Summary

[NIFI-10141](https://issues.apache.org/jira/browse/NIFI-10141) The current error logging when a field cannot be written out uses the record's (i.e the record reader's) schema, which is not an accurate depiction of why the field cannot be written. Instead the record writer's schema should be used in the logging statement to show the schema used to write the record.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
