### PR TITLE
NIFI-10161 Add Gzip Content-Encoding to InvokeHTTP and ListenHTTP

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/ContentEncodingStrategy.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/ContentEncodingStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.http;
+
+import org.apache.nifi.components.DescribedValue;
+
+/**
+ * HTTP Content-Encoding configuration strategy
+ */
+public enum ContentEncodingStrategy implements DescribedValue {
+    DISABLED("Content encoding not applied during transmission"),
+
+    GZIP( "Gzip content encoding and HTTP Content-Encoding header applied during transmission");
+
+    private final String description;
+
+    ContentEncodingStrategy(final String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return name();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -101,6 +101,7 @@ public class ListenHTTPServlet extends HttpServlet {
     public static final String GZIPPED_HEADER = "flowfile-gzipped";
     public static final String PROTOCOL_VERSION_HEADER = "x-nifi-transfer-protocol-version";
     public static final String PROTOCOL_VERSION = "3";
+    protected static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
 
     private final AtomicLong filesReceived = new AtomicLong(0L);
     private final AtomicBoolean spaceAvailable = new AtomicBoolean(true);
@@ -193,7 +194,10 @@ public class ListenHTTPServlet extends HttpServlet {
             }
             response.setHeader("Content-Type", MediaType.TEXT_PLAIN);
 
-            final boolean contentGzipped = Boolean.parseBoolean(request.getHeader(GZIPPED_HEADER));
+            final boolean flowFileGzipped = Boolean.parseBoolean(request.getHeader(GZIPPED_HEADER));
+            final String contentEncoding = request.getHeader(CONTENT_ENCODING_HEADER);
+            final boolean contentEncodingGzip = ACCEPT_ENCODING_VALUE.equals(contentEncoding);
+            final boolean contentGzipped = flowFileGzipped || contentEncodingGzip;
 
             final X509Certificate[] certs = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
             foundSubject = DEFAULT_FOUND_SUBJECT;


### PR DESCRIPTION
# Summary

[NIFI-10161](https://issues.apache.org/jira/browse/NIFI-10161) Adds support for optional HTTP request content compression using Gzip with the standard `Content-Encoding` header described in [RFC 7231 Section 3.1.2.2](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.2).

The implementation adds a new property named `Content-Encoding` to `InvokeHTTP` with a default value of `DISABLED` and an optional value of `GZIP` to enable request compression.

The `ListenHTTP` Processor currently supports reading Gzip compressed requests when requests have the non-standard `flowfile-gzipped` header, and this implementation extends that behavior to check for the presence of a `Content-Encoding` header with a value of `gzip`.

Both `InvokeHTTP` and `ListenHTTP` changes include new unit tests to validate Gzip compression handling.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
