### PR TITLE
NIFI-10070 - Updated merging of status DTO for ControllerService and …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ReportingTaskStatusDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ReportingTaskStatusDTO.java
@@ -27,6 +27,10 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(name = "reportingTaskStatus")
 public class ReportingTaskStatusDTO extends ComponentStatusDTO {
 
+    public static final String RUNNING = "RUNNING";
+    public static final String STOPPED = "STOPPED";
+    public static final String DISABLED = "DISABLED";
+
     @ApiModelProperty(value = "The run status of this ReportingTask",
             accessMode = ApiModelProperty.AccessMode.READ_ONLY,
             allowableValues = "RUNNING, STOPPED, DISABLED")

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ControllerServicesEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ControllerServicesEndpointMerger.java
@@ -54,13 +54,7 @@ public class ControllerServicesEndpointMerger implements EndpointResponseMerger 
             final Set<ControllerServiceEntity> nodeControllerServiceEntities = nodeResponseEntity.getControllerServices();
 
             for (final ControllerServiceEntity nodeControllerServiceEntity : nodeControllerServiceEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, ControllerServiceEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodeControllerServiceEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, ControllerServiceEntity> innerMap = entityMap.computeIfAbsent(nodeControllerServiceEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodeControllerServiceEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/InputPortsEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/InputPortsEndpointMerger.java
@@ -53,13 +53,7 @@ public class InputPortsEndpointMerger implements EndpointResponseMerger {
             final Set<PortEntity> nodePortEntities = nodeResponseEntity.getInputPorts();
 
             for (final PortEntity nodePortEntity : nodePortEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, PortEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodePortEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, PortEntity> innerMap = entityMap.computeIfAbsent(nodePortEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodePortEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/OutputPortsEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/OutputPortsEndpointMerger.java
@@ -53,13 +53,7 @@ public class OutputPortsEndpointMerger implements EndpointResponseMerger {
             final Set<PortEntity> nodePortEntities = nodeResponseEntity.getOutputPorts();
 
             for (final PortEntity nodePortEntity : nodePortEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, PortEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodePortEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, PortEntity> innerMap = entityMap.computeIfAbsent(nodePortEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodePortEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ProcessGroupsEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ProcessGroupsEndpointMerger.java
@@ -53,13 +53,7 @@ public class ProcessGroupsEndpointMerger implements EndpointResponseMerger {
             final Set<ProcessGroupEntity> nodeProcessGroupEntities = nodeResponseEntity.getProcessGroups();
 
             for (final ProcessGroupEntity nodeProcessGroupEntity : nodeProcessGroupEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, ProcessGroupEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodeProcessGroupEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, ProcessGroupEntity> innerMap = entityMap.computeIfAbsent(nodeProcessGroupEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodeProcessGroupEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ProcessorsEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ProcessorsEndpointMerger.java
@@ -53,13 +53,7 @@ public class ProcessorsEndpointMerger implements EndpointResponseMerger {
             final Set<ProcessorEntity> nodeProcessorEntities = nodeResponseEntity.getProcessors();
 
             for (final ProcessorEntity nodeProcessorEntity : nodeProcessorEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, ProcessorEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodeProcessorEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, ProcessorEntity> innerMap = entityMap.computeIfAbsent(nodeProcessorEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodeProcessorEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RemoteProcessGroupsEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RemoteProcessGroupsEndpointMerger.java
@@ -65,13 +65,7 @@ public class RemoteProcessGroupsEndpointMerger implements EndpointResponseMerger
 
                 if (nodeRpgEntities != null) {
                     for (final RemoteProcessGroupEntity nodeRpgEntity : nodeRpgEntities) {
-                        final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                        Map<NodeIdentifier, RemoteProcessGroupEntity> innerMap = entityMap.get(nodeId);
-                        if (innerMap == null) {
-                            innerMap = new HashMap<>();
-                            entityMap.put(nodeRpgEntity.getId(), innerMap);
-                        }
-
+                        Map<NodeIdentifier, RemoteProcessGroupEntity> innerMap = entityMap.computeIfAbsent(nodeRpgEntity.getId(), k -> new HashMap<>());
                         innerMap.put(nodeResponse.getNodeId(), nodeRpgEntity);
                     }
                 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ReportingTasksEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ReportingTasksEndpointMerger.java
@@ -52,13 +52,7 @@ public class ReportingTasksEndpointMerger  implements EndpointResponseMerger {
             final Set<ReportingTaskEntity> nodeReportingTaskEntities = nodeResponseEntity.getReportingTasks();
 
             for (final ReportingTaskEntity nodeReportingTaskEntity : nodeReportingTaskEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, ReportingTaskEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodeReportingTaskEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, ReportingTaskEntity> innerMap = entityMap.computeIfAbsent(nodeReportingTaskEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodeReportingTaskEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RuntimeManifestEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RuntimeManifestEndpointMerger.java
@@ -25,6 +25,7 @@ import org.apache.nifi.web.api.entity.RuntimeManifestEntity;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -48,7 +49,7 @@ public class RuntimeManifestEndpointMerger implements EndpointResponseMerger {
 
         final RuntimeManifestEntity responseEntity = clientResponse.getClientResponse().readEntity(RuntimeManifestEntity.class);
         final RuntimeManifest responseManifest = responseEntity.getRuntimeManifest();
-        final Set<Bundle> responseBundles = responseManifest.getBundles() == null ? Collections.emptySet() : new LinkedHashSet<>(responseManifest.getBundles());
+        final Set<Bundle> responseBundles = responseManifest.getBundles() == null ? new HashSet<>() : new LinkedHashSet<>(responseManifest.getBundles());
 
         for (final NodeResponse nodeResponse : successfulResponses) {
             final RuntimeManifestEntity nodeResponseEntity = nodeResponse.getClientResponse().readEntity(RuntimeManifestEntity.class);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RuntimeManifestEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RuntimeManifestEndpointMerger.java
@@ -25,7 +25,6 @@ import org.apache.nifi.web.api.entity.RuntimeManifestEntity;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,7 +48,7 @@ public class RuntimeManifestEndpointMerger implements EndpointResponseMerger {
 
         final RuntimeManifestEntity responseEntity = clientResponse.getClientResponse().readEntity(RuntimeManifestEntity.class);
         final RuntimeManifest responseManifest = responseEntity.getRuntimeManifest();
-        final Set<Bundle> responseBundles = responseManifest.getBundles() == null ? new HashSet<>() : new LinkedHashSet<>(responseManifest.getBundles());
+        final Set<Bundle> responseBundles = responseManifest.getBundles() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(responseManifest.getBundles());
 
         for (final NodeResponse nodeResponse : successfulResponses) {
             final RuntimeManifestEntity nodeResponseEntity = nodeResponse.getClientResponse().readEntity(RuntimeManifestEntity.class);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/UserGroupsEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/UserGroupsEndpointMerger.java
@@ -57,13 +57,7 @@ public class UserGroupsEndpointMerger implements EndpointResponseMerger {
             userGroupEntities.retainAll(nodeUserGroupEntities);
 
             for (final UserGroupEntity nodeUserGroupEntity : nodeUserGroupEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, UserGroupEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodeUserGroupEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, UserGroupEntity> innerMap = entityMap.computeIfAbsent(nodeUserGroupEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodeUserGroupEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/UsersEndpointMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/UsersEndpointMerger.java
@@ -57,13 +57,7 @@ public class UsersEndpointMerger implements EndpointResponseMerger {
             userEntities.retainAll(nodeUserEntities);
 
             for (final UserEntity nodeUserEntity : nodeUserEntities) {
-                final NodeIdentifier nodeId = nodeResponse.getNodeId();
-                Map<NodeIdentifier, UserEntity> innerMap = entityMap.get(nodeId);
-                if (innerMap == null) {
-                    innerMap = new HashMap<>();
-                    entityMap.put(nodeUserEntity.getId(), innerMap);
-                }
-
+                Map<NodeIdentifier, UserEntity> innerMap = entityMap.computeIfAbsent(nodeUserEntity.getId(), k -> new HashMap<>());
                 innerMap.put(nodeResponse.getNodeId(), nodeUserEntity);
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMerger.java
@@ -36,6 +36,17 @@ import java.util.stream.Collectors;
 
 public class ControllerServiceEntityMerger implements ComponentEntityMerger<ControllerServiceEntity> {
 
+    @Override
+    public void merge(ControllerServiceEntity clientEntity, Map<NodeIdentifier, ControllerServiceEntity> entityMap) {
+        ComponentEntityMerger.super.merge(clientEntity, entityMap);
+        for (Map.Entry<NodeIdentifier, ControllerServiceEntity> entry : entityMap.entrySet()) {
+            final ControllerServiceEntity entityStatus = entry.getValue();
+            if (clientEntity != entityStatus) {
+                StatusMerger.merge(clientEntity.getStatus(), entry.getValue().getStatus());
+            }
+        }
+    }
+
     /**
      * Merges the ControllerServiceEntity responses.
      *

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMerger.java
@@ -29,6 +29,17 @@ import java.util.stream.Collectors;
 
 public class ReportingTaskEntityMerger implements ComponentEntityMerger<ReportingTaskEntity> {
 
+    @Override
+    public void merge(ReportingTaskEntity clientEntity, Map<NodeIdentifier, ReportingTaskEntity> entityMap) {
+        ComponentEntityMerger.super.merge(clientEntity, entityMap);
+        for (Map.Entry<NodeIdentifier, ReportingTaskEntity> entry : entityMap.entrySet()) {
+            final ReportingTaskEntity entityStatus = entry.getValue();
+            if (clientEntity != entityStatus) {
+                StatusMerger.merge(clientEntity.getStatus(), entry.getValue().getStatus());
+            }
+        }
+    }
+
     /**
      * Merges the ReportingTaskEntity responses.
      *

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMerger.java
@@ -34,8 +34,8 @@ public class ReportingTaskEntityMerger implements ComponentEntityMerger<Reportin
         ComponentEntityMerger.super.merge(clientEntity, entityMap);
         for (Map.Entry<NodeIdentifier, ReportingTaskEntity> entry : entityMap.entrySet()) {
             final ReportingTaskEntity entityStatus = entry.getValue();
-            if (clientEntity != entityStatus) {
-                StatusMerger.merge(clientEntity.getStatus(), entry.getValue().getStatus());
+            if (!clientEntity.equals(entityStatus)) {
+                StatusMerger.merge(clientEntity.getStatus(), entityStatus.getStatus());
             }
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMerger.java
@@ -34,7 +34,7 @@ public class ReportingTaskEntityMerger implements ComponentEntityMerger<Reportin
         ComponentEntityMerger.super.merge(clientEntity, entityMap);
         for (Map.Entry<NodeIdentifier, ReportingTaskEntity> entry : entityMap.entrySet()) {
             final ReportingTaskEntity entityStatus = entry.getValue();
-            if (!clientEntity.equals(entityStatus)) {
+            if (clientEntity != entityStatus) {
                 StatusMerger.merge(clientEntity.getStatus(), entityStatus.getStatus());
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -1026,15 +1026,15 @@ public class StatusMerger {
 
         // RunStatus for ControllerServiceStatusDTO can be one of [ENABLED, ENABLING, DISABLED, DISABLING]
         if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
-            target.setRunStatus(ControllerServiceState.DISABLING.toString());
+            target.setRunStatus(ControllerServiceState.DISABLING.name());
         } else if (ControllerServiceState.ENABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
-            target.setRunStatus(ControllerServiceState.ENABLING.toString());
+            target.setRunStatus(ControllerServiceState.ENABLING.name());
         }
 
         if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
-            target.setValidationStatus(ValidationStatus.VALIDATING.toString());
+            target.setValidationStatus(ValidationStatus.VALIDATING.name());
         } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
-            target.setValidationStatus(ValidationStatus.INVALID.toString());
+            target.setValidationStatus(ValidationStatus.INVALID.name());
         }
     }
 
@@ -1046,9 +1046,9 @@ public class StatusMerger {
         target.setActiveThreadCount(target.getActiveThreadCount() + toMerge.getActiveThreadCount());
 
         if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
-            target.setValidationStatus(ValidationStatus.VALIDATING.toString());
+            target.setValidationStatus(ValidationStatus.VALIDATING.name());
         } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
-            target.setValidationStatus(ValidationStatus.INVALID.toString());
+            target.setValidationStatus(ValidationStatus.INVALID.name());
         }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -1025,15 +1025,15 @@ public class StatusMerger {
         }
 
         // RunStatus for ControllerServiceStatusDTO can be one of [ENABLED, ENABLING, DISABLED, DISABLING]
-        if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+        if (ControllerServiceState.DISABLING.name().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setRunStatus(ControllerServiceState.DISABLING.name());
-        } else if (ControllerServiceState.ENABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+        } else if (ControllerServiceState.ENABLING.name().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setRunStatus(ControllerServiceState.ENABLING.name());
         }
 
-        if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
+        if (ValidationStatus.VALIDATING.name().equalsIgnoreCase(toMerge.getValidationStatus())) {
             target.setValidationStatus(ValidationStatus.VALIDATING.name());
-        } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+        } else if (ValidationStatus.INVALID.name().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setValidationStatus(ValidationStatus.INVALID.name());
         }
     }
@@ -1045,9 +1045,9 @@ public class StatusMerger {
 
         target.setActiveThreadCount(target.getActiveThreadCount() + toMerge.getActiveThreadCount());
 
-        if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
+        if (ValidationStatus.VALIDATING.name().equalsIgnoreCase(toMerge.getValidationStatus())) {
             target.setValidationStatus(ValidationStatus.VALIDATING.name());
-        } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+        } else if (ValidationStatus.INVALID.name().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setValidationStatus(ValidationStatus.INVALID.name());
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -1025,8 +1025,8 @@ public class StatusMerger {
         }
 
         // RunStatus for ControllerServiceStatusDTO can be one of [ENABLED, ENABLING, DISABLED, DISABLING]
-        if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus()) &&
-            ControllerServiceState.DISABLED.toString().equalsIgnoreCase(target.getRunStatus())) {
+        if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())
+            && ControllerServiceState.DISABLED.toString().equalsIgnoreCase(target.getRunStatus())) {
             target.setRunStatus(ControllerServiceState.DISABLING.toString());
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -1025,13 +1025,14 @@ public class StatusMerger {
         }
 
         // RunStatus for ControllerServiceStatusDTO can be one of [ENABLED, ENABLING, DISABLED, DISABLING]
-        if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())
-            && ControllerServiceState.DISABLED.toString().equalsIgnoreCase(target.getRunStatus())) {
+        if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setRunStatus(ControllerServiceState.DISABLING.toString());
+        } else if (ControllerServiceState.ENABLING.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+            target.setRunStatus(ControllerServiceState.ENABLING.toString());
         }
 
         if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
-            target.setValidationStatus(RunStatus.Validating.toString());
+            target.setValidationStatus(ValidationStatus.VALIDATING.toString());
         } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setValidationStatus(ValidationStatus.INVALID.toString());
         }
@@ -1044,14 +1045,10 @@ public class StatusMerger {
 
         target.setActiveThreadCount(target.getActiveThreadCount() + toMerge.getActiveThreadCount());
 
-        // RunStatus for ReportingTaskStatusDTO can be one of [RUNNING, STOPPED, DISABLED]
-        target.setRunStatus(toMerge.getRunStatus());
-
         if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
-            target.setValidationStatus(RunStatus.Validating.toString());
+            target.setValidationStatus(ValidationStatus.VALIDATING.toString());
         } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
             target.setValidationStatus(ValidationStatus.INVALID.toString());
         }
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -17,6 +17,8 @@
 
 package org.apache.nifi.cluster.manager;
 
+import org.apache.nifi.components.validation.ValidationStatus;
+import org.apache.nifi.controller.service.ControllerServiceState;
 import org.apache.nifi.controller.status.FlowFileAvailability;
 import org.apache.nifi.controller.status.ProcessGroupStatus;
 import org.apache.nifi.controller.status.RunStatus;
@@ -41,6 +43,7 @@ import org.apache.nifi.web.api.dto.diagnostics.JVMSystemDiagnosticsSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.ConnectionStatusDTO;
 import org.apache.nifi.web.api.dto.status.ConnectionStatusPredictionsSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.ConnectionStatusSnapshotDTO;
+import org.apache.nifi.web.api.dto.status.ControllerServiceStatusDTO;
 import org.apache.nifi.web.api.dto.status.ControllerStatusDTO;
 import org.apache.nifi.web.api.dto.status.NodeConnectionStatusSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.NodePortStatusSnapshotDTO;
@@ -55,6 +58,7 @@ import org.apache.nifi.web.api.dto.status.ProcessorStatusDTO;
 import org.apache.nifi.web.api.dto.status.ProcessorStatusSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.RemoteProcessGroupStatusDTO;
 import org.apache.nifi.web.api.dto.status.RemoteProcessGroupStatusSnapshotDTO;
+import org.apache.nifi.web.api.dto.status.ReportingTaskStatusDTO;
 import org.apache.nifi.web.api.entity.ConnectionStatusSnapshotEntity;
 import org.apache.nifi.web.api.entity.PortStatusSnapshotEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupStatusSnapshotEntity;
@@ -1013,6 +1017,41 @@ public class StatusMerger {
         }
 
         return formatCount(count) + " (" + formatDataSize(bytes) + ")";
+    }
+
+    public static void merge(final ControllerServiceStatusDTO target, final ControllerServiceStatusDTO toMerge) {
+        if (target == null || toMerge == null) {
+            return;
+        }
+
+        // RunStatus for ControllerServiceStatusDTO can be one of [ENABLED, ENABLING, DISABLED, DISABLING]
+        if (ControllerServiceState.DISABLING.toString().equalsIgnoreCase(toMerge.getRunStatus()) &&
+            ControllerServiceState.DISABLED.toString().equalsIgnoreCase(target.getRunStatus())) {
+            target.setRunStatus(ControllerServiceState.DISABLING.toString());
+        }
+
+        if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
+            target.setValidationStatus(RunStatus.Validating.toString());
+        } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+            target.setValidationStatus(ValidationStatus.INVALID.toString());
+        }
+    }
+
+    public static void merge(final ReportingTaskStatusDTO target, final ReportingTaskStatusDTO toMerge) {
+        if (target == null || toMerge == null) {
+            return;
+        }
+
+        target.setActiveThreadCount(target.getActiveThreadCount() + toMerge.getActiveThreadCount());
+
+        // RunStatus for ReportingTaskStatusDTO can be one of [RUNNING, STOPPED, DISABLED]
+        target.setRunStatus(toMerge.getRunStatus());
+
+        if (ValidationStatus.VALIDATING.toString().equalsIgnoreCase(toMerge.getValidationStatus())) {
+            target.setValidationStatus(RunStatus.Validating.toString());
+        } else if (ValidationStatus.INVALID.toString().equalsIgnoreCase(toMerge.getRunStatus())) {
+            target.setValidationStatus(ValidationStatus.INVALID.toString());
+        }
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
@@ -1,0 +1,69 @@
+package org.apache.nifi.cluster.manager;
+
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.components.validation.ValidationStatus;
+import org.apache.nifi.controller.ScheduledState;
+import org.apache.nifi.controller.status.RunStatus;
+import org.apache.nifi.web.api.dto.ControllerServiceDTO;
+import org.apache.nifi.web.api.dto.PermissionsDTO;
+import org.apache.nifi.web.api.dto.RevisionDTO;
+import org.apache.nifi.web.api.dto.status.ControllerServiceStatusDTO;
+import org.apache.nifi.web.api.entity.ControllerServiceEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ControllerServiceEntityMergerTest {
+
+    @Test
+    void TestMergeStatusFields() {
+        final ControllerServiceEntity nodeOneControllerserviceEntity = getControllerServiceEntity("id1", RunStatus.Stopped.toString(), ValidationStatus.VALIDATING.toString());
+        final ControllerServiceEntity nodeTwoControllerServiceEntity = getControllerServiceEntity("id2", RunStatus.Validating.toString(), ValidationStatus.INVALID.toString());
+        final Map<NodeIdentifier, ControllerServiceEntity> entityMap = new HashMap();
+        entityMap.put(getNodeIdentifier("node1", 8000), nodeOneControllerserviceEntity);
+        entityMap.put(getNodeIdentifier("node2", 8010), nodeTwoControllerServiceEntity);
+
+        ControllerServiceEntityMerger merger = new ControllerServiceEntityMerger();
+        merger.merge(nodeOneControllerserviceEntity, entityMap);
+        assertEquals("Stopped", nodeOneControllerserviceEntity.getStatus().getRunStatus());
+    }
+
+    private NodeIdentifier getNodeIdentifier(final String id, final int port) {
+        return new NodeIdentifier(id, "localhost", port, "localhost", port+1, "localhost", port+2, port+3, true);
+    }
+
+    private ControllerServiceEntity getControllerServiceEntity(final String id, final String runStatus, final String validationStatus) {
+        final ControllerServiceDTO dto = new ControllerServiceDTO();
+        dto.setId(id);
+        dto.setState(ScheduledState.STOPPED.name());
+        dto.setValidationStatus(ValidationStatus.VALIDATING.toString());
+
+        final ControllerServiceStatusDTO statusDto = new ControllerServiceStatusDTO();
+        statusDto.setRunStatus(RunStatus.Stopped.toString());
+        statusDto.setActiveThreadCount(1);
+        statusDto.setValidationStatus(ValidationStatus.VALIDATING.toString());
+
+        final PermissionsDTO permissed = new PermissionsDTO();
+        permissed.setCanRead(true);
+        permissed.setCanWrite(true);
+
+        final ControllerServiceEntity entity = new ControllerServiceEntity();
+        entity.setComponent(dto);
+        entity.setRevision(createNewRevision());
+        entity.setDisconnectedNodeAcknowledged(true);
+        entity.setPermissions(permissed);
+        entity.setStatus(statusDto);
+
+        return entity;
+    }
+
+    public RevisionDTO createNewRevision() {
+        final RevisionDTO revisionDto = new RevisionDTO();
+        revisionDto.setClientId(getClass().getName());
+        revisionDto.setVersion(0L);
+        return revisionDto;
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ControllerServiceEntityMergerTest {
 
     @Test
-    void TestMergeStatusFields() {
+    void testMergeStatusFields() {
         final ControllerServiceEntity nodeOneControllerserviceEntity = getControllerServiceEntity("id1", RunStatus.Stopped.toString(), ValidationStatus.VALIDATING.toString());
         final ControllerServiceEntity nodeTwoControllerServiceEntity = getControllerServiceEntity("id2", RunStatus.Validating.toString(), ValidationStatus.INVALID.toString());
         final Map<NodeIdentifier, ControllerServiceEntity> entityMap = new HashMap();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
@@ -37,8 +37,8 @@ class ControllerServiceEntityMergerTest {
 
     @Test
     void testMergeStatusFields() {
-        final ControllerServiceEntity nodeOneControllerserviceEntity = getControllerServiceEntity("id1", RunStatus.Stopped.toString(), ValidationStatus.VALIDATING.toString());
-        final ControllerServiceEntity nodeTwoControllerServiceEntity = getControllerServiceEntity("id2", RunStatus.Validating.toString(), ValidationStatus.INVALID.toString());
+        final ControllerServiceEntity nodeOneControllerserviceEntity = getControllerServiceEntity("id1", RunStatus.Stopped.name(), ValidationStatus.VALIDATING.name());
+        final ControllerServiceEntity nodeTwoControllerServiceEntity = getControllerServiceEntity("id2", RunStatus.Validating.name(), ValidationStatus.INVALID.name());
         final Map<NodeIdentifier, ControllerServiceEntity> entityMap = new HashMap();
         entityMap.put(getNodeIdentifier("node1", 8000), nodeOneControllerserviceEntity);
         entityMap.put(getNodeIdentifier("node2", 8010), nodeTwoControllerServiceEntity);
@@ -56,12 +56,12 @@ class ControllerServiceEntityMergerTest {
         final ControllerServiceDTO dto = new ControllerServiceDTO();
         dto.setId(id);
         dto.setState(ScheduledState.STOPPED.name());
-        dto.setValidationStatus(ValidationStatus.VALIDATING.toString());
+        dto.setValidationStatus(ValidationStatus.VALIDATING.name());
 
         final ControllerServiceStatusDTO statusDto = new ControllerServiceStatusDTO();
-        statusDto.setRunStatus(RunStatus.Stopped.toString());
+        statusDto.setRunStatus(RunStatus.Stopped.name());
         statusDto.setActiveThreadCount(1);
-        statusDto.setValidationStatus(ValidationStatus.VALIDATING.toString());
+        statusDto.setValidationStatus(ValidationStatus.VALIDATING.name());
 
         final PermissionsDTO permissed = new PermissionsDTO();
         permissed.setCanRead(true);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ControllerServiceEntityMergerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.nifi.cluster.manager;
 
 import org.apache.nifi.cluster.protocol.NodeIdentifier;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ReportingTaskEntityMergerTest {
 
     @Test
-    void TestMergeStatusFields() {
+    void testMergeStatusFields() {
         final ReportingTaskEntity nodeOneReportingTaskEntity = getReportingTaskEntity("id1", ReportingTaskStatusDTO.RUNNING, ValidationStatus.VALID.name());
         final ReportingTaskEntity nodeTwoReportingTaskEntity = getReportingTaskEntity("id2", ReportingTaskStatusDTO.RUNNING, ValidationStatus.VALIDATING.name());
         final Map<NodeIdentifier, ReportingTaskEntity> entityMap = new HashMap();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
@@ -1,0 +1,71 @@
+package org.apache.nifi.cluster.manager;
+
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.components.validation.ValidationStatus;
+import org.apache.nifi.controller.ScheduledState;
+import org.apache.nifi.controller.service.ControllerServiceState;
+import org.apache.nifi.controller.status.RunStatus;
+import org.apache.nifi.web.api.dto.PermissionsDTO;
+import org.apache.nifi.web.api.dto.ReportingTaskDTO;
+import org.apache.nifi.web.api.dto.RevisionDTO;
+import org.apache.nifi.web.api.dto.status.ReportingTaskStatusDTO;
+import org.apache.nifi.web.api.entity.ReportingTaskEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportingTaskEntityMergerTest {
+
+    @Test
+    void TestMergeStatusFields() {
+        final ReportingTaskEntity nodeOneReportingTaskEntity = getReportingTaskEntity("id1", RunStatus.Disabled.toString(), ValidationStatus.VALIDATING.toString());
+        final ReportingTaskEntity nodeTwoReportingTaskEntity = getReportingTaskEntity("id2", ControllerServiceState.DISABLING.toString(), ValidationStatus.INVALID.toString());
+        final Map<NodeIdentifier, ReportingTaskEntity> entityMap = new HashMap();
+        entityMap.put(getNodeIdentifier("node1", 8000), nodeOneReportingTaskEntity);
+        entityMap.put(getNodeIdentifier("node2", 8010), nodeTwoReportingTaskEntity);
+
+        ReportingTaskEntityMerger merger = new ReportingTaskEntityMerger();
+        merger.merge(nodeOneReportingTaskEntity, entityMap);
+        assertEquals(2, nodeOneReportingTaskEntity.getStatus().getActiveThreadCount());
+        assertEquals("DISABLING", nodeOneReportingTaskEntity.getStatus().getRunStatus());
+    }
+
+    private NodeIdentifier getNodeIdentifier(final String id, final int port) {
+        return new NodeIdentifier(id, "localhost", port, "localhost", port+1, "localhost", port+2, port+3, true);
+    }
+
+    private ReportingTaskEntity getReportingTaskEntity(final String id, final String runStatus, final String validationStatus) {
+        final ReportingTaskDTO dto = new ReportingTaskDTO();
+        dto.setId(id);
+        dto.setState(ScheduledState.STOPPED.name());
+        dto.setValidationStatus(validationStatus);
+
+        final ReportingTaskStatusDTO statusDto = new ReportingTaskStatusDTO();
+        statusDto.setRunStatus(runStatus);
+        statusDto.setActiveThreadCount(1);
+        statusDto.setValidationStatus(validationStatus);
+
+        final PermissionsDTO permissed = new PermissionsDTO();
+        permissed.setCanRead(true);
+        permissed.setCanWrite(true);
+
+        final ReportingTaskEntity entity = new ReportingTaskEntity();
+        entity.setComponent(dto);
+        entity.setRevision(createNewRevision());
+        entity.setDisconnectedNodeAcknowledged(true);
+        entity.setPermissions(permissed);
+        entity.setStatus(statusDto);
+
+        return entity;
+    }
+
+    public RevisionDTO createNewRevision() {
+        final RevisionDTO revisionDto = new RevisionDTO();
+        revisionDto.setClientId(getClass().getName());
+        revisionDto.setVersion(0L);
+        return revisionDto;
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.nifi.cluster.manager;
 
 import org.apache.nifi.cluster.protocol.NodeIdentifier;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ReportingTaskEntityMergerTest.java
@@ -20,8 +20,6 @@ package org.apache.nifi.cluster.manager;
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.components.validation.ValidationStatus;
 import org.apache.nifi.controller.ScheduledState;
-import org.apache.nifi.controller.service.ControllerServiceState;
-import org.apache.nifi.controller.status.RunStatus;
 import org.apache.nifi.web.api.dto.PermissionsDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
 import org.apache.nifi.web.api.dto.RevisionDTO;
@@ -38,8 +36,8 @@ class ReportingTaskEntityMergerTest {
 
     @Test
     void TestMergeStatusFields() {
-        final ReportingTaskEntity nodeOneReportingTaskEntity = getReportingTaskEntity("id1", RunStatus.Disabled.toString(), ValidationStatus.VALIDATING.toString());
-        final ReportingTaskEntity nodeTwoReportingTaskEntity = getReportingTaskEntity("id2", ControllerServiceState.DISABLING.toString(), ValidationStatus.INVALID.toString());
+        final ReportingTaskEntity nodeOneReportingTaskEntity = getReportingTaskEntity("id1", ReportingTaskStatusDTO.RUNNING, ValidationStatus.VALID.name());
+        final ReportingTaskEntity nodeTwoReportingTaskEntity = getReportingTaskEntity("id2", ReportingTaskStatusDTO.RUNNING, ValidationStatus.VALIDATING.name());
         final Map<NodeIdentifier, ReportingTaskEntity> entityMap = new HashMap();
         entityMap.put(getNodeIdentifier("node1", 8000), nodeOneReportingTaskEntity);
         entityMap.put(getNodeIdentifier("node2", 8010), nodeTwoReportingTaskEntity);
@@ -47,7 +45,8 @@ class ReportingTaskEntityMergerTest {
         ReportingTaskEntityMerger merger = new ReportingTaskEntityMerger();
         merger.merge(nodeOneReportingTaskEntity, entityMap);
         assertEquals(2, nodeOneReportingTaskEntity.getStatus().getActiveThreadCount());
-        assertEquals("DISABLING", nodeOneReportingTaskEntity.getStatus().getRunStatus());
+        assertEquals(ReportingTaskStatusDTO.RUNNING, nodeOneReportingTaskEntity.getStatus().getRunStatus());
+        assertEquals(ValidationStatus.VALIDATING.name(), nodeOneReportingTaskEntity.getStatus().getValidationStatus());
     }
 
     private NodeIdentifier getNodeIdentifier(final String id, final int port) {


### PR DESCRIPTION
…ReportingTask entities.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10070](https://issues.apache.org/jira/browse/NIFI-10070) - The status DTO's in the ControllerServiceEntityMerger and the ReportingTaskEntityMerger both needed to be merged along with their entity to correct an issue with shutdown of a NiFi flow.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
