### PR TITLE
NIFI-8248 Modify PutAzureDataLakeStorage processor to use temp file i…

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
@@ -101,6 +101,8 @@ public abstract class AbstractAzureDataLakeStorageProcessor extends AbstractProc
             REL_FAILURE
     )));
 
+    public static final String TEMP_FILE_DIRECTORY = "_$azuretempdirectory$";
+
     @Override
     public Set<Relationship> getRelationships() {
         return RELATIONSHIPS;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
@@ -101,7 +101,7 @@ public abstract class AbstractAzureDataLakeStorageProcessor extends AbstractProc
             REL_FAILURE
     )));
 
-    public static final String TEMP_FILE_DIRECTORY = "_$azuretempdirectory$";
+    public static final String TEMP_FILE_DIRECTORY = "_nifitempdirectory";
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
@@ -132,7 +132,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
 
     public static final PropertyDescriptor INCLUDE_TEMPORARY_FILES = new PropertyDescriptor.Builder()
             .name("include-temporary-files")
-            .displayName("include temporary files")
+            .displayName("Include Temporary Files")
             .description("Whether to include temporary files when listing the contents of configured directory paths.")
             .required(true)
             .allowableValues(Boolean.TRUE.toString(), Boolean.FALSE.toString())

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -20,7 +20,9 @@ import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -30,20 +32,24 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.azure.AbstractAzureDataLakeStorageProcessor;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.StringUtils;
 
 import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_DESCRIPTION_DIRECTORY;
@@ -83,11 +89,23 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .allowableValues(FAIL_RESOLUTION, REPLACE_RESOLUTION, IGNORE_RESOLUTION)
             .build();
 
+    public static final PropertyDescriptor TEMP_FILE_DIRECTORY_PATH = new PropertyDescriptor.Builder()
+            .name("temp-file-directory-path")
+            .displayName("Temp File Directory Path")
+            .description("The Path where the temporary files will be created. The Path name cannot contain a leading '/'." +
+                    " The root directory can be designated by the empty string value. Non-existing directories will be created." +
+                    "The Temp File Directory name will be " + TEMP_FILE_DIRECTORY)
+            .defaultValue("")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(new DirectoryValidator("Temp File Directory"))
+            .build();
+
     private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
             ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             DIRECTORY,
             FILE,
+            TEMP_FILE_DIRECTORY_PATH,
             CONFLICT_RESOLUTION,
             AzureStorageUtils.PROXY_CONFIGURATION_SERVICE
     ));
@@ -107,41 +125,39 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         final long startNanos = System.nanoTime();
         try {
             final String fileSystem = evaluateFileSystemProperty(context, flowFile);
-            final String directory = evaluateDirectoryProperty(context, flowFile);
+            final String originalDirectory = evaluateDirectoryProperty(context, flowFile);
+            final String tempPath = evaluateDirectoryProperty(context, flowFile, TEMP_FILE_DIRECTORY_PATH);
+            final String tempDirectory = createPath(tempPath, TEMP_FILE_DIRECTORY);
             final String fileName = evaluateFileNameProperty(context, flowFile);
 
             final DataLakeServiceClient storageClient = getStorageClient(context, flowFile);
             final DataLakeFileSystemClient fileSystemClient = storageClient.getFileSystemClient(fileSystem);
-            final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(directory);
-            final DataLakeFileClient fileClient;
+            final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(originalDirectory);
+            final DataLakeFileClient tempFileClient;
+            final DataLakeFileClient renamedFileClient;
 
+            final String tempFilePrefix = UUID.randomUUID().toString();
+            final DataLakeDirectoryClient tempDirectoryClient = fileSystemClient.getDirectoryClient(tempDirectory);
             final String conflictResolution = context.getProperty(CONFLICT_RESOLUTION).getValue();
             boolean overwrite = conflictResolution.equals(REPLACE_RESOLUTION);
 
             try {
-                fileClient = directoryClient.createFile(fileName, overwrite);
-
-                final long length = flowFile.getSize();
-                if (length > 0) {
-                    try (final InputStream rawIn = session.read(flowFile); final BufferedInputStream bufferedIn = new BufferedInputStream(rawIn)) {
-                        uploadContent(fileClient, bufferedIn, length);
-                    } catch (Exception e) {
-                        removeTempFile(fileClient);
-                        throw e;
-                    }
-                }
+                tempFileClient = tempDirectoryClient.createFile(tempFilePrefix + fileName, true);
+                appendContent(flowFile, tempFileClient, session);
+                createDirectoryIfNotExists(directoryClient);
+                renamedFileClient = renameFile(fileName, directoryClient.getDirectoryPath(), tempFileClient, overwrite);
 
                 final Map<String, String> attributes = new HashMap<>();
                 attributes.put(ATTR_NAME_FILESYSTEM, fileSystem);
-                attributes.put(ATTR_NAME_DIRECTORY, directory);
+                attributes.put(ATTR_NAME_DIRECTORY, originalDirectory);
                 attributes.put(ATTR_NAME_FILENAME, fileName);
-                attributes.put(ATTR_NAME_PRIMARY_URI, fileClient.getFileUrl());
-                attributes.put(ATTR_NAME_LENGTH, String.valueOf(length));
+                attributes.put(ATTR_NAME_PRIMARY_URI, renamedFileClient.getFileUrl());
+                attributes.put(ATTR_NAME_LENGTH, String.valueOf(flowFile.getSize()));
                 flowFile = session.putAllAttributes(flowFile, attributes);
 
                 session.transfer(flowFile, REL_SUCCESS);
                 final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-                session.getProvenanceReporter().send(flowFile, fileClient.getFileUrl(), transferMillis);
+                session.getProvenanceReporter().send(flowFile, renamedFileClient.getFileUrl(), transferMillis);
             } catch (DataLakeStorageException dlsException) {
                 if (dlsException.getStatusCode() == 409) {
                     if (conflictResolution.equals(IGNORE_RESOLUTION)) {
@@ -164,14 +180,26 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         }
     }
 
-    private void removeTempFile(DataLakeFileClient fileClient) {
-        try {
-            fileClient.delete();
-        } catch (Exception e) {
-            getLogger().error("Error while removing temp file on Azure Data Lake Storage", e);
+    private void createDirectoryIfNotExists(DataLakeDirectoryClient directoryClient) {
+        if (!directoryClient.getDirectoryPath().isEmpty() && !directoryClient.exists()) {
+            directoryClient.create();
         }
     }
 
+    @VisibleForTesting
+    void appendContent(FlowFile flowFile, DataLakeFileClient fileClient, ProcessSession session) throws IOException {
+        final long length = flowFile.getSize();
+        if (length > 0) {
+            try (final InputStream rawIn = session.read(flowFile); final BufferedInputStream bufferedIn = new BufferedInputStream(rawIn)) {
+                uploadContent(fileClient, bufferedIn, length);
+            } catch (Exception e) {
+                removeTempFile(fileClient);
+                throw e;
+            }
+        }
+    }
+
+    @VisibleForTesting
     static void uploadContent(DataLakeFileClient fileClient, InputStream in, long length) {
         long chunkStart = 0;
         long chunkSize;
@@ -189,5 +217,35 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         }
 
         fileClient.flush(length);
+    }
+
+    @VisibleForTesting
+    DataLakeFileClient renameFile(final String fileName, final String directoryPath, final DataLakeFileClient fileClient, final boolean overwrite) {
+        try {
+            final DataLakeRequestConditions destinationCondition = new DataLakeRequestConditions();
+            if (!overwrite) {
+                destinationCondition.setIfNoneMatch("*");
+            }
+            final String destinationPath = createPath(directoryPath, fileName);
+            return fileClient.renameWithResponse(null, destinationPath, null, destinationCondition, null, null).getValue();
+        } catch (DataLakeStorageException dataLakeStorageException) {
+            getLogger().error("Error while renaming temp file " + fileClient.getFileName() + " on Azure Data Lake Storage", dataLakeStorageException);
+            removeTempFile(fileClient);
+            throw dataLakeStorageException;
+        }
+    }
+
+    private String createPath(final String baseDirectory, final String path) {
+        return StringUtils.isNotBlank(baseDirectory)
+                ? baseDirectory + "/" + path
+                : path;
+    }
+
+    private void removeTempFile(final DataLakeFileClient fileClient) {
+        try {
+            fileClient.delete();
+        } catch (Exception e) {
+            getLogger().error("Error while removing temp file " + fileClient.getFileName() + " on Azure Data Lake Storage", e);
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -96,7 +96,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
                     "The Temporary File Directory name is " + TEMP_FILE_DIRECTORY)
             .defaultValue("")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .addValidator(new DirectoryValidator("Temp File Directory"))
+            .addValidator(new DirectoryValidator("Base Temporary Path"))
             .build();
 
     private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/docs/org.apache.nifi.processors.azure.storage.PutAzureDataLakeStorage/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/docs/org.apache.nifi.processors.azure.storage.PutAzureDataLakeStorage/additionalDetails.html
@@ -28,27 +28,29 @@
 
 <h3>File uploading and cleanup process</h3>
 
-<h4>New file</h4>
+<h4>New file upload</h4>
 
 <ol>
-    <li>An empty file is created.</li>
-    <li>Content is appended to file.</li>
-    <li>In case append failure the file is deleted.</li>
-    <li>In case file deletion failure the empty file remains on the server.</li>
+    <li>A temporary file is created with random prefix under the given path in '_$azuretempdirectory$'.</li>
+    <li>Content is appended to temp file.</li>
+    <li>Temp file is renamed to its original name, the original file is overwritten.</li>
+    <li>In case of appending or renaming failure the temp file is deleted, the original file remains intact.</li>
+    <li>In case of temporary file deletion failure both temp file and original file remain on the server.</li>
 </ol>
 
-<h4>Existing file</h4>
+<h4>Existing file upload</h4>
 
 <ul>
     <li>Processors with "fail" conflict resolution strategy will be directed to "Failure" relationship.</li>
-     <li>Processors with "ignore" conflict resolution strategy will be directed to "Success" relationship.</li>
+    <li>Processors with "ignore" conflict resolution strategy will be directed to "Success" relationship.</li>
     <li>Processors with "replace" conflict resolution strategy:</li>
 
     <ol>
-        <li>An empty file overwrites the existing file, the original file is lost.</li>
-        <li>Content is appended to file.</li>
-        <li>In case append failure the file is deleted.</li>
-        <li>In case file deletion failure the empty file remains on the server.</li>
+        <li>A temporary file is created with random prefix under the given path in '_$azuretempdirectory$'.</li>
+        <li>Content is appended to temp file.</li>
+        <li>Temp file is renamed to its original name, the original file is overwritten.</li>
+        <li>In case of appending or renaming failure the temp file is deleted, the original file remains intact.</li>
+        <li>In case of temporary file deletion failure both temp file and original file remain on the server.</li>
     </ol>
 </ul>
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/docs/org.apache.nifi.processors.azure.storage.PutAzureDataLakeStorage/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/docs/org.apache.nifi.processors.azure.storage.PutAzureDataLakeStorage/additionalDetails.html
@@ -31,7 +31,7 @@
 <h4>New file upload</h4>
 
 <ol>
-    <li>A temporary file is created with random prefix under the given path in '_$azuretempdirectory$'.</li>
+    <li>A temporary file is created with random prefix under the given path in '_nifitempdirectory'.</li>
     <li>Content is appended to temp file.</li>
     <li>Temp file is renamed to its original name, the original file is overwritten.</li>
     <li>In case of appending or renaming failure the temp file is deleted, the original file remains intact.</li>
@@ -46,7 +46,7 @@
     <li>Processors with "replace" conflict resolution strategy:</li>
 
     <ol>
-        <li>A temporary file is created with random prefix under the given path in '_$azuretempdirectory$'.</li>
+        <li>A temporary file is created with random prefix under the given path in '_nifitempdirectory'.</li>
         <li>Content is appended to temp file.</li>
         <li>Temp file is renamed to its original name, the original file is overwritten.</li>
         <li>In case of appending or renaming failure the temp file is deleted, the original file remains intact.</li>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITListAzureDataLakeStorage.java
@@ -58,7 +58,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         uploadFile(testFile1);
         testFiles.put(testFile1.getFilePath(), testFile1);
 
-        TestFile testTempFile1 = new TestFile("_$azuretempdirectory$", "1234file1");
+        TestFile testTempFile1 = new TestFile(AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY, "1234file1");
         uploadFile(testTempFile1);
         testFiles.put(testTempFile1.getFilePath(), testTempFile1);
 
@@ -70,7 +70,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         createDirectoryAndUploadFile(testFile11);
         testFiles.put(testFile11.getFilePath(), testFile11);
 
-        TestFile testTempFile11 = new TestFile("dir1/_$azuretempdirectory$", "5678file11");
+        TestFile testTempFile11 = new TestFile(String.format("dir1/%s", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY), "5678file11");
         uploadFile(testTempFile11);
         testFiles.put(testTempFile11.getFilePath(), testTempFile11);
 
@@ -82,7 +82,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         createDirectoryAndUploadFile(testFile111);
         testFiles.put(testFile111.getFilePath(), testFile111);
 
-        TestFile testTempFile111 = new TestFile("dir1/dir11/_$azuretempdirectory$", "9010file111");
+        TestFile testTempFile111 = new TestFile(String.format("dir1/dir11/%s", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY), "9010file111");
         uploadFile(testTempFile111);
         testFiles.put(testTempFile111.getFilePath(), testTempFile111);
 
@@ -90,7 +90,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         createDirectoryAndUploadFile(testFile21);
         testFiles.put(testFile21.getFilePath(), testFile21);
 
-        TestFile testTempFile21 = new TestFile("dir2/_$azuretempdirectory$", "1112file21", "Test");
+        TestFile testTempFile21 = new TestFile(String.format("dir2/%s", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY), "1112file21", "Test");
         uploadFile(testTempFile21);
         testFiles.put(testTempFile21.getFilePath(), testTempFile21);
 
@@ -109,13 +109,15 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     @Test
     public void testListRootRecursiveWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
         assertSuccess("file1", "file2", "dir1/file11", "dir1/file12", "dir1/dir11/file111", "dir 2/file 21",
-                "_$azuretempdirectory$/1234file1", "dir1/_$azuretempdirectory$/5678file11",
-                "dir1/dir11/_$azuretempdirectory$/9010file111", "dir2/_$azuretempdirectory$/1112file21");
+                String.format("%s/1234file1", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir2/%s/1112file21", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -142,7 +144,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListRootNonRecursiveWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.RECURSE_SUBDIRECTORIES, "false");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
@@ -161,12 +163,13 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     @Test
     public void testListSubdirectoryRecursiveWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "dir1");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
-        assertSuccess("dir1/file11", "dir1/file12", "dir1/dir11/file111", "dir1/_$azuretempdirectory$/5678file11",
-                "dir1/dir11/_$azuretempdirectory$/9010file111");
+        assertSuccess("dir1/file11", "dir1/file12", "dir1/dir11/file111",
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -183,7 +186,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListSubdirectoryNonRecursiveWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "dir1");
         runner.setProperty(ListAzureDataLakeStorage.RECURSE_SUBDIRECTORIES, "false");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
@@ -204,12 +207,14 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListWithFileFilterWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.FILE_FILTER, ".*file1.*$");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
-        assertSuccess("file1", "dir1/file11", "dir1/file12", "dir1/dir11/file111", "_$azuretempdirectory$/1234file1",
-                "dir1/_$azuretempdirectory$/5678file11", "dir1/dir11/_$azuretempdirectory$/9010file111");
+        assertSuccess("file1", "dir1/file11", "dir1/file12", "dir1/dir11/file111",
+                String.format("%s/1234file1", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -228,12 +233,14 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.FILE_FILTER, ".*file${suffix}$");
         runner.setVariable("suffix", "1.*");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
-        assertSuccess("file1", "dir1/file11", "dir1/file12", "dir1/dir11/file111", "_$azuretempdirectory$/1234file1",
-                "dir1/_$azuretempdirectory$/5678file11", "dir1/dir11/_$azuretempdirectory$/9010file111");
+        assertSuccess("file1", "dir1/file11", "dir1/file12", "dir1/dir11/file111",
+                String.format("%s/1234file1", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -250,12 +257,13 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListRootWithPathFilterWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.PATH_FILTER, "^dir1.*$");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
         assertSuccess("dir1/file11", "dir1/file12", "dir1/dir11/file111",
-                "dir1/_$azuretempdirectory$/5678file11", "dir1/dir11/_$azuretempdirectory$/9010file111");
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -276,12 +284,13 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         runner.setProperty(ListAzureDataLakeStorage.PATH_FILTER, "${prefix}${suffix}");
         runner.setVariable("prefix", "^dir");
         runner.setVariable("suffix", "1.*$");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
         assertSuccess("dir1/file11", "dir1/file12", "dir1/dir11/file111",
-                "dir1/_$azuretempdirectory$/5678file11", "dir1/dir11/_$azuretempdirectory$/9010file111");
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -298,11 +307,11 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListSubdirectoryWithPathFilterWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "dir1");
         runner.setProperty(ListAzureDataLakeStorage.PATH_FILTER, "dir1.*");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
-        assertSuccess("dir1/dir11/file111", "dir1/dir11/_$azuretempdirectory$/9010file111");
+        assertSuccess("dir1/dir11/file111", String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -321,12 +330,12 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.FILE_FILTER, ".*11");
         runner.setProperty(ListAzureDataLakeStorage.PATH_FILTER, "dir1.*");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
-        assertSuccess("dir1/file11", "dir1/dir11/file111", "dir1/_$azuretempdirectory$/5678file11",
-                "dir1/dir11/_$azuretempdirectory$/9010file111");
+        assertSuccess("dir1/file11", "dir1/dir11/file111", String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -382,7 +391,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         runner.enableControllerService(recordWriter);
         runner.setProperty(ListAzureDataLakeStorage.RECORD_WRITER, "record-writer");
 
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runner.run();
 
@@ -405,7 +414,7 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListWithMinAgeWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.MIN_AGE, "1 hour");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
@@ -426,13 +435,15 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListWithMaxAgeWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.MAX_AGE, "1 hour");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
         assertSuccess("file1", "file2", "dir1/file11", "dir1/file12", "dir1/dir11/file111", "dir 2/file 21",
-                "_$azuretempdirectory$/1234file1", "dir1/_$azuretempdirectory$/5678file11",
-                "dir1/dir11/_$azuretempdirectory$/9010file111", "dir2/_$azuretempdirectory$/1112file21");
+                String.format("%s/1234file1", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir2/%s/1112file21", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -449,13 +460,14 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListWithMinSizeWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.MIN_SIZE, "5 B");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
         assertSuccess("file1", "file2", "dir1/file11", "dir1/file12", "dir1/dir11/file111",
-                "_$azuretempdirectory$/1234file1", "dir1/_$azuretempdirectory$/5678file11",
-                "dir1/dir11/_$azuretempdirectory$/9010file111");
+                String.format("%s/1234file1", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/%s/5678file11", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY),
+                String.format("dir1/dir11/%s/9010file111", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     @Test
@@ -472,11 +484,11 @@ public class ITListAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     public void testListWithMaxSizeWithTempFiles() throws Exception {
         runner.setProperty(AbstractAzureDataLakeStorageProcessor.DIRECTORY, "");
         runner.setProperty(ListAzureDataLakeStorage.MAX_SIZE, "5 B");
-        runner.setProperty(ListAzureDataLakeStorage.SHOW_TEMPORARY_FILES, "true");
+        runner.setProperty(ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES, "true");
 
         runProcessor();
 
-        assertSuccess("dir 2/file 21", "dir2/_$azuretempdirectory$/1112file21");
+        assertSuccess("dir 2/file 21", String.format("dir2/%s/1112file21", AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY));
     }
 
     private void runProcessor() {


### PR DESCRIPTION
# Summary

[NIFI-8248](https://issues.apache.org/jira/browse/NIFI-8248) enables the usage of a temporary file instead of immediate overwrite.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
