### PR TITLE
NIFI-10158 Correct ListFTP expression support for Hostname and Port

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ftp/StandardFTPClientProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ftp/StandardFTPClientProvider.java
@@ -79,11 +79,16 @@ public class StandardFTPClientProvider implements FTPClientProvider {
 
         final boolean attributesEmpty = attributes.isEmpty();
 
+        // Evaluate Hostname and Port properties based on the presence of attributes because ListFTP does not support FlowFile attributes
         final PropertyValue hostnameProperty = context.getProperty(HOSTNAME);
-        final String hostname = attributesEmpty ? hostnameProperty.getValue() : hostnameProperty.evaluateAttributeExpressions(attributes).getValue();
+        final String hostname = attributesEmpty
+                ? hostnameProperty.evaluateAttributeExpressions().getValue()
+                : hostnameProperty.evaluateAttributeExpressions(attributes).getValue();
 
         final PropertyValue portProperty = context.getProperty(PORT);
-        final int port = attributesEmpty ? portProperty.asInteger() : portProperty.evaluateAttributeExpressions(attributes).asInteger();
+        final int port = attributesEmpty
+                ? portProperty.evaluateAttributeExpressions().asInteger()
+                : portProperty.evaluateAttributeExpressions(attributes).asInteger();
         final String address = String.format(ADDRESS_FORMAT, hostname, port);
 
         try {
@@ -96,7 +101,9 @@ public class StandardFTPClientProvider implements FTPClientProvider {
         }
 
         final PropertyValue usernameProperty = context.getProperty(USERNAME);
-        final String username = attributesEmpty ? usernameProperty.getValue() : usernameProperty.evaluateAttributeExpressions(attributes).getValue();
+        final String username = attributesEmpty
+                ? usernameProperty.evaluateAttributeExpressions().getValue()
+                : usernameProperty.evaluateAttributeExpressions(attributes).getValue();
         final String password = context.getProperty(PASSWORD).evaluateAttributeExpressions(attributes).getValue();
 
         try {


### PR DESCRIPTION
# Summary

[NIFI-10158](https://issues.apache.org/jira/browse/NIFI-10158) Corrects `ListFTP` support for expression language in `Hostname` and `Port` properties.

The `ListFTP` processor declares support for expression language values derived from a variable registry, but property resolution did not perform expression evaluation in `StandardFTPClientProvider`. `ListFTP` does not have access to a FlowFile and so provides an empty Map of attributes, whereas other FTP processors provide a Map of attributes from an input FlowFile.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
