### PR TITLE
NIFI-10182 Remove optional vendor Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1089,31 +1089,6 @@
                 </dependencies>
             </dependencyManagement>
         </profile>
-        <!-- The following profiles are here as a convenience for folks that
-            want to build against vendor-specific distributions of the various Hadoop
-            ecosystem libraries. These will alter which dependencies are sourced in a
-            manner that can adjust the correct LICENSE and NOTICE requirements for any
-            affected jar and the resulting assembly overall. These L&N impacts are not
-            automatically handled by the build process and are the responsibility of
-            those creating and using the resulting binary artifacts. -->
-        <profile>
-            <!-- This profile will add the Cloudera repository for resolving
-                Cloudera Distribution of Hadoop (CDH) artifacts for the Hadoop bundles -->
-            <id>cloudera</id>
-            <repositories>
-                <repository>
-                    <id>cloudera-repo</id>
-                    <name>Cloudera Repository</name>
-                    <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
         <profile>
             <!-- Run "mvn validate -P dependency-check" to generate dependency-check-report.html in the target directory -->
             <!-- Report results require detailed analysis to determine whether the vulnerability impacts the application -->


### PR DESCRIPTION
# Summary

[NIFI-10182](https://issues.apache.org/jira/browse/NIFI-10182) Removes the remaining optional vendor profile and repository definition from the root Maven configuration. This follows the same pattern as the changes for NIFI-10180 implemented in #6168.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
