### PR TITLE
NIFI-10181: Upgrade Groovy to 3.0.9

### DIFF
--- a/nifi-nar-bundles/nifi-groovyx-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <groovyx.groovy.version>2.5.14</groovyx.groovy.version>
+        <groovyx.groovy.version>${nifi.groovy.version}</groovyx.groovy.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -359,7 +359,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>${nifi.groovy.version}-01</version>
+                        <version>${groovy.eclipse.batch.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,8 @@
         <jaxb.runtime.version>2.3.5</jaxb.runtime.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <json.smart.version>2.4.8</json.smart.version>
-        <nifi.groovy.version>3.0.8</nifi.groovy.version>
+        <nifi.groovy.version>3.0.9</nifi.groovy.version>
+        <groovy.eclipse.batch.version>3.0.8-01</groovy.eclipse.batch.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <!-- The Hadoop version used by nifi-hadoop-libraries-nar and any NARs that depend on it, other NARs that need
             a specific version should override this property, or use a more specific property like abc.hadoop.version -->
@@ -620,7 +621,7 @@
                 <plugin>
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-eclipse-batch</artifactId>
-                    <version>${nifi.groovy.version}-01</version>
+                    <version>${groovy.eclipse.batch.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -767,7 +768,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>${nifi.groovy.version}-01</version>
+                        <version>${groovy.eclipse.batch.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
# Summary

[NIFI-10181](https://issues.apache.org/jira/browse/NIFI-10181) This upgrades the Groovy version to 3.0.9 from 3.0.8 and in the groovyx NAR from 2.5. Upgrading to 3.0.10 or 3.0.11 causes test errors with the TLS toolkit and such. I also separated the version of Groovy Maven plugin we use from the actual Groovy version used in such things as the scripting components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

A full build with contrib-check succeeded, validating that no regression was introduced.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
