### PR TITLE
NIFI-10186 - PutFTP: adjust ExpressionLanguageScope

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFTP.java
@@ -39,6 +39,7 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessorInitializationContext;
@@ -71,6 +72,11 @@ public class PutFTP extends PutFileTransfer<FTPTransfer> {
 
     private List<PropertyDescriptor> properties;
 
+    // PutFileTransfer.onTrigger() uses FlowFile attributes
+    public static final PropertyDescriptor REMOTE_PATH = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(FTPTransfer.REMOTE_PATH)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES).build();
+
     @Override
     protected void init(final ProcessorInitializationContext context) {
         final List<PropertyDescriptor> properties = new ArrayList<>();
@@ -78,7 +84,7 @@ public class PutFTP extends PutFileTransfer<FTPTransfer> {
         properties.add(FTPTransfer.PORT);
         properties.add(FTPTransfer.USERNAME);
         properties.add(FTPTransfer.PASSWORD);
-        properties.add(FTPTransfer.REMOTE_PATH);
+        properties.add(REMOTE_PATH);
         properties.add(FTPTransfer.CREATE_DIRECTORY);
         properties.add(FTPTransfer.BATCH_SIZE);
         properties.add(FTPTransfer.CONNECTION_TIMEOUT);


### PR DESCRIPTION
# Summary

[NIFI-10186](https://issues.apache.org/jira/browse/NIFI-10186)
- Additional PutFTP property needs broader ExpressionLanguageScope.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
