### PR TITLE
NIFI-10193 - ExecuteStateless - add SupportsSensitiveDynamicProperties

### DIFF
--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor/src/main/java/org/apache/nifi/processors/stateless/ExecuteStateless.java
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor/src/main/java/org/apache/nifi/processors/stateless/ExecuteStateless.java
@@ -22,6 +22,7 @@ import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.behavior.SystemResource;
 import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.SystemResourceConsiderations;
@@ -120,6 +121,7 @@ import static org.apache.nifi.processor.util.StandardValidators.createDirectoryE
 
 @Restricted
 @SupportsBatching
+@SupportsSensitiveDynamicProperties
 @SystemResourceConsiderations({
     @SystemResourceConsideration(resource= SystemResource.CPU),
     @SystemResourceConsideration(resource= SystemResource.DISK),
@@ -403,7 +405,6 @@ public class ExecuteStateless extends AbstractProcessor implements Searchable {
             .name(propertyDescriptorName)
             .defaultValue("Value for the " + propertyDescriptorName + " parameter")
             .addValidator(Validator.VALID)
-            .sensitive(true)
             .dynamic(true)
             .build();
     }

--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor/src/main/resources/docs/org.apache.nifi.processors.stateless.ExecuteStateless/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor/src/main/resources/docs/org.apache.nifi.processors.stateless.ExecuteStateless/additionalDetails.html
@@ -212,11 +212,6 @@
     a property to ExecuteStateless with the name "Kafka Topic" and the value "book-sales."
 </p>
 
-<p>
-    It is important to note, however, that often times we need the ability to make use of Sensitive Parameters. For example, we may want to parameterize
-    a "password" property. Because of this, any property that is added to ExecuteStateless is considered a sensitive property.
-</p>
-
 
 
 <h1>Exposing the Dataflow</h1>


### PR DESCRIPTION
# Summary

[NIFI-10193](https://issues.apache.org/jira/browse/NIFI-10193)

As of now, the ExecuteStateless processor only accepts sensitive dynamic properties. Because of this, it is not possible to reference non-sensitive parameters. Thanks to [NIFI-9958](https://issues.apache.org/jira/browse/NIFI-9958), we can now leverage the new feature allowing to define if a dynamic property is sensitive or not. This will give the users the option to reference sensitive and non sensitive parameters.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
