### PR TITLE
NIFI-10199: PublishKafka InFlightMessageTracker should not log batch …

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-1-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.processors.kafka.pubsub;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +30,7 @@ import org.apache.nifi.logging.ComponentLog;
 public class InFlightMessageTracker {
     private final ConcurrentMap<FlowFile, Counts> messageCountsByFlowFile = new ConcurrentHashMap<>();
     private final ConcurrentMap<FlowFile, Exception> failures = new ConcurrentHashMap<>();
+    private final ConcurrentMap<FlowFile, Set<Exception>> encounteredFailures = new ConcurrentHashMap<>();
     private final Object progressMutex = new Object();
     private final ComponentLog logger;
 
@@ -70,7 +72,12 @@ public class InFlightMessageTracker {
 
     public void fail(final FlowFile flowFile, final Exception exception) {
         failures.putIfAbsent(flowFile, exception);
-        logger.error("Failed to send " + flowFile + " to Kafka", exception);
+        boolean newException = encounteredFailures
+            .computeIfAbsent(flowFile, (k) -> ConcurrentHashMap.newKeySet())
+            .add(exception);
+        if (newException) {
+            logger.error("Failed to send {} to Kafka", flowFile, exception);
+        }
 
         synchronized (progressMutex) {
             progressMutex.notify();
@@ -88,6 +95,7 @@ public class InFlightMessageTracker {
     public void reset() {
         messageCountsByFlowFile.clear();
         failures.clear();
+        encounteredFailures.clear();
     }
 
     public PublishResult failOutstanding(final Exception exception) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.processors.kafka.pubsub;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +30,7 @@ import org.apache.nifi.logging.ComponentLog;
 public class InFlightMessageTracker {
     private final ConcurrentMap<FlowFile, Counts> messageCountsByFlowFile = new ConcurrentHashMap<>();
     private final ConcurrentMap<FlowFile, Exception> failures = new ConcurrentHashMap<>();
+    private final ConcurrentMap<FlowFile, Set<Exception>> encounteredFailures = new ConcurrentHashMap<>();
     private final Object progressMutex = new Object();
     private final ComponentLog logger;
 
@@ -70,7 +72,12 @@ public class InFlightMessageTracker {
 
     public void fail(final FlowFile flowFile, final Exception exception) {
         failures.putIfAbsent(flowFile, exception);
-        logger.error("Failed to send " + flowFile + " to Kafka", exception);
+        boolean newException = encounteredFailures
+            .computeIfAbsent(flowFile, (k) -> ConcurrentHashMap.newKeySet())
+            .add(exception);
+        if (newException) {
+            logger.error("Failed to send {} to Kafka", flowFile, exception);
+        }
 
         synchronized (progressMutex) {
             progressMutex.notify();
@@ -88,6 +95,7 @@ public class InFlightMessageTracker {
     public void reset() {
         messageCountsByFlowFile.clear();
         failures.clear();
+        encounteredFailures.clear();
     }
 
     public PublishResult failOutstanding(final Exception exception) {


### PR DESCRIPTION
…level errors on each record

Currently, when a batch level error occurs (e.g. delivery timeout), the same error is logged for each record of the batch, needlessly flooding the logs.
InFlightMessageTracker now only logs an exception when a flow file encounters it for the first time.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10199](https://issues.apache.org/jira/browse/NIFI-10199)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
