### PR TITLE
NIFI-10208 Create Resource Fetcher over HTTPS with Basic Authentication

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/flow/resource/ExternalResourceDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/flow/resource/ExternalResourceDescriptor.java
@@ -30,4 +30,14 @@ public interface ExternalResourceDescriptor {
      * @return Returns the modification time of the original resource file using Unix timestamp format.
      */
     long getLastModified();
+
+    /**
+     * @return The path of the resource, where the format depends on the actual provider implementation.
+     */
+    String getPath();
+
+    /**
+     * @return Returns whether the resource is a directory.
+     */
+    boolean isDirectory();
 }

--- a/nifi-api/src/main/java/org/apache/nifi/flow/resource/ExternalResourceProvider.java
+++ b/nifi-api/src/main/java/org/apache/nifi/flow/resource/ExternalResourceProvider.java
@@ -34,7 +34,7 @@ public interface ExternalResourceProvider {
     /**
      * Performs a listing of all resources that are available.
      *
-     * @Return The result is a list of descriptors for the available resources.
+     * @return The result is a list of descriptors for the available resources.
      */
     Collection<ExternalResourceDescriptor> listResources() throws IOException;
 
@@ -43,4 +43,11 @@ public interface ExternalResourceProvider {
      * but implementations might differ.
      */
     InputStream fetchExternalResource(ExternalResourceDescriptor descriptor) throws IOException;
+
+    /**
+     * Performs a listing of a given resource.
+     *
+     * @return The result is a list of descriptors for the available resources.
+     */
+    Collection<ExternalResourceDescriptor> listResources(final ExternalResourceDescriptor descriptor) throws IOException;
 }

--- a/nifi-api/src/main/java/org/apache/nifi/flow/resource/ImmutableExternalResourceDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/flow/resource/ImmutableExternalResourceDescriptor.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 public class ImmutableExternalResourceDescriptor implements ExternalResourceDescriptor {
     private final String location;
     private final long modifiedAt;
+    private final String path;
+    private boolean directory = false;
 
     public ImmutableExternalResourceDescriptor(final String location, final long modifiedAt) {
         if (modifiedAt < 0) {
@@ -29,6 +31,18 @@ public class ImmutableExternalResourceDescriptor implements ExternalResourceDesc
 
         this.location = Objects.requireNonNull(location);
         this.modifiedAt = modifiedAt;
+        this.path = null;
+    }
+
+    public ImmutableExternalResourceDescriptor(final String location, final long modifiedAt, final String path, final boolean isDirectory) {
+        if (modifiedAt < 0) {
+            throw new IllegalArgumentException("The modification time cannot be negative");
+        }
+
+        this.location = Objects.requireNonNull(location);
+        this.modifiedAt = modifiedAt;
+        this.path = Objects.requireNonNull(path);
+        this.directory = isDirectory;
     }
 
     @Override
@@ -39,5 +53,15 @@ public class ImmutableExternalResourceDescriptor implements ExternalResourceDesc
     @Override
     public long getLastModified() {
         return modifiedAt;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return directory;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-security-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/ConflictResolvingExternalResourceProviderWorker.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/ConflictResolvingExternalResourceProviderWorker.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -108,17 +109,22 @@ abstract class ConflictResolvingExternalResourceProviderWorker implements Extern
     private void poll() throws IOException {
         LOGGER.debug("Worker starts polling provider for resources");
 
-        final Collection<ExternalResourceDescriptor> availableResources;
+        Collection<ExternalResourceDescriptor> availableResources;
         try (final NarCloseable narCloseable = NarCloseable.withComponentNarLoader(providerClassLoader)) {
             availableResources = provider.listResources();
         }
-
-        for (final ExternalResourceDescriptor availableResource : availableResources) {
-            if (resolutionStrategy.shouldBeFetched(targetDirectory, availableResource)) {
-                acquireResource(availableResource);
-            } else {
-                LOGGER.trace("External resource {} is not to be fetched", availableResource.getLocation());
+        while (!availableResources.isEmpty()) {
+            final Collection<ExternalResourceDescriptor> resourcesToCheck = new ArrayList<>();
+            for (final ExternalResourceDescriptor availableResource : availableResources) {
+                if (availableResource.isDirectory()) {
+                    resourcesToCheck.addAll(provider.listResources(availableResource));
+                } else if (resolutionStrategy.shouldBeFetched(targetDirectory, availableResource)) {
+                    acquireResource(availableResource);
+                } else {
+                    LOGGER.trace("External resource {} is not to be fetched", availableResource.getLocation());
+                }
             }
+            availableResources = resourcesToCheck;
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/ExternalResourceListAsHtmlParser.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/ExternalResourceListAsHtmlParser.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flow.resource;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ExternalResourceListAsHtmlParser {
+    private static final String DEFAULT_X_PATH_IDENTIFIER_FOR_FILE_LIST = "//tr[count(td)>2]";
+    private static final String DEFAULT_X_PATH_IDENTIFIER_FOR_LOCATION = "./td[1]/a/text()";
+    private static final String DEFAULT_X_PATH_IDENTIFIER_FOR_LAST_MODIFIED = "./td[2]/text()";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyy-MM-dd HH:mm");
+
+    private final XPathExpression xPathIdentifierForFileList;
+    private final XPathExpression xPathIdentifierForLocation;
+    private final XPathExpression xPathIdentifierForLastModified;
+
+    public ExternalResourceListAsHtmlParser() throws XPathExpressionException {
+        final XPath xPath = XPathFactory.newInstance().newXPath();
+        xPathIdentifierForFileList = xPath.compile(DEFAULT_X_PATH_IDENTIFIER_FOR_FILE_LIST);
+        xPathIdentifierForLocation = xPath.compile(DEFAULT_X_PATH_IDENTIFIER_FOR_LOCATION);
+        xPathIdentifierForLastModified = xPath.compile(DEFAULT_X_PATH_IDENTIFIER_FOR_LAST_MODIFIED);
+    }
+
+    public Collection<ExternalResourceDescriptor> parseResponse(final String response, final String url) throws ParserConfigurationException, XPathExpressionException, IOException, SAXException {
+        final Collection<ExternalResourceDescriptor> result = new ArrayList<>();
+        final NodeList nodeList = gatherResourceNodeList(response);
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            final Node node = nodeList.item(i);
+            if (isFile(node)) {
+                final ExternalResourceDescriptor descriptor = createDescriptor(node, url, true);
+                result.add(descriptor);
+            } else {
+                final ExternalResourceDescriptor descriptor = createDescriptor(node, url, false);
+                result.add(descriptor);
+            }
+        }
+        return result;
+    }
+
+    private NodeList gatherResourceNodeList(final String response) throws ParserConfigurationException, XPathExpressionException, IOException, SAXException {
+        final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(response)));
+        return (NodeList) xPathIdentifierForFileList.evaluate(doc, XPathConstants.NODESET);
+    }
+
+    private boolean isFile(Node node) throws XPathExpressionException {
+        return !xPathIdentifierForLocation.evaluate(node).endsWith("/");
+    }
+
+    private ImmutableExternalResourceDescriptor createDescriptor(final Node node, final String url, final boolean isFile) throws XPathExpressionException {
+        if (isFile) {
+            return new ImmutableExternalResourceDescriptor(parseLocation(node),
+                    parseLastModified(node),
+                    url,
+                    false);
+        }
+        return new ImmutableExternalResourceDescriptor(parseLocation(node),
+                0,
+                url,
+                true);
+    }
+
+    private String parseLocation(final Node node) throws XPathExpressionException {
+            return xPathIdentifierForLocation.evaluate(node);
+    }
+
+    private long parseLastModified(final Node node) throws XPathExpressionException {
+        final String time = xPathIdentifierForLastModified.evaluate(node);
+        return LocalDateTime.parse(time, FORMATTER).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/HttpsExternalResourceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/HttpsExternalResourceProvider.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flow.resource;
+
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.nifi.util.FormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class HttpsExternalResourceProvider implements ExternalResourceProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpsExternalResourceProvider.class);
+
+    private static final String PROXY_USER = "proxy.user";
+    private static final String PROXY_PASSWORD = "proxy.password";
+    private static final String PROXY_SERVER = "proxy.server";
+    private static final String PROXY_SERVER_PORT = "proxy.server.port";
+    private static final String USER_NAME = "user.name";
+    private static final String PASSWORD = "password";
+    private static final String CONNECT_TIMEOUT = "connect.timeout";
+    private static final String READ_TIMEOUT = "read.timeout";
+    private static final String BASE_URL = "base.url";
+    private static final String FILTER = "filter";
+    private static final String NAR_LOCATION = "nar.location";
+
+    private static final long DEFAULT_CONNECTION_TIMEOUT = 15;
+    private static final long DEFAULT_READ_TIMEOUT = 60;
+
+    private volatile OkHttpClient client;
+    private volatile String baseUrl;
+    private volatile String filter;
+    private volatile ExternalResourceProviderInitializationContext context;
+    private volatile boolean initialized = false;
+    private volatile String narLocation;
+
+    @Override
+    public void initialize(ExternalResourceProviderInitializationContext context) {
+        final Map<String, String> properties = context.getProperties();
+        final String baseUrl = properties.get(BASE_URL);
+        final String narLocation = properties.get(NAR_LOCATION);
+        final String filter = properties.get(FILTER);
+
+        if (baseUrl == null) {
+            throw new IllegalArgumentException("Base URL is required.");
+        }
+        if (baseUrl.endsWith("/")) {
+            this.baseUrl = baseUrl;
+        } else {
+            this.baseUrl = baseUrl + "/";
+        }
+
+        if (filter == null) {
+            throw new IllegalArgumentException("Filter is required.");
+        }
+        this.filter = filter;
+
+        if (narLocation == null) {
+            this.narLocation = "";
+        } else if (narLocation.endsWith("/")) {
+            this.narLocation = narLocation;
+        } else {
+            this.narLocation = narLocation + "/";
+        }
+
+        this.client = createHttpClient(properties);
+        this.context = context;
+        this.initialized = true;
+    }
+
+    @Override
+    public Collection<ExternalResourceDescriptor> listResources() throws IOException {
+        if (!initialized) {
+            throw new IllegalStateException("Provider is not initialized.");
+        }
+
+        final Collection<ExternalResourceDescriptor> result;
+
+        try {
+            final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+            result = collectResources(parser, this.baseUrl);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("The following NARs were found: " + result.stream().map(ExternalResourceDescriptor::getLocation).collect(Collectors.joining(", ")));
+            }
+
+        } catch (Exception e){
+            throw new IOException("Provider cannot list resources", e);
+        }
+
+        return result;
+    }
+
+    @Override
+    public InputStream fetchExternalResource(ExternalResourceDescriptor descriptor) throws IOException {
+        if (!initialized) {
+            throw new IllegalStateException("Provider is not initialized");
+        }
+
+        final Response httpResponse = sendRequest(descriptor.getPath() + descriptor.getLocation());
+
+        return httpResponse.body().byteStream();
+    }
+
+    @Override
+    public Collection<ExternalResourceDescriptor> listResources(ExternalResourceDescriptor descriptor) throws IOException {
+        if (!initialized) {
+            throw new IllegalStateException("Provider is not initialized.");
+        }
+
+        final Collection<ExternalResourceDescriptor> result;
+
+        try {
+            final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+            result = collectResources(parser, createNarLocationUrl(descriptor));
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("The following NARs were found: " + result.stream().map(ExternalResourceDescriptor::getLocation).collect(Collectors.joining(", ")));
+            }
+
+        } catch (Exception e){
+            throw new IOException("Provider cannot list resources", e);
+        }
+
+        return result;
+    }
+
+    private OkHttpClient createHttpClient(final Map<String, String> properties) {
+        final OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+        final String proxyUser = properties.get(PROXY_USER);
+        final String proxyPassword = properties.get(PROXY_PASSWORD);
+        final String proxyServer = properties.get(PROXY_SERVER);
+        final String proxyServerPort = properties.get(PROXY_SERVER_PORT);
+        final String userName = properties.get(USER_NAME);
+        final String password = properties.get(PASSWORD);
+
+        if (proxyServer != null && proxyServerPort != null) {
+            clientBuilder.proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyServer, Integer.parseInt(proxyServerPort))));
+        }
+
+        if (proxyUser != null && proxyPassword != null) {
+            final Authenticator proxyAuthenticator = createAuthenticator(proxyUser, proxyPassword, "Proxy-Authorization");
+            clientBuilder.proxyAuthenticator(proxyAuthenticator);
+        }
+
+        try {
+            final long connectionTimeout = Math.round(FormatUtils.getPreciseTimeDuration(Objects.requireNonNull(properties.get(CONNECT_TIMEOUT)), TimeUnit.SECONDS));
+            clientBuilder.connectTimeout(connectionTimeout, TimeUnit.SECONDS);
+        } catch (NullPointerException e) {
+            clientBuilder.connectTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+        }
+
+        try {
+            final long readTimeout = Math.round(FormatUtils.getPreciseTimeDuration(Objects.requireNonNull(properties.get(READ_TIMEOUT)), TimeUnit.SECONDS));
+            clientBuilder.readTimeout(readTimeout, TimeUnit.SECONDS);
+        } catch (NullPointerException e) {
+            clientBuilder.readTimeout(DEFAULT_READ_TIMEOUT, TimeUnit.SECONDS);
+        }
+
+        if (userName != null && password != null) {
+            clientBuilder.authenticator(createAuthenticator(userName, password, "Authorization"));
+        } else {
+            throw new IllegalArgumentException("User name and password are required.");
+        }
+
+        return clientBuilder.build();
+    }
+
+    private Authenticator createAuthenticator(final String user, final String password, final String header) {
+        return (route, response) -> {
+            final String credential = Credentials.basic(user, password);
+            return response.request().newBuilder()
+                    .header(header, credential)
+                    .build();
+        };
+    }
+
+    private Response sendRequest(final String url) throws IOException {
+        final Request.Builder requestBuilder = new Request.Builder();
+        requestBuilder.url(normalizeURL(url));
+        requestBuilder.get();
+
+        final Request httpRequest = requestBuilder.build();
+        final Response httpResponse = client.newCall(httpRequest).execute();
+
+        if (!httpResponse.isSuccessful()) {
+            throw new IOException("Provider cannot list resources due to http error " + httpResponse.code());
+        }
+        return httpResponse;
+    }
+
+    private String normalizeURL(final String url) {
+        return url.replaceAll("(?<!http:|https:)/+/", "/");
+    }
+
+    private String createNarLocationUrl(final ExternalResourceDescriptor descriptor) {
+        return normalizeURL(descriptor.getPath() + descriptor.getLocation() + this.narLocation);
+    }
+
+    private Collection<ExternalResourceDescriptor> collectResources(final ExternalResourceListAsHtmlParser parser, final String url)
+            throws IOException, ParserConfigurationException, XPathExpressionException, SAXException {
+        final String response = sendRequest(url).body().string();
+
+        final Collection<ExternalResourceDescriptor> descriptors = parser.parseResponse(response, url);
+
+        return descriptors.stream()
+                .filter(descriptor -> descriptor.getLocation().matches(this.filter))
+                .collect(Collectors.toList());
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/NarProviderAdapter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/main/java/org/apache/nifi/flow/resource/NarProviderAdapter.java
@@ -23,6 +23,7 @@ import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -49,6 +50,11 @@ public class NarProviderAdapter implements ExternalResourceProvider {
     @Override
     public InputStream fetchExternalResource(final ExternalResourceDescriptor descriptor) throws IOException {
         return payload.fetchNarContents(descriptor.getLocation());
+    }
+
+    @Override
+    public Collection<ExternalResourceDescriptor> listResources(ExternalResourceDescriptor descriptor) throws IOException {
+        return Collections.emptyList();
     }
 
     private static class NarProviderInitializationContextAdapter implements NarProviderInitializationContext {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/AbstractHttpsExternalResourceProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/AbstractHttpsExternalResourceProviderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flow.resource;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class AbstractHttpsExternalResourceProviderTest {
+    private static final Comparator<ExternalResourceDescriptor> DESCRIPTOR_COMPARATOR =
+            Comparator.comparing(ExternalResourceDescriptor::getLocation)
+                    .thenComparing(ExternalResourceDescriptor::getPath)
+                    .thenComparing(ExternalResourceDescriptor::getLastModified)
+                    .thenComparing(ExternalResourceDescriptor::isDirectory);
+
+    protected void assertSuccess(final Collection<ExternalResourceDescriptor> expected, final Collection<ExternalResourceDescriptor> actual) {
+        assertEquals(expected.size(), actual.size());
+
+        Set<String> missingDescriptors = new HashSet<>();
+        for (ExternalResourceDescriptor desc1 : actual) {
+            boolean found = false;
+            for (ExternalResourceDescriptor desc2 : expected) {
+                if (DESCRIPTOR_COMPARATOR.compare(desc1, desc2) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                missingDescriptors.add(desc1.getLocation());
+            }
+        }
+
+        assertTrue(missingDescriptors.isEmpty(), "Unexpected elemet(s): " + StringUtils.join(missingDescriptors, " ,"));
+    }
+
+    protected void assertResourceIsNotIncluded(final Collection<ExternalResourceDescriptor> actual, final String location) {
+        assertFalse(actual.stream()
+                .map(ExternalResourceDescriptor::getLocation)
+                .collect(Collectors.toSet())
+                .contains(location));
+    }
+
+    protected String normalizeURL(final String url) {
+        return url.replaceAll("(?<!http:|https:)/+/", "/");
+    }
+
+    protected static class HtmlBuilder {
+        private String html = "";
+
+        public static HtmlBuilder newInstance() {
+            return new HtmlBuilder();
+        }
+
+        private HtmlBuilder() {}
+
+        public HtmlBuilder htmlStart() {
+            html = html + "<html>" + System.lineSeparator();
+            return this;
+        }
+
+        public HtmlBuilder htmlEnd() {
+            html = html + "</html>";
+            return this;
+        }
+
+        public HtmlBuilder tableStart() {
+            html = html + "<table>" + System.lineSeparator();
+            return this;
+        }
+
+        public HtmlBuilder tableEnd() {
+            html = html + "</table>" + System.lineSeparator();
+            return this;
+        }
+
+        public HtmlBuilder tableHeaderEntry() {
+            html = html + "<tr>" + System.lineSeparator() +
+                    "<th>Name</th><th>Last Modified</th><th>Size</th>" + System.lineSeparator() +
+                    "</tr>" + System.lineSeparator();
+            return this;
+        }
+
+        public HtmlBuilder parentEntry() {
+            html = html + "<tr>" + System.lineSeparator() +
+                    "<td><a href=\"../\">Parent Directory</a></td>" + System.lineSeparator() +
+                    "</tr>" + System.lineSeparator();
+            return this;
+        }
+
+        public HtmlBuilder fileEntry(final String fileName, final String lastModified, final String size) {
+            html = html +  "<tr>" + System.lineSeparator() +
+                    "<td><a href=\"" + fileName + "\">" + fileName + "</a></td>" + System.lineSeparator() +
+                    "<td>" + lastModified + "</td>" + System.lineSeparator() +
+                    "<td>" + size + "</td>" + System.lineSeparator() +
+                    "</tr>" + System.lineSeparator();
+            return this;
+        }
+
+        public HtmlBuilder directoryEntry(final String directoryName) {
+            html = html +  "<tr>" + System.lineSeparator() +
+                    "<td><a href=\"" + directoryName + "/\">" + directoryName + "/</a></td>" + System.lineSeparator() +
+                    "<td>-</td>" + System.lineSeparator() +
+                    "<td>-</td>" + System.lineSeparator() +
+                    "</tr>" + System.lineSeparator();
+            return this;
+        }
+
+        public String build() {
+            return html;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/CollisionAwareResourceProviderWorkerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/CollisionAwareResourceProviderWorkerTest.java
@@ -430,6 +430,11 @@ public class CollisionAwareResourceProviderWorkerTest {
             }
         }
 
+        @Override
+        public Collection<ExternalResourceDescriptor> listResources(ExternalResourceDescriptor descriptor) throws IOException {
+            return Collections.emptyList();
+        }
+
         public int getListCounter() {
             return listCounter.get();
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/ExternalResourceListAsHtmlParserTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/ExternalResourceListAsHtmlParserTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flow.resource;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+
+import java.io.IOException;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ExternalResourceListAsHtmlParserTest extends AbstractHttpsExternalResourceProviderTest {
+
+    @Test
+    void parseEmptyResponse() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        final String emptyHtml = HtmlBuilder.newInstance()
+                .htmlStart()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+        final Collection<ExternalResourceDescriptor> expected = Collections.emptySet();
+
+        final Collection<ExternalResourceDescriptor> result = parser.parseResponse(emptyHtml, "https://test/");
+
+        assertSuccess(expected, result);
+    }
+
+    @Test
+    void parseResponseWithParentItemOnly() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        final String parentOnlyHtml = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .tableEnd()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+        final Collection<ExternalResourceDescriptor> expected = Collections.emptySet();
+
+        final Collection<ExternalResourceDescriptor> result = parser.parseResponse(parentOnlyHtml, "https://test/");
+
+        assertSuccess(expected, result);
+    }
+
+    @Test
+    void parseResponseWithFileItemsOnly() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        final String fileOnlyHtml = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .fileEntry("file1", "2021-05-17 21:09", "size")
+                .tableEnd()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+
+        final Collection<ExternalResourceDescriptor> expected = new HashSet<>();
+        final ExternalResourceDescriptor file1 = new ImmutableExternalResourceDescriptor("file1", 1621285740000L, "https://test/", false);
+        expected.add(file1);
+
+        final Collection<ExternalResourceDescriptor> result = parser.parseResponse(fileOnlyHtml, "https://test/");
+
+        assertSuccess(expected, result);
+    }
+
+    @Test
+    void parseResponseWithDirectoryItemsOnly() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        final String directoryOnlyHtml = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .directoryEntry("dir1")
+                .tableEnd()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+
+        final Collection<ExternalResourceDescriptor> expected = new HashSet<>();
+        final ExternalResourceDescriptor dir1 = new ImmutableExternalResourceDescriptor("dir1/", 0, "https://test/", true);
+        expected.add(dir1);
+
+        final Collection<ExternalResourceDescriptor> result = parser.parseResponse(directoryOnlyHtml, "https://test/");
+
+        assertSuccess(expected, result);
+    }
+
+    @Test
+    void parseResponseWithMixedItems() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        final String mixedHtml = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .directoryEntry("dir1")
+                .fileEntry("file1", "2021-05-17 21:09", "size")
+                .tableEnd()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+
+        final Collection<ExternalResourceDescriptor> expected = new HashSet<>();
+        final ExternalResourceDescriptor dir1 = new ImmutableExternalResourceDescriptor("dir1/", 0, "https://test/", true);
+        final ExternalResourceDescriptor file1 = new ImmutableExternalResourceDescriptor("file1", 1621285740000L, "https://test/", false);
+        expected.add(dir1);
+        expected.add(file1);
+
+        final Collection<ExternalResourceDescriptor> result = parser.parseResponse(mixedHtml, "https://test/");
+
+        assertSuccess(expected, result);
+    }
+
+    @Test
+    void parseResponseWithIncorrectHtml() throws XPathExpressionException {
+        final String incorrectHtml = HtmlBuilder.newInstance().htmlStart().build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+
+        assertThrows(SAXException.class, () -> parser.parseResponse(incorrectHtml, "https://test/"));
+    }
+
+    @Test
+    void parseResponseWithIncorrectDate() throws XPathExpressionException {
+        final String htmlWithIncorrectDate = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .fileEntry("file1", "-", "size")
+                .tableEnd()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+
+        assertThrows(DateTimeParseException.class, () -> parser.parseResponse(htmlWithIncorrectDate, "https://test/"));
+    }
+
+    @Test
+    void parseResponseWithIncorrectDateFormat() throws XPathExpressionException {
+        final String htmlWithIncorrectDateFormat = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .fileEntry("file1", "2021.05.17 21:09", "size")
+                .tableEnd()
+                .htmlEnd()
+                .build();
+
+        final ExternalResourceListAsHtmlParser parser = new ExternalResourceListAsHtmlParser();
+
+        assertThrows(DateTimeParseException.class, () -> parser.parseResponse(htmlWithIncorrectDateFormat, "https://test/"));
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/HttpsExternalResourceProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-external-resource-utils/src/test/java/org/apache/nifi/flow/resource/HttpsExternalResourceProviderTest.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flow.resource;
+
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HttpsExternalResourceProviderTest extends AbstractHttpsExternalResourceProviderTest {
+    private static final List<String> AVAILABLE_VERSIONS = Arrays.asList("1.15.0", "1.16.0", "1.16.1", "1.16.2", "1.16.13", "1.17.0");
+    private static final List<String> EXPECTED_VERSIONS = Arrays.asList("1.16.0", "1.16.1", "1.16.2", "1.16.13");
+    private static final String NAR_LOCATION_NOT_SPECIFIED = "";
+    private static final String NAR_LOCATION = "nars";
+    private static final String NAR_NAME_FORMAT = "file1-%s.nar";
+    private static final String LAST_MODIFIED = "2021-05-17 21:09";
+    private static final String SIZE = "size";
+    private static final long LAST_MODIFIED_AS_LONG = 1621285740000L;
+    private static final String URL = "https://test/versions/";
+    private static final String VERSION_BASED_PATH_FILTER = "1\\.16\\.\\d*\\/|.*\\.nar";
+    private static final String DIRECT_PATH_FILTER = ".*1\\.16\\.\\d*\\.nar";
+    private static final String NAR_LOCATION_SPECIFIC_FILTER_WITHOUT_PROPERTY = "1\\.16.\\d*\\/|nars\\/|.*\\.nar";
+    private static final String NAR_LOCATION_SPECIFIC_FILTER_WITH_PROPERTY = "1\\.16.\\d*\\/|.*\\.nar";
+    private static final Request REQUEST = new Request.Builder().get().url(URL).build();
+    private static final String FILE1_1_16_0_NAR = String.format(NAR_NAME_FORMAT, EXPECTED_VERSIONS.get(0));
+    private static final String FILE1_1_16_1_NAR = String.format(NAR_NAME_FORMAT, EXPECTED_VERSIONS.get(1));
+    private static final String FILE1_1_16_2_NAR = String.format(NAR_NAME_FORMAT, EXPECTED_VERSIONS.get(2));
+    private static final String FILE1_1_16_13_NAR = String.format(NAR_NAME_FORMAT, EXPECTED_VERSIONS.get(3));
+    private static final String HTML_FOR_DIRECTORY_LIKE_ENTRIES_WITH_ALL_AVAILABLE_VERSIONS = createHtmlForDirectoryLikeEntriesWithAllAvailableVersions();
+    private static final String HTML_FOR_RESOURCE_FILE1_1_16_0_NAR = createHtmlForResource(FILE1_1_16_0_NAR);
+    private static final String HTML_FOR_RESOURCE_FILE1_1_16_1_NAR = createHtmlForResource(FILE1_1_16_1_NAR);
+    private static final String HTML_FOR_RESOURCE_FILE1_1_16_2_NAR = createHtmlForResource(FILE1_1_16_2_NAR);
+    private static final String HTML_FOR_RESOURCE_FILE1_1_16_13_NAR = createHtmlForResource(FILE1_1_16_13_NAR);
+    private static final String HTML_FOR_ALL_AVAILABLE_RESOURCES = createHtmlWithAllAvailableResources();
+    private static final String HTML_FOR_NAR_LOCATION = createHtmlForNarLocation();
+    public static final long SLEEPING_TIME = 1000L;
+
+    @Test
+    void testWhenAvailableResourcesAreUnderVersionBasedPaths() throws IOException, IllegalAccessException {
+        // Example url for resources may be:
+        // http://test/versions/1.15.0/file1-1.15.0.nar
+        // http://test/versions/1.16.0/file1-1.16.0.nar
+        // and so on...
+
+        final HttpsExternalResourceProvider providerSpy = getHttpsExternalResourceProviderSpy(VERSION_BASED_PATH_FILTER, NAR_LOCATION_NOT_SPECIFIED);
+
+        final Response versionResponse = createResponse(HTML_FOR_DIRECTORY_LIKE_ENTRIES_WITH_ALL_AVAILABLE_VERSIONS);
+        final Response responseForResource1 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_0_NAR);
+        final Response responseForResource2 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_1_NAR);
+        final Response responseForResource3 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_2_NAR);
+        final Response responseForResource4 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_13_NAR);
+
+        final Call call = configureHttpCallForProvider(providerSpy);
+        when(call.execute()).thenReturn(versionResponse, responseForResource1, responseForResource2, responseForResource3, responseForResource4);
+
+        final Collection<ExternalResourceDescriptor> expected = createExpectedVersionBasedDescriptors();
+
+        final Collection<ExternalResourceDescriptor> result = poll(providerSpy);
+
+        assertSuccess(expected, result);
+        verify(providerSpy, times(1)).listResources();
+        verify(providerSpy, times(4)).listResources(any());
+    }
+
+    @Test
+    void testWhenAvailableResourcesDirectlyUnderAPath() throws IOException, IllegalAccessException {
+        // Example url for resources may be:
+        // http://test/versions/file1-1.15.0.nar
+        // http://test/versions/file1-1.16.0.nar
+        // and so on...
+
+        final HttpsExternalResourceProvider providerSpy = getHttpsExternalResourceProviderSpy(DIRECT_PATH_FILTER, NAR_LOCATION_NOT_SPECIFIED);
+
+        final Response response = createResponse(HTML_FOR_ALL_AVAILABLE_RESOURCES);
+
+        final Call call = configureHttpCallForProvider(providerSpy);
+        when(call.execute()).thenReturn(response);
+
+        final Collection<ExternalResourceDescriptor> expected = createExpectedDescriptorsWithDirectPath();
+
+        final Collection<ExternalResourceDescriptor> result = poll(providerSpy);
+
+        assertSuccess(expected, result);
+        assertResourceIsNotIncluded(result,"read.me");
+        verify(providerSpy, times(1)).listResources();
+        verify(providerSpy, never()).listResources(any());
+    }
+
+    @Test
+    void testWhenAvailableResourcesAreUnderAVersionBasedPathWithSpecificNarLocation_WithNarLocationPropertyProvided() throws IOException, IllegalAccessException {
+        // Example url for resources may be:
+        // http://test/versions/1.15.0/nars/file1-1.15.0.nar
+        // http://test/versions/1.16.0/nars/file1-1.16.0.nar
+        // and so on...
+        // nar.location property = nars
+
+        final HttpsExternalResourceProvider providerSpy = getHttpsExternalResourceProviderSpy(NAR_LOCATION_SPECIFIC_FILTER_WITH_PROPERTY, NAR_LOCATION);
+
+        final Response versionResponse = createResponse(HTML_FOR_DIRECTORY_LIKE_ENTRIES_WITH_ALL_AVAILABLE_VERSIONS);
+        final Response responseForResource1 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_0_NAR);
+        final Response responseForResource2 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_1_NAR);
+        final Response responseForResource3 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_2_NAR);
+        final Response responseForResource4 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_13_NAR);
+
+        final Call call = configureHttpCallForProvider(providerSpy);
+        when(call.execute()).thenReturn(versionResponse, responseForResource1, responseForResource2, responseForResource3, responseForResource4);
+
+        final Collection<ExternalResourceDescriptor> expected = createExpectedNarLocationSpecificDescriptors();
+
+        final Collection<ExternalResourceDescriptor> result = poll(providerSpy);
+
+        assertSuccess(expected, result);
+        verify(providerSpy, times(1)).listResources();
+        verify(providerSpy, times(4)).listResources(any());
+    }
+
+    @Test
+    void testWhenAvailableResourcesAreUnderAVersionBasedPathWithSpecificNarLocation_WithoutNarLocationPropertyProvided() throws IOException, IllegalAccessException {
+        // Example url for resources may be:
+        // http://test/versions/1.15.0/nars/file1-1.15.0.nar
+        // http://test/versions/1.16.0/nars/file1-1.16.0.nar
+        // and so on...
+        // nar.location property = "" or not provided
+
+       final HttpsExternalResourceProvider providerSpy = getHttpsExternalResourceProviderSpy(NAR_LOCATION_SPECIFIC_FILTER_WITHOUT_PROPERTY, NAR_LOCATION_NOT_SPECIFIED);
+
+        final Response versionResponse = createResponse(HTML_FOR_DIRECTORY_LIKE_ENTRIES_WITH_ALL_AVAILABLE_VERSIONS);
+        final Response responseForNarLocation1 = createResponse(HTML_FOR_NAR_LOCATION);
+        final Response responseForNarLocation2 = createResponse(HTML_FOR_NAR_LOCATION);
+        final Response responseForNarLocation3 = createResponse(HTML_FOR_NAR_LOCATION);
+        final Response responseForNarLocation4 = createResponse(HTML_FOR_NAR_LOCATION);
+        final Response responseForResource1 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_0_NAR);
+        final Response responseForResource2 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_1_NAR);
+        final Response responseForResource3 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_2_NAR);
+        final Response responseForResource4 = createResponse(HTML_FOR_RESOURCE_FILE1_1_16_13_NAR);
+
+        final Call call = configureHttpCallForProvider(providerSpy);
+        when(call.execute()).thenReturn(versionResponse, responseForNarLocation1, responseForNarLocation2, responseForNarLocation3, responseForNarLocation4,
+                responseForResource1, responseForResource2, responseForResource3, responseForResource4);
+
+        final Collection<ExternalResourceDescriptor> expected = createExpectedNarLocationSpecificDescriptors();
+
+        final Collection<ExternalResourceDescriptor> result = poll(providerSpy);
+
+        assertSuccess(expected, result);
+        verify(providerSpy, times(1)).listResources();
+        verify(providerSpy, times(8)).listResources(any());
+    }
+
+    private Response createResponse(final String body) {
+        return new Response.Builder()
+                .request(REQUEST)
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("")
+                .body(createResponseBody(body))
+                .build();
+    }
+
+    @NotNull
+    private ResponseBody createResponseBody(final String responseBody) {
+        return ResponseBody.create(responseBody, MediaType.get("text/html"));
+    }
+
+    private HttpsExternalResourceProvider getHttpsExternalResourceProviderSpy(final String filter, final String narLocation) {
+        final HttpsExternalResourceProvider provider = new HttpsExternalResourceProvider();
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("base.url", URL);
+        properties.put("filter", filter);
+        properties.put("user.name", "user");
+        properties.put("password", "password");
+        if (!narLocation.isEmpty()) {
+            properties.put("nar.location", narLocation);
+        }
+
+
+        final ExternalResourceProviderInitializationContext context = mock(ExternalResourceProviderInitializationContext.class);
+        when(context.getProperties()).thenReturn(properties);
+
+        provider.initialize(context);
+
+        return spy(provider);
+    }
+
+    private Call configureHttpCallForProvider(final ExternalResourceProvider provider) throws IllegalAccessException {
+        final OkHttpClient client = mock(OkHttpClient.class);
+        FieldUtils.writeField(provider, "client", client, true);
+        final Call call = mock(Call.class);
+        when(client.newCall(any())).thenReturn(call);
+        return call;
+    }
+
+    private Collection<ExternalResourceDescriptor> createExpectedDescriptors(final boolean withVersions, final String narLocation) {
+        final Collection<ExternalResourceDescriptor> expected = new ArrayList<>();
+        String url = normalizeURL(String.format("%s%s/", URL, narLocation));
+
+        for (final String version : EXPECTED_VERSIONS) {
+            final String narName = String.format(NAR_NAME_FORMAT, version);
+            if (withVersions) {
+                url = normalizeURL(String.format("%s%s/%s/", URL, version, narLocation));
+            }
+            final ExternalResourceDescriptor descriptor = new ImmutableExternalResourceDescriptor(narName, LAST_MODIFIED_AS_LONG, url, false);
+            expected.add(descriptor);
+        }
+
+        return expected;
+    }
+
+    private Collection<ExternalResourceDescriptor> createExpectedVersionBasedDescriptors() {
+        return createExpectedDescriptors(true, NAR_LOCATION_NOT_SPECIFIED);
+    }
+
+    private Collection<ExternalResourceDescriptor> createExpectedDescriptorsWithDirectPath() {
+        return createExpectedDescriptors(false, NAR_LOCATION_NOT_SPECIFIED);
+    }
+
+    private Collection<ExternalResourceDescriptor> createExpectedNarLocationSpecificDescriptors() {
+        return createExpectedDescriptors(true, NAR_LOCATION);
+    }
+
+    private static String createHtmlForResource(final String fileName) {
+        return HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .fileEntry(fileName, LAST_MODIFIED, SIZE)
+                .tableEnd()
+                .htmlEnd()
+                .build();
+    }
+
+    private static String createHtmlWithAllAvailableResources() {
+        final HtmlBuilder builder = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry();
+
+        for (final String version : AVAILABLE_VERSIONS) {
+            builder.fileEntry(String.format(NAR_NAME_FORMAT, version), LAST_MODIFIED, SIZE);
+        }
+
+        builder.fileEntry("read.me", LAST_MODIFIED, SIZE)
+                .tableEnd()
+                .htmlEnd();
+
+        return builder.build();
+    }
+
+    private static String createHtmlForDirectoryLikeEntriesWithAllAvailableVersions() {
+        final HtmlBuilder builder = HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry();
+
+        for (String version : AVAILABLE_VERSIONS) {
+            builder.directoryEntry(version);
+        }
+
+        builder.tableEnd()
+                .htmlEnd();
+
+        return builder.build();
+    }
+
+    private static String createHtmlForNarLocation() {
+        return HtmlBuilder.newInstance()
+                .htmlStart()
+                .tableStart()
+                .tableHeaderEntry()
+                .parentEntry()
+                .directoryEntry(NAR_LOCATION)
+                .tableEnd()
+                .htmlEnd()
+                .build();
+    }
+
+    private Collection<ExternalResourceDescriptor> poll(final ExternalResourceProvider provider) {
+        final Collection<ExternalResourceDescriptor> result = new ArrayList<>();
+
+        final File targetDirectory = mock(File.class);
+        final ExternalResourceConflictResolutionStrategy strategy = mock(ExternalResourceConflictResolutionStrategy.class);
+
+        final ConflictResolvingExternalResourceProviderWorker worker = new ConflictResolvingExternalResourceProviderWorker(
+                "",
+                provider.getClass().getClassLoader(),
+                provider,
+                strategy,
+                targetDirectory,
+                SLEEPING_TIME,
+                mock(CountDownLatch.class)
+        ) {
+            @Override
+            protected void acquireResource(ExternalResourceDescriptor availableResource) {
+                result.add(availableResource);
+            }
+        };
+
+        when(targetDirectory.isDirectory()).thenReturn(true);
+        when(targetDirectory.exists()).thenReturn(true);
+        when(targetDirectory.canRead()).thenReturn(true);
+        when(targetDirectory.canWrite()).thenReturn(true);
+        when(strategy.shouldBeFetched(any(), any())).thenReturn(true);
+
+        Thread thread = new Thread(() -> {
+            try {
+                Thread.sleep(SLEEPING_TIME);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            worker.stop();
+        });
+        thread.start();
+        worker.run();
+
+        return result;
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/extension/NiFiRegistryExternalResourceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/extension/NiFiRegistryExternalResourceProvider.java
@@ -93,4 +93,9 @@ public class NiFiRegistryExternalResourceProvider implements ExternalResourcePro
             throw new RuntimeException(e.getMessage(), e);
         }
     }
+
+    @Override
+    public Collection<ExternalResourceDescriptor> listResources(final ExternalResourceDescriptor descriptor) throws IOException {
+        return Collections.emptySet();
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/META-INF/services/org.apache.nifi.flow.resource.ExternalResourceProvider
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/resources/META-INF/services/org.apache.nifi.flow.resource.ExternalResourceProvider
@@ -13,3 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 org.apache.nifi.registry.extension.NiFiRegistryExternalResourceProvider
+org.apache.nifi.flow.resource.HttpsExternalResourceProvider

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/flow/resource/hadoop/HDFSExternalResourceProvider.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/flow/resource/hadoop/HDFSExternalResourceProvider.java
@@ -47,6 +47,7 @@ import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -259,5 +260,10 @@ public class HDFSExternalResourceProvider implements ExternalResourceProvider {
         } catch (final InterruptedException e) {
             throw new IOException("Unable to create file system: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public Collection<ExternalResourceDescriptor> listResources(final ExternalResourceDescriptor descriptor) throws IOException {
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-10208](https://issues.apache.org/jira/browse/NIFI-10208) creates a Resource Provider implementation that will download NAR files over HTTPS with Basic Authentication.
Using a filter, all matching directories/versions would download the corresponding NARs and an HTML parser evaluates the responses.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
