### PR TITLE
NIFI-9451 add input character set property for PutEmail and additiona…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.standard;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -253,7 +254,7 @@ public class PutEmail extends AbstractProcessor {
                     + "If not set, UTF-8 will be the default value.")
             .required(true)
             .addValidator(StandardValidators.CHARACTER_SET_VALIDATOR)
-            .defaultValue("UTF-8")
+            .defaultValue(StandardCharsets.UTF_8.name())
             .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestPutEmail {
@@ -115,6 +117,7 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.FROM, "test@apache.org");
         runner.setProperty(PutEmail.MESSAGE, "Message Body");
         runner.setProperty(PutEmail.TO, "recipient@apache.org");
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
 
         runner.enqueue("Some Text".getBytes());
 
@@ -128,7 +131,7 @@ public class TestPutEmail {
         Message message = processor.getMessages().get(0);
         assertEquals("test@apache.org", message.getFrom()[0].toString());
         assertEquals("TestingNiFi", message.getHeader("X-Mailer")[0], "X-Mailer Header");
-        assertEquals("Message Body", message.getContent());
+        assertEquals("Message Body", getMessageText(message, StandardCharsets.UTF_8));
         assertEquals("recipient@apache.org", message.getRecipients(RecipientType.TO)[0].toString());
         assertNull(message.getRecipients(RecipientType.BCC));
         assertNull(message.getRecipients(RecipientType.CC));
@@ -145,6 +148,7 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.BCC, "${bcc}");
         runner.setProperty(PutEmail.CC, "${cc}");
         runner.setProperty(PutEmail.ATTRIBUTE_NAME_REGEX, "Precedence.*");
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put("from", "test@apache.org <NiFi>");
@@ -166,7 +170,7 @@ public class TestPutEmail {
         Message message = processor.getMessages().get(0);
         assertEquals("\"test@apache.org\" <NiFi>", message.getFrom()[0].toString());
         assertEquals("TestingNíFiNonASCII", MimeUtility.decodeText(message.getHeader("X-Mailer")[0]), "X-Mailer Header");
-        assertEquals("the message body", message.getContent());
+        assertEquals("the message body", getMessageText(message, StandardCharsets.UTF_8));
         assertEquals(1, message.getRecipients(RecipientType.TO).length);
         assertEquals("to@apache.org", message.getRecipients(RecipientType.TO)[0].toString());
         assertEquals(1, message.getRecipients(RecipientType.BCC).length);
@@ -220,6 +224,8 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.MESSAGE, "Message Body");
         runner.setProperty(PutEmail.ATTACH_FILE, "true");
         runner.setProperty(PutEmail.CONTENT_TYPE, "text/html");
+        runner.setProperty(PutEmail.TO, "recipient@apache.org");
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.FILENAME.key(), "test한的ほу́.pdf");
@@ -240,10 +246,8 @@ public class TestPutEmail {
         assertInstanceOf(MimeMultipart.class, message.getContent());
 
         final MimeMultipart multipart = (MimeMultipart) message.getContent();
-        final BodyPart part = multipart.getBodyPart(0);
-        final InputStream is = part.getDataHandler().getInputStream();
-        final String decodedText = StringUtils.newStringUtf8(Base64.decodeBase64(IOUtils.toString(is, StandardCharsets.UTF_8)));
-        assertEquals("Message Body", decodedText);
+
+        assertEquals("Message Body", getMessageText(message, StandardCharsets.UTF_8));
 
         final BodyPart attachPart = multipart.getBodyPart(1);
         final InputStream attachIs = attachPart.getDataHandler().getInputStream();
@@ -263,6 +267,7 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
         runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
         runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put("sendContent", "true");
@@ -280,7 +285,7 @@ public class TestPutEmail {
         assertEquals("test@apache.org", message.getFrom()[0].toString());
         assertEquals("from@apache.org", message.getFrom()[1].toString());
         assertEquals("TestingNiFi", message.getHeader("X-Mailer")[0], "X-Mailer Header");
-        assertEquals("Some Text", message.getContent());
+        assertEquals("Some Text", getMessageText(message, StandardCharsets.UTF_8));
         assertEquals("recipient@apache.org", message.getRecipients(RecipientType.TO)[0].toString());
         assertEquals("another@apache.org", message.getRecipients(RecipientType.TO)[1].toString());
         assertEquals("recipientcc@apache.org", message.getRecipients(RecipientType.CC)[0].toString());
@@ -307,7 +312,6 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
 
         runner.setProperty("mail.", "sample_value");
-        runner.assertNotValid();
     }
 
     @Test
@@ -320,11 +324,63 @@ public class TestPutEmail {
         runner.assertNotValid();
     }
 
+    @Test
+    public void testUnrecognizedCharset() {
+        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
+        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        runner.setProperty(PutEmail.FROM, "test@apache.org");
+        runner.setProperty(PutEmail.MESSAGE, "test message");
+        runner.setProperty(PutEmail.TO, "recipient@apache.org");
+
+        // not one of the recognized charsets
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, "NOT A CHARACTER SET");
+
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testPutEmailWithMismatchedCharset() throws Exception {
+        // String specifically chosen to have characters encoded differently in US_ASCII and UTF_8
+        final String rawString = "SoftwÄrë Ënginëër Ön NiFi";
+        final byte[] rawBytes = rawString.getBytes(StandardCharsets.US_ASCII);
+        final byte[] rawBytesUTF8 = rawString.getBytes(StandardCharsets.UTF_8);
+
+        // verify that the message bytes are different (some messages are not)
+        assertNotEquals(rawBytes, rawBytesUTF8);
+
+        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
+        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        runner.setProperty(PutEmail.FROM, "test@apache.org");
+        runner.setProperty(PutEmail.MESSAGE, new String(rawBytes, StandardCharsets.US_ASCII));
+        runner.setProperty(PutEmail.TO, "recipient@apache.org");
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
+
+        runner.enqueue("Some Text".getBytes());
+
+        runner.run();
+
+        runner.assertQueueEmpty();
+        runner.assertAllFlowFilesTransferred(PutEmail.REL_SUCCESS);
+
+        // Verify that the Message was populated correctly
+        assertEquals(1, processor.getMessages().size(), "Expected a single message to be sent");
+        Message message = processor.getMessages().get(0);
+        assertNotEquals(rawString, message.getContent());
+    }
+
     private void setRequiredProperties(final TestRunner runner) {
         // values here may be overridden in some tests
         runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
         runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
         runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
         runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
+    }
+
+    private String getMessageText(final Message message, final Charset charset) throws Exception {
+        final MimeMultipart multipart = (MimeMultipart) message.getContent();
+        final BodyPart part = multipart.getBodyPart(0);
+        final InputStream is = part.getDataHandler().getInputStream();
+        final String decodedText = StringUtils.newString(Base64.decodeBase64(IOUtils.toByteArray(is)), charset.name());
+        return decodedText;
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -351,9 +351,9 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
         runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
         runner.setProperty(PutEmail.FROM, "test@apache.org");
-        runner.setProperty(PutEmail.MESSAGE, new String(rawBytes, StandardCharsets.US_ASCII));
+        runner.setProperty(PutEmail.MESSAGE, new String(rawBytesUTF8, StandardCharsets.UTF_8));
         runner.setProperty(PutEmail.TO, "recipient@apache.org");
-        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
+        runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.US_ASCII.name());
 
         runner.enqueue("Some Text".getBytes());
 
@@ -365,7 +365,8 @@ public class TestPutEmail {
         // Verify that the Message was populated correctly
         assertEquals(1, processor.getMessages().size(), "Expected a single message to be sent");
         Message message = processor.getMessages().get(0);
-        assertNotEquals(rawString, message.getContent());
+        final String retrievedMessageText = getMessageText(message, StandardCharsets.US_ASCII);
+        assertNotEquals(rawString, retrievedMessageText);
     }
 
     private void setRequiredProperties(final TestRunner runner) {


### PR DESCRIPTION
…l tests

Also fixed an issue regarding sending non US-ASCII messages in PutEmail. The original version had non US-ASCII messages appear as "?" in the resulting email.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-9451](https://issues.apache.org/jira/browse/NIFI-9451)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
