### PR TITLE
NIFI-10215 Upgrade Curator from 5.2.1 to 5.3.0

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -23,7 +23,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <curator.version>5.2.1</curator.version>
+        <curator.version>5.3.0</curator.version>
     </properties>
     <modules>
         <module>nifi-framework</module>

--- a/nifi-toolkit/nifi-toolkit-zookeeper-migrator/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-zookeeper-migrator/pom.xml
@@ -24,7 +24,7 @@
         <version>1.17.0-SNAPSHOT</version>
     </parent>
     <properties>
-        <curator.version>5.2.1</curator.version>
+        <curator.version>5.3.0</curator.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
# Summary

[NIFI-10215](https://issues.apache.org/jira/browse/NIFI-10215) Upgrades Apache Curator from 5.2.1 to [5.3.0](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12314425&version=12351883) in framework and ZooKeeper migrator modules.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
