### PR TITLE
NIFI-10216 Refactor NiFi Web API Security Configuration

### DIFF
--- a/nifi-commons/nifi-web-utils/src/main/java/org/apache/nifi/web/util/WebUtils.java
+++ b/nifi-commons/nifi-web-utils/src/main/java/org/apache/nifi/web/util/WebUtils.java
@@ -128,7 +128,7 @@ public final class WebUtils {
 
         // Check it against the allowed list
         if (!allowedContextPaths.contains(determinedContextPath)) {
-            final String msg = "The provided context path [" + determinedContextPath + "] was not registered as allowed [" + allowedContextPaths + "]";
+            final String msg = "The provided context path [" + determinedContextPath + "] was not registered as allowed " + allowedContextPaths;
             throw new UriBuilderException(msg);
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -128,6 +128,7 @@
 
     <!-- Suppress non-error messages due to excessive logging by class or library -->
     <logger name="org.springframework" level="ERROR"/>
+    <logger name="org.springframework.security" level="INFO"/>
 
     <!-- Suppress non-error messages due to known warning about redundant path annotation (NIFI-574) -->
     <logger name="org.glassfish.jersey.internal.Errors" level="ERROR"/>
@@ -171,9 +172,6 @@
         <appender-ref ref="USER_FILE"/>
     </logger>
     <logger name="org.apache.nifi.web.api.AccessResource" level="INFO" additivity="false">
-        <appender-ref ref="USER_FILE"/>
-    </logger>
-    <logger name="org.springframework.security.saml.log" level="WARN" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
     <logger name="org.opensaml" level="WARN" additivity="false">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
@@ -18,115 +18,119 @@ package org.apache.nifi.web;
 
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationFilter;
-import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationProvider;
 import org.apache.nifi.web.security.csrf.CsrfCookieRequestMatcher;
 import org.apache.nifi.web.security.csrf.StandardCookieCsrfTokenRepository;
-import org.apache.nifi.web.security.jwt.provider.BearerTokenProvider;
-import org.apache.nifi.web.security.jwt.resolver.StandardBearerTokenResolver;
 import org.apache.nifi.web.security.knox.KnoxAuthenticationFilter;
-import org.apache.nifi.web.security.knox.KnoxAuthenticationProvider;
 import org.apache.nifi.web.security.log.AuthenticationUserFilter;
 import org.apache.nifi.web.security.oidc.OIDCEndpoints;
 import org.apache.nifi.web.security.saml2.web.authentication.logout.Saml2LocalLogoutFilter;
 import org.apache.nifi.web.security.saml2.web.authentication.logout.Saml2SingleLogoutFilter;
 import org.apache.nifi.web.security.x509.X509AuthenticationFilter;
-import org.apache.nifi.web.security.x509.X509AuthenticationProvider;
-import org.apache.nifi.web.security.x509.X509CertificateExtractor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
-import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.saml2.provider.service.servlet.filter.Saml2WebSsoAuthenticationFilter;
 import org.springframework.security.saml2.provider.service.servlet.filter.Saml2WebSsoAuthenticationRequestFilter;
 import org.springframework.security.saml2.provider.service.web.Saml2MetadataFilter;
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutRequestFilter;
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutResponseFilter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
-import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.util.matcher.AndRequestMatcher;
 
+import java.util.List;
+
 /**
- * NiFi Web Api Spring security. Applies the various NiFiAuthenticationFilter servlet filters which will extract authentication
- * credentials from API requests.
+ * Application Security Configuration using Spring Security
  */
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-public class NiFiWebApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
-    private NiFiProperties properties;
-
-    private X509AuthenticationFilter x509AuthenticationFilter;
-    private X509CertificateExtractor certificateExtractor;
-    private X509PrincipalExtractor principalExtractor;
-    private X509AuthenticationProvider x509AuthenticationProvider;
-    private JwtAuthenticationProvider jwtAuthenticationProvider;
-
-    private KnoxAuthenticationFilter knoxAuthenticationFilter;
-    private KnoxAuthenticationProvider knoxAuthenticationProvider;
-
-    private NiFiAnonymousAuthenticationFilter anonymousAuthenticationFilter;
-    private NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider;
-
-    private BearerTokenProvider bearerTokenProvider;
-
-    private Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter;
-    private Saml2WebSsoAuthenticationRequestFilter saml2WebSsoAuthenticationRequestFilter;
-    private Saml2MetadataFilter saml2MetadataFilter;
-    private Saml2LogoutRequestFilter saml2LogoutRequestFilter;
-    private Saml2LogoutResponseFilter saml2LogoutResponseFilter;
-    private Saml2SingleLogoutFilter saml2SingleLogoutFilter;
-    private Saml2LocalLogoutFilter saml2LocalLogoutFilter;
-    private AuthenticationProvider openSamlAuthenticationProvider;
-
-    public NiFiWebApiSecurityConfiguration() {
-        super(true); // disable defaults
-    }
-
+public class NiFiWebApiSecurityConfiguration {
     /**
-     * Configure Web Security with ignoring matchers for authentication requests
+     * Spring Security Authentication Manager configured using Authentication Providers from specific configuration classes
      *
-     * @param webSecurity Spring Web Security Configuration
+     * @param authenticationProviders Autowired Authentication Providers
+     * @return Authentication Manager
      */
-    @Override
-    public void configure(final WebSecurity webSecurity) {
-        webSecurity
-                .ignoring()
-                    .antMatchers(
-                            "/access",
-                            "/access/config",
-                            "/access/token",
-                            "/access/kerberos",
-                            OIDCEndpoints.TOKEN_EXCHANGE,
-                            OIDCEndpoints.LOGIN_REQUEST,
-                            OIDCEndpoints.LOGIN_CALLBACK,
-                            OIDCEndpoints.LOGOUT_CALLBACK,
-                            "/access/knox/callback",
-                            "/access/knox/request",
-                            "/access/logout/complete");
+    @Bean
+    public AuthenticationManager authenticationManager(final List<AuthenticationProvider> authenticationProviders) {
+        return new ProviderManager(authenticationProviders);
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            final HttpSecurity http,
+            final NiFiProperties properties,
+            final X509AuthenticationFilter x509AuthenticationFilter,
+            final BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter,
+            final KnoxAuthenticationFilter knoxAuthenticationFilter,
+            final NiFiAnonymousAuthenticationFilter anonymousAuthenticationFilter,
+            final Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter,
+            final Saml2WebSsoAuthenticationRequestFilter saml2WebSsoAuthenticationRequestFilter,
+            final Saml2MetadataFilter saml2MetadataFilter,
+            final Saml2LogoutRequestFilter saml2LogoutRequestFilter,
+            final Saml2LogoutResponseFilter saml2LogoutResponseFilter,
+            final Saml2SingleLogoutFilter saml2SingleLogoutFilter,
+            final Saml2LocalLogoutFilter saml2LocalLogoutFilter
+    ) throws Exception {
         http
+                .logout().disable()
+                .anonymous().disable()
+                .requestCache().disable()
                 .rememberMe().disable()
-                .authorizeRequests().anyRequest().fullyAuthenticated().and()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-                .csrf().requireCsrfProtectionMatcher(
-                        new AndRequestMatcher(CsrfFilter.DEFAULT_CSRF_MATCHER, new CsrfCookieRequestMatcher()))
-                        .csrfTokenRepository(new StandardCookieCsrfTokenRepository(properties.getAllowedContextPathsAsList()));
+                .sessionManagement().disable()
+                .headers().disable()
+                .servletApi().disable()
+                .securityContext().disable()
+                .authorizeHttpRequests(authorize -> authorize
+                        .antMatchers(
+                                "/access",
+                                "/access/config",
+                                "/access/token",
+                                "/access/kerberos",
+                                "/access/knox/callback",
+                                "/access/knox/request",
+                                "/access/logout/complete",
+                                OIDCEndpoints.TOKEN_EXCHANGE,
+                                OIDCEndpoints.LOGIN_REQUEST,
+                                OIDCEndpoints.LOGIN_CALLBACK,
+                                OIDCEndpoints.LOGOUT_CALLBACK
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(
+                                new StandardCookieCsrfTokenRepository()
+                        )
+                        .requireCsrfProtectionMatcher(
+                                new AndRequestMatcher(CsrfFilter.DEFAULT_CSRF_MATCHER, new CsrfCookieRequestMatcher())
+                        )
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                )
+                .addFilterBefore(x509AuthenticationFilter, AnonymousAuthenticationFilter.class)
+                .addFilterBefore(bearerTokenAuthenticationFilter, AnonymousAuthenticationFilter.class)
+                .addFilterBefore(new AuthenticationUserFilter(), ExceptionTranslationFilter.class);
+
+        if (properties.isKnoxSsoEnabled()) {
+            http.addFilterBefore(knoxAuthenticationFilter, AnonymousAuthenticationFilter.class);
+        }
+
+        if (properties.isAnonymousAuthenticationAllowed()) {
+            http.addFilterAfter(anonymousAuthenticationFilter, AnonymousAuthenticationFilter.class);
+        }
 
         if (properties.isSamlEnabled()) {
             http.addFilterBefore(saml2WebSsoAuthenticationFilter, AnonymousAuthenticationFilter.class);
@@ -143,158 +147,6 @@ public class NiFiWebApiSecurityConfiguration extends WebSecurityConfigurerAdapte
             }
         }
 
-        http.addFilterBefore(x509FilterBean(), AnonymousAuthenticationFilter.class);
-        http.addFilterBefore(bearerTokenAuthenticationFilter(), AnonymousAuthenticationFilter.class);
-        http.addFilterBefore(knoxFilterBean(), AnonymousAuthenticationFilter.class);
-        http.addFilterAfter(anonymousFilterBean(), AnonymousAuthenticationFilter.class);
-        http.addFilterAfter(new AuthenticationUserFilter(), AnonymousAuthenticationFilter.class);
-
-        // disable default anonymous handling because it doesn't handle conditional authentication well
-        http.anonymous().disable();
-    }
-
-    @Bean
-    @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        // override xxxBean method so the authentication manager is available in app context (necessary for the method level security)
-        return super.authenticationManagerBean();
-    }
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth
-                .authenticationProvider(x509AuthenticationProvider)
-                .authenticationProvider(jwtAuthenticationProvider)
-                .authenticationProvider(knoxAuthenticationProvider)
-                .authenticationProvider(anonymousAuthenticationProvider);
-
-        if (properties.isSamlEnabled()) {
-            auth.authenticationProvider(openSamlAuthenticationProvider);
-        }
-    }
-
-    @Bean
-    public KnoxAuthenticationFilter knoxFilterBean() throws Exception {
-        if (knoxAuthenticationFilter == null) {
-            knoxAuthenticationFilter = new KnoxAuthenticationFilter();
-            knoxAuthenticationFilter.setProperties(properties);
-            knoxAuthenticationFilter.setAuthenticationManager(authenticationManager());
-        }
-        return knoxAuthenticationFilter;
-    }
-
-    @Bean
-    public X509AuthenticationFilter x509FilterBean() throws Exception {
-        if (x509AuthenticationFilter == null) {
-            x509AuthenticationFilter = new X509AuthenticationFilter();
-            x509AuthenticationFilter.setProperties(properties);
-            x509AuthenticationFilter.setCertificateExtractor(certificateExtractor);
-            x509AuthenticationFilter.setPrincipalExtractor(principalExtractor);
-            x509AuthenticationFilter.setAuthenticationManager(authenticationManager());
-        }
-        return x509AuthenticationFilter;
-    }
-
-    @Bean
-    public BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter() throws Exception {
-        final BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(authenticationManager());
-        filter.setBearerTokenResolver(bearerTokenResolver());
-        return filter;
-    }
-
-    @Bean
-    public BearerTokenResolver bearerTokenResolver() {
-        return new StandardBearerTokenResolver();
-    }
-
-    @Bean
-    public NiFiAnonymousAuthenticationFilter anonymousFilterBean() throws Exception {
-        if (anonymousAuthenticationFilter == null) {
-            anonymousAuthenticationFilter = new NiFiAnonymousAuthenticationFilter();
-            anonymousAuthenticationFilter.setProperties(properties);
-            anonymousAuthenticationFilter.setAuthenticationManager(authenticationManager());
-        }
-        return anonymousAuthenticationFilter;
-    }
-
-    @Autowired
-    public void setProperties(NiFiProperties properties) {
-        this.properties = properties;
-    }
-
-    @Autowired
-    public void setJwtAuthenticationProvider(JwtAuthenticationProvider jwtAuthenticationProvider) {
-        this.jwtAuthenticationProvider = jwtAuthenticationProvider;
-    }
-
-    @Autowired
-    public void setKnoxAuthenticationProvider(KnoxAuthenticationProvider knoxAuthenticationProvider) {
-        this.knoxAuthenticationProvider = knoxAuthenticationProvider;
-    }
-
-    @Autowired
-    public void setAnonymousAuthenticationProvider(NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider) {
-        this.anonymousAuthenticationProvider = anonymousAuthenticationProvider;
-    }
-
-    @Autowired
-    public void setX509AuthenticationProvider(X509AuthenticationProvider x509AuthenticationProvider) {
-        this.x509AuthenticationProvider = x509AuthenticationProvider;
-    }
-
-    @Autowired
-    public void setCertificateExtractor(X509CertificateExtractor certificateExtractor) {
-        this.certificateExtractor = certificateExtractor;
-    }
-
-    @Autowired
-    public void setPrincipalExtractor(X509PrincipalExtractor principalExtractor) {
-        this.principalExtractor = principalExtractor;
-    }
-
-    @Autowired
-    public void setBearerTokenProvider(final BearerTokenProvider bearerTokenProvider) {
-        this.bearerTokenProvider = bearerTokenProvider;
-    }
-
-    @Autowired
-    public void setSaml2WebSsoAuthenticationFilter(final Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter) {
-        this.saml2WebSsoAuthenticationFilter = saml2WebSsoAuthenticationFilter;
-    }
-
-    @Autowired
-    public void setSaml2WebSsoAuthenticationRequestFilter(final Saml2WebSsoAuthenticationRequestFilter saml2WebSsoAuthenticationRequestFilter) {
-        this.saml2WebSsoAuthenticationRequestFilter = saml2WebSsoAuthenticationRequestFilter;
-    }
-
-    @Autowired
-    public void setSaml2MetadataFilter(final Saml2MetadataFilter saml2MetadataFilter) {
-        this.saml2MetadataFilter = saml2MetadataFilter;
-    }
-
-    @Autowired
-    public void setSaml2LogoutRequestFilter(final Saml2LogoutRequestFilter saml2LogoutRequestFilter) {
-        this.saml2LogoutRequestFilter = saml2LogoutRequestFilter;
-    }
-
-    @Autowired
-    public void setSaml2LogoutResponseFilter(final Saml2LogoutResponseFilter saml2LogoutResponseFilter) {
-        this.saml2LogoutResponseFilter = saml2LogoutResponseFilter;
-    }
-
-    @Autowired
-    public void setSaml2SingleLogoutFilter(final Saml2SingleLogoutFilter saml2SingleLogoutFilter) {
-        this.saml2SingleLogoutFilter = saml2SingleLogoutFilter;
-    }
-
-    @Autowired
-    public void setSaml2LocalLogoutFilter(final Saml2LocalLogoutFilter saml2LocalLogoutFilter) {
-        this.saml2LocalLogoutFilter = saml2LocalLogoutFilter;
-    }
-
-    @Qualifier("openSamlAuthenticationProvider")
-    @Autowired
-    public void setOpenSamlAuthenticationProvider(final AuthenticationProvider openSamlAuthenticationProvider) {
-        this.openSamlAuthenticationProvider = openSamlAuthenticationProvider;
+        return http.build();
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationProvider.java
@@ -21,8 +21,6 @@ import org.apache.nifi.authorization.util.IdentityMapping;
 import org.apache.nifi.authorization.util.IdentityMappingUtil;
 import org.apache.nifi.authorization.util.UserGroupUtil;
 import org.apache.nifi.util.NiFiProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationProvider;
 
 import java.util.Collections;
@@ -34,17 +32,11 @@ import java.util.Set;
  */
 public abstract class NiFiAuthenticationProvider implements AuthenticationProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NiFiAuthenticationProvider.class);
+    private final Authorizer authorizer;
 
-    private NiFiProperties properties;
-    private Authorizer authorizer;
-    private List<IdentityMapping> mappings;
+    private final List<IdentityMapping> mappings;
 
-    /**
-     * @param properties the NiFiProperties instance
-     */
     public NiFiAuthenticationProvider(final NiFiProperties properties, final Authorizer authorizer) {
-        this.properties = properties;
         this.mappings = Collections.unmodifiableList(IdentityMappingUtil.getIdentityMappings(properties));
         this.authorizer = authorizer;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationFilter.java
@@ -17,8 +17,6 @@
 package org.apache.nifi.web.security.anonymous;
 
 import org.apache.nifi.web.security.NiFiAuthenticationFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 
 import javax.servlet.http.HttpServletRequest;
@@ -28,12 +26,9 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class NiFiAnonymousAuthenticationFilter extends NiFiAuthenticationFilter {
 
-    private static final Logger logger = LoggerFactory.getLogger(NiFiAnonymousAuthenticationFilter.class);
-
     @Override
     public Authentication attemptAuthentication(final HttpServletRequest request) {
         // return the anonymous authentication request for this http request
         return new NiFiAnonymousAuthenticationRequestToken(request.isSecure(), request.getRemoteAddr());
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/AuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/AuthenticationSecurityConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.nifi.web.security.configuration;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationFilter;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationProvider;
 import org.apache.nifi.web.security.logout.LogoutRequestManager;
 import org.apache.nifi.web.security.spring.LoginIdentityProviderFactoryBean;
@@ -26,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.AuthenticationManager;
 
 /**
  * Spring Configuration for Authentication Security
@@ -55,6 +57,14 @@ public class AuthenticationSecurityConfiguration {
         this.niFiProperties = niFiProperties;
         this.extensionManager = extensionManager;
         this.authorizer = authorizer;
+    }
+
+    @Bean
+    public NiFiAnonymousAuthenticationFilter anonymousAuthenticationFilter(final AuthenticationManager authenticationManager) {
+        final NiFiAnonymousAuthenticationFilter anonymousAuthenticationFilter = new NiFiAnonymousAuthenticationFilter();
+        anonymousAuthenticationFilter.setProperties(niFiProperties);
+        anonymousAuthenticationFilter.setAuthenticationManager(authenticationManager);
+        return anonymousAuthenticationFilter;
     }
 
     @Bean

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
@@ -38,6 +38,7 @@ import org.apache.nifi.web.security.jwt.key.service.VerificationKeyService;
 import org.apache.nifi.web.security.jwt.provider.BearerTokenProvider;
 import org.apache.nifi.web.security.jwt.provider.StandardBearerTokenProvider;
 import org.apache.nifi.web.security.jwt.provider.SupportedClaim;
+import org.apache.nifi.web.security.jwt.resolver.StandardBearerTokenResolver;
 import org.apache.nifi.web.security.jwt.revocation.JwtLogoutListener;
 import org.apache.nifi.web.security.jwt.revocation.JwtRevocationService;
 import org.apache.nifi.web.security.jwt.revocation.JwtRevocationValidator;
@@ -48,6 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -55,6 +57,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -98,6 +102,19 @@ public class JwtAuthenticationSecurityConfiguration {
         this.idpUserGroupService = idpUserGroupService;
         this.stateManagerProvider = stateManagerProvider;
         this.keyRotationPeriod = niFiProperties.getSecurityUserJwsKeyRotationPeriod();
+    }
+
+
+    @Bean
+    public BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter(final AuthenticationManager authenticationManager) {
+        final BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter = new BearerTokenAuthenticationFilter(authenticationManager);
+        bearerTokenAuthenticationFilter.setBearerTokenResolver(bearerTokenResolver());
+        return bearerTokenAuthenticationFilter;
+    }
+
+    @Bean
+    public BearerTokenResolver bearerTokenResolver() {
+        return new StandardBearerTokenResolver();
     }
 
     @Bean

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KnoxAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KnoxAuthenticationSecurityConfiguration.java
@@ -18,12 +18,14 @@ package org.apache.nifi.web.security.configuration;
 
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.security.knox.KnoxAuthenticationFilter;
 import org.apache.nifi.web.security.knox.KnoxAuthenticationProvider;
 import org.apache.nifi.web.security.knox.KnoxService;
 import org.apache.nifi.web.security.knox.KnoxServiceFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 
 /**
  * Knox Configuration for Authentication Security
@@ -41,6 +43,14 @@ public class KnoxAuthenticationSecurityConfiguration {
     ) {
         this.niFiProperties = niFiProperties;
         this.authorizer = authorizer;
+    }
+
+    @Bean
+    public KnoxAuthenticationFilter knoxAuthenticationFilter(final AuthenticationManager authenticationManager) {
+        final KnoxAuthenticationFilter knoxAuthenticationFilter = new KnoxAuthenticationFilter();
+        knoxAuthenticationFilter.setAuthenticationManager(authenticationManager);
+        knoxAuthenticationFilter.setProperties(niFiProperties);
+        return knoxAuthenticationFilter;
     }
 
     @Bean

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/X509AuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/X509AuthenticationSecurityConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.nifi.web.security.configuration;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.x509.SubjectDnX509PrincipalExtractor;
+import org.apache.nifi.web.security.x509.X509AuthenticationFilter;
 import org.apache.nifi.web.security.x509.X509AuthenticationProvider;
 import org.apache.nifi.web.security.x509.X509CertificateExtractor;
 import org.apache.nifi.web.security.x509.X509CertificateValidator;
@@ -27,6 +28,7 @@ import org.apache.nifi.web.security.x509.ocsp.OcspCertificateValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
 
 /**
@@ -45,6 +47,16 @@ public class X509AuthenticationSecurityConfiguration {
     ) {
         this.niFiProperties = niFiProperties;
         this.authorizer = authorizer;
+    }
+
+    @Bean
+    public X509AuthenticationFilter x509AuthenticationFilter(final AuthenticationManager authenticationManager) {
+        final X509AuthenticationFilter x509AuthenticationFilter = new X509AuthenticationFilter();
+        x509AuthenticationFilter.setProperties(niFiProperties);
+        x509AuthenticationFilter.setCertificateExtractor(certificateExtractor());
+        x509AuthenticationFilter.setPrincipalExtractor(principalExtractor());
+        x509AuthenticationFilter.setAuthenticationManager(authenticationManager);
+        return x509AuthenticationFilter;
     }
 
     @Bean

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/csrf/StandardCookieCsrfTokenRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/csrf/StandardCookieCsrfTokenRepository.java
@@ -29,8 +29,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
-import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -48,17 +46,6 @@ public class StandardCookieCsrfTokenRepository implements CsrfTokenRepository {
     private static final int MAX_AGE_EXPIRED = 0;
 
     private static final int MAX_AGE_SESSION = -1;
-
-    private final List<String> allowedContextPaths;
-
-    /**
-     * Standard Cookie CSRF Token Repository with list of allowed context paths from proxy headers
-     *
-     * @param allowedContextPaths Allowed context paths from proxy headers
-     */
-    public StandardCookieCsrfTokenRepository(final List<String> allowedContextPaths) {
-        this.allowedContextPaths = Objects.requireNonNull(allowedContextPaths, "Allowed Context Paths required");
-    }
 
     /**
      * Generate CSRF Token or return current Token when present in HTTP Servlet Request Cookie header
@@ -118,7 +105,7 @@ public class StandardCookieCsrfTokenRepository implements CsrfTokenRepository {
     }
 
     private String getCookiePath(final HttpServletRequest httpServletRequest) {
-        final RequestUriBuilder requestUriBuilder = RequestUriBuilder.fromHttpServletRequest(httpServletRequest, allowedContextPaths);
+        final RequestUriBuilder requestUriBuilder = RequestUriBuilder.fromHttpServletRequest(httpServletRequest);
         requestUriBuilder.path(ROOT_PATH);
         final URI uri = requestUriBuilder.build();
         return uri.getPath();


### PR DESCRIPTION
# Summary

[NIFI-10216](https://issues.apache.org/jira/browse/NIFI-10216) Refactors the Spring Security Configuration in `nifi-web-api` and `nifi-web-security` to remove references to the deprecated `WebSecurityConfigurerAdapter` class.

The refactored implementation provides a streamlined `SecurityFilterChain` configuration in `NiFiWebApiSecurityConfiguration` and moves individual `Filter` creation to associated configuration classes.

Additional updates include setting the default Spring Security logging level to `INFO` and updating the Standard CSRF Token Repository to leverage the streamlined version of `RequestUriBuilder`, which retrieves allowed context path configuration from available initialization parameters.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
