### PR TITLE
NIFI-10196 Correct Jolt UI CSRF Header Handling

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/webapp/app/app.js
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/src/main/webapp/app/app.js
@@ -19,11 +19,9 @@
 
 var AppRun =  function($rootScope,$state,$http){
 
-    // Get the Request Token for CSRF mitigation and send on all requests
-    if (nf.AuthorizationStorage.hasToken()) {
-        var token = nf.AuthorizationStorage.getRequestToken();
-        $http.defaults.headers.common['Request-Token'] = token;
-    }
+    // Set CSRF Cookie and Header names to match Spring Security configuration in StandardCookieCsrfTokenRepository
+    $http.defaults.xsrfCookieName = '__Secure-Request-Token';
+    $http.defaults.xsrfHeaderName = 'Request-Token';
 
     $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error){
         event.preventDefault();


### PR DESCRIPTION
# Summary

[NIFI-10196](https://issues.apache.org/jira/browse/NIFI-10196) Corrects Cross Site Request Forgery header handling in the advanced user interface for the `JoltTransformJSON` Processor.

Previous adjustments for CSRF handling in [NIFI-9339](https://issues.apache.org/jira/browse/NIFI-9339) set the `Request-Token` header during initialization, but the approach does not handle subsequent requests when the CSRF cookie value changes.

The corrected approach uses [AngularJS XSRF Protection](https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection) request interception based configuring the `xsrfCookieName` and `xsrfHeaderName` properties of the HTTP service. The standard AngularJS XSRF interceptor reads the cookie value and sets the request header for each request to leverage the current value.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
