### PR TITLE
NIFI-10219 Remove jna-platform from nifi-bootstrap-utils

### DIFF
--- a/nifi-commons/nifi-bootstrap-utils/pom.xml
+++ b/nifi-commons/nifi-bootstrap-utils/pom.xml
@@ -24,12 +24,5 @@ language governing permissions and limitations under the License. -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <!-- This needs to be here because it is relied upon by the nifi-runtime which starts NiFi.  It uses this bootstrap module
-        and the libs that get laid down in lib/bootstrap to create a child classloader with these bits in it -->
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>5.10.0</version>
-        </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-bootstrap-utils/src/test/java/org/apache/nifi/bootstrap/util/OSUtilsTest.java
+++ b/nifi-commons/nifi-bootstrap-utils/src/test/java/org/apache/nifi/bootstrap/util/OSUtilsTest.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.bootstrap.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class OSUtilsTest {
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testGetPid() throws IOException {
         final ProcessBuilder builder = new ProcessBuilder();


### PR DESCRIPTION
# Summary

[NIFI-10219](https://issues.apache.org/jira/browse/NIFI-10219) Removes the `jna-platform` dependency from `nifi-bootstrap-utils` and removes the private `OSUtils.getWindowsProcessId()` method which depends on reflection and JNA access for Java 8 on Windows.

Removing the `jna-platform` dependency removes support for retrieving spawned Process Identifiers on Windows when running on Java 8, but all references to `OSUtils.getProcessId()` treat the PID as optional. Furthermore, the bootstrap components leverage `ps` and `kill` commands that are not available on Windows, so having the PID available on Windows does not support additional operations. Java 9 and following provide a standard method for retrieving the PID.

Eliminating the direct dependency on `jna-platform` removes the library from `lib/bootstrap` and allows the library to be placed in `lib/properties` as a transitive dependency of `nifi-property-protection-azure`, avoiding runtime class definition issues. This also avoids the need to adjust the `nifi-assembly` configuration to remove the `jna-platform` dependency to a different location, or provide multiple copies.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
