### PR TITLE
NIFI-10224 Move Static Analysis to Separate Workflow Job

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ env:
     -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
-  MAVEN_COMMAND: >-
+  MAVEN_BUILD_COMMAND: >-
     mvn package verify
     -V
     -D dir-only
@@ -33,8 +33,7 @@ env:
     -nsu
     -ntp
     -ff
-  MAVEN_PROFILES: >-
-    -P contrib-check
+  MAVEN_BUILD_PROFILES: >-
     -P include-grpc
     -P skip-nifi-bin-assembly
   MAVEN_PROJECTS: >-
@@ -51,6 +50,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  static-analysis:
+    timeout-minutes: 30
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'maven'
+      - name: Maven Build
+        run: >
+          mvn validate
+          --no-snapshot-updates
+          --no-transfer-progress
+          --fail-fast
+          -P contrib-check
+          -P include-grpc
+
   ubuntu-build-en:
     timeout-minutes: 120
     runs-on: ubuntu-latest
@@ -63,17 +84,9 @@ jobs:
           cat /proc/meminfo
           df
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Cache Maven Dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+        uses: actions/checkout@v3
       - name: Cache Node Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.npm
@@ -82,10 +95,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm16-
       - name: Set up Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'
+          cache: 'maven'
       - name: Maven Build
         env:
           NIFI_CI_LOCALE: >-
@@ -100,11 +114,11 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_PROFILES }}
+          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: surefire-reports-ubuntu-17
           path: |
@@ -127,17 +141,9 @@ jobs:
           cat /proc/meminfo
           df
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Cache Maven Dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+        uses: actions/checkout@v3
       - name: Cache Node Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.npm
@@ -146,10 +152,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm16-
       - name: Set up Java 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
+          cache: 'maven'
       - name: Maven Build
         env:
           NIFI_CI_LOCALE: >-
@@ -164,11 +171,11 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_PROFILES }}
+          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: surefire-reports-ubuntu-en
           path: |
@@ -182,7 +189,7 @@ jobs:
   macos-build-jp:
     timeout-minutes: 120
     runs-on: macos-latest
-    name: MacOS Adopt JDK 8 JP
+    name: MacOS Temurin JDK 8 JP
     steps:
       - name: System Information
         run: |
@@ -191,17 +198,9 @@ jobs:
           sysctl machdep.cpu
           df
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Cache Maven Dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+        uses: actions/checkout@v3
       - name: Cache Node Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.npm
@@ -210,10 +209,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm16-
       - name: Set up Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
+          cache: 'maven'
       - name: Maven Build
         env:
           NIFI_CI_LOCALE: >-
@@ -228,11 +228,11 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >-
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_PROFILES }}
+          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: surefire-reports-macos-jp
           path: |
@@ -257,21 +257,13 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.longpaths true
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Cache Maven Dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+        uses: actions/checkout@v3
       - name: Get NPM Cache Directory
         id: npm-cache-directory
         run: |
           echo "::set-output name=directory::$(npm config get cache)"
       - name: Cache Node Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.npm-cache-directory.outputs.directory }}
@@ -280,10 +272,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm16-
       - name: Set up Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '8'
+          cache: 'maven'
       - name: Maven Build
         env:
           NIFI_CI_LOCALE: >-
@@ -298,10 +291,11 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >-
-          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: surefire-reports-windows-fr
           path: |

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -453,44 +453,6 @@
             </build>
         </profile>
         <profile>
-            <!-- Checks style and licensing requirements. This is a good idea to run
-            for contributions and for the release process. While it would be nice to
-            run always these plugins can considerably slow the build and have proven
-            to create unstable builds in our multi-module project and when building using
-            multiple threads. The stability issues seen with Checkstyle in multi-module
-            builds include false-positives and false negatives. -->
-            <id>contrib-check</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.rat</groupId>
-                        <artifactId>apache-rat-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                                <phase>verify</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>check-style</id>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                                <phase>verify</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <!-- Enables execution of integration tests managed by the Maven FailSafe plugin. -->
             <id>nifi-registry-integration-tests</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -991,7 +991,7 @@
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
-                                <phase>verify</phase>
+                                <phase>validate</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -1001,7 +1001,7 @@
                         <executions>
                             <execution>
                                 <id>check-style</id>
-                                <phase>verify</phase>
+                                <phase>validate</phase>
                                 <configuration>
                                     <encoding>UTF-8</encoding>
                                     <excludes>**/generated-sources/**/*</excludes>


### PR DESCRIPTION
# Summary

[NIFI-10224](https://issues.apache.org/jira/browse/NIFI-10224) Moves Maven Checkstyle Plugin and Apache Rat Plugin execution to a separate Static Analysis job in the GitHub continuous integration workflow. This strategy avoids running static analysis in multiple build jobs and also makes it easier to distinguish between different types of workflow failures.

Additional updates include upgrading multiple GitHub Actions from Version 2 to 3 and replacing a separate Maven cache step with Maven caching integrated with the Setup Java Action. Changes also include replacing AdoptOpenJDK with Eclipse Temurin, which is the supported successor to AdoptOpenJDK.

Maven configuration changes include removing an unnecessary duplication `contrib-check` profile definition in the `nifi-registry` module and changing the Maven phase from `verify` to `validate` for the Checkstyle and Rat Plugins.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
