### PR TITLE
NIFI-9758 implemented additional Dynamic Properties for JavaMail session

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import jakarta.activation.DataHandler;
@@ -51,6 +52,7 @@ import jakarta.mail.internet.PreencodedMimeBodyPart;
 import jakarta.mail.util.ByteArrayDataSource;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
@@ -62,6 +64,7 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -79,9 +82,16 @@ import org.apache.nifi.stream.io.StreamUtils;
 @Tags({"email", "put", "notify", "smtp"})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @CapabilityDescription("Sends an e-mail to configured recipients for each incoming FlowFile")
+@DynamicProperty(name = "mail._____",
+        value = "Value for a specific property to be set in the JavaMail Session object",
+        description = "The values specified in this dynamic property will be set in the JavaMail Session object. " +
+                "Possible properties can be found in: https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html.",
+        expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
 @SystemResourceConsideration(resource = SystemResource.MEMORY, description = "The entirety of the FlowFile's content (as a String object) "
         + "will be read into memory in case the property to use the flow file content as the email body is set to true.")
 public class PutEmail extends AbstractProcessor {
+
+    private static final Pattern MAIL_PROPERTY_PATTERN = Pattern.compile("^mail\\.([a-z0-9\\.]+)$");
 
     public static final PropertyDescriptor SMTP_HOSTNAME = new PropertyDescriptor.Builder()
             .name("SMTP Hostname")
@@ -150,8 +160,8 @@ public class PutEmail extends AbstractProcessor {
             .name("attribute-name-regex")
             .displayName("Attributes to Send as Headers (Regex)")
             .description("A Regular Expression that is matched against all FlowFile attribute names. "
-                + "Any attribute whose name matches the regex will be added to the Email messages as a Header. "
-                + "If not specified, no FlowFile attributes will be added as headers.")
+                    + "Any attribute whose name matches the regex will be added to the Email messages as a Header. "
+                    + "If not specified, no FlowFile attributes will be added as headers.")
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
             .required(false)
             .build();
@@ -303,6 +313,18 @@ public class PutEmail extends AbstractProcessor {
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return properties;
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .description("Mail properties to be set to the JavaMail Session")
+                .required(false)
+                .dynamic(true)
+                .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+                .addValidator(new DynamicMailPropertyValidator())
+                .build();
     }
 
     @Override
@@ -464,6 +486,16 @@ public class PutEmail extends AbstractProcessor {
             }
         }
 
+        for (final PropertyDescriptor descriptor : context.getProperties().keySet()) {
+            if (descriptor.isDynamic()) {
+                final String flowFileValue = context.getProperty(descriptor).evaluateAttributeExpressions(flowFile).getValue();
+                // Nullable values are not allowed, so filter out
+                if (null != flowFileValue) {
+                    properties.setProperty(descriptor.getName(), flowFileValue);
+                }
+            }
+        }
+
         return properties;
 
     }
@@ -493,7 +525,7 @@ public class PutEmail extends AbstractProcessor {
      * @throws AddressException if the property cannot be parsed to a valid InternetAddress[]
      */
     private InternetAddress[] toInetAddresses(final ProcessContext context, final FlowFile flowFile,
-            PropertyDescriptor propertyDescriptor) throws AddressException {
+                                              PropertyDescriptor propertyDescriptor) throws AddressException {
         InternetAddress[] parse;
         final String value = context.getProperty(propertyDescriptor).evaluateAttributeExpressions(flowFile).getValue();
         if (value == null || value.isEmpty()){
@@ -522,5 +554,58 @@ public class PutEmail extends AbstractProcessor {
      */
     protected void send(final Message msg) throws MessagingException {
         Transport.send(msg);
+    }
+
+    /**
+     * Utility function to return a Map of optional {@code mail._____} properties that were set dynamically.
+     * @param context the ProcessContext
+     * @return a Map with optional {@code mail._____} properties
+     */
+    private Map<String, String> getDynamicMailProperties(final ProcessContext context) {
+        final Map<String, String> dynamicMailProperties = new HashMap<>();
+
+        for (final Map.Entry<PropertyDescriptor, String> entry: context.getProperties().entrySet()) {
+            final PropertyDescriptor descriptor = entry.getKey();
+            if (descriptor.isDynamic()) {
+                final String name = descriptor.getName();
+                final Matcher matcher = MAIL_PROPERTY_PATTERN.matcher(name);
+                if (matcher.matches()) {
+                    dynamicMailProperties.put(name, entry.getValue());
+                }
+            }
+        }
+
+        return dynamicMailProperties;
+    }
+
+    private static class DynamicMailPropertyValidator implements Validator {
+        @Override
+        public ValidationResult validate(String subject, String input, ValidationContext context) {
+            final Matcher matcher = MAIL_PROPERTY_PATTERN.matcher(subject);
+            if (!matcher.matches()) {
+                return new ValidationResult.Builder()
+                        .input(input)
+                        .subject(subject)
+                        .valid(false)
+                        .explanation(String.format("[%s] is an invalid mail._____ property", subject))
+                        .build();
+            }
+
+            if (propertyToContext.containsKey(subject)) {
+                return new ValidationResult.Builder()
+                        .input(input)
+                        .subject(subject)
+                        .valid(false)
+                        .explanation(String.format("[%s] overwrites required existing properties", subject))
+                        .build();
+            }
+
+            return new ValidationResult.Builder()
+                    .subject(subject)
+                    .input(input)
+                    .valid(true)
+                    .explanation("Valid mail._____ property that does not overwrite existing required properties")
+                    .build();
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -299,4 +299,51 @@ public class TestPutEmail {
         assertEquals("anotherbcc@apache.org", message.getRecipients(RecipientType.BCC)[1].toString());
     }
 
+    @Test
+    public void testValidDynamicMailProperties() throws Exception {
+        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
+        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        runner.setProperty(PutEmail.MESSAGE, "${body}");
+        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
+        runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
+        runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
+        runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
+
+        runner.setProperty("mail.smtp.timeout", "sample dynamic mail property");
+        runner.setProperty("mail.smtp.writetimeout", "sample dynamic mail property");
+        runner.setProperty("mail.smtp.connectiontimeout", "sample dynamic mail property");
+        runner.setProperty("mail.smtp.auth.xoauth2.disable", "sample dynamic mail property");
+        runner.assertValid();
+    }
+
+    @Test
+    public void testInvalidDynamicMailPropertyName() {
+        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
+        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        runner.setProperty(PutEmail.MESSAGE, "${body}");
+        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
+        runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
+        runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
+        runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
+
+        runner.setProperty("mail.", "sample_value");
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testOverwritingDynamicMailProperty() {
+        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
+        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        runner.setProperty(PutEmail.MESSAGE, "${body}");
+        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
+        runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
+        runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
+        runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
+
+        runner.setProperty("mail.smtp.user", "test-user-value");
+        runner.assertNotValid();
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -180,11 +180,9 @@ public class TestPutEmail {
     @Test
     public void testInvalidAddress() {
         // verifies that unparsable addresses lead to the flow file being routed to failure
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.FROM, "test@apache.org <invalid");
         runner.setProperty(PutEmail.MESSAGE, "Message Body");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org");
 
         runner.enqueue("Some Text".getBytes());
 
@@ -200,11 +198,9 @@ public class TestPutEmail {
     public void testEmptyFrom() {
         // verifies that if the FROM property evaluates to an empty string at
         // runtime the flow file is transferred to failure.
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.FROM, "${MISSING_PROPERTY}");
         runner.setProperty(PutEmail.MESSAGE, "Message Body");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org");
 
         runner.enqueue("Some Text".getBytes());
 
@@ -220,13 +216,10 @@ public class TestPutEmail {
     @Test
     public void testOutgoingMessageAttachment() throws Exception {
         // verifies that are set on the outgoing Message correctly
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
-        runner.setProperty(PutEmail.FROM, "test@apache.org");
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.MESSAGE, "Message Body");
         runner.setProperty(PutEmail.ATTACH_FILE, "true");
         runner.setProperty(PutEmail.CONTENT_TYPE, "text/html");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org");
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.FILENAME.key(), "test한的ほу́.pdf");
@@ -265,11 +258,8 @@ public class TestPutEmail {
     @Test
     public void testOutgoingMessageWithFlowfileContent() throws Exception {
         // verifies that are set on the outgoing Message correctly
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
-        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.MESSAGE, "${body}");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
         runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
         runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
         runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
@@ -300,32 +290,20 @@ public class TestPutEmail {
     }
 
     @Test
-    public void testValidDynamicMailProperties() throws Exception {
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
-        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+    public void testValidDynamicMailProperties() {
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.MESSAGE, "${body}");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
-        runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
-        runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
         runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
 
-        runner.setProperty("mail.smtp.timeout", "sample dynamic mail property");
-        runner.setProperty("mail.smtp.writetimeout", "sample dynamic mail property");
-        runner.setProperty("mail.smtp.connectiontimeout", "sample dynamic mail property");
-        runner.setProperty("mail.smtp.auth.xoauth2.disable", "sample dynamic mail property");
+        runner.setProperty("mail.smtp.timeout", "sample dynamic smtp property");
+        runner.setProperty("mail.smtps.timeout", "sample dynamic smtps property");
         runner.assertValid();
     }
 
     @Test
     public void testInvalidDynamicMailPropertyName() {
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
-        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.MESSAGE, "${body}");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
-        runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
-        runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
         runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
 
         runner.setProperty("mail.", "sample_value");
@@ -334,16 +312,19 @@ public class TestPutEmail {
 
     @Test
     public void testOverwritingDynamicMailProperty() {
-        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
-        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
-        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        setRequiredProperties(runner);
         runner.setProperty(PutEmail.MESSAGE, "${body}");
-        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
-        runner.setProperty(PutEmail.CC, "recipientcc@apache.org,anothercc@apache.org");
-        runner.setProperty(PutEmail.BCC, "recipientbcc@apache.org,anotherbcc@apache.org");
         runner.setProperty(PutEmail.CONTENT_AS_MESSAGE, "${sendContent}");
 
         runner.setProperty("mail.smtp.user", "test-user-value");
         runner.assertNotValid();
+    }
+
+    private void setRequiredProperties(final TestRunner runner) {
+        // values here may be overridden in some tests
+        runner.setProperty(PutEmail.SMTP_HOSTNAME, "smtp-host");
+        runner.setProperty(PutEmail.HEADER_XMAILER, "TestingNiFi");
+        runner.setProperty(PutEmail.FROM, "test@apache.org,from@apache.org");
+        runner.setProperty(PutEmail.TO, "recipient@apache.org,another@apache.org");
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-9758](https://issues.apache.org/jira/browse/NIFI-9758)

These dynamic properties allow the `mail.smtp.timeout` property for the `JavaMail` session to be set.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
