### PR TITLE
NIFI-10233 Correct Anonymous Authentication for HTTP Access

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -696,6 +696,15 @@ public class NiFiProperties extends ApplicationProperties {
         return sslPort;
     }
 
+    /**
+     * Is HTTP without TLS enabled based on configuring nifi.web.http.port property
+     *
+     * @return HTTP enabled status
+     */
+    public boolean isHttpEnabled() {
+        return getPort() != null;
+    }
+
     public boolean isHTTPSConfigured() {
         return getSslPort() != null;
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
@@ -128,7 +128,7 @@ public class NiFiWebApiSecurityConfiguration {
             http.addFilterBefore(knoxAuthenticationFilter, AnonymousAuthenticationFilter.class);
         }
 
-        if (properties.isAnonymousAuthenticationAllowed()) {
+        if (properties.isAnonymousAuthenticationAllowed() || properties.isHttpEnabled()) {
             http.addFilterAfter(anonymousAuthenticationFilter, AnonymousAuthenticationFilter.class);
         }
 


### PR DESCRIPTION
# Summary

[NIFI-10233](https://issues.apache.org/jira/browse/NIFI-10233) Corrects anonymous authentication when NiFi is configured for unencrypted HTTP access. The correction restores standard behavior prior to changes for [NIFI-10216](https://issues.apache.org/jira/browse/NIFI-10216), enabling the standard anonymous authentication filter when unencrypted HTTP is enabled.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
