### PR TITLE
NIFI-9812 Skip Native Lib loading tests on ARM64

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/AbstractTestNarLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/AbstractTestNarLoader.java
@@ -16,15 +16,12 @@
  */
 package org.apache.nifi.nar;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.nifi.bundle.Bundle;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.reporting.ReportingTask;
 import org.apache.nifi.util.NiFiProperties;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,8 +33,8 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractTestNarLoader {
     abstract String getWorkDir();
@@ -52,12 +49,7 @@ public abstract class AbstractTestNarLoader {
     NarClassLoaders narClassLoaders;
     ExtensionDiscoveringManager extensionManager;
 
-    @BeforeClass
-    public static void setupClass() {
-        Assume.assumeTrue("Test only runs on *nix", !SystemUtils.IS_OS_WINDOWS);
-    }
-
-    @Before
+    @BeforeEach
     public void setup() throws IOException, ClassNotFoundException {
         deleteDir(getWorkDir());
         deleteDir(getNarAutoloadDir());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibFromNar.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibFromNar.java
@@ -17,8 +17,10 @@
 package org.apache.nifi.nar;
 
 import org.apache.nifi.bundle.Bundle;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -34,20 +36,16 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@EnabledOnOs({ OS.MAC })
+@DisabledIfSystemProperty(named = "os.arch", matches = "aarch64|arm64")
 public class TestLoadNativeLibFromNar extends AbstractTestNarLoader {
     static final String WORK_DIR = "./target/work";
     static final String NAR_AUTOLOAD_DIR = "./target/nars_with_native_lib";
     static final String PROPERTIES_FILE = "./src/test/resources/conf/nifi.nar_with_native_lib.properties";
     static final String EXTENSIONS_DIR = "./src/test/resources/nars_with_native_lib";
-
-    @BeforeClass
-    public static void setUpSuite() {
-        assumeTrue("Test only runs on Mac OS", new OSUtil(){}.isOsMac());
-    }
 
     @Test
     public void testLoadSameLibraryFromBy2NarClassLoadersFromNar() throws Exception {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibViaSystemProperty.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibViaSystemProperty.java
@@ -17,9 +17,12 @@
 package org.apache.nifi.nar;
 
 import org.apache.nifi.bundle.Bundle;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -35,10 +38,12 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+
+@EnabledOnOs({ OS.MAC })
+@DisabledIfSystemProperty(named = "os.arch", matches = "aarch64|arm64")
 public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
     static final String WORK_DIR = "./target/work";
     static final String NAR_AUTOLOAD_DIR = "./target/nars_without_native_lib";
@@ -47,15 +52,13 @@ public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
 
     private static String oldJavaLibraryPath;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
-        assumeTrue("Test only runs on Mac OS", new OSUtil(){}.isOsMac());
-
         oldJavaLibraryPath = System.getProperty("java.library.path");
         System.setProperty("java.library.path", "./src/test/resources/native");
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownSuite() {
         if (oldJavaLibraryPath != null) {
             System.setProperty("java.library.path", oldJavaLibraryPath);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestNarLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestNarLoader.java
@@ -16,13 +16,13 @@
  */
 package org.apache.nifi.nar;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.reporting.ReportingTask;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,19 +33,17 @@ import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+
+@DisabledOnOs({ OS.WINDOWS })
+@DisabledIfSystemProperty(named = "os.arch", matches = "aarch64|arm64")
 public class TestNarLoader extends AbstractTestNarLoader {
     static final String WORK_DIR = "./target/work";
     static final String NAR_AUTOLOAD_DIR = "./target/extensions";
     static final String PROPERTIES_FILE = "./src/test/resources/conf/nifi.properties";
     static final String EXTENSIONS_DIR = "./src/test/resources/extensions";
-
-    @BeforeClass
-    public static void setUpSuite() {
-        Assume.assumeTrue("Test only runs on *nix", !SystemUtils.IS_OS_WINDOWS);
-    }
 
     @Test
     public void testNarLoaderWhenAllAvailable() throws IOException {


### PR DESCRIPTION
- Migrate tests in nifi-framework-nar-loading-utils to JUnit5
- Annotate tests that use x86_64 native binaries to be conditional on x86_64 os.arch

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-9812](https://issues.apache.org/jira/browse/NIFI-9812)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
