### PR TITLE
NIFI-10228: parse json flow using instanceIdentifier as the UUID

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/util/FlowParser.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/util/FlowParser.java
@@ -180,7 +180,7 @@ public class FlowParser {
         mapPorts(rootGroup.getInputPorts(), ports);
         mapPorts(rootGroup.getOutputPorts(), ports);
 
-        return new FlowInfo(rootGroup.getIdentifier(), ports);
+        return new FlowInfo(rootGroup.getInstanceIdentifier(), ports);
     }
 
     private void mapPorts(final Set<VersionedPort> versionedPorts, final List<PortDTO> portDtos) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Updates the FlowParser to use the "Instance Identifier" of the root process group versus "Identifier". When using flow.json.gz (versus flow.xml.gz), this nuance makes a difference in particular when establishing access policies on initial startup. Policies were being incorrectly defined when not using Instance Identifier.

For testing, NiFi was configured with the 'managed-authorizer' (nifi.properties) and a specific initial admin user (authorizers.xml). NiFi was started in order to generate an initial, empty flow.xml.gz/flow.json.gz. NiFi was shutdown and the authorizations.xml and users.xml files were removed. NiFi was started again.

Now, since both the flow and a root process group exist, component access policies for the group are created and the initial admin user is added to the policy. Prior to this fix, the component access policies would be populated incorrectly with the "Identifier" UUID. Now, they are populated correctly with the "Instance Identifier" UUID.

[NIFI-10228](https://issues.apache.org/jira/browse/NIFI-10228)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
