### PR TITLE
NIFI-10249 Enable Parallel Builds in GitHub Workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -33,6 +33,7 @@ env:
     -nsu
     -ntp
     -ff
+    --threads 1C
   MAVEN_BUILD_PROFILES: >-
     -P include-grpc
     -P skip-nifi-bin-assembly
@@ -57,12 +58,18 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+      - name: Cache Maven Modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+          # Cache Maven modules using a cache key different from setup-java steps
+          key: ${{ runner.os }}-maven-static-analysis-${{ hashFiles('**/pom.xml') }}
       - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'
-          cache: 'maven'
       - name: Maven Build
         run: >
           mvn validate
@@ -91,9 +98,7 @@ jobs:
           path: |
             ~/.npm
             **/node_modules
-          key: ${{ runner.os }}-npm16-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm16-
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
@@ -148,9 +153,7 @@ jobs:
           path: |
             ~/.npm
             **/node_modules
-          key: ${{ runner.os }}-npm16-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm16-
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
@@ -205,9 +208,7 @@ jobs:
           path: |
             ~/.npm
             **/node_modules
-          key: ${{ runner.os }}-npm16-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm16-
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:
@@ -268,9 +269,7 @@ jobs:
           path: |
             ${{ steps.npm-cache-directory.outputs.directory }}
             **/node_modules
-          key: ${{ runner.os }}-npm16-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm16-
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -709,7 +709,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>
@@ -724,14 +724,14 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.2.1</version>
+                            <version>9.3</version>
                         </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>
@@ -797,7 +797,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven-version</id>
@@ -975,12 +975,6 @@
             </build>
         </profile>
         <profile>
-            <!-- Checks style and licensing requirements. This is a good
-                idea to run for contributions and for the release process. While it would
-                be nice to run always these plugins can considerably slow the build and have
-                proven to create unstable builds in our multi-module project and when building
-                using multiple threads. The stability issues seen with Checkstyle in multi-module
-                builds include false-positives and false negatives. -->
             <id>contrib-check</id>
             <build>
                 <plugins>


### PR DESCRIPTION
# Summary

[NIFI-10249](https://issues.apache.org/jira/browse/NIFI-10249) Enables parallel builds in GitHub continuous integration workflows. The configuration uses `--threads 1C` resulting in one thread per CPU core.

Current Ubuntu Linux runners have two cores, macOS runners have three cores, and Windows runners have one core, resulting in different behavior based on each OS.

Additional changes include using a direct GitHub Actions Cache step for Static Analysis to have a cache key different from standard setup-java build steps.

Maven plugin version updates include the following:

- Upgraded maven-enforcer-plugin from 3.0.0 to 3.1.0
- Upgraded maven-dependency-plugin from 3.2.0 to 3.3.0
- Upgraded checkstyle from 9.2.1 to 9.3
- Upgraded buildnumber-maven-plugin from 1.4 to 3.0.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
