### PR TITLE
NIFI-10250 Added query string as attribute in ListenHTTP processor

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -923,6 +923,11 @@ The following binary components are provided under the Apache Software License v
       Google Cloud Client Library for Java
       Copyright 2016-2021 Google Inc. All Rights Reserved.
 
+  (ASLv2) Google Java API Client Services - Drive API
+    The following NOTICE information applies:
+      Google Java API Client Services - Drive API
+      Copyright 2011-2022 Google Inc. All Rights Reserved.
+
   (ASLv2) Guava
     The following NOTICE information applies:
       Guava

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-nar/src/main/resources/META-INF/NOTICE
@@ -15,6 +15,11 @@ The following binary components are provided under the Apache Software License v
       Google Cloud Client Library for Java
       Copyright 2016 Google Inc. All Rights Reserved.
 
+  (ASLv2) Google Java API Client Services - Drive API
+    The following NOTICE information applies:
+      Google Java API Client Services - Drive API
+      Copyright 2011-2022 Google Inc. All Rights Reserved.
+
   (ASLv2) The Netty Project
     The following NOTICE information applies:
       The Netty Project

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -115,6 +115,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-drive</artifactId>
+            <version>v3-rev20220709-1.32.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.tdunning</groupId>
             <artifactId>json</artifactId>
             <version>1.8</version>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/AbstractGCPProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/AbstractGCPProcessor.java
@@ -31,6 +31,7 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.gcp.util.GoogleUtils;
 import org.apache.nifi.proxy.ProxyConfiguration;
 
 import java.net.Proxy;
@@ -106,16 +107,13 @@ public abstract class AbstractGCPProcessor<
             .build();
 
     /**
-     * Links to the {@link GCPCredentialsService} which provides credentials for this particular processor.
+     * Deprecated - Use {@link GoogleUtils#GCP_CREDENTIALS_PROVIDER_SERVICE} instead
      */
+    @Deprecated
     public static final PropertyDescriptor GCP_CREDENTIALS_PROVIDER_SERVICE = new PropertyDescriptor.Builder()
-            .name("gcp-credentials-provider-service")
-            .name("GCP Credentials Provider Service")
-            .description("The Controller Service used to obtain Google Cloud Platform credentials.")
-            .required(true)
-            .identifiesControllerService(GCPCredentialsService.class)
+            .fromPropertyDescriptor(GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE)
+            .name("GCP Credentials Provider Service") // For backward compatibility
             .build();
-
 
     protected volatile CloudService cloudService;
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.drive;
+
+import org.apache.nifi.processor.util.list.ListableEntity;
+import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.RecordSchema;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GoogleDriveFileInfo implements ListableEntity {
+
+    private static final RecordSchema SCHEMA;
+    private static final String ID = "id";
+    private static final String FILENAME = "filename";
+    private static final String SIZE = "size";
+    private static final String CREATED_TIME = "createdTime";
+    private static final String MODIFIED_TIME = "modifiedTime";
+    private static final String MIME_TYPE = "mimeType";
+
+    static {
+        final List<RecordField> recordFields = new ArrayList<>();
+        recordFields.add(new RecordField(ID, RecordFieldType.STRING.getDataType(), false));
+        recordFields.add(new RecordField(FILENAME, RecordFieldType.STRING.getDataType(), false));
+        recordFields.add(new RecordField(SIZE, RecordFieldType.LONG.getDataType(), false));
+        recordFields.add(new RecordField(CREATED_TIME, RecordFieldType.TIMESTAMP.getDataType(), false));
+        recordFields.add(new RecordField(MODIFIED_TIME, RecordFieldType.TIMESTAMP.getDataType(), false));
+        recordFields.add(new RecordField(MIME_TYPE, RecordFieldType.STRING.getDataType()));
+        SCHEMA = new SimpleRecordSchema(recordFields);
+    }
+
+    private final String id;
+    private final String fileName;
+    private final long size;
+    private final long createdTime;
+    private final long modifiedTime;
+    private final String mimeType;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public long getCreatedTime() {
+        return createdTime;
+    }
+
+    public long getModifiedTime() {
+        return modifiedTime;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    @Override
+    public Record toRecord() {
+        final Map<String, Object> values = new HashMap<>();
+
+        values.put(ID, getId());
+        values.put(FILENAME, getName());
+        values.put(SIZE, getSize());
+        values.put(CREATED_TIME, getCreatedTime());
+        values.put(MODIFIED_TIME, getModifiedTime());
+        values.put(MIME_TYPE, getMimeType());
+
+        return new MapRecord(SCHEMA, values);
+    }
+
+    public static RecordSchema getRecordSchema() {
+        return SCHEMA;
+    }
+
+    public static final class Builder {
+        private String id;
+        private String fileName;
+        private long size;
+        private long createdTime;
+        private long modifiedTime;
+        private String mimeType;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder fileName(String fileName) {
+            this.fileName = fileName;
+            return this;
+        }
+
+        public Builder size(long size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder createdTime(long createdTime) {
+            this.createdTime = createdTime;
+            return this;
+        }
+
+        public Builder modifiedTime(long modifiedTime) {
+            this.modifiedTime = modifiedTime;
+            return this;
+        }
+
+        public Builder mimeType(String mimeType) {
+            this.mimeType = mimeType;
+            return this;
+        }
+
+        public GoogleDriveFileInfo build() {
+            return new GoogleDriveFileInfo(this);
+        }
+
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        GoogleDriveFileInfo other = (GoogleDriveFileInfo) obj;
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        return true;
+    }
+
+    private GoogleDriveFileInfo(final Builder builder) {
+        this.id = builder.id;
+        this.fileName = builder.fileName;
+        this.size = builder.size;
+        this.createdTime = builder.createdTime;
+        this.modifiedTime = builder.modifiedTime;
+        this.mimeType = builder.mimeType;
+    }
+
+    @Override
+    public String getName() {
+        return getFileName();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return getId();
+    }
+
+    @Override
+    public long getTimestamp() {
+        long timestamp = Math.max(getCreatedTime(), getModifiedTime());
+
+        return timestamp;
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/util/GoogleUtils.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/util/GoogleUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.util;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.gcp.credentials.service.GCPCredentialsService;
+
+public class GoogleUtils {
+    /**
+     * Links to the {@link GCPCredentialsService} which provides credentials for this particular processor.
+     */
+    public static final PropertyDescriptor GCP_CREDENTIALS_PROVIDER_SERVICE = new PropertyDescriptor.Builder()
+            .name("gcp-credentials-provider-service")
+            .displayName("GCP Credentials Provider Service")
+            .description("The Controller Service used to obtain Google Cloud Platform credentials.")
+            .required(true)
+            .identifiesControllerService(GCPCredentialsService.class)
+            .build();
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -22,3 +22,4 @@ org.apache.nifi.processors.gcp.pubsub.lite.PublishGCPubSubLite
 org.apache.nifi.processors.gcp.pubsub.lite.ConsumeGCPubSubLite
 org.apache.nifi.processors.gcp.bigquery.PutBigQueryBatch
 org.apache.nifi.processors.gcp.bigquery.PutBigQueryStreaming
+org.apache.nifi.processors.gcp.drive.ListGoogleDrive

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveIT.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.drive;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.AbstractInputStreamContent;
+import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.DriveScopes;
+import com.google.api.services.drive.model.File;
+import org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors;
+import org.apache.nifi.processors.gcp.credentials.service.GCPCredentialsControllerService;
+import org.apache.nifi.processors.gcp.util.GoogleUtils;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Set the following constants before running:<br />
+ * <br />
+ * CREDENTIAL_JSON_FILE_PATH - A Service Account credentials JSON file.<br />
+ * SHARED_FOLDER_ID - The ID of a Folder that is shared with the Service Account. The test will create files and sub-folders within this folder.<br />
+ * <br />
+ * Created files and folders are cleaned up, but it's advisable to dedicate a folder for this test so that it can be cleaned up easily should the test fail to do so.
+ * <br /><br />
+ * WARNING: The creation of a file is not a synchronized operation so tests may fail because the processor may not list all of them.
+ */
+public class ListGoogleDriveIT {
+    public static final String CREDENTIAL_JSON_FILE_PATH = "";
+    public static final String SHARED_FOLDER_ID = "";
+
+    public static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+
+    private TestRunner testRunner;
+
+    private Drive driveService;
+
+    private String mainFolderId;
+
+    @BeforeEach
+    public void init() throws Exception {
+        ListGoogleDrive testSubject = new ListGoogleDrive();
+
+        testRunner = TestRunners.newTestRunner(testSubject);
+
+        GCPCredentialsControllerService gcpCredentialsControllerService = new GCPCredentialsControllerService();
+        testRunner.addControllerService("gcp_credentials_provider_service", gcpCredentialsControllerService);
+        testRunner.setProperty(gcpCredentialsControllerService, CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE, CREDENTIAL_JSON_FILE_PATH);
+        testRunner.enableControllerService(gcpCredentialsControllerService);
+        testRunner.setProperty(GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE, "gcp_credentials_provider_service");
+
+        NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+
+        driveService = new Drive.Builder(
+                httpTransport,
+                JSON_FACTORY,
+                testSubject.getHttpCredentialsAdapter(
+                        testRunner.getProcessContext(),
+                        DriveScopes.all()
+                )
+        )
+                .setApplicationName(this.getClass().getSimpleName())
+                .build();
+
+        File file = createFolder("main", SHARED_FOLDER_ID);
+
+        mainFolderId = file.getId();
+        testRunner.setProperty(ListGoogleDrive.FOLDER_ID, mainFolderId);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        driveService.files()
+                .delete(mainFolderId)
+                .execute();
+    }
+
+    @Test
+    void listFilesFrom3LayerDeepDirectoryTree() throws Exception {
+        // GIVEN
+        File main_sub1 = createFolder("main_sub1", mainFolderId);
+        File main_sub2 = createFolder("main_sub2", mainFolderId);
+
+        File main_sub1_sub1 = createFolder("main_sub1_sub1", main_sub1.getId());
+
+        createFile("main_file1", mainFolderId);
+        createFile("main_file2", mainFolderId);
+        createFile("main_file3", mainFolderId);
+
+        createFile("main_sub1_file1", main_sub1.getId());
+
+        createFile("main_sub2_file1", main_sub2.getId());
+        createFile("main_sub2_file2", main_sub2.getId());
+
+        createFile("main_sub1_sub1_file1", main_sub1_sub1.getId());
+        createFile("main_sub1_sub1_file2", main_sub1_sub1.getId());
+        createFile("main_sub1_sub1_file3", main_sub1_sub1.getId());
+
+        Set<String> expectedFileNames = new HashSet<>(Arrays.asList(
+                "main_file1", "main_file2", "main_file3",
+                "main_sub1_file1",
+                "main_sub2_file1", "main_sub2_file2",
+                "main_sub1_sub1_file1", "main_sub1_sub1_file2", "main_sub1_sub1_file3"
+        ));
+
+        // The creation of the files are not (completely) synchronized.
+        Thread.sleep(2000);
+
+        // WHEN
+        testRunner.run();
+
+        // THEN
+        List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
+
+        Set<String> actualFileNames = successFlowFiles.stream()
+                .map(flowFile -> flowFile.getAttribute("filename"))
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedFileNames, actualFileNames);
+
+        // Next, list a sub folder, non-recursively this time. (Changing these properties will clear the Processor state as well
+        //  so all files are eligible for listing again.)
+
+        // GIVEN
+        testRunner.clearTransferState();
+
+        expectedFileNames = new HashSet<>(Arrays.asList(
+                "main_sub1_file1"
+        ));
+
+        // WHEN
+        testRunner.setProperty(ListGoogleDrive.FOLDER_ID, main_sub1.getId());
+        testRunner.setProperty(ListGoogleDrive.RECURSIVE_SEARCH, "false");
+        testRunner.run();
+
+        // THEN
+        successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
+
+        actualFileNames = successFlowFiles.stream()
+                .map(flowFile -> flowFile.getAttribute("filename"))
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedFileNames, actualFileNames);
+    }
+
+    @Test
+    void doNotListTooYoungFilesWhenMinAgeIsSet() throws Exception {
+        // GIVEN
+        testRunner.setProperty(ListGoogleDrive.MIN_AGE, "15 s");
+
+        createFile("main_file", mainFolderId);
+
+        // Make sure the file 'arrives' and could be listed
+        Thread.sleep(5000);
+
+        // WHEN
+        testRunner.run();
+
+        // THEN
+        List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
+
+        Set<String> actualFileNames = successFlowFiles.stream()
+                .map(flowFile -> flowFile.getAttribute("filename"))
+                .collect(Collectors.toSet());
+
+        assertEquals(Collections.emptySet(), actualFileNames);
+
+        // Next, wait for another 10+ seconds for MIN_AGE to expire then list again
+
+        // GIVEN
+        Thread.sleep(10000);
+
+        Set<String> expectedFileNames = new HashSet<>(Arrays.asList(
+                "main_file"
+        ));
+
+        // WHEN
+        testRunner.run();
+
+        // THEN
+        successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
+
+        actualFileNames = successFlowFiles.stream()
+                .map(flowFile -> flowFile.getAttribute("filename"))
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedFileNames, actualFileNames);
+    }
+
+    private File createFolder(String folderName, String... parentFolderIds) throws IOException {
+        File fileMetaData = new File();
+        fileMetaData.setName(folderName);
+
+        if (parentFolderIds != null) {
+            fileMetaData.setParents(Arrays.asList(parentFolderIds));
+        }
+
+        fileMetaData.setMimeType("application/vnd.google-apps.folder");
+
+        Drive.Files.Create create = driveService.files()
+                .create(fileMetaData)
+                .setFields("id");
+
+        File file = create.execute();
+
+        return file;
+    }
+
+    private File createFile(String name, String... folderIds) throws IOException {
+        File fileMetadata = new File();
+        fileMetadata.setName(name);
+        fileMetadata.setParents(Arrays.asList(folderIds));
+
+        AbstractInputStreamContent content = new ByteArrayContent("text/plain", "test_content".getBytes(StandardCharsets.UTF_8));
+
+        Drive.Files.Create create = driveService.files()
+                .create(fileMetadata, content)
+                .setFields("id, modifiedTime");
+
+        File file = create.execute();
+
+        return file;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -440,6 +440,7 @@ public class ListenHTTPServlet extends HttpServlet {
         flowFile = session.putAllAttributes(flowFile, attributes);
         flowFile = session.putAttribute(flowFile, "restlistener.remote.source.host", request.getRemoteHost());
         flowFile = session.putAttribute(flowFile, "restlistener.request.uri", request.getRequestURI());
+        flowFile = session.putAttribute(flowFile, "restlistener.query.string", request.getQueryString());
         flowFile = session.putAttribute(flowFile, "restlistener.remote.user.dn", foundSubject);
         flowFile = session.putAttribute(flowFile, "restlistener.remote.issuer.dn", foundIssuer);
         return flowFile;


### PR DESCRIPTION
# Summary

Extends the ListenHTTP processor by adding the query string of incoming requests as an attribute to the flow file.

[NIFI-10250](https://issues.apache.org/jira/browse/NIFI-10250)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
