### PR TITLE
NIFI-10235 Set Replay ContentClaim Length from Content Repository

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -2891,12 +2891,15 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
             resourceClaimManager.incrementClaimantCount(resourceClaim);
             final long claimOffset = event.getPreviousContentClaimOffset() == null ? 0L : event.getPreviousContentClaimOffset();
             contentClaim = new StandardContentClaim(resourceClaim, claimOffset);
-            contentClaim.setLength(event.getPreviousFileSize() == null ? -1L : event.getPreviousFileSize());
 
             if (!contentRepository.isAccessible(contentClaim)) {
                 resourceClaimManager.decrementClaimantCount(resourceClaim);
                 throw new IllegalStateException("Cannot replay data from Provenance Event because the data is no longer available in the Content Repository");
             }
+
+            // Determine ContentClaim length according to Repository ContentClaim size returned
+            final long contentClaimLength = contentRepository.size(contentClaim);
+            contentClaim.setLength(contentClaimLength);
         }
 
         final String parentUUID = event.getFlowFileUuid();


### PR DESCRIPTION
# Summary

[NIFI-10235](https://issues.apache.org/jira/browse/NIFI-10235) Changes the behavior of Provenance Replay handling to resolve issues when running with encrypted repositories enabled.

When running with encrypted repositories, the content stored in the repository is larger than the file size itself, since it contains an encryption metadata header. This difference in size causes Provenance Replays to fail due to setting the replay ContentClaim length based on the previous file size. Changing the approach to set the ContentClaim length based on the ContentClaim size that the Content Repository reports allows replays to function as expected.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
