### PR TITLE
NIFI-10270 Upgrade AWS SDK from 1.12.182 to 1.12.267

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -41,7 +41,7 @@ limitations under the License.
     </modules>
     <properties>
         <system.rules.version>1.19.0</system.rules.version>
-        <aws.sdk.version>1.11.172</aws.sdk.version>
+        <aws.sdk.version>1.12.267</aws.sdk.version>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
     </properties>
 

--- a/nifi-nar-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <!-- keep AWS 1.x until NIFI-8287 -->
-        <aws-java-sdk-version>1.12.182</aws-java-sdk-version>
+        <aws-java-sdk-version>1.12.267</aws-java-sdk-version>
         <!-- keep KCL 1.x until NIFI-8531 (blocked by NIFI-8287) -->
         <aws-kinesis-client-library-version>1.14.7</aws-kinesis-client-library-version>
     </properties>


### PR DESCRIPTION
# Summary

[NIFI-10270](https://issues.apache.org/jira/browse/NIFI-10270) Upgrades AWS SDK references in `nifi-aws-bundle` and MiNiFi to 1.12.267.

This upgrade addresses vulnerabilities associated with the S3 TransferManager, described in CVE-2022-31159. Apache NiFi components do not include direct references to the S3 TransferManager.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
