### PR TITLE
NIFI-10269 Upgrade H2 from 2.1.210 to 2.1.214

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <netty.4.version>4.1.77.Final</netty.4.version>
         <spring.version>5.3.21</spring.version>
         <spring.security.version>5.7.2</spring.security.version>
-        <h2.version>2.1.210</h2.version>
+        <h2.version>2.1.214</h2.version>
         <zookeeper.version>3.8.0</zookeeper.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-10269](https://issues.apache.org/jira/browse/NIFI-10269) Upgrades H2 database dependencies from 2.1.210 to [2.1.214](https://h2database.com/html/changelog.html).

H2 2.1.214 changed the specific exception class from `JdbcSQLNonTransientException` to `JdbcSQLNonTransientConnectException` when encountering an older version of the database file structure, but retained the same exception message and wrapped exception cause. Instead of catching the specific exception class, the catch block now handles the more generalized `SQLNonTransientException`. This change to Apache NiFi `H2DatabaseUpdater` maintains the current approach to handle and ignore this specific exception scenario, allowing upgrades from earlier versions of NiFi that depend on H2 1.4.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
