### PR TITLE
NIFI-10271 Upgrade Xerces from 2.12.1 to 2.12.2

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -129,4 +129,9 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sinks/flume\-ng\-morphline\-solr\-sink@.*$</packageUrl>
         <cpe>cpe:/a:apache:solr</cpe>
     </suppress>
+    <suppress>
+        <notes>CVE-2017-10355 does not apply to Xerces 2.12.2</notes>
+        <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
+        <cve>CVE-2017-10355</cve>
+    </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -97,6 +97,12 @@
                 <artifactId>ant</artifactId>
                 <version>1.10.12</version>
             </dependency>
+            <!-- Override Xerces 2.9.1 in Hive 1.1 and 1.2 -->
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>2.12.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -29,6 +29,16 @@
         <tika.version>2.4.1</tika.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Xerces 2.12.1 from Tika -->
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>2.12.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.12.1</version>
+            <version>2.12.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>


### PR DESCRIPTION
# Summary

[NIFI-10271](https://issues.apache.org/jira/browse/NIFI-10271) Upgrades Xerces to 2.12.2 in the following modules:

- nifi-hive-bundle
- nifi-media-processors
- nifi-scripting-processors

Upgrading to Xerces 2.12.2 resolves a resource exhaustion vulnerability described in CVE-2022-23437.

Additional changes include suppressing false positive reports for CVE-2017-10355 in the OWASP Dependency Check Report.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
