### PR TITLE
NIFI-10240: Removed validation in ListenSyslog on sslContextService a…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
@@ -267,15 +267,6 @@ public class ListenSyslog extends AbstractSyslogProcessor {
                 .explanation("Cannot set Parse Messages to 'true' if Batch Size is greater than 1").build());
         }
 
-        final String protocol = validationContext.getProperty(PROTOCOL).getValue();
-        final SSLContextService sslContextService = validationContext.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-
-        if (UDP_VALUE.getValue().equals(protocol) && sslContextService != null) {
-            results.add(new ValidationResult.Builder()
-                    .explanation("SSL can not be used with UDP")
-                    .valid(false).subject("SSL Context").build());
-        }
-
         return results;
     }
 
@@ -305,7 +296,7 @@ public class ListenSyslog extends AbstractSyslogProcessor {
         factory.setSocketKeepAlive(socketKeepAlive);
 
         final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-        if (sslContextService != null) {
+        if (protocol == TransportProtocol.TCP && sslContextService != null) {
             final SSLContext sslContext = sslContextService.createContext();
             ClientAuth clientAuth = ClientAuth.REQUIRED;
             final PropertyValue clientAuthProperty = context.getProperty(CLIENT_AUTH);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
@@ -24,8 +24,6 @@ import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.remote.io.socket.NetworkUtils;
-import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.ssl.RestrictedSSLContextService;
 import org.apache.nifi.syslog.attributes.SyslogAttributes;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -42,8 +40,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TestListenSyslog {
     private static final String PRIORITY = "34";
@@ -77,17 +73,9 @@ public class TestListenSyslog {
     }
 
     @Test
-    public void testUdpSslContextServiceInvalid() throws InitializationException {
-        runner.setProperty(ListenSyslog.PROTOCOL, TransportProtocol.UDP.toString());
-        final int port = NetworkUtils.getAvailableUdpPort();
-        runner.setProperty(ListenSyslog.PORT, Integer.toString(port));
-
-        final RestrictedSSLContextService sslContextService = mock(RestrictedSSLContextService.class);
-        final String identifier = RestrictedSSLContextService.class.getName();
-        when(sslContextService.getIdentifier()).thenReturn(identifier);
-        runner.addControllerService(identifier, sslContextService);
-        runner.enableControllerService(sslContextService);
-        runner.setProperty(ListenSyslog.SSL_CONTEXT_SERVICE, identifier);
+    public void testInvalidListenSyslog() {
+        runner.setProperty(ListenSyslog.MAX_BATCH_SIZE, "2");
+        runner.setProperty(ListenSyslog.PARSE_MESSAGES, "true");
 
         runner.assertNotValid();
     }


### PR DESCRIPTION
…nd made it ignore sslContextService if it is configured while protocol is set to UDP. Also modified tests on processor validation

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10240](https://issues.apache.org/jira/browse/NIFI-10240)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
