### PR TITLE
NIFI-10284 Correct HTTP Request Authenticated User logging

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/filter/StandardRequestFilterProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/filter/StandardRequestFilterProvider.java
@@ -59,11 +59,11 @@ public class StandardRequestFilterProvider implements RequestFilterProvider {
 
         final List<FilterHolder> filters = new ArrayList<>();
 
-        filters.add(getHeaderWriterFilter());
-
         if (properties.isHTTPSConfigured()) {
             filters.add(getFilterHolder(RequestAuthenticationFilter.class));
         }
+
+        filters.add(getHeaderWriterFilter());
 
         final int maxContentSize = getMaxContentSize(properties);
         if (maxContentSize > MAX_CONTENT_SIZE_DISABLED) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/StandardRequestFilterProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/StandardRequestFilterProviderTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,6 +80,10 @@ public class StandardRequestFilterProviderTest {
         assertStandardFiltersFound(filters);
 
         assertFilterClassFound(filters, RequestAuthenticationFilter.class);
+
+        final FilterHolder firstFilterHolder = filters.get(0);
+        final Class<? extends Filter> firstFilterClass = firstFilterHolder.getHeldClass();
+        assertEquals(RequestAuthenticationFilter.class, firstFilterClass);
     }
 
     private void assertStandardFiltersFound(final List<FilterHolder> filters) {


### PR DESCRIPTION
# Summary

[NIFI-10284](https://issues.apache.org/jira/browse/NIFI-10284) Corrects HTTP request authenticated user logging in `nifi-request.log`.

Moving the `HeaderWriterFilter` after `RequestAuthenticationFilter` in `StandardRequestFilterProvider` ensures that `RequestAuthenticationFilter` receives the Jetty `Request` object, which `RequestAuthenticationFilter` requires to set the authenticated user for logging. Changes include updating the unit test for `StandardRequestFilterProvider` to verify that `RequestAuthenticationFilter` is the first filter configured when HTTPS is enabled.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
