### PR TITLE
NIFI-10286 Remove c2-client-api references from nifi-nar-utils

### DIFF
--- a/c2/c2-client-bundle/c2-client-http/pom.xml
+++ b/c2/c2-client-bundle/c2-client-http/pom.xml
@@ -32,7 +32,6 @@ limitations under the License.
             <groupId>org.apache.nifi</groupId>
             <artifactId>c2-client-api</artifactId>
             <version>1.17.0-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/c2/c2-client-bundle/c2-client-service/pom.xml
+++ b/c2/c2-client-bundle/c2-client-service/pom.xml
@@ -32,7 +32,6 @@ limitations under the License.
             <groupId>org.apache.nifi</groupId>
             <artifactId>c2-client-api</artifactId>
             <version>1.17.0-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -303,7 +303,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                     c2NifiClientService = new C2NifiClientService(nifiProperties, this.controller);
                     c2NifiClientService.start();
                 } else {
-                    logger.info("C2 Property [{}] missing or disabled: C2 client not created", C2NiFiProperties.C2_ENABLE_KEY);
+                    logger.debug("C2 Property [{}] missing or disabled: C2 client not created", C2NiFiProperties.C2_ENABLE_KEY);
                     c2NifiClientService = null;
                 }
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/pom.xml
@@ -34,11 +34,6 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-framework-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>c2-client-api</artifactId>
-            <version>1.17.0-SNAPSHOT</version>
-        </dependency>
 
         <!-- Compile-only dependency. At runtime, the agent will use aspectjweaver.jar directly, not from the classpath (see bootstrap.conf).-->
         <dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoaders.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoaders.java
@@ -20,7 +20,6 @@ import org.apache.nifi.NiFiServer;
 import org.apache.nifi.bundle.Bundle;
 import org.apache.nifi.bundle.BundleCoordinate;
 import org.apache.nifi.bundle.BundleDetails;
-import org.apache.nifi.c2.client.api.C2Client;
 import org.apache.nifi.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,6 @@ import java.util.stream.Collectors;
 
 /**
  * Used to initialize the extension and framework classloaders.
- *
  * The core framework should obtain a singleton reference from NarClassLoadersHolder.
  */
 public final class NarClassLoaders {
@@ -69,7 +67,6 @@ public final class NarClassLoaders {
                 final Bundle frameworkBundle,
                 final Bundle jettyBundle,
                 final NiFiServer serverInstance,
-                final C2Client c2ClientInstance,
                 final Map<String, Bundle> bundles) {
             this.frameworkWorkingDir = frameworkDir;
             this.extensionWorkingDir = extensionDir;
@@ -168,7 +165,6 @@ public final class NarClassLoaders {
         }
 
         NiFiServer serverInstance = null;
-        C2Client c2ClientInstance = null;
         if (!narWorkingDirContents.isEmpty()) {
             final List<BundleDetails> narDetails = new ArrayList<>();
             final Map<String, String> narCoordinatesToWorkingDir = new HashMap<>();
@@ -311,7 +307,7 @@ public final class NarClassLoaders {
                 .filter(b -> b.getBundleDetails().getCoordinate().getId().equals(JETTY_NAR_ID))
                 .findFirst().orElse(null);
 
-        return new InitContext(frameworkWorkingDir, extensionsWorkingDir, frameworkBundle, jettyBundle, serverInstance, c2ClientInstance, new LinkedHashMap<>(narDirectoryBundleLookup));
+        return new InitContext(frameworkWorkingDir, extensionsWorkingDir, frameworkBundle, jettyBundle, serverInstance, new LinkedHashMap<>(narDirectoryBundleLookup));
     }
 
     /**


### PR DESCRIPTION
# Summary

[NIFI-10286](https://issues.apache.org/jira/browse/NIFI-10286) Removes unnecessary `c2-client-api` references from the `nifi-nar-utils` module and `NarClassLoaders` class, which removes unnecessary C2 API dependencies from the root `lib` directory.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
