### PR TITLE
NIFI-10295 Upgrade GRPC from 1.34.0 to 1.48.0

### DIFF
--- a/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-processors/pom.xml
@@ -64,11 +64,6 @@ language governing permissions and limitations under the License. -->
             <version>${grpc.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.35.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <version>1.17.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-grpc-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-grpc-bundle/pom.xml
@@ -32,8 +32,8 @@
     </modules>
 
     <properties>
-        <grpc.version>1.34.0</grpc.version>
-        <protoc.version>3.14.0</protoc.version>
+        <grpc.version>1.48.0</grpc.version>
+        <protoc.version>3.21.4</protoc.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-10295](https://issues.apache.org/jira/browse/NIFI-10295) Upgrades GRPC dependencies in `nifi-grpc-bundle` from 1.34.0 to 1.48.0 and also upgrades Protobuf from 3.14.0 to 3.21.4. Additional changes include remove the dependency on `netty-tcnative-boringssl-static`, which is no longer necessary following SSLContext creation changes in NIFI-9897.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
