### PR TITLE
NIFI-3964 Update Grok Patterns to support TEXT and URL Resources

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExtractGrok.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExtractGrok.java
@@ -47,9 +47,21 @@ public class TestExtractGrok {
     }
 
     @Test
+    public void testExtractGrokPatternsProperty() {
+        testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{USERNAME:username} - %{DATA}");
+        testRunner.setProperty(ExtractGrok.GROK_PATTERNS, "USERNAME [a-zA-Z0-9._-]+");
+        testRunner.enqueue("admin - 127.0.0.1");
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(ExtractGrok.REL_MATCH);
+        final MockFlowFile matched = testRunner.getFlowFilesForRelationship(ExtractGrok.REL_MATCH).get(0);
+
+        matched.assertAttributeEquals("grok.username","admin");
+    }
+
+    @Test
     public void testExtractGrokWithMatchedContent() throws IOException {
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{COMMONAPACHELOG}");
-        testRunner.setProperty(ExtractGrok.GROK_PATTERN_FILE, "src/test/resources/TestExtractGrok/patterns");
+        testRunner.setProperty(ExtractGrok.GROK_PATTERNS, "src/test/resources/TestExtractGrok/patterns");
         testRunner.enqueue(GROK_LOG_INPUT);
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ExtractGrok.REL_MATCH);
@@ -66,7 +78,7 @@ public class TestExtractGrok {
     }
 
     @Test
-    public void testExtractGrokKeepEmptyCaptures() throws Exception {
+    public void testExtractGrokKeepEmptyCaptures()  {
         String expression = "%{NUMBER}|%{NUMBER}";
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION,expression);
         testRunner.enqueue("-42");
@@ -77,7 +89,7 @@ public class TestExtractGrok {
     }
 
     @Test
-    public void testExtractGrokDoNotKeepEmptyCaptures() throws Exception {
+    public void testExtractGrokDoNotKeepEmptyCaptures() {
         String expression = "%{NUMBER}|%{NUMBER}";
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION,expression);
         testRunner.setProperty(ExtractGrok.KEEP_EMPTY_CAPTURES,"false");
@@ -92,7 +104,7 @@ public class TestExtractGrok {
     @Test
     public void testExtractGrokWithUnMatchedContent() throws IOException {
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{URI}");
-        testRunner.setProperty(ExtractGrok.GROK_PATTERN_FILE, "src/test/resources/TestExtractGrok/patterns");
+        testRunner.setProperty(ExtractGrok.GROK_PATTERNS, "src/test/resources/TestExtractGrok/patterns");
         testRunner.enqueue(GROK_TEXT_INPUT);
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ExtractGrok.REL_NO_MATCH);
@@ -103,7 +115,7 @@ public class TestExtractGrok {
     @Test
     public void testExtractGrokWithNotFoundPatternFile() throws IOException {
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{COMMONAPACHELOG}");
-        testRunner.setProperty(ExtractGrok.GROK_PATTERN_FILE, "src/test/resources/TestExtractGrok/toto_file");
+        testRunner.setProperty(ExtractGrok.GROK_PATTERNS, "file:///src/test/resources/TestExtractGrok/file-not-found");
         testRunner.enqueue(GROK_LOG_INPUT);
         testRunner.assertNotValid();
     }
@@ -111,7 +123,7 @@ public class TestExtractGrok {
     @Test
     public void testExtractGrokWithBadGrokExpression() throws IOException {
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{TOTO");
-        testRunner.setProperty(ExtractGrok.GROK_PATTERN_FILE, "src/test/resources/TestExtractGrok/patterns");
+        testRunner.setProperty(ExtractGrok.GROK_PATTERNS, "src/test/resources/TestExtractGrok/patterns");
         testRunner.enqueue(GROK_LOG_INPUT);
         testRunner.assertNotValid();
     }
@@ -119,7 +131,7 @@ public class TestExtractGrok {
     @Test
     public void testExtractGrokWithNamedCapturesOnly() throws IOException {
         testRunner.setProperty(ExtractGrok.GROK_EXPRESSION, "%{COMMONAPACHELOG}");
-        testRunner.setProperty(ExtractGrok.GROK_PATTERN_FILE, "src/test/resources/TestExtractGrok/patterns");
+        testRunner.setProperty(ExtractGrok.GROK_PATTERNS, "src/test/resources/TestExtractGrok/patterns");
         testRunner.setProperty(ExtractGrok.NAMED_CAPTURES_ONLY, "true");
         testRunner.enqueue(GROK_LOG_INPUT);
         testRunner.run();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/grok/GrokExpressionValidator.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/grok/GrokExpressionValidator.java
@@ -21,38 +21,29 @@ import io.krakens.grok.api.GrokCompiler;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
+import org.apache.nifi.components.resource.ResourceReference;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 
 public class GrokExpressionValidator implements Validator {
-    private GrokCompiler grokCompiler;
-    private String patternFileName;
+    private final GrokCompiler grokCompiler;
+    private final ResourceReference patternsReference;
 
-    public GrokExpressionValidator(String patternFileName, GrokCompiler compiler) {
-        this.patternFileName = patternFileName;
+    public GrokExpressionValidator(ResourceReference patternsReference, GrokCompiler compiler) {
+        this.patternsReference = patternsReference;
         this.grokCompiler = compiler;
-    }
-
-    public GrokExpressionValidator() {
-        this.grokCompiler = GrokCompiler.newInstance();
     }
 
     @Override
     public ValidationResult validate(final String subject, final String input, final ValidationContext context) {
         try {
-            try (final InputStream in = getClass().getResourceAsStream(GrokReader.DEFAULT_PATTERN_NAME);
-                 final Reader reader = new InputStreamReader(in)) {
+            try (final InputStream in = getClass().getResourceAsStream(GrokReader.DEFAULT_PATTERN_NAME)) {
                 grokCompiler.register(in);
             }
 
-            if (patternFileName != null) {
-                try (final InputStream in = new FileInputStream(new File(patternFileName));
-                     final Reader reader = new InputStreamReader(in)) {
-                    grokCompiler.register(reader);
+            if (patternsReference != null) {
+                try (final InputStream patterns = patternsReference.read()) {
+                    grokCompiler.register(patterns);
                 }
             }
             grokCompiler.compile(input);


### PR DESCRIPTION
# Summary

[NIFI-3964](https://issues.apache.org/jira/browse/NIFI-3964) Updates the `Groks Patterns` property in `ExtractGrok` and `GrokReader` to support `TEXT` and `URL` resources, enabling direct specification of custom patterns in the property value, as well as external file locations.

The change in both components retains the current `Grok Patterns file` property name for compatibility, but adds a display name value of `Grok Patterns` to reflect more generalized capabilities. Additional changes include new unit tests to illustrate property value specification of a custom pattern.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
