### PR TITLE
NIFI-10306: Add logging to StandardProcessGroup.addConnection() with more details

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -1197,42 +1197,75 @@ public final class StandardProcessGroup implements ProcessGroup {
             if (isInputPort(source)) { // if source is an input port, its destination must be in the same group unless it's an input port
                 if (isInputPort(destination)) { // if destination is input port, it must be in a child group.
                     if (!processGroups.containsKey(destinationGroup.getIdentifier())) {
-                        throw new IllegalStateException("Cannot add Connection to Process Group because destination is an Input Port that does not belong to a child Process Group");
+                        throw new IllegalStateException("Cannot add Connection for Input Port[" + source.getIdentifier() +
+                                "] from Process Group [" + sourceGroup.getIdentifier() +
+                                "] to Process Group [" + destinationGroup.getIdentifier() +
+                                "] because destination [" + destination.getIdentifier() +
+                                "] is an Input Port that does not belong to a child Process Group");
                     }
                 } else if (sourceGroup != this || destinationGroup != this) {
-                    throw new IllegalStateException("Cannot add Connection to Process Group because source and destination are not both in this Process Group");
+                    throw new IllegalStateException("Cannot add Connection for Input Port[" + source.getIdentifier() +
+                            "] from Process Group [" + sourceGroup.getIdentifier() +
+                            "] to Process Group [" + destinationGroup.getIdentifier() +
+                            "] destination [" + destination.getIdentifier() +
+                            "] because source and destination are not both in this Process Group");
                 }
             } else if (isOutputPort(source)) {
                 // if source is an output port, its group must be a child of this group, and its destination must be in this
                 // group (processor/output port) or a child group (input port)
                 if (!processGroups.containsKey(sourceGroup.getIdentifier())) {
-                    throw new IllegalStateException("Cannot add Connection to Process Group because source is an Output Port that does not belong to a child Process Group");
+                    throw new IllegalStateException("Cannot add Connection for Output Port[" + source.getIdentifier() +
+                            "] from Process Group [" + sourceGroup.getIdentifier() +
+                            "] to Process Group [" + destinationGroup.getIdentifier() +
+                            "] destination [" + destination.getIdentifier() +
+                            "] because source is an Output Port that does not belong to a child Process Group");
                 }
 
                 if (isInputPort(destination)) {
                     if (!processGroups.containsKey(destinationGroup.getIdentifier())) {
-                        throw new IllegalStateException("Cannot add Connection to Process Group because its destination is an Input Port that does not belong to a child Process Group");
+                        throw new IllegalStateException("Cannot add Connection for Output Port[" + source.getIdentifier() +
+                                "] from Process Group [" + sourceGroup.getIdentifier() +
+                                "] to Process Group [" + destinationGroup.getIdentifier() +
+                                "] because destination [" + destination.getIdentifier() +
+                                "] is an Input Port that does not belong to a child Process Group");
                     }
                 } else if (destinationGroup != this) {
-                    throw new IllegalStateException("Cannot add Connection to Process Group because its destination does not belong to this Process Group");
+                    throw new IllegalStateException("Cannot add Connection for Output Port[" + source.getIdentifier() +
+                            "] from Process Group [" + sourceGroup.getIdentifier() +
+                            "] to Process Group [" + destinationGroup.getIdentifier() +
+                            "] because its destination [" + destination.getIdentifier() +
+                            "] does not belong to this Process Group");
                 }
             } else { // source is not a port
                 if (sourceGroup != this) {
-                    throw new IllegalStateException("Cannot add Connection to Process Group because the source does not belong to this Process Group");
+                    throw new IllegalStateException("Cannot add Connection from " + source.getConnectableType().name() + "[" + source.getIdentifier() +
+                            "] from Process Group [" + sourceGroup.getIdentifier() +
+                            "] to Process Group [" + destinationGroup.getIdentifier() +
+                            "] because the source does not belong to this Process Group");
                 }
 
                 if (isOutputPort(destination)) {
                     if (destinationGroup != this) {
-                        throw new IllegalStateException("Cannot add Connection to Process Group because its destination is an Output Port but does not belong to this Process Group");
+                        throw new IllegalStateException("Cannot add Connection from " + source.getConnectableType().name() + "[" + source.getIdentifier() +
+                                "] from Process Group [" + sourceGroup.getIdentifier() +
+                                "] to Process Group [" + destinationGroup.getIdentifier() +
+                                "] because its destination [" + destination.getIdentifier() +
+                                "] is an Output Port that does not belong to this Process Group");
                     }
                 } else if (isInputPort(destination)) {
                     if (!processGroups.containsKey(destinationGroup.getIdentifier())) {
-                        throw new IllegalStateException("Cannot add Connection to Process Group because its destination is an Input "
-                            + "Port but the Input Port does not belong to a child Process Group");
+                        throw new IllegalStateException("Cannot add Connection from " + source.getConnectableType().name() + "[" + source.getIdentifier() +
+                                "] from Process Group [" + sourceGroup.getIdentifier() +
+                                "] to Process Group [" + destinationGroup.getIdentifier() +
+                                "] because its destination [" + destination.getIdentifier() +
+                                "] is an Input Port but the Input Port does not belong to a child Process Group");
                     }
                 } else if (destinationGroup != this) {
-                    throw new IllegalStateException("Cannot add Connection between " + source.getIdentifier() + " and " + destination.getIdentifier()
-                        + " because they are in different Process Groups and neither is an Input Port or Output Port");
+                    throw new IllegalStateException("Cannot add Connection from " + source.getConnectableType().name() + "[" + source.getIdentifier() +
+                            "] from Process Group [" + sourceGroup.getIdentifier() +
+                            "] to Process Group [" + destinationGroup.getIdentifier() +
+                            "] destination " + destination.getConnectableType().name() + "[" + destination.getIdentifier() +
+                            "] because they are in different Process Groups and neither is an Input Port or Output Port");
                 }
             }
 


### PR DESCRIPTION

# Summary

[NIFI-10306](https://issues.apache.org/jira/browse/NIFI-10306) This PR adds logging to better identify the components of a Connection that cannot be added to the flow, to include source and destination process groups and types, plus the reason.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
