### PR TITLE
NIFI-10236: ByteArrayContentRepository in nifi-framework-components

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -3338,14 +3338,14 @@ FlowFile Repository, if also on that disk, could become corrupt. To avoid this s
 
 |====
 |*Property*|*Description*
-|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository`.
+|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository` and should only be changed with caution. To store flowfile content in memory instead of on disk (at the risk of data loss in the event of power/machine failure), set this property to `org.apache.nifi.controller.repository.ByteArrayContentRepository`.
 |====
 
 === File System Content Repository Properties
 
 |====
 |*Property*|*Description*
-|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository`.
+|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository` and should only be changed with caution. To store flowfile content in memory instead of on disk (at the risk of data loss in the event of power/machine failure), set this property to `org.apache.nifi.controller.repository.ByteArrayContentRepository`.
 |`nifi.content.claim.max.appendable.size`|When NiFi processes many small FlowFiles, the contents of those FlowFiles are stored in the content repository, but we do not store the content of each
 individual FlowFile as a separate file in the content repository. Doing so would be very detrimental to performance, if each 120 byte FlowFile, for instance, was written to its own file. Instead,
 we continue writing to the same file until it reaches some threshold. This property configures that threshold. Setting the value too small can result in poor performance due to reading from and
@@ -3394,6 +3394,14 @@ All of the properties defined above (see <<file-system-content-repository-proper
 |`nifi.content.repository.encryption.key.id`|The active key ID to use for encryption (e.g. `Key1`).
 |`nifi.content.repository.encryption.key`|The key to use for `StaticKeyProvider`. The key format is hex-encoded (`0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210`) but can also be encrypted using the `./encrypt-config.sh` tool in NiFi Toolkit (see the <<toolkit-guide.adoc#encrypt_config_tool,Encrypt-Config Tool>> section in the link:toolkit-guide.html[NiFi Toolkit Guide] for more information).
 |`nifi.content.repository.encryption.key.id.`*|Allows for additional keys to be specified for the `StaticKeyProvider`. For example, the line `nifi.content.repository.encryption.key.id.Key2=012...210` would provide an available key `Key2`.
+|====
+
+[[byte-array-content-repository-properties]]
+=== Byte Array Content Repository Properties
+
+|====
+|*Property*|*Description*
+|`nifi.bytearray.content.repository.max.size`|The Content Repository maximum size in memory. The default value is `100 MB`.
 |====
 
 === Provenance Repository

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/claim/ContentClaim.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/claim/ContentClaim.java
@@ -44,4 +44,6 @@ public interface ContentClaim extends Comparable<ContentClaim> {
      * @return the length of this ContentClaim
      */
     long getLength();
+
+    void setLength(final long length);
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/resources/META-INF/services/org.apache.nifi.controller.repository.ContentRepository
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/resources/META-INF/services/org.apache.nifi.controller.repository.ContentRepository
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.controller.repository.ByteArrayContentRepository

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/TestByteArrayContentRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/TestByteArrayContentRepository.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.nifi.controller.repository.claim.ContentClaim;
+import org.apache.nifi.controller.repository.claim.ResourceClaimManager;
+import org.apache.nifi.controller.repository.claim.StandardResourceClaimManager;
+import org.apache.nifi.events.EventReporter;
+import org.apache.nifi.util.NiFiProperties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestByteArrayContentRepository {
+
+    private ResourceClaimManager claimManager;
+
+    @Before
+    public void setup() {
+        claimManager = new StandardResourceClaimManager();
+    }
+
+    @Test
+    public void testCreateUniqueClaim() throws IOException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+        final ByteArrayContentRepository.ByteArrayContentClaim claim1 = ByteArrayContentRepository.verifyContentClaim(contentRepo.create(true));
+        final ByteArrayContentRepository.ByteArrayContentClaim claim2 = ByteArrayContentRepository.verifyContentClaim(contentRepo.create(true));
+
+        Assert.assertTrue(claim1.equals(claim1));
+        Assert.assertFalse(claim1.equals(claim2));
+    }
+
+    @Test
+    public void testRedirects() throws IOException {
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "10 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        contentRepo.initialize(contextRepo);
+        final ContentClaim claim = contentRepo.create(true);
+        final OutputStream out = contentRepo.write(claim);
+
+        final byte[] oneK = new byte[1024];
+        Arrays.fill(oneK, (byte) 55);
+
+        // Write 10 MB to the repo
+        for (int i = 0; i < 10240; i++) {
+            out.write(oneK);
+        }
+
+        final long currentUsableSpaceExpectedZero = contentRepo.getContainerUsableSpace(ByteArrayContentRepository.CONTAINER_NAME);
+        Assert.assertEquals(currentUsableSpaceExpectedZero, 0L);
+
+        try {
+            out.write(1);
+            Assert.fail("Expected to be out of space on content repo");
+        } catch (final OutOfMemoryError e) {
+        }
+
+        try {
+            out.write(1);
+            Assert.fail("Expected to be out of space on content repo");
+        } catch (final OutOfMemoryError e) {
+        }
+    }
+
+    @Test
+    public void testMemoryIsFreed() throws IOException, InterruptedException, ExecutionException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+
+        final byte[] oneK = new byte[1024];
+        Arrays.fill(oneK, (byte) 55);
+
+        final ExecutorService exec = Executors.newFixedThreadPool(10);
+
+        try {
+            for (int t = 0; t < 10; t++) {
+                final Callable writeAndRemoveToRepo = new Callable<Long>() {
+                    @Override
+                    public Long call() throws IOException, ExecutionException {
+                        for (int j = 0; j < 10000; j++) {
+                            final ContentClaim claim = contentRepo.create(true);
+                            final OutputStream out = contentRepo.write(claim);
+        
+                            // Write 1 MB to the repo
+                            for (int i = 0; i < 1024; i++) {
+                                out.write(oneK);
+                            }
+        
+                            final int count = contentRepo.decrementClaimantCount(claim);
+                            if (count <= 0) {
+                                contentRepo.remove(claim);
+                            }
+                        }
+                        return Long.valueOf(contentRepo.getContainerUsableSpace(ByteArrayContentRepository.CONTAINER_NAME));
+                    }
+                };
+                Future<Long> future = exec.submit(writeAndRemoveToRepo);
+                Long currentSize = future.get();
+            }
+        } finally {
+            exec.shutdown();
+            exec.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testSimpleReadWrite() throws IOException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+        final ContentClaim claim = contentRepo.create(true);
+
+        final int byteCount = 2398473 * 4;
+        final byte[] x = new byte[4];
+        x[0] = 48;
+        x[1] = 29;
+        x[2] = 49;
+        x[3] = 51;
+
+        try (final OutputStream out = contentRepo.write(claim);) {
+            for (int i = 0; i < byteCount / 4; i++) {
+                out.write(x);
+            }
+        }
+
+        final InputStream in = contentRepo.read(claim);
+        for (int i = 0; i < byteCount; i++) {
+            final int val = in.read();
+            final int index = i % 4;
+            final byte expectedVal = x[index];
+            assertEquals(expectedVal, val);
+        }
+
+        assertEquals(-1, in.read());
+    }
+
+    public class TestContentRepositoryContext implements ContentRepositoryContext {
+
+        private final ResourceClaimManager resourceClaimManager;
+        private final EventReporter eventReporter;
+    
+        public TestContentRepositoryContext(ResourceClaimManager resourceClaimManager, EventReporter eventReporter) {
+            this.resourceClaimManager = resourceClaimManager;
+            this.eventReporter = eventReporter;
+        }
+    
+        @Override
+        public ResourceClaimManager getResourceClaimManager() {
+            return resourceClaimManager;
+        }
+    
+        @Override
+        public EventReporter getEventReporter() {
+            return eventReporter;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaimWriteCache.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaimWriteCache.java
@@ -84,14 +84,7 @@ public class StandardContentClaimWriteCache implements ContentClaimWriteCache {
             out = registerStream(claim);
         }
 
-        if (!(claim instanceof StandardContentClaim)) {
-            // we know that we will only create Content Claims that are of type StandardContentClaim, so if we get anything
-            // else, just throw an Exception because it is not valid for this Repository
-            throw new IllegalArgumentException("Cannot write to " + claim + " because that Content Claim does belong to this Claim Cache");
-        }
-
-        final StandardContentClaim scc = (StandardContentClaim) claim;
-        final long initialLength = Math.max(0L, scc.getLength());
+        final long initialLength = Math.max(0L, claim.getLength());
 
         final OutputStream bcos = out;
         return new OutputStream() {
@@ -101,14 +94,14 @@ public class StandardContentClaimWriteCache implements ContentClaimWriteCache {
             public void write(final int b) throws IOException {
                 bcos.write(b);
                 bytesWritten++;
-                scc.setLength(initialLength + bytesWritten);
+                claim.setLength(initialLength + bytesWritten);
             }
 
             @Override
             public void write(byte[] b, int off, int len) throws IOException {
                 bcos.write(b, off, len);
                 bytesWritten += len;
-                scc.setLength(initialLength + bytesWritten);
+                claim.setLength(initialLength + bytesWritten);
             }
 
             @Override
@@ -173,5 +166,20 @@ public class StandardContentClaimWriteCache implements ContentClaimWriteCache {
 
     private interface StreamProcessor {
         void process(final OutputStream out) throws IOException;
+    }
+
+    private class ContentClaimWrapper {
+        ContentClaim contentClaim;
+        long length;
+
+        ContentClaimWrapper(ContentClaim contentClaim) {
+            this.contentClaim = contentClaim;
+            long legnth = Math.max(0L, contentClaim.getLength());
+        }
+
+        public ContentClaim get() {
+            return this.contentClaim;
+        }
+
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-repository-models/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaim.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-repository-models/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaim.java
@@ -25,7 +25,7 @@ package org.apache.nifi.controller.repository.claim;
  * Must be thread safe</p>
  *
  */
-public final class StandardContentClaim implements ContentClaim, Comparable<ContentClaim> {
+public final class StandardContentClaim implements ContentClaim {
 
     private final ResourceClaim resourceClaim;
     private final long offset;
@@ -37,6 +37,7 @@ public final class StandardContentClaim implements ContentClaim, Comparable<Cont
         this.length = -1L;
     }
 
+    @Override
     public void setLength(final long length) {
         this.length = length;
     }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
@@ -19,6 +19,7 @@ package org.apache.nifi.stateless.flow;
 
 import org.apache.nifi.components.state.StatelessStateManagerProvider;
 import org.apache.nifi.controller.kerberos.KerberosConfig;
+import org.apache.nifi.controller.repository.ByteArrayContentRepository;
 import org.apache.nifi.controller.repository.ContentRepository;
 import org.apache.nifi.controller.repository.ContentRepositoryContext;
 import org.apache.nifi.controller.repository.CounterRepository;
@@ -69,7 +70,6 @@ import org.apache.nifi.stateless.engine.StatelessEngineInitializationContext;
 import org.apache.nifi.stateless.engine.StatelessFlowManager;
 import org.apache.nifi.stateless.engine.StatelessProcessContextFactory;
 import org.apache.nifi.stateless.engine.StatelessProvenanceAuthorizableFactory;
-import org.apache.nifi.stateless.repository.ByteArrayContentRepository;
 import org.apache.nifi.stateless.repository.RepositoryContextFactory;
 import org.apache.nifi.stateless.repository.StatelessFileSystemContentRepository;
 import org.apache.nifi.stateless.repository.StatelessFlowFileRepository;


### PR DESCRIPTION
Improved ByteArrayContentRepository for nifi-framework-components, to be used in the classical nifi engine and the stateless engine

- added implementation of the ByteArrayContentRepository with an optional max size
- changed the interface ContentClaim for ContentClaims to implement if needed a setLength method used in the StandardContentClaimWriteCache
- added tests inspired from the previous VolatileContentRepository and new use cases
- added ByteArrayContentRepository to the administration guide

Signed-off-by: mathemare <mathemare@hotmail.fr>

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10236](https://issues.apache.org/jira/browse/NIFI-10236)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
