### PR TITLE
NIFI-10318 Correct HandleHttpRequest TLS client authentication

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -368,7 +368,7 @@ public class HandleHttpRequest extends AbstractProcessor {
         final boolean needClientAuth = CLIENT_NEED.getValue().equals(clientAuthValue);
         serverConnectorFactory.setNeedClientAuth(needClientAuth);
         final boolean wantClientAuth = CLIENT_WANT.getValue().equals(clientAuthValue);
-        serverConnectorFactory.setNeedClientAuth(wantClientAuth);
+        serverConnectorFactory.setWantClientAuth(wantClientAuth);
         final SSLContext sslContext = sslService == null ? null : sslService.createContext();
         serverConnectorFactory.setSslContext(sslContext);
         final HttpProtocolStrategy httpProtocolStrategy = HttpProtocolStrategy.valueOf(context.getProperty(HTTP_PROTOCOL_STRATEGY).getValue());


### PR DESCRIPTION
# Summary

[NIFI-10318](https://issues.apache.org/jira/browse/NIFI-10318) Corrects the TLS client authentication configuration settings in `HandleHttpRequest` to call `setWantClientAuth()` instead of `setNeedClientAuth()` based on the selected Client Authentication property configuration.

Changes for NIFI-3869 introduced a problem with the TLS connector configuration, setting the value of `needClientAuth` based on the Client Authentication property setting of `Want Authentication`. As a result of this problem, setting `Need Authentication` for the Client Authentication property in `HandleHttpRequest` is not honored.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
