### PR TITLE
NIFI-10322 Correct Cookie path when removing Bearer Token

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/StandardAuthenticationEntryPoint.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/StandardAuthenticationEntryPoint.java
@@ -45,6 +45,8 @@ public class StandardAuthenticationEntryPoint implements AuthenticationEntryPoin
 
     protected static final String UNAUTHORIZED = "Unauthorized";
 
+    private static final String ROOT_PATH = "/";
+
     private static final ApplicationCookieService applicationCookieService = new StandardApplicationCookieService();
 
     private final BearerTokenAuthenticationEntryPoint bearerTokenAuthenticationEntryPoint;
@@ -91,7 +93,7 @@ public class StandardAuthenticationEntryPoint implements AuthenticationEntryPoin
     private void removeAuthorizationBearerCookie(final HttpServletRequest request, final HttpServletResponse response) {
         final Optional<String> authorizationBearer = applicationCookieService.getCookieValue(request, ApplicationCookieName.AUTHORIZATION_BEARER);
         if (authorizationBearer.isPresent()) {
-            final URI uri = RequestUriBuilder.fromHttpServletRequest(request).build();
+            final URI uri = RequestUriBuilder.fromHttpServletRequest(request).path(ROOT_PATH).build();
             applicationCookieService.removeCookie(uri, response, ApplicationCookieName.AUTHORIZATION_BEARER);
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/Saml2AuthenticationSuccessHandler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/Saml2AuthenticationSuccessHandler.java
@@ -47,6 +47,8 @@ import java.util.stream.Collectors;
 public class Saml2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private static final String UI_PATH = "/nifi/";
 
+    private static final String ROOT_PATH = "/";
+
     private final ApplicationCookieService applicationCookieService = new StandardApplicationCookieService();
 
     private final BearerTokenProvider bearerTokenProvider;
@@ -108,7 +110,7 @@ public class Saml2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
      */
     @Override
     public String determineTargetUrl(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) {
-        final URI resourceUri = RequestUriBuilder.fromHttpServletRequest(request).build();
+        final URI resourceUri = RequestUriBuilder.fromHttpServletRequest(request).path(ROOT_PATH).build();
         processAuthentication(response, authentication, resourceUri);
 
         final URI targetUri = RequestUriBuilder.fromHttpServletRequest(request).path(UI_PATH).build();


### PR DESCRIPTION
# Summary

[NIFI-10322](https://issues.apache.org/jira/browse/NIFI-10322) Corrects path attribute building when sending the `Set-Cookie` header to remove the `__Secure-Authorization-Bearer` Cookie as part of HTTP 401 Unauthorized response processing.

When access Apache NiFi through a proxy server that provides access through a prefixed path, the HTTP response processing does not append a `/` character to the `path` attribute to the `Set-Cookie` as part of the 401 Unauthorized response handling. The initial login process does append the `/` character to the `path` attribute, resulting in a mismatch between the initial addition of the Cookie and the later request to remove the Cookie from browser storage. As a result of failing to remove the Cookie from browser storage, the browser continues to send an expired JSON Web Token, resulting in an HTTP 401 Unauthorized response.

Changes include setting the root path in the `RequestUriBuilder`, following the same pattern used in application REST resources, and updating unit tests to verify the expected path for both the default root path as well as a forwarded root path.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
