### PR TITLE
NIFI-10183 Upgrade swagger-annotations to 1.6.6

### DIFF
--- a/c2/c2-protocol/c2-protocol-component-api/pom.xml
+++ b/c2/c2-protocol/c2-protocol-component-api/pom.xml
@@ -33,7 +33,6 @@ limitations under the License.
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.5.16</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -476,13 +476,6 @@ limitations under the License.
                 <version>3.2.2</version>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-annotations</artifactId>
-                <version>1.5.16</version>
-                <scope>compile</scope>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>1.3.1</version>

--- a/nifi-api/pom.xml
+++ b/nifi-api/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.5.16</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/nifi-manifest/nifi-extension-manifest-model/pom.xml
+++ b/nifi-manifest/nifi-extension-manifest-model/pom.xml
@@ -24,10 +24,9 @@
     <packaging>jar</packaging>
 
     <dependencies>
-	<dependency>
+	    <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-	    <version>1.5.16</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -255,11 +255,6 @@
                 <version>2.3.2</version>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-annotations</artifactId>
-                <version>1.6.0</version>
-            </dependency>
-            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${h2.version}</version>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -106,11 +106,6 @@
                 <artifactId>javax.el</artifactId>
                 <version>3.0.1-b08</version>
             </dependency>
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-annotations</artifactId>
-                <version>1.5.16</version>
-            </dependency>
             <!-- open id connect - override transitive dependency version ranges -->
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-toolkit/nifi-toolkit-api/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-api/pom.xml
@@ -33,9 +33,6 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <!-- TODO - remove version tag here after core NiFi upgrades dependency
-                from com.wordnik:swagger-annotations to io.swagger:swagger-annotations. -->
-            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <netty.4.version>4.1.79.Final</netty.4.version>
         <spring.version>5.3.22</spring.version>
         <spring.security.version>5.7.2</spring.security.version>
+        <swagger.annotations.version>1.6.6</swagger.annotations.version>
         <h2.version>2.1.214</h2.version>
         <zookeeper.version>3.8.0</zookeeper.version>
     </properties>
@@ -503,6 +504,11 @@
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>${json.smart.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>${swagger.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
# Summary

[NIFI-10183](https://issues.apache.org/jira/browse/NIFI-10183) Upgrades different minor versions of Swagger Annotations to 1.6.6. This change removes specific version references in multiple Maven configurations and centralizes the version using a managed dependency in the root Maven configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
