### PR TITLE
NIFI-10340: fix build error, when use targz profile

### DIFF
--- a/nifi-registry/nifi-registry-assembly/pom.xml
+++ b/nifi-registry/nifi-registry-assembly/pom.xml
@@ -190,6 +190,7 @@
         <nifi.registry.registry.alias.configuration.file>./conf/registry-aliases.xml</nifi.registry.registry.alias.configuration.file>
 
         <!-- nifi-registry.properties: extension properties -->
+        <nifi.registry.extension.archive.type>zip</nifi.registry.extension.archive.type>
         <nifi.registry.extensions.working.directory>./work/extensions</nifi.registry.extensions.working.directory>
         <nifi.registry.extension.dir.aws />
 
@@ -395,7 +396,7 @@
                     <version>1.18.0-SNAPSHOT</version>
                     <classifier>bin</classifier>
                     <scope>runtime</scope>
-                    <type>zip</type>
+                    <type>${nifi.registry.extension.archive.type}</type>
                 </dependency>
             </dependencies>
             <build>
@@ -438,7 +439,7 @@
                     <version>1.18.0-SNAPSHOT</version>
                     <classifier>bin</classifier>
                     <scope>runtime</scope>
-                    <type>zip</type>
+                    <type>${nifi.registry.extension.archive.type}</type>
                 </dependency>
             </dependencies>
             <build>
@@ -469,6 +470,9 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <properties>
+                <nifi.registry.extension.archive.type>tar.gz</nifi.registry.extension.archive.type>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10340](https://issues.apache.org/jira/browse/NIFI-10340)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10340) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- N/A [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- N/A [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- N/A [ ] Documentation formatting appears as expected in rendered files
