### PR TITLE
NIFI-10346 Add OWASP Dependency Check Suppressions

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -134,4 +134,64 @@
         <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
         <cve>CVE-2017-10355</cve>
     </suppress>
+    <suppress>
+        <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Avatica</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/avatica\-core@.*$</packageUrl>
+        <cve>CVE-2020-13955</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Avatica</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\/calcite-avatica@.*$</packageUrl>
+        <cve>CVE-2020-13955</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Druid</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\/calcite-druid@.*$</packageUrl>
+        <cve>CVE-2020-13955</cve>
+    </suppress>
+    <suppress>
+        <notes>OpenTSDB vulnerabilities do not apply to HBase Async library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.hbase/asynchbase@.*$</packageUrl>
+        <cpe>cpe:/a:opentsdb:opentsdb</cpe>
+    </suppress>
+    <suppress>
+        <notes>Eclipse Equinox vulnerabilities do not apply to DataNucleus core library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.datanucleus/datanucleus\-core@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:equinox</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-8025 applies to HBase Server not HBase Client</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-client@.*$</packageUrl>
+        <cve>CVE-2018-8025</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-0212 applies to HBase Server not HBase Client</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-client@.*$</packageUrl>
+        <cve>CVE-2019-0212</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2014-3643 applies to Jersey Server not Jersey Core</notes>
+        <packageUrl regex="true">^pkg:maven/com\.sun\.jersey/jersey\-core@.*$</packageUrl>
+        <vulnerabilityName>CVE-2014-3643</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Fan Platform vulnerabilities do not apply to JUnit Platform libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.junit\.platform/junit\-platform\-engine@.*$</packageUrl>
+        <cpe>cpe:/a:fan_platform_project:fan_platform</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2007-6465 applies to Ganglia Server not Ganglia client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/com\.yammer\.metrics/metrics\-ganglia@.*$</packageUrl>
+        <cve>CVE-2007-6465</cve>
+    </suppress>
+    <suppress>
+        <notes>Pro Search vulnerabilities do not apply to Spatial4j</notes>
+        <packageUrl regex="true">^pkg:maven/org\.locationtech\.spatial4j/spatial4j@.*$</packageUrl>
+        <cpe>cpe:/a:pro_search:pro_search</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-43045 applies to the Apache Avro .NET SDK and not to the Java SDK</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
+        <cve>CVE-2021-43045</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
# Summary

[NIFI-10346](https://issues.apache.org/jira/browse/NIFI-10346) Updates the OWASP Dependency Check plugin suppressions configuration with the following changes:

- Suppressed Apache Calcite vulnerabilities not applicable to Calcite Avatica subproject
- Suppressed HBase server vulnerabilities not applicable to client libraries
- Suppressed several mismatched product vulnerabilities

The OWASP Dependency Check report can be run using the following build command:

```
mvn validate -P dependency-check
```

These updates incorporate incremental progress in eliminating false positives.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
