### PR TITLE
NIFI-10348 Upgrade Tomcat Embed to 8.5.82 for Flume NAR

### DIFF
--- a/nifi-nar-bundles/nifi-flume-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-flume-bundle/pom.xml
@@ -40,6 +40,12 @@
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>
             </dependency>
+            <!-- Override Tomcat Embed Core 8.5.46 from Flume 1.10.0 -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>8.5.82</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-10348](https://issues.apache.org/jira/browse/NIFI-10348) Upgrades Tomcat Embed Core from 8.5.46 to 8.5.82 for Flume components to incorporate bug fixes and resolve several false positive vulnerabilities related to Apache Tomcat server capabilities.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
