### PR TITLE
NIFI-10350 Corrected Registry User Authorization for OIDC

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/login/dialogs/nf-registry-user-login.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/login/dialogs/nf-registry-user-login.js
@@ -56,13 +56,9 @@ NfRegistryUserLogin.prototype = {
         var self = this;
         this.nfRegistryApi.postToLogin(username.value, password.value).subscribe(function (response) {
             if (response || response.status === 200) {
-                //successful login update registry config
-                self.nfRegistryApi.getRegistryConfig().subscribe(function (registryConfig) {
-                    self.nfRegistryService.registry.config = registryConfig;
-                    self.nfRegistryService.currentUser.anonymous = false;
-                    self.dialogRef.close();
-                    self.nfRegistryLoginAuthGuard.checkLogin(self.nfRegistryService.redirectUrl);
-                });
+                self.nfRegistryService.currentUser.anonymous = false;
+                self.dialogRef.close();
+                self.nfRegistryLoginAuthGuard.checkLogin(self.nfRegistryService.redirectUrl);
             }
         });
     },

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-registry.auth-guard.service.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-registry.auth-guard.service.js
@@ -78,6 +78,11 @@ NfRegistryUsersAdministrationAuthGuard.prototype = {
                             // render the logout button if there is a token locally
                             if (self.nfStorage.getItem('jwt') !== null) {
                                 self.nfRegistryService.currentUser.canLogout = true;
+
+                                // Update Registry Configuration following successful login
+                                self.nfRegistryApi.getRegistryConfig().subscribe(function (registryConfig) {
+                                    self.nfRegistryService.registry.config = registryConfig;
+                                });
                             }
 
                             // redirect to explorer perspective if not admin
@@ -201,6 +206,11 @@ NfRegistryWorkflowsAdministrationAuthGuard.prototype = {
                             // render the logout button if there is a token locally
                             if (self.nfStorage.getItem('jwt') !== null) {
                                 self.nfRegistryService.currentUser.canLogout = true;
+
+                                // Update Registry Configuration following successful login
+                                self.nfRegistryApi.getRegistryConfig().subscribe(function (registryConfig) {
+                                    self.nfRegistryService.registry.config = registryConfig;
+                                });
                             }
 
                             // redirect to explorer perspective if not admin
@@ -303,6 +313,11 @@ NfRegistryLoginAuthGuard.prototype = {
                         // render the logout button if there is a token locally
                         if (self.nfStorage.getItem('jwt') !== null) {
                             self.nfRegistryService.currentUser.canLogout = true;
+
+                            // Update Registry Configuration following successful login
+                            self.nfRegistryApi.getRegistryConfig().subscribe(function (registryConfig) {
+                                self.nfRegistryService.registry.config = registryConfig;
+                            });
                         }
                         self.nfRegistryService.currentUser.canActivateResourcesAuthGuard = true;
                         resolve(false);
@@ -382,6 +397,11 @@ NfRegistryResourcesAuthGuard.prototype = {
                             if (self.nfStorage.hasItem('jwt')) {
                                 self.nfRegistryService.currentUser.canLogout = true;
                                 self.nfRegistryService.currentUser.canActivateResourcesAuthGuard = true;
+
+                                // Update Registry Configuration following successful login
+                                self.nfRegistryApi.getRegistryConfig().subscribe(function (registryConfig) {
+                                    self.nfRegistryService.registry.config = registryConfig;
+                                });
                                 resolve(true);
                             } else {
                                 self.router.navigateByUrl('login');


### PR DESCRIPTION
# Summary

[NIFI-10350](https://issues.apache.org/jira/browse/NIFI-10350) Corrects NiFi Registry user authorization determination when authenticating using OpenID Connect.

The current implementation refreshes the Registry Configuration after successful username and password authentication with LDAP or Kerberos, but does not refresh the configuration after OIDC authentication.

The solution moves the Registry Configuration refresh to the shared `checkLogin` functions, which incorporate a ticket exchange request to an OIDC provider when configured. This approach ensures that the user interface has the current Registry Configuration regardless of the authentication strategy.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
