### PR TITLE
NIFI-10358 Update CaptureChangeMySQL to use SSL JDBC properties

### DIFF
--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/ssl/ConnectionPropertiesProvider.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/ssl/ConnectionPropertiesProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cdc.mysql.processors.ssl;
+
+import java.util.Map;
+
+/**
+ * JDBC Connection Properties Provider
+ */
+public interface ConnectionPropertiesProvider {
+    /**
+     * Get Connection Properties
+     *
+     * @return JDBC Connection Properties
+     */
+    Map<String, String> getConnectionProperties();
+}

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/ssl/SecurityProperty.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/ssl/SecurityProperty.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cdc.mysql.processors.ssl;
+
+/**
+ * MySQL Connector/J Security Properties
+ */
+public enum SecurityProperty {
+    /** Deprecated alias for tlsVersions */
+    ENABLED_TLS_PROTOCOLS("enabledTLSProtocols"),
+
+    /** Added in MySQL 5.1.0 */
+    TRUST_CERTIFICATE_KEY_STORE_URL("trustsCertificateKeyStoreUrl"),
+
+    /** Added in MySQL 5.1.0 and defaults to JKS */
+    TRUST_CERTIFICATE_KEY_STORE_TYPE("trustCertificateKeyStoreType"),
+
+    /** Added in MySQL 5.1.0 */
+    TRUST_CERTIFICATE_KEY_STORE_PASSWORD("trustCertificateKeyStorePassword"),
+
+    /** Added in MySQL 5.1.0 */
+    CLIENT_CERTIFICATE_KEY_STORE_URL("clientCertificateKeyStoreUrl"),
+
+    /** Added in MySQL 5.1.0 and defaults to JKS */
+    CLIENT_CERTIFICATE_KEY_STORE_TYPE("clientCertificateKeyStoreType"),
+
+    /** Added in MySQL 5.1.0 */
+    CLIENT_CERTIFICATE_KEY_STORE_PASSWORD("clientCertificateKeyStorePassword"),
+
+    /** Deprecated in favor of sslMode and evaluated when useSSL is enabled */
+    REQUIRE_SSL("requireSSL"),
+
+    /** Deprecated in favor of sslMode and defaults to true in 8.0.13 and later */
+    USE_SSL("useSSL"),
+
+    /** Deprecated in favor of sslMode and defaults to false in 8.0.13 and later */
+    VERIFY_SERVER_CERTIFICATE("verifyServerCertificate");
+
+    private final String property;
+
+    SecurityProperty(final String property) {
+        this.property = property;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+}

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/ssl/StandardConnectionPropertiesProvider.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/ssl/StandardConnectionPropertiesProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cdc.mysql.processors.ssl;
+
+import com.github.shyiko.mysql.binlog.network.SSLMode;
+import org.apache.nifi.security.util.TlsConfiguration;
+import org.apache.nifi.security.util.TlsPlatform;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Standard implementation of Connection Properties Provider
+ */
+public class StandardConnectionPropertiesProvider implements ConnectionPropertiesProvider {
+    private static final String COMMA_SEPARATOR = ",";
+
+    private final SSLMode sslMode;
+
+    private final TlsConfiguration tlsConfiguration;
+
+    public StandardConnectionPropertiesProvider(
+            final SSLMode sslMode,
+            final TlsConfiguration tlsConfiguration
+    ) {
+        this.sslMode = Objects.requireNonNull(sslMode, "SSL Mode required");
+        this.tlsConfiguration = tlsConfiguration;
+    }
+
+    /**
+     * Get Connection Properties based on SSL Mode and TLS Configuration
+     *
+     * @return JDBC Connection Properties
+     */
+    @Override
+    public Map<String, String> getConnectionProperties() {
+        final Map<String, String> properties = new LinkedHashMap<>();
+
+        if (SSLMode.DISABLED == sslMode) {
+            properties.put(SecurityProperty.USE_SSL.getProperty(), Boolean.FALSE.toString());
+        } else {
+            // Enable TLS negotiation for all modes
+            properties.put(SecurityProperty.USE_SSL.getProperty(), Boolean.TRUE.toString());
+
+            if (SSLMode.PREFERRED == sslMode) {
+                properties.put(SecurityProperty.REQUIRE_SSL.getProperty(), Boolean.FALSE.toString());
+            } else {
+                // Modes other than preferred require SSL
+                properties.put(SecurityProperty.REQUIRE_SSL.getProperty(), Boolean.TRUE.toString());
+            }
+
+            if (SSLMode.VERIFY_IDENTITY == sslMode) {
+                properties.put(SecurityProperty.VERIFY_SERVER_CERTIFICATE.getProperty(), Boolean.TRUE.toString());
+            }
+
+            if (tlsConfiguration == null) {
+                // Set preferred protocols based on Java platform configuration
+                final String protocols = TlsPlatform.getPreferredProtocols().stream().collect(Collectors.joining(COMMA_SEPARATOR));
+                properties.put(SecurityProperty.ENABLED_TLS_PROTOCOLS.getProperty(), protocols);
+            } else {
+                final Map<String, String> certificateProperties = getCertificateProperties();
+                properties.putAll(certificateProperties);
+            }
+        }
+
+        return properties;
+    }
+
+    private Map<String, String> getCertificateProperties() {
+        final Map<String, String> properties = new LinkedHashMap<>();
+
+        final String protocols = Arrays.stream(tlsConfiguration.getEnabledProtocols()).collect(Collectors.joining(COMMA_SEPARATOR));
+        properties.put(SecurityProperty.ENABLED_TLS_PROTOCOLS.getProperty(), protocols);
+
+        if (tlsConfiguration.isKeystorePopulated()) {
+            properties.put(SecurityProperty.CLIENT_CERTIFICATE_KEY_STORE_URL.getProperty(), tlsConfiguration.getKeystorePath());
+            properties.put(SecurityProperty.CLIENT_CERTIFICATE_KEY_STORE_TYPE.getProperty(), tlsConfiguration.getKeystoreType().getType());
+            properties.put(SecurityProperty.CLIENT_CERTIFICATE_KEY_STORE_PASSWORD.getProperty(), tlsConfiguration.getKeystorePassword());
+        }
+
+        if (tlsConfiguration.isTruststorePopulated()) {
+            properties.put(SecurityProperty.TRUST_CERTIFICATE_KEY_STORE_URL.getProperty(), tlsConfiguration.getTruststorePath());
+            properties.put(SecurityProperty.TRUST_CERTIFICATE_KEY_STORE_TYPE.getProperty(), tlsConfiguration.getTruststoreType().getType());
+            properties.put(SecurityProperty.TRUST_CERTIFICATE_KEY_STORE_PASSWORD.getProperty(), tlsConfiguration.getTruststorePassword());
+        }
+
+        return properties;
+    }
+}

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/java/org/apache/nifi/cdc/mysql/processors/ssl/StandardConnectionPropertiesProviderTest.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/java/org/apache/nifi/cdc/mysql/processors/ssl/StandardConnectionPropertiesProviderTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cdc.mysql.processors.ssl;
+
+import com.github.shyiko.mysql.binlog.network.SSLMode;
+import org.apache.nifi.security.util.KeystoreType;
+import org.apache.nifi.security.util.TlsConfiguration;
+import org.apache.nifi.security.util.TlsPlatform;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class StandardConnectionPropertiesProviderTest {
+    private static final String KEY_STORE_PATH = "keystore.p12";
+
+    private static final KeystoreType KEY_STORE_TYPE = KeystoreType.PKCS12;
+
+    private static final String KEY_STORE_PASSWORD = String.class.getName();
+
+    private static final String TRUST_STORE_PATH = "cacerts";
+
+    private static final KeystoreType TRUST_STORE_TYPE = KeystoreType.PKCS12;
+
+    private static final String TRUST_STORE_PASSWORD = Integer.class.getName();
+
+    @Mock
+    TlsConfiguration tlsConfiguration;
+
+    @Test
+    void testGetConnectionPropertiesSslModeDisabled() {
+        final StandardConnectionPropertiesProvider provider = new StandardConnectionPropertiesProvider(SSLMode.DISABLED, null);
+
+        final Map<String, String> properties = provider.getConnectionProperties();
+
+        assertNotNull(properties);
+
+        final String useSsl = properties.get(SecurityProperty.USE_SSL.getProperty());
+        assertEquals(Boolean.FALSE.toString(), useSsl);
+    }
+
+    @Test
+    void testGetConnectionPropertiesSslModePreferred() {
+        final StandardConnectionPropertiesProvider provider = new StandardConnectionPropertiesProvider(SSLMode.PREFERRED, null);
+
+        final Map<String, String> properties = provider.getConnectionProperties();
+
+        assertNotNull(properties);
+
+        final String useSsl = properties.get(SecurityProperty.USE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), useSsl);
+
+        final String requireSsl = properties.get(SecurityProperty.REQUIRE_SSL.getProperty());
+        assertEquals(Boolean.FALSE.toString(), requireSsl);
+
+        final String protocols = properties.get(SecurityProperty.ENABLED_TLS_PROTOCOLS.getProperty());
+        assertNotNull(protocols);
+    }
+
+    @Test
+    void testGetConnectionPropertiesSslModeRequired() {
+        final StandardConnectionPropertiesProvider provider = new StandardConnectionPropertiesProvider(SSLMode.REQUIRED, null);
+
+        final Map<String, String> properties = provider.getConnectionProperties();
+
+        assertNotNull(properties);
+
+        final String useSsl = properties.get(SecurityProperty.USE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), useSsl);
+
+        final String requireSsl = properties.get(SecurityProperty.REQUIRE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), requireSsl);
+
+        final String protocols = properties.get(SecurityProperty.ENABLED_TLS_PROTOCOLS.getProperty());
+        assertNotNull(protocols);
+    }
+
+    @Test
+    void testGetConnectionPropertiesSslModeVerifyIdentity() {
+        final StandardConnectionPropertiesProvider provider = new StandardConnectionPropertiesProvider(SSLMode.VERIFY_IDENTITY, null);
+
+        final Map<String, String> properties = provider.getConnectionProperties();
+
+        assertNotNull(properties);
+
+        final String useSsl = properties.get(SecurityProperty.USE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), useSsl);
+
+        final String requireSsl = properties.get(SecurityProperty.REQUIRE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), requireSsl);
+
+        final String protocols = properties.get(SecurityProperty.ENABLED_TLS_PROTOCOLS.getProperty());
+        assertNotNull(protocols);
+
+        final String verifyServerCertificate = properties.get(SecurityProperty.VERIFY_SERVER_CERTIFICATE.getProperty());
+        assertEquals(Boolean.TRUE.toString(), verifyServerCertificate);
+    }
+
+    @Test
+    void testGetConnectionPropertiesSslModeRequiredTlsConfiguration() {
+        final String latestProtocol = TlsPlatform.getLatestProtocol();
+        when(tlsConfiguration.getEnabledProtocols()).thenReturn(new String[]{latestProtocol});
+        when(tlsConfiguration.isKeystorePopulated()).thenReturn(true);
+        when(tlsConfiguration.getKeystorePath()).thenReturn(KEY_STORE_PATH);
+        when(tlsConfiguration.getKeystoreType()).thenReturn(KEY_STORE_TYPE);
+        when(tlsConfiguration.getKeystorePassword()).thenReturn(KEY_STORE_PASSWORD);
+        when(tlsConfiguration.isTruststorePopulated()).thenReturn(true);
+        when(tlsConfiguration.getTruststorePath()).thenReturn(TRUST_STORE_PATH);
+        when(tlsConfiguration.getTruststoreType()).thenReturn(TRUST_STORE_TYPE);
+        when(tlsConfiguration.getTruststorePassword()).thenReturn(TRUST_STORE_PASSWORD);
+
+        final StandardConnectionPropertiesProvider provider = new StandardConnectionPropertiesProvider(SSLMode.REQUIRED, tlsConfiguration);
+
+        final Map<String, String> properties = provider.getConnectionProperties();
+
+        assertNotNull(properties);
+
+        final String useSsl = properties.get(SecurityProperty.USE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), useSsl);
+
+        final String requireSsl = properties.get(SecurityProperty.REQUIRE_SSL.getProperty());
+        assertEquals(Boolean.TRUE.toString(), requireSsl);
+
+        final String protocols = properties.get(SecurityProperty.ENABLED_TLS_PROTOCOLS.getProperty());
+        assertEquals(latestProtocol, protocols);
+
+        final String clientCertificateUrl = properties.get(SecurityProperty.CLIENT_CERTIFICATE_KEY_STORE_URL.getProperty());
+        assertEquals(KEY_STORE_PATH, clientCertificateUrl);
+
+        final String clientCertificateType = properties.get(SecurityProperty.CLIENT_CERTIFICATE_KEY_STORE_TYPE.getProperty());
+        assertEquals(KEY_STORE_TYPE.getType(), clientCertificateType);
+
+        final String clientCertificatePassword = properties.get(SecurityProperty.CLIENT_CERTIFICATE_KEY_STORE_PASSWORD.getProperty());
+        assertEquals(KEY_STORE_PASSWORD, clientCertificatePassword);
+
+        final String trustCertificateUrl = properties.get(SecurityProperty.TRUST_CERTIFICATE_KEY_STORE_URL.getProperty());
+        assertEquals(TRUST_STORE_PATH, trustCertificateUrl);
+
+        final String trustCertificateType = properties.get(SecurityProperty.TRUST_CERTIFICATE_KEY_STORE_TYPE.getProperty());
+        assertEquals(TRUST_STORE_TYPE.getType(), trustCertificateType);
+
+        final String trustCertificatePassword = properties.get(SecurityProperty.TRUST_CERTIFICATE_KEY_STORE_PASSWORD.getProperty());
+        assertEquals(TRUST_STORE_PASSWORD, trustCertificatePassword);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-10358](https://issues.apache.org/jira/browse/NIFI-10358) Updates the `CaptureChangeMySQL` Processor apply `SSL Mode` and `SSL Context Service` configuration settings to the enrichment JDBC connection.

In addition to the primary binary log connection, the `CaptureChangeMySQL` Processor maintains a secondary JDBC connection to the MySQL server when configured with a `Distributed Map Cache Client` to provide schema information.

Recent versions of the MySQL Connector for Java attempt to negotiate a TLS connection in the default configuration, based on MySQL server support for TLS. MySQL JDBC Driver versions prior to 8.0.28 have TLS 1.0 and TLS 1.1 enabled, which can result in connection attempts throwing an `SSLException` when running Apache NiFi on versions of Java that disable those deprecated TLS protocol versions.

In addition to TLS protocol negotiation issues, the `CaptureChangeMySQL` Processor does not support the option to configure JDBC connection properties. Updating the Processor to set MySQL JDBC connection properties based on the `SSL Mode` selected provides a more intuitive configuration and improves support for TLS negotiation using certificates issued by private certificate authorities.

The implementation leverages several [MySQL Connector Security Properties](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-security.html) that have been deprecated, but remain supported. This approach enables compatibility with a wide range of MySQL JDBC Driver versions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
