### PR TITLE
NIFI-10366: Make Default Run Duration configurable

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DefaultRunDuration.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DefaultRunDuration.java
@@ -16,23 +16,25 @@
  */
 package org.apache.nifi.annotation.behavior;
 
-public enum RunDuration {
-    ZERO_MILLIS(0),
+import java.time.Duration;
+
+public enum DefaultRunDuration {
+    NO_BATCHING(0),
     TWENTY_FIVE_MILLIS(25),
     FIFTY_MILLIS(50),
     ONE_HUNDRED_MILLIS(100),
     TWO_HUNDRED_FIFTY_MILLIS(250),
     FIVE_HUNDRED_MILLIS(500),
-    ONE_SECONDS(1000),
+    ONE_SECOND(1000),
     TWO_SECONDS(2000);
 
     private final long millis;
 
-    RunDuration(final long millis) {
+    DefaultRunDuration(final long millis) {
         this.millis = millis;
     }
 
-    public long getMillis() {
-        return millis;
+    public Duration getDuration() {
+        return Duration.ofMillis(1000);
     }
 }

--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DefaultRunDuration.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DefaultRunDuration.java
@@ -19,19 +19,19 @@ package org.apache.nifi.annotation.behavior;
 import java.time.Duration;
 
 public enum DefaultRunDuration {
-    NO_BATCHING(0),
-    TWENTY_FIVE_MILLIS(25),
-    FIFTY_MILLIS(50),
-    ONE_HUNDRED_MILLIS(100),
-    TWO_HUNDRED_FIFTY_MILLIS(250),
-    FIVE_HUNDRED_MILLIS(500),
-    ONE_SECOND(1000),
-    TWO_SECONDS(2000);
+    NO_BATCHING(Duration.ZERO),
+    TWENTY_FIVE_MILLIS(Duration.ofMillis(25)),
+    FIFTY_MILLIS(Duration.ofMillis(50)),
+    ONE_HUNDRED_MILLIS(Duration.ofMillis(100)),
+    TWO_HUNDRED_FIFTY_MILLIS(Duration.ofMillis(250)),
+    FIVE_HUNDRED_MILLIS(Duration.ofMillis(500)),
+    ONE_SECOND(Duration.ofSeconds(1)),
+    TWO_SECONDS(Duration.ofSeconds(2));
 
-    private final long millis;
+    private final Duration duration;
 
-    DefaultRunDuration(final long millis) {
-        this.millis = millis;
+    DefaultRunDuration(final Duration duration) {
+        this.duration = duration;
     }
 
     public Duration getDuration() {

--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DefaultRunDuration.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/DefaultRunDuration.java
@@ -35,6 +35,6 @@ public enum DefaultRunDuration {
     }
 
     public Duration getDuration() {
-        return Duration.ofMillis(1000);
+        return duration;
     }
 }

--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/RunDuration.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/RunDuration.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.annotation.behavior;
+
+public enum RunDuration {
+    ZERO_MILLIS(0),
+    TWENTY_FIVE_MILLIS(25),
+    FIFTY_MILLIS(50),
+    ONE_HUNDRED_MILLIS(100),
+    TWO_HUNDRED_FIFTY_MILLIS(250),
+    FIVE_HUNDRED_MILLIS(500),
+    ONE_SECONDS(1000),
+    TWO_SECONDS(2000);
+
+    private final long millis;
+
+    RunDuration(final long millis) {
+        this.millis = millis;
+    }
+
+    public long getMillis() {
+        return millis;
+    }
+}

--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/SupportsBatching.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/SupportsBatching.java
@@ -41,11 +41,13 @@ import java.lang.annotation.Target;
  * ProcessSession.commit() to ensure data is persisted before deleting the data
  * from a remote source.
  *
+ * When the defaultDuration parameter is set, the processor is created with the supplied duration time, which can be adjusted afterwards.
+ * The supplied values can be selected from {@link org.apache.nifi.annotation.behavior.DefaultRunDuration}.
  */
 @Documented
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface SupportsBatching {
-    RunDuration duration() default RunDuration.ZERO_MILLIS;
+    DefaultRunDuration defaultDuration() default DefaultRunDuration.NO_BATCHING;
 }

--- a/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/SupportsBatching.java
+++ b/nifi-api/src/main/java/org/apache/nifi/annotation/behavior/SupportsBatching.java
@@ -47,5 +47,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface SupportsBatching {
-
+    RunDuration duration() default RunDuration.ZERO_MILLIS;
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -369,7 +369,7 @@ public class ExtensionBuilder {
 
             final SupportsBatching sb = procClass.getAnnotation(SupportsBatching.class);
             if (sb != null) {
-                processorNode.setRunDuration(sb.duration().getMillis(), TimeUnit.MILLISECONDS);
+                processorNode.setRunDuration(sb.defaultDuration().getDuration().toMillis(), TimeUnit.MILLISECONDS);
             }
         } catch (final Exception ex) {
             logger.error("Error while setting default run duration from SupportsBatching annotation: {}", ex.toString(), ex);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -372,7 +372,7 @@ public class ExtensionBuilder {
                 processorNode.setRunDuration(sb.defaultDuration().getDuration().toMillis(), TimeUnit.MILLISECONDS);
             }
         } catch (final Exception ex) {
-            logger.error("Error while setting default run duration from SupportsBatching annotation: {}", ex.toString(), ex);
+            logger.error("Set Default Run Duration failed", ex);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -16,9 +16,11 @@
  */
 package org.apache.nifi.controller;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.configuration.DefaultSettings;
 import org.apache.nifi.bundle.Bundle;
 import org.apache.nifi.bundle.BundleCoordinate;
@@ -320,6 +322,8 @@ public class ExtensionBuilder {
         }
 
         applyDefaultSettings(procNode);
+        applyDefaultRunDuration(procNode);
+
         return procNode;
     }
 
@@ -356,6 +360,19 @@ public class ExtensionBuilder {
             }
         } catch (final Exception ex) {
             logger.error("Error while setting default settings from DefaultSettings annotation: {}", ex.toString(), ex);
+        }
+    }
+
+    private void applyDefaultRunDuration(final ProcessorNode processorNode) {
+        try {
+            final Class<?> procClass = processorNode.getProcessor().getClass();
+
+            final SupportsBatching sb = procClass.getAnnotation(SupportsBatching.class);
+            if (sb != null) {
+                processorNode.setRunDuration(sb.duration().getMillis(), TimeUnit.MILLISECONDS);
+            }
+        } catch (final Exception ex) {
+            logger.error("Error while setting default run duration from SupportsBatching annotation: {}", ex.toString(), ex);
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10366](https://issues.apache.org/jira/browse/NIFI-10366)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10366) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
