### PR TITLE
NIFI-10368 Upgrade jQuery UI from 1.12.1 to 1.13.2

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/frontend/package-lock.json
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "jquery": "3.6.0",
         "jquery-form": "3.50.0",
         "jquery-minicolors": "2.1.10",
-        "jquery-ui-dist": "1.12.1",
+        "jquery-ui-dist": "1.13.2",
         "JSON2": "0.1.0",
         "jsonlint": "1.6.3",
         "lodash": "4.17.21",
@@ -468,9 +468,12 @@
       }
     },
     "node_modules/jquery-ui-dist": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz",
-      "integrity": "sha1-XAgV08xvkP9fqvWyaKbiO0ypBPo="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.13.2.tgz",
+      "integrity": "sha512-oVDRd1NLtTbBwpRKAYdIRgpWVDzeBhfy7Gu0RmY6JEaZtmBq6kDn1pm5SgDiAotrnDS+RoTRXO6xvcNTxA9tOA==",
+      "dependencies": {
+        "jquery": ">=1.8.0 <4.0.0"
+      }
     },
     "node_modules/json-format": {
       "version": "1.0.1",
@@ -1027,9 +1030,12 @@
       }
     },
     "jquery-ui-dist": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz",
-      "integrity": "sha1-XAgV08xvkP9fqvWyaKbiO0ypBPo="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.13.2.tgz",
+      "integrity": "sha512-oVDRd1NLtTbBwpRKAYdIRgpWVDzeBhfy7Gu0RmY6JEaZtmBq6kDn1pm5SgDiAotrnDS+RoTRXO6xvcNTxA9tOA==",
+      "requires": {
+        "jquery": ">=1.8.0 <4.0.0"
+      }
     },
     "json-format": {
       "version": "1.0.1",

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/frontend/package.json
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/frontend/package.json
@@ -35,7 +35,7 @@
     "jquery": "3.6.0",
     "jquery-form": "3.50.0",
     "jquery-minicolors": "2.1.10",
-    "jquery-ui-dist": "1.12.1",
+    "jquery-ui-dist": "1.13.2",
     "JSON2": "0.1.0",
     "jsonlint": "1.6.3",
     "lodash": "4.17.21",


### PR DESCRIPTION
# Summary

[NIFI-10368](https://issues.apache.org/jira/browse/NIFI-10368) Upgrades jQuery UI from 1.12.1 to 1.13.2 to resolve CVE-2022-31160, related to the `checkboxradio()` function, which Apache NiFi does not use directly. The 1.12.1 version of jQuery UI is no longer supported, and version [1.13.2](https://jqueryui.com/changelog/1.13.2/) provides a compatible upgrade with a number of fixes added in [1.13.0](https://jqueryui.com/changelog/1.13.0/).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
