### PR TITLE
NIFI-10384 Upgrade Avatica to 1.22.0 for Hive 3

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -150,6 +150,11 @@
         <cve>CVE-2020-13955</cve>
     </suppress>
     <suppress>
+        <notes>CVE-2020-13955 applies to Apache Calcite Core not Apache Calcite Avatica subproject</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica\/avatica(-metrics)?@.*$</packageUrl>
+        <cve>CVE-2020-13955</cve>
+    </suppress>
+    <suppress>
         <notes>OpenTSDB vulnerabilities do not apply to HBase Async library</notes>
         <packageUrl regex="true">^pkg:maven/org\.hbase/asynchbase@.*$</packageUrl>
         <cpe>cpe:/a:opentsdb:opentsdb</cpe>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -61,6 +61,12 @@
                 <artifactId>calcite-core</artifactId>
                 <version>${calcite.version}</version>
             </dependency>
+            <!-- Override Apache Calcite Avatica subproject version for Hive 3 -->
+            <dependency>
+                <groupId>org.apache.calcite.avatica</groupId>
+                <artifactId>avatica</artifactId>
+                <version>${avatica.version}</version>
+            </dependency>
             <!-- Override snakeyaml:1.17 -->
             <dependency>
                 <groupId>org.yaml</groupId>
@@ -113,6 +119,7 @@
         <hive12.hadoop.version>2.6.2</hive12.hadoop.version>
         <hive3.version>3.1.3</hive3.version>
         <hive.version>${hive3.version}</hive.version>
+        <avatica.version>1.22.0</avatica.version>
         <calcite.version>1.31.0</calcite.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
     </properties>


### PR DESCRIPTION
# Summary

[NIFI-10384](https://issues.apache.org/jira/browse/NIFI-10384) Upgrades the Apache Calcite Avatica dependency for Hive 3 components from 1.11.0 to 1.22.0. This upgrade includes updates to several shaded libraries bundled in the Avatica JAR.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
