### PR TITLE
NIFI-10392 - ResizeImage - add option to maintain aspect ratio

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/image/TestResizeImage.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/image/TestResizeImage.java
@@ -157,4 +157,48 @@ public class TestResizeImage {
         final File out = new File("target/mspaint-8x10resized.png");
         ImageIO.write(img, "PNG", out);
     }
+
+    @Test
+    public void testResizeBiggerPNGWithRatio() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new ResizeImage());
+        runner.setProperty(ResizeImage.IMAGE_HEIGHT, "64");
+        runner.setProperty(ResizeImage.IMAGE_WIDTH, "64");
+        runner.setProperty(ResizeImage.SCALING_ALGORITHM, ResizeImage.RESIZE_SMOOTH);
+        runner.setProperty(ResizeImage.KEEP_RATIO, "true");
+
+        runner.enqueue(Paths.get("src/test/resources/mspaint-8x10.png"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ResizeImage.REL_SUCCESS, 1);
+        final MockFlowFile mff = runner.getFlowFilesForRelationship(ResizeImage.REL_SUCCESS).get(0);
+        final byte[] data = mff.toByteArray();
+
+        final BufferedImage img = ImageIO.read(new ByteArrayInputStream(data));
+        assertEquals(42, img.getWidth());
+        assertEquals(64, img.getHeight());
+        final File out = new File("target/mspaint-8x10resized.png");
+        ImageIO.write(img, "PNG", out);
+    }
+
+    @Test
+    public void testResizeSmallerPNGWithRatio() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new ResizeImage());
+        runner.setProperty(ResizeImage.IMAGE_HEIGHT, "5");
+        runner.setProperty(ResizeImage.IMAGE_WIDTH, "5");
+        runner.setProperty(ResizeImage.SCALING_ALGORITHM, ResizeImage.RESIZE_SMOOTH);
+        runner.setProperty(ResizeImage.KEEP_RATIO, "true");
+
+        runner.enqueue(Paths.get("src/test/resources/mspaint-8x10.png"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ResizeImage.REL_SUCCESS, 1);
+        final MockFlowFile mff = runner.getFlowFilesForRelationship(ResizeImage.REL_SUCCESS).get(0);
+        final byte[] data = mff.toByteArray();
+
+        final BufferedImage img = ImageIO.read(new ByteArrayInputStream(data));
+        assertEquals(3, img.getWidth());
+        assertEquals(5, img.getHeight());
+        final File out = new File("target/mspaint-8x10resized.png");
+        ImageIO.write(img, "PNG", out);
+    }
 }


### PR DESCRIPTION
# Summary

[NIFI-10392](https://issues.apache.org/jira/browse/NIFI-10392)

Add an option to the ResizeImage processor to retain the aspect ratio of the input image. This property is a boolean defaulting to false for maintaining backward compatibility/behavior.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
