### PR TITLE
NIFI-10395 Add Apache Xalan to banned dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -859,6 +859,8 @@
                                         <exclude>org.apache.logging.log4j:log4j-core:*</exclude>
                                         <!-- Commons Logging excluded in favor of jcl-over-slf4j -->
                                         <exclude>commons-logging:commons-logging:*</exclude>
+                                        <!-- Apache Xalan is no longer maintained and is bundled in the standard JRE -->
+                                        <exclude>xalan:xalan</exclude>
                                     </excludes>
                                     <includes>
                                         <!-- Versions of JSR305 after 3.0.1 are allowed https://github.com/findbugsproject/findbugs/issues/128 -->


### PR DESCRIPTION
# Summary

[NIFI-10395](https://issues.apache.org/jira/browse/NIFI-10395) Adds Apache Xalan to the list of banned dependencies. The last version 2.7.2 was released in April 2014 and CVE-2022-34169 highlights the fact that the project is dormant, with no future releases expected. The dependency is not currently used and should not be necessary as standard Java distributions include a repackaged version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
