### PR TITLE
Update TestPrometheusRecordSink.java

### DIFF
--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -48,6 +48,7 @@ import org.apache.nifi.util.MockPropertyValue;
 import org.apache.nifi.util.MockVariableRegistry;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.HttpURLConnection;
@@ -80,12 +81,14 @@ public class TestPrometheusRecordSink {
         );
         RecordSchema recordSchema = new SimpleRecordSchema(recordFields);
 
-        Map<String, Object> row1 = new HashMap<>();
+        // Map<String, Object> row1 = new HashMap<>();
+        Map<String, Object> row1 = new LinkedHashMap<>();
         row1.put("field1", 15);
         row1.put("field2", BigDecimal.valueOf(12.34567D));
         row1.put("field3", "Hello");
 
-        Map<String, Object> row2 = new HashMap<>();
+        // Map<String, Object> row2 = new HashMap<>();
+        Map<String, Object> row2 = new LinkedHashMap<>();
         row2.put("field1", 6);
         row2.put("field2", BigDecimal.valueOf(0.1234567890123456789D));
         row2.put("field3", "World!");
@@ -94,8 +97,9 @@ public class TestPrometheusRecordSink {
                 new MapRecord(recordSchema, row1),
                 new MapRecord(recordSchema, row2)
         ));
-
-        Map<String, String> attributes = new HashMap<>();
+        
+        // Map<String, String> attributes = new HashMap<>();
+        Map<String, Object> attributes = new LinkedHashMap<>();
         attributes.put("a", "Hello");
         WriteResult writeResult = sink.sendData(recordSet, attributes, true);
         assertNotNull(writeResult);
@@ -104,8 +108,13 @@ public class TestPrometheusRecordSink {
 
 
         final String content = getMetrics();
-        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
-        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
+        // assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
+        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n") ||
+                   content.contains("field1{field3=\"World!\",} 6.0\nfield1{field3=\"Hello\",} 15.0\n"));
+        
+        // assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
+        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n") ||
+                   content.contains("field2{field3=\"World!\",} 0.12345678901234568\nfield2{field3=\"Hello\",} 12.34567\n"));
 
         try {
             sink.onStopped();


### PR DESCRIPTION
The test of "testSendData" in TestPrometheusRecordSink.java is flaky because of HashMaps. The orders of elements in the HashMaps are not the same every time being called. In this case, LinkedHashMap is applied to replace HashMaps in order to ensure the orders are not changing. Also, the MapRecord cannot keep the same orders of row1 and row2 as well. To deal with this situation, two possible combinations of row1 and row2 are applied in the test cases to avoid possible failures due to orders. 

It matters to fix this flaky test as it may causes potential issues due to the uncertainty of orders from Maps rather than the program itself.