### PR TITLE
fix flaky test case

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
@@ -88,6 +88,7 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -600,7 +601,7 @@ public class TestHttpClient {
     }
 
     private static class DataPacketBuilder {
-        private final Map<String, String> attributes = new HashMap<>();
+        private final Map<String, String> attributes = new LinkedHashMap<>();
         private String contents;
 
         private DataPacketBuilder attr(final String k, final String v) {
@@ -803,7 +804,7 @@ public class TestHttpClient {
     private void testSend(SiteToSiteClient client) throws Exception {
 
         testSendIgnoreProxyError(client, transaction -> {
-            serverChecksum = "1071206772";
+            serverChecksum = "40272532";
 
             for (int i = 0; i < 20; i++) {
                 DataPacket packet = new DataPacketBuilder()
@@ -1380,3 +1381,4 @@ public class TestHttpClient {
         tlsConfiguration = new TemporaryKeyStoreBuilder().build();
     }
 }
+


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
The test `org.apache.nifi.remote.client.http.TestHttpClient#testSendSuccessWithProxy` is flaky. The reason for that is due to the non-deterministic behavior of `java.util.HashMap`, which makes no guarantees as to the order of the map.

The fix is mainly to preserve the ordering when interact with the map object.
 
# Brief changelog
Change the usage of `java.util.HashMap` to `java.util.LinkedHashMap`. 

LinkedHashMap in Java 8 is implemented using double-linked list, the list will define the iteration ordering, therefore, when interact with the map object, the order will be the same for different iteration of the test. 

Due to this change, I also update the expected value used in the test.

# Verification
`mvn -pl nifi-commons/nifi-site-to-site-client edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.remote.client.http.TestHttpClient#testSendSuccessWithProxy -DnondexRuns=10`

### Build

- [x] Build completed using `mvn install -pl nifi-commons/nifi-site-to-site-client -am -DskipTests`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17
