### PR TITLE
NIFI-10434 - flaky test in TestHttpClient.java

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
@@ -88,6 +88,7 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -600,7 +601,7 @@ public class TestHttpClient {
     }
 
     private static class DataPacketBuilder {
-        private final Map<String, String> attributes = new HashMap<>();
+        private final Map<String, String> attributes = new LinkedHashMap<>();
         private String contents;
 
         private DataPacketBuilder attr(final String k, final String v) {
@@ -803,7 +804,7 @@ public class TestHttpClient {
     private void testSend(SiteToSiteClient client) throws Exception {
 
         testSendIgnoreProxyError(client, transaction -> {
-            serverChecksum = "1071206772";
+            serverChecksum = "40272532";
 
             for (int i = 0; i < 20; i++) {
                 DataPacket packet = new DataPacketBuilder()
@@ -952,7 +953,7 @@ public class TestHttpClient {
     private static void testSendLargeFile(SiteToSiteClient client) throws IOException {
 
         testSendIgnoreProxyError(client, transaction -> {
-            serverChecksum = "1527414060";
+            serverChecksum = "2387509971";
 
             final int contentSize = 10_000;
             final StringBuilder sb = new StringBuilder(contentSize);
@@ -1067,7 +1068,7 @@ public class TestHttpClient {
 
             assertNotNull(transaction);
 
-            serverChecksum = "1071206772";
+            serverChecksum = "40272532";
 
 
             for (int i = 0; i < 20; i++) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
[NIFI-10434](https://issues.apache.org/jira/browse/NIFI-10434)

From code trace, the root cause is the method `java.util.HashMap`, which is no guarantee in order of the returned fields and thus, some tests can fail due to a different order:

* `org.apache.nifi.remote.client.http.TestHttpClient#testSendSuccessWithProxyAuth`

* `org.apache.nifi.remote.client.http.TestHttpClient#testSendLargeFileHTTPSWithProxy`

The fix is to replace allocations of `HashMap`with `LinkedHashMap`, because the ` LinkedHashMap` classes have a precisely defined iteration order. This test implemented the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool to find the codes where non-determination happened.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn install -pl nifi-commons/nifi-site-to-site-client -am -DskipTests`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

Test: 

- `mvn -pl nifi-commons/nifi-site-to-site-client edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.remote.client.http.TestHttpClient#testSendSuccessWithProxyAuth -Denforcer.skip -Ddependency-check.skip -DnondexRuns=10`

- `mvn -pl nifi-commons/nifi-site-to-site-client edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.remote.client.http.TestHttpClient#testSendLargeFileHTTPSWithProxy -Denforcer.skip -Ddependency-check.skip -DnondexRuns=10`

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
