### PR TITLE
NIFI-10273: added support for files larger than 8.5GB to MergeContent…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -783,6 +783,7 @@ public class MergeContent extends BinFiles {
                         try (final OutputStream bufferedOut = new BufferedOutputStream(rawOut);
                             final TarArchiveOutputStream out = new TarArchiveOutputStream(bufferedOut)) {
                             out.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+                            out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
                             for (final FlowFile flowFile : contents) {
                                 final String path = keepPath ? getPath(flowFile) : "";
                                 final String entryName = path + flowFile.getAttribute(CoreAttributes.FILENAME.key());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -774,7 +774,7 @@ public class MergeContent extends BinFiles {
             final List<FlowFile> contents = bin.getContents();
             final ProcessSession session = bin.getSession();
             // if any one of the FlowFiles is larger than the default maximum tar entry size, then we set bigNumberMode to handle it
-            boolean setBigNumberMode;
+            boolean setBigNumberMode = false;
             if (getMaxEntrySize(contents) >= TarConstants.MAXSIZE) {
                 setBigNumberMode = true;
             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -92,7 +92,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -834,14 +834,11 @@ public class MergeContent extends BinFiles {
         }
 
         private long getMaxEntrySize(List<FlowFile> contents) {
-            Optional<FlowFile> ffOpt = contents.stream()
+            OptionalLong maxSize = contents.stream()
                 .parallel()
-                .max(Comparator.comparingLong(ff -> ff.getSize()));
-            if (ffOpt.isPresent()) {
-                return ffOpt.get().getSize();
-            } else {
-                return 0L;
-            }
+                .mapToLong(ff -> ff.getSize())
+                .max();
+            return maxSize.orElse(0L);
         }
 
         @Override


### PR DESCRIPTION
… (tar) processor

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10273](https://issues.apache.org/jira/browse/NIFI-10273)

Adds support for the MergeContent processor to handle individual files larger than 8.5GB when Tar archiving them. I attempted to unit test this, but due to how the NiFi mock framework works, every flowfile is read into memory in full even if that FlowFile is backed by a `NullInputStream`. I couldn't find a nice alternative to verify with a unit test.

So to verify i deployed this processor and tested with the following setup, with the `MergeContent` processor configured to tar archive the bins:

`GenerateFlowFile` --- 9GB file ---> `MergeContent` --> `LogAttribute`

Prior to this fix, the MergeContent processor would complain with the following error:
```
java.lang.RuntimeException: entry size '<FlowFileSize>' is too big (> 8589934591)
```

A similar fix was made in a different project: https://github.com/DataConservancy/dcs-packaging-tool/pull/36/files

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
