### PR TITLE
NIFI-9500 Add nifi.cmd for Windows

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.cmd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.cmd
@@ -20,7 +20,9 @@ rem Set Java version
 rem set JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
 
 rem Set application home directory based on parent directory of script location
-set NIFI_HOME=%~dp0..
+pushd %~dp0..
+set NIFI_HOME=%CD%
+popd
 
 rem Set run directory for process identifier tracking
 set NIFI_PID_DIR=%NIFI_HOME%\run

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.cmd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.cmd
@@ -1,0 +1,29 @@
+@echo off
+rem
+rem    Licensed to the Apache Software Foundation (ASF) under one or more
+rem    contributor license agreements.  See the NOTICE file distributed with
+rem    this work for additional information regarding copyright ownership.
+rem    The ASF licenses this file to You under the Apache License, Version 2.0
+rem    (the "License"); you may not use this file except in compliance with
+rem    the License.  You may obtain a copy of the License at
+rem
+rem       http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem    Unless required by applicable law or agreed to in writing, software
+rem    distributed under the License is distributed on an "AS IS" BASIS,
+rem    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem    See the License for the specific language governing permissions and
+rem    limitations under the License.
+rem
+
+rem Set Java version
+rem set JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+
+rem Set application home directory based on parent directory of script location
+set NIFI_HOME=%~dp0..
+
+rem Set run directory for process identifier tracking
+set NIFI_PID_DIR=%NIFI_HOME%\run
+
+rem Set application log directory
+set NIFI_LOG_DIR=%NIFI_HOME%\logs

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
@@ -1,0 +1,56 @@
+@echo off
+rem
+rem    Licensed to the Apache Software Foundation (ASF) under one or more
+rem    contributor license agreements.  See the NOTICE file distributed with
+rem    this work for additional information regarding copyright ownership.
+rem    The ASF licenses this file to You under the Apache License, Version 2.0
+rem    (the "License"); you may not use this file except in compliance with
+rem    the License.  You may obtain a copy of the License at
+rem
+rem       http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem    Unless required by applicable law or agreed to in writing, software
+rem    distributed under the License is distributed on an "AS IS" BASIS,
+rem    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem    See the License for the specific language governing permissions and
+rem    limitations under the License.
+rem
+
+call %~dp0\nifi-env.cmd
+
+if exist "%JAVA_HOME%\bin\java.exe" (
+  set JAVA_EXE=%JAVA_HOME%\bin\java.exe
+) else (
+  echo JAVA_HOME not defined: using PATH for java command
+  set JAVA_EXE=java
+)
+
+set BOOTSTRAP_LIB_DIR=%NIFI_HOME%\lib\bootstrap
+set CONF_DIR=%NIFI_HOME%\conf
+
+set LOG_DIR_PROPERTY=-Dorg.apache.nifi.bootstrap.config.log.dir=%NIFI_LOG_DIR%
+set PID_DIR_PROPERTY=-Dorg.apache.nifi.bootstrap.config.pid.dir=%NIFI_PID_DIR%
+set CONFIG_FILE_PROPERTY=-Dorg.apache.nifi.bootstrap.config.file=%CONF_DIR%\bootstrap.conf
+set PROPERTIES_FILE_PROPERTY=-Dnifi.properties.file.path=%CONF_DIR%\nifi.properties
+set BOOTSTRAP_HEAP_SIZE=48m
+
+set JAVA_ARGS=%LOG_DIR_PROPERTY% %PID_DIR_PROPERTY% %CONFIG_FILE_PROPERTY% %PROPERTIES_FILE_PROPERTY%
+set JAVA_PARAMS=-cp %BOOTSTRAP_LIB_DIR%\*;%CONF_DIR% %JAVA_ARGS%
+set JAVA_MEMORY=-Xms%BOOTSTRAP_HEAP_SIZE% -Xmx%BOOTSTRAP_HEAP_SIZE%
+
+echo JAVA_HOME: %JAVA_HOME%
+echo NIFI_HOME: %NIFI_HOME%
+echo.
+
+set RUN_COMMAND="%~1"
+if %RUN_COMMAND% == "set-single-user-credentials" (
+  rem Set credentials with quoted arguments passed to Java command
+  set "CREDENTIALS=^"%~2^" ^"%~3^""
+  call "%JAVA_EXE%" %JAVA_PARAMS% org.apache.nifi.authentication.single.user.command.SetSingleUserCredentials %CREDENTIALS%
+) else if %RUN_COMMAND% == "set-sensitive-properties-key" (
+  call "%JAVA_EXE%" %JAVA_PARAMS% org.apache.nifi.flow.encryptor.command.SetSensitivePropertiesKey %~2
+) else if %RUN_COMMAND% == "set-sensitive-properties-algorithm" (
+  call "%JAVA_EXE%" %JAVA_PARAMS% org.apache.nifi.flow.encryptor.command.SetSensitivePropertiesAlgorithm %~2
+) else (
+  call "%JAVA_EXE%" %JAVA_MEMORY% %JAVA_PARAMS% org.apache.nifi.bootstrap.RunNiFi %RUN_COMMAND%
+)

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
@@ -42,6 +42,8 @@ echo JAVA_HOME: %JAVA_HOME%
 echo NIFI_HOME: %NIFI_HOME%
 echo.
 
+pushd %NIFI_HOME%
+
 set RUN_COMMAND="%~1"
 if %RUN_COMMAND% == "set-single-user-credentials" (
   rem Set credentials with quoted arguments passed to Java command
@@ -54,3 +56,5 @@ if %RUN_COMMAND% == "set-single-user-credentials" (
 ) else (
   call "%JAVA_EXE%" %JAVA_MEMORY% %JAVA_PARAMS% org.apache.nifi.bootstrap.RunNiFi %RUN_COMMAND%
 )
+
+popd


### PR DESCRIPTION
# Summary

[NIFI-9500](https://issues.apache.org/jira/browse/NIFI-9500) Adds a `nifi.cmd` script for running application actions on Windows. 

The implementation contains a basic set of capabilities similar to `nifi.sh`, including support for the `set-single-user-credentials`, `set-sensitive-properties-key`, and `set-sensitive-properties-algorithm` commands.

The script leverages a new `nifi-env.cmd` to avoid depending on the current `nifi-env.bat` script. The `cmd` approach and current directory resolution avoids directory name truncation artifacts present in the `bat` versions.

This implementation should provide a way forward for support on Windows, with the opportunity to deprecate the `bat` files in a future major release version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
