### PR TITLE
NIFI-10449: Fix ScriptedLookupServices to reload after disabled and first validation after changes made

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -721,7 +721,10 @@ public class StandardProcessorTestRunner implements TestRunner {
         }
 
         try {
-            ReflectionUtils.invokeMethodsWithAnnotation(OnDisabled.class, service);
+            // Create a config context to pass into the controller service's OnDisabled method (it will be ignored if the controller service has no arguments)
+            final MockConfigurationContext configContext = new MockConfigurationContext(service, configuration.getProperties(), context, variableRegistry);
+            configContext.setValidateExpressions(validateExpressionUsage);
+            ReflectionUtils.invokeMethodsWithAnnotation(OnDisabled.class, service, configContext);
         } catch (final Exception e) {
             e.printStackTrace();
             Assertions.fail("Failed to disable Controller Service " + service + " due to " + e);

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
@@ -230,7 +230,7 @@ public class ScriptingComponentHelper {
             }
 
             // Get a list of URLs from the configurator (if present), or just convert modules from Strings to URLs
-            final String[] locations = modules.asLocations().toArray(new String[0]);
+            final String[] locations = (modules == null) ? new String[0] : modules.asLocations().toArray(new String[0]);
             final URL[] additionalClasspathURLs = ScriptRunnerFactory.getInstance().getModuleURLsForClasspath(scriptEngineName, locations, log);
 
 

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_simple_lookup_inline.groovy
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_simple_lookup_inline.groovy
@@ -24,8 +24,8 @@ import org.apache.nifi.reporting.InitializationException
 class SimpleGroovyLookupService implements StringLookupService {
 
     def lookupTable = [
-            'Hello': 'Hi',
-            'World': 'there'
+            'Hello': 'Goodbye',
+            'World': 'Stranger'
     ]
 
 


### PR DESCRIPTION
# Summary

[NIFI-10449](https://issues.apache.org/jira/browse/NIFI-10449) This PR fixes an issue where ScriptedLookupService controller services were not reloading at certain times, such as after being disabled with no changes made. This causes things like Parameter value changes not to be picked up. The approach to the fix was basically to do the same as is done with InvokeScriptedProcessor and other scripted controller services.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
