### PR TITLE
NIFI-10236: ByteArrayContentRepository in nifi-framework-components

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -3387,14 +3387,14 @@ FlowFile Repository, if also on that disk, could become corrupt. To avoid this s
 
 |====
 |*Property*|*Description*
-|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository`.
+|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository` and should only be changed with caution. To store flowfile content in memory instead of on disk (at the risk of data loss in the event of power/machine failure), set this property to `org.apache.nifi.controller.repository.ByteArrayContentRepository`.
 |====
 
 === File System Content Repository Properties
 
 |====
 |*Property*|*Description*
-|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository`.
+|`nifi.content.repository.implementation`|The Content Repository implementation. The default value is `org.apache.nifi.controller.repository.FileSystemRepository` and should only be changed with caution. To store flowfile content in memory instead of on disk (at the risk of data loss in the event of power/machine failure), set this property to `org.apache.nifi.controller.repository.ByteArrayContentRepository`.
 |`nifi.content.claim.max.appendable.size`|When NiFi processes many small FlowFiles, the contents of those FlowFiles are stored in the content repository, but we do not store the content of each
 individual FlowFile as a separate file in the content repository. Doing so would be very detrimental to performance, if each 120 byte FlowFile, for instance, was written to its own file. Instead,
 we continue writing to the same file until it reaches some threshold. This property configures that threshold. Setting the value too small can result in poor performance due to reading from and
@@ -3443,6 +3443,14 @@ All of the properties defined above (see <<file-system-content-repository-proper
 |`nifi.content.repository.encryption.key.id`|The active key ID to use for encryption (e.g. `Key1`).
 |`nifi.content.repository.encryption.key`|The key to use for `StaticKeyProvider`. The key format is hex-encoded (`0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210`) but can also be encrypted using the `./encrypt-config.sh` tool in NiFi Toolkit (see the <<toolkit-guide.adoc#encrypt_config_tool,Encrypt-Config Tool>> section in the link:toolkit-guide.html[NiFi Toolkit Guide] for more information).
 |`nifi.content.repository.encryption.key.id.`*|Allows for additional keys to be specified for the `StaticKeyProvider`. For example, the line `nifi.content.repository.encryption.key.id.Key2=012...210` would provide an available key `Key2`.
+|====
+
+[[byte-array-content-repository-properties]]
+=== Byte Array Content Repository Properties
+
+|====
+|*Property*|*Description*
+|`nifi.bytearray.content.repository.max.size`|The Content Repository maximum size in memory. The default value is `100 MB`.
 |====
 
 === Provenance Repository

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/claim/ContentClaim.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/claim/ContentClaim.java
@@ -44,4 +44,10 @@ public interface ContentClaim extends Comparable<ContentClaim> {
      * @return the length of this ContentClaim
      */
     long getLength();
+
+    /**
+     * sets the length of this ContentClaim
+     */
+    void setLength(final long length);
+
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/ByteArrayContentRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/ByteArrayContentRepository.java
@@ -15,15 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.stateless.repository;
+package org.apache.nifi.controller.repository;
 
-import org.apache.nifi.controller.repository.ContentRepository;
-import org.apache.nifi.controller.repository.ContentRepositoryContext;
 import org.apache.nifi.controller.repository.claim.ContentClaim;
 import org.apache.nifi.controller.repository.claim.ResourceClaim;
 import org.apache.nifi.controller.repository.claim.ResourceClaimManager;
+import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.stream.io.ByteCountingOutputStream;
 import org.apache.nifi.stream.io.StreamUtils;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.engine.FlowEngine;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,14 +39,47 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ByteArrayContentRepository implements ContentRepository {
-    private ResourceClaimManager resourceClaimManager;
+    private static final Logger logger = LoggerFactory.getLogger(ByteArrayContentRepository.class);
+    private final ScheduledExecutorService executor = new FlowEngine(3, "ByteArrayContentRepository Cleaning Workers", true);
 
+    private ResourceClaimManager resourceClaimManager;
+    public static final String MAX_SIZE_PROPERTY = "nifi.bytearray.content.repository.max.size";
+    public static final String CONTAINER_NAME = "in-memory";
+    public static final String SECTION_NAME = "in-memory";
+
+    private final AtomicLong repoCurrentSize = new AtomicLong(0L);
+    private final AtomicLong idCounter = new AtomicLong(0L);
+    private final long maxBytes;
+
+    public ByteArrayContentRepository() {
+        maxBytes = 0L;
+    }
+
+    public ByteArrayContentRepository(final NiFiProperties nifiProperties) {
+        final String maxSizeProperty = nifiProperties.getProperty(MAX_SIZE_PROPERTY);
+        if (maxSizeProperty == null) {
+            maxBytes = (long) DataUnit.B.convert(100D, DataUnit.MB);
+        } else {
+            maxBytes = DataUnit.parseDataSize(maxSizeProperty, DataUnit.B).longValue();
+        }
+    }
     @Override
-    public void initialize(final ContentRepositoryContext context) {
+    public void initialize(final ContentRepositoryContext context) throws IOException {
         resourceClaimManager = context.getResourceClaimManager();
+
+        for (int i = 0; i < 3; i++) {
+            executor.scheduleWithFixedDelay(new CleanupOldClaims(), 1000, 10, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override
@@ -54,28 +88,33 @@ public class ByteArrayContentRepository implements ContentRepository {
 
     @Override
     public Set<String> getContainerNames() {
-        return Collections.singleton("container");
+        return Collections.singleton(CONTAINER_NAME);
     }
 
     @Override
     public long getContainerCapacity(final String containerName) {
-        return 0;
+        return maxBytes;
     }
 
     @Override
     public long getContainerUsableSpace(final String containerName) {
-        return 0;
+        final long usableSpace = maxBytes - repoCurrentSize.get();
+        logger.trace("Usable Space of container "+containerName+" is " + usableSpace);
+        return usableSpace;
     }
 
     @Override
     public String getContainerFileStoreName(final String containerName) {
-        return "container";
+        return CONTAINER_NAME;
     }
 
     @Override
-    public ContentClaim create(final boolean lossTolerant) {
+    public ContentClaim create(final boolean lossTolerant) throws IOException {
+        // Loss Tolerance is not configurable
+        // This is an in-memory repository without any backup
         final ContentClaim contentClaim = new ByteArrayContentClaim();
         resourceClaimManager.incrementClaimantCount(contentClaim.getResourceClaim());
+        logger.trace("A ContentClaim has been created : " + contentClaim.toString());
         return contentClaim;
     }
 
@@ -108,7 +147,8 @@ public class ByteArrayContentRepository implements ContentRepository {
 
     @Override
     public boolean remove(final ContentClaim claim) {
-        return true;
+        final ByteArrayContentClaim byteArrayContentClaim = verifyContentClaim(claim);
+        return byteArrayContentClaim.delete();
     }
 
     @Override
@@ -172,7 +212,7 @@ public class ByteArrayContentRepository implements ContentRepository {
             new StandardOpenOption[] {StandardOpenOption.CREATE};
 
         try (final OutputStream out = Files.newOutputStream(destination, openOptions)) {
-            return exportTo(claim, out);
+            return exportTo(claim, out, 0L, size(claim));
         }
     }
 
@@ -196,7 +236,9 @@ public class ByteArrayContentRepository implements ContentRepository {
     @Override
     public long exportTo(final ContentClaim claim, final OutputStream destination, final long offset, final long length) throws IOException {
         try (final InputStream in = read(claim)) {
-            StreamUtils.skip(in, offset);
+            if (offset > 0) {
+                StreamUtils.skip(in, offset);
+            }       
             StreamUtils.copy(in, destination, length);
         }
 
@@ -205,21 +247,21 @@ public class ByteArrayContentRepository implements ContentRepository {
 
     @Override
     public long size(final ContentClaim claim) {
-        return claim.getLength();
+        return verifyContentClaim(claim).getSize();
     }
 
     @Override
     public long size(final ResourceClaim claim) throws IOException {
-        return 0;
+        return verifyResourceClaim(claim).getSize();
     }
 
     @Override
-    public InputStream read(final ContentClaim claim) {
+    public InputStream read(final ContentClaim claim) throws IOException {
         if (claim == null) {
             return new ByteArrayInputStream(new byte[0]);
         }
 
-        final ByteArrayContentClaim byteArrayContentClaim = verifyClaim(claim);
+        final ByteArrayContentClaim byteArrayContentClaim = verifyContentClaim(claim);
         return byteArrayContentClaim.read();
     }
 
@@ -229,31 +271,39 @@ public class ByteArrayContentRepository implements ContentRepository {
             return new ByteArrayInputStream(new byte[0]);
         }
 
-        if (!(claim instanceof ByteArrayResourceClaim)) {
-            throw new IllegalArgumentException("Cannot access Resource Claim " + claim + " because the Resource Claim does not belong to this Content Repository");
-        }
-
-        final ByteArrayResourceClaim byteArrayResourceClaim = (ByteArrayResourceClaim) claim;
+        final ByteArrayResourceClaim byteArrayResourceClaim = verifyResourceClaim(claim);
         return byteArrayResourceClaim.read();
     }
 
     @Override
     public OutputStream write(final ContentClaim claim) {
-        final ByteArrayContentClaim byteArrayContentClaim = verifyClaim(claim);
+        final ByteArrayContentClaim byteArrayContentClaim = verifyContentClaim(claim);
         return byteArrayContentClaim.writeTo();
     }
 
-    private ByteArrayContentClaim verifyClaim(final ContentClaim claim) {
+    protected static ByteArrayContentClaim verifyContentClaim(final ContentClaim claim) {
         Objects.requireNonNull(claim);
         if (!(claim instanceof ByteArrayContentClaim)) {
-            throw new IllegalArgumentException("Cannot access Content Claim " + claim + " because the Content Claim does not belong to this Content Repository");
+            throw new IllegalArgumentException("Cannot access Content Claim " + claim
+                    + " because the Content Claim does not belong to this Content Repository");
         }
 
         return (ByteArrayContentClaim) claim;
     }
 
+    protected static ByteArrayResourceClaim verifyResourceClaim(final ResourceClaim claim) {
+        Objects.requireNonNull(claim);
+        if (!(claim instanceof ByteArrayResourceClaim)) {
+            throw new IllegalArgumentException("Cannot access Resouce Claim " + claim
+                    + " because the Resouce Claim does not belong to this Content Repository");
+        }
+
+        return (ByteArrayResourceClaim) claim;
+    }
+
     @Override
     public void purge() {
+        resourceClaimManager.purge();
     }
 
     @Override
@@ -262,11 +312,7 @@ public class ByteArrayContentRepository implements ContentRepository {
 
     public byte[] getBytes(final ContentClaim contentClaim) {
         final ResourceClaim resourceClaim = contentClaim.getResourceClaim();
-        if (!(resourceClaim instanceof ByteArrayResourceClaim)) {
-            throw new IllegalArgumentException("Given ContentClaim was not created by this Repository");
-        }
-
-        return ((ByteArrayResourceClaim) resourceClaim).contents;
+        return verifyResourceClaim(resourceClaim).contents;
     }
 
     @Override
@@ -274,8 +320,19 @@ public class ByteArrayContentRepository implements ContentRepository {
         return false;
     }
 
-    private static class ByteArrayContentClaim implements ContentClaim {
+    protected class ByteArrayContentClaim implements ContentClaim {
+        private long length = -1;
         private final ByteArrayResourceClaim resourceClaim = new ByteArrayResourceClaim();
+
+        @Override
+        public int compareTo(final ContentClaim arg0) {
+            return resourceClaim.compareTo(arg0.getResourceClaim());
+        }
+
+        @Override
+        public void setLength(final long length) {
+            this.length = length;
+        }
 
         @Override
         public ResourceClaim getResourceClaim() {
@@ -284,17 +341,16 @@ public class ByteArrayContentRepository implements ContentRepository {
 
         @Override
         public long getOffset() {
-            return 0;
+            return 0L;
         }
 
         @Override
         public long getLength() {
-            return resourceClaim.getLength();
+            return length;
         }
 
-        @Override
-        public int compareTo(final ContentClaim o) {
-            return resourceClaim.compareTo(o.getResourceClaim());
+        public long getSize() {
+            return resourceClaim.getSize();
         }
 
         public OutputStream writeTo() {
@@ -304,12 +360,43 @@ public class ByteArrayContentRepository implements ContentRepository {
         public InputStream read() {
             return resourceClaim.read();
         }
+
+        public boolean delete() {
+            return resourceClaim.delete();
+        }
+
+        @Override
+        public String toString() {
+            return "ByteArrayContentClaim[resourceClaim=" + resourceClaim.toString() + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 37;
+            int result = 1;
+            result = prime * result;
+            result = prime * result + (resourceClaim == null ? 0 : resourceClaim.hashCode());
+            return result;
+        }
+    
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+
+            try {
+                return resourceClaim.equals(verifyContentClaim((ContentClaim) other).getResourceClaim());
+            } catch (Exception e) {
+                return false;
+            }
+        }
     }
 
-    private static class ByteArrayResourceClaim implements ResourceClaim {
-        private static final AtomicLong idCounter = new AtomicLong(0L);
-        private final String id = String.valueOf(idCounter.getAndIncrement());
+    protected class ByteArrayResourceClaim implements ResourceClaim {
         private byte[] contents;
+        private final String id = String.valueOf(idCounter.getAndIncrement());
+        private AtomicLong internalSize = new AtomicLong(0);
 
         @Override
         public String getId() {
@@ -318,12 +405,12 @@ public class ByteArrayContentRepository implements ContentRepository {
 
         @Override
         public String getContainer() {
-            return "container";
+            return CONTAINER_NAME;
         }
 
         @Override
         public String getSection() {
-            return "section";
+            return SECTION_NAME;
         }
 
         @Override
@@ -341,18 +428,12 @@ public class ByteArrayContentRepository implements ContentRepository {
             return true;
         }
 
-        public long getLength() {
-            return contents == null ? 0L : contents.length;
+        public long getSize() {
+            return internalSize.get();
         }
 
         public OutputStream writeTo() {
-            return new ByteArrayOutputStream() {
-                @Override
-                public void close() throws IOException {
-                    super.close();
-                    ByteArrayResourceClaim.this.contents = toByteArray();
-                }
-            };
+            return new ManagedByteArrayOutputStream();
         }
 
         public InputStream read() {
@@ -361,6 +442,13 @@ public class ByteArrayContentRepository implements ContentRepository {
             }
 
             return new ByteArrayInputStream(contents);
+        }
+
+        public boolean delete() {
+            repoCurrentSize.addAndGet(-internalSize.get());
+            internalSize.lazySet(0L);
+            contents = null;      
+            return true;
         }
 
         @Override
@@ -380,6 +468,83 @@ public class ByteArrayContentRepository implements ContentRepository {
         @Override
         public int hashCode() {
             return Objects.hash(id);
+        }
+
+        @Override
+        public String toString() {
+            return "ByteArrayResourceClaim[ container=" + getContainer() + ", section=" + getSection() + ", id=" + id + ", size=" + getSize() + " ]";
+        }
+
+        class ManagedByteArrayOutputStream extends ByteArrayOutputStream {
+
+            @Override
+            public synchronized void write(int b) {
+                if (ByteArrayContentRepository.this.repoCurrentSize.get() + 1 > ByteArrayContentRepository.this.maxBytes) {
+                    throw new OutOfMemoryError("Content repository is out of space");
+                }
+
+                try {
+                    super.write(b);
+                }
+                finally {
+                    ByteArrayContentRepository.this.repoCurrentSize.incrementAndGet();
+                    internalSize.incrementAndGet();
+                }
+            }
+        
+            @Override
+            public void write(byte[] b, int off, int len) {
+                if (ByteArrayContentRepository.this.repoCurrentSize.get() + len > ByteArrayContentRepository.this.maxBytes) {
+                    throw new OutOfMemoryError("Content repository is out of space");                }
+
+                try {
+                    super.write(b, off, len);
+                }
+                finally {
+                    ByteArrayContentRepository.this.repoCurrentSize.addAndGet(len);
+                    internalSize.addAndGet(len);
+                    logger.trace("Wrote " + b.toString() + " with offset "+ off +" and length " + len);
+                }
+            }
+        
+            @Override
+            public void write(byte[] b) throws IOException {
+                write(b, 0, b.length);
+            }
+            
+            @Override
+            public synchronized void reset() {
+                logger.trace("Reseting " + ByteArrayContentRepository.this.toString());
+                super.reset();
+                repoCurrentSize.addAndGet(-internalSize.get());
+                internalSize.lazySet(0L);
+                contents = null;
+            }
+        
+            @Override
+            public void close() throws IOException {
+                super.close();
+                ByteArrayResourceClaim.this.contents = toByteArray();
+            }
+        }
+    }
+
+    private class CleanupOldClaims implements Runnable {
+
+        @Override
+        public void run() {
+            final List<ResourceClaim> destructable = new ArrayList<>(1000);
+            while (true) {
+                destructable.clear();
+                resourceClaimManager.drainDestructableClaims(destructable, 1000, 5, TimeUnit.SECONDS);
+                if (destructable.isEmpty()) {
+                    return;
+                }
+
+                for (final ResourceClaim resourceClaim : destructable) {
+                    verifyResourceClaim(resourceClaim).delete();
+                }
+            }
         }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/resources/META-INF/services/org.apache.nifi.controller.repository.ContentRepository
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/resources/META-INF/services/org.apache.nifi.controller.repository.ContentRepository
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.controller.repository.ByteArrayContentRepository

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/TestByteArrayContentRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/TestByteArrayContentRepository.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.nifi.controller.repository.claim.ContentClaim;
+import org.apache.nifi.controller.repository.claim.ResourceClaimManager;
+import org.apache.nifi.controller.repository.claim.StandardResourceClaimManager;
+import org.apache.nifi.events.EventReporter;
+import org.apache.nifi.util.NiFiProperties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestByteArrayContentRepository {
+
+    private ResourceClaimManager claimManager;
+
+    @Before
+    public void setup() {
+        claimManager = new StandardResourceClaimManager();
+    }
+
+    @Test
+    public void testCreateUniqueClaim() throws IOException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+        final ByteArrayContentRepository.ByteArrayContentClaim claim1 = ByteArrayContentRepository.verifyContentClaim(contentRepo.create(true));
+        final ByteArrayContentRepository.ByteArrayContentClaim claim2 = ByteArrayContentRepository.verifyContentClaim(contentRepo.create(true));
+
+        Assert.assertTrue(claim1.equals(claim1));
+        Assert.assertFalse(claim1.equals(claim2));
+    }
+
+    @Test
+    public void testRedirects() throws IOException {
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "10 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        contentRepo.initialize(contextRepo);
+        final ContentClaim claim = contentRepo.create(true);
+        final OutputStream out = contentRepo.write(claim);
+
+        final byte[] oneK = new byte[1024];
+        Arrays.fill(oneK, (byte) 55);
+
+        // Write 10 MB to the repo
+        for (int i = 0; i < 10240; i++) {
+            out.write(oneK);
+        }
+
+        final long currentUsableSpaceExpectedZero = contentRepo.getContainerUsableSpace(ByteArrayContentRepository.CONTAINER_NAME);
+        Assert.assertEquals(currentUsableSpaceExpectedZero, 0L);
+
+        try {
+            out.write(1);
+            Assert.fail("Expected to be out of space on content repo");
+        } catch (final OutOfMemoryError e) {
+        }
+
+        try {
+            out.write(1);
+            Assert.fail("Expected to be out of space on content repo");
+        } catch (final OutOfMemoryError e) {
+        }
+    }
+
+    @Test
+    public void testMemoryIsFreed() throws IOException, InterruptedException, ExecutionException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+
+        final byte[] oneK = new byte[1024];
+        Arrays.fill(oneK, (byte) 55);
+
+        final ExecutorService exec = Executors.newFixedThreadPool(10);
+
+        try {
+            for (int t = 0; t < 10; t++) {
+                final Callable writeAndRemoveToRepo = new Callable<Long>() {
+                    @Override
+                    public Long call() throws IOException, ExecutionException {
+                        for (int j = 0; j < 10000; j++) {
+                            final ContentClaim claim = contentRepo.create(true);
+                            final OutputStream out = contentRepo.write(claim);
+        
+                            // Write 1 MB to the repo
+                            for (int i = 0; i < 1024; i++) {
+                                out.write(oneK);
+                            }
+        
+                            final int count = contentRepo.decrementClaimantCount(claim);
+                            if (count <= 0) {
+                                contentRepo.remove(claim);
+                            }
+                        }
+                        return Long.valueOf(contentRepo.getContainerUsableSpace(ByteArrayContentRepository.CONTAINER_NAME));
+                    }
+                };
+                Future<Long> future = exec.submit(writeAndRemoveToRepo);
+                Long currentSize = future.get();
+            }
+        } finally {
+            exec.shutdown();
+            exec.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testSimpleReadWrite() throws IOException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+        final ContentClaim claim = contentRepo.create(true);
+
+        final int byteCount = 2398473 * 4;
+        final byte[] x = new byte[4];
+        x[0] = 48;
+        x[1] = 29;
+        x[2] = 49;
+        x[3] = 51;
+
+        try (final OutputStream out = contentRepo.write(claim);) {
+            for (int i = 0; i < byteCount / 4; i++) {
+                out.write(x);
+            }
+        }
+
+        final InputStream in = contentRepo.read(claim);
+        for (int i = 0; i < byteCount; i++) {
+            final int val = in.read();
+            final int index = i % 4;
+            final byte expectedVal = x[index];
+            assertEquals(expectedVal, val);
+        }
+
+        assertEquals(-1, in.read());
+    }
+
+    @Test
+    public void testReadWriteWithOffset() throws IOException {
+        System.setProperty(NiFiProperties.PROPERTIES_FILE_PATH, TestByteArrayContentRepository.class.getResource("/conf/nifi.properties").getFile());
+        final Map<String, String> addProps = new HashMap<>();
+        addProps.put(ByteArrayContentRepository.MAX_SIZE_PROPERTY, "11 MB");
+        final NiFiProperties nifiProps = NiFiProperties.createBasicNiFiProperties(null, addProps);
+        final ByteArrayContentRepository contentRepo = new ByteArrayContentRepository(nifiProps);
+        final TestContentRepositoryContext contextRepo = new TestContentRepositoryContext(claimManager, EventReporter.NO_OP);
+
+        contentRepo.initialize(contextRepo);
+        final ContentClaim claim = contentRepo.create(true);
+
+        final String string_1 = "[{\"test\": \"ouais\"}]";
+        final String string_2 = "[{\"test\": \"non\"}]";
+
+        final byte[] bytes_1 = string_1.getBytes(Charset.forName("UTF-8"));
+        final byte[] bytes_2 = string_2.getBytes(Charset.forName("UTF-8"));
+
+        try (final OutputStream out = contentRepo.write(claim);) {
+            out.write(bytes_1);
+            out.write(bytes_2);
+        }
+
+        assertEquals(contentRepo.size(claim), bytes_1.length + bytes_2.length);
+
+        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream();) {
+            final long length_1 = contentRepo.exportTo(claim, bout, 0L, bytes_1.length);
+            assertEquals(length_1, bytes_1.length);
+            assertEquals(bout.toString(Charset.forName("UTF-8")), string_1);
+        }
+
+        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream();) {
+            final long length_2 = contentRepo.exportTo(claim, bout, bytes_1.length, bytes_2.length);
+            assertEquals(length_2, bytes_2.length);
+            assertEquals(bout.toString(Charset.forName("UTF-8")), string_2);
+        }
+
+        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream();) {
+            final long length_3 = contentRepo.exportTo(claim, bout);
+            assertEquals(length_3, bytes_1.length + bytes_2.length);
+            assertEquals(bout.toString(Charset.forName("UTF-8")), string_1 + string_2);
+        }
+    }
+
+    public class TestContentRepositoryContext implements ContentRepositoryContext {
+
+        private final ResourceClaimManager resourceClaimManager;
+        private final EventReporter eventReporter;
+    
+        public TestContentRepositoryContext(ResourceClaimManager resourceClaimManager, EventReporter eventReporter) {
+            this.resourceClaimManager = resourceClaimManager;
+            this.eventReporter = eventReporter;
+        }
+    
+        @Override
+        public ResourceClaimManager getResourceClaimManager() {
+            return resourceClaimManager;
+        }
+    
+        @Override
+        public EventReporter getEventReporter() {
+            return eventReporter;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaimWriteCache.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaimWriteCache.java
@@ -84,14 +84,7 @@ public class StandardContentClaimWriteCache implements ContentClaimWriteCache {
             out = registerStream(claim);
         }
 
-        if (!(claim instanceof StandardContentClaim)) {
-            // we know that we will only create Content Claims that are of type StandardContentClaim, so if we get anything
-            // else, just throw an Exception because it is not valid for this Repository
-            throw new IllegalArgumentException("Cannot write to " + claim + " because that Content Claim does belong to this Claim Cache");
-        }
-
-        final StandardContentClaim scc = (StandardContentClaim) claim;
-        final long initialLength = Math.max(0L, scc.getLength());
+        final long initialLength = Math.max(0L, claim.getLength());
 
         final OutputStream bcos = out;
         return new OutputStream() {
@@ -101,14 +94,14 @@ public class StandardContentClaimWriteCache implements ContentClaimWriteCache {
             public void write(final int b) throws IOException {
                 bcos.write(b);
                 bytesWritten++;
-                scc.setLength(initialLength + bytesWritten);
+                claim.setLength(initialLength + bytesWritten);
             }
 
             @Override
             public void write(byte[] b, int off, int len) throws IOException {
                 bcos.write(b, off, len);
                 bytesWritten += len;
-                scc.setLength(initialLength + bytesWritten);
+                claim.setLength(initialLength + bytesWritten);
             }
 
             @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-repository-models/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaim.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-repository-models/src/main/java/org/apache/nifi/controller/repository/claim/StandardContentClaim.java
@@ -25,7 +25,7 @@ package org.apache.nifi.controller.repository.claim;
  * Must be thread safe</p>
  *
  */
-public final class StandardContentClaim implements ContentClaim, Comparable<ContentClaim> {
+public final class StandardContentClaim implements ContentClaim {
 
     private final ResourceClaim resourceClaim;
     private final long offset;
@@ -37,6 +37,7 @@ public final class StandardContentClaim implements ContentClaim, Comparable<Cont
         this.length = -1L;
     }
 
+    @Override
     public void setLength(final long length) {
         this.length = length;
     }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessDataflowFactory.java
@@ -19,6 +19,7 @@ package org.apache.nifi.stateless.flow;
 
 import org.apache.nifi.components.state.StatelessStateManagerProvider;
 import org.apache.nifi.controller.kerberos.KerberosConfig;
+import org.apache.nifi.controller.repository.ByteArrayContentRepository;
 import org.apache.nifi.controller.repository.ContentRepository;
 import org.apache.nifi.controller.repository.ContentRepositoryContext;
 import org.apache.nifi.controller.repository.CounterRepository;
@@ -69,7 +70,6 @@ import org.apache.nifi.stateless.engine.StatelessEngineInitializationContext;
 import org.apache.nifi.stateless.engine.StatelessFlowManager;
 import org.apache.nifi.stateless.engine.StatelessProcessContextFactory;
 import org.apache.nifi.stateless.engine.StatelessProvenanceAuthorizableFactory;
-import org.apache.nifi.stateless.repository.ByteArrayContentRepository;
 import org.apache.nifi.stateless.repository.RepositoryContextFactory;
 import org.apache.nifi.stateless.repository.StatelessFileSystemContentRepository;
 import org.apache.nifi.stateless.repository.StatelessFlowFileRepository;


### PR DESCRIPTION
Improved ByteArrayContentRepository for nifi-framework-components, to be used in the classical nifi engine and the stateless engine

- added implementation of the ByteArrayContentRepository with an optional max size
- changed the interface ContentClaim for ContentClaims to implement if needed a setLength method used in the StandardContentClaimWriteCache
- added tests inspired from the previous VolatileContentRepository and new use cases
- added ByteArrayContentRepository to the administration guide

Signed-off-by: mathemare <mathemare@hotmail.fr>

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10236](https://issues.apache.org/jira/browse/NIFI-10236)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
