### PR TITLE
NIFI-10468 Upgrade Netty from 4.1.79 to 4.1.81

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <logback.version>1.2.11</logback.version>
         <mockito.version>3.11.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
-        <netty.4.version>4.1.79.Final</netty.4.version>
+        <netty.4.version>4.1.81.Final</netty.4.version>
         <spring.version>5.3.22</spring.version>
         <spring.security.version>5.7.3</spring.security.version>
         <swagger.annotations.version>1.6.6</swagger.annotations.version>


### PR DESCRIPTION
# Summary

[NIFI-10468](https://issues.apache.org/jira/browse/NIFI-10468) Upgrades Netty from 4.1.79 to 4.1.81, incorporating several bug fixes and improvements related to TLS and buffer allocation.

- [4.1.80](https://netty.io/news/2022/08/26/4-1-80-Final.html)
- [4.1.81](https://netty.io/news/2022/09/08/4-1-81-Final.html)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
