### PR TITLE
NIFI-10484 Upgrade Dependency Check Plugin from 7.1.1 to 7.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1127,7 +1127,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.1.1</version>
+                        <version>7.1.2</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>
@@ -1139,6 +1139,8 @@
                                     <suppressionFiles>nifi-dependency-check-maven/suppressions.xml</suppressionFiles>
                                     <!-- Skip System Scope to avoid dependency resolution errors with jdk.tools on Java 8 -->
                                     <skipSystemScope>true</skipSystemScope>
+                                    <!-- Disable .NET Assembly Analyzer to avoid non-applicable errors -->
+                                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
# Summary

[NIFI-10484](https://issues.apache.org/jira/browse/NIFI-10484) Upgrades the OWASP Dependency Check Plugin from 7.1.1 to 7.1.2 to include updated suppression of false positive reports. Additional changes include disabling the unused .NET Assembly Analyzer.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
