### PR TITLE
NIFI-9751: Commenting out ClusteredVerifiableParameterProviderSystemI…

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/verification/ClusteredVerifiableParameterProviderSystemIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/verification/ClusteredVerifiableParameterProviderSystemIT.java
@@ -57,6 +57,6 @@ public class ClusteredVerifiableParameterProviderSystemIT extends VerifiablePara
         // Second verification result will be verification results
         assertEquals(Outcome.SUCCESSFUL.name(), resultList.get(1).getOutcome());
         // Third verification result is for Fail On Primary Node
-        assertEquals(Outcome.FAILED.name(), resultList.get(2).getOutcome());
+        //assertEquals(Outcome.FAILED.name(), resultList.get(2).getOutcome());   // NIFI-9717
     }
 }


### PR DESCRIPTION
…T assertion until NIFI-9717 can be implemented

In staying consistent with the other similar ITs affected by NIFI-9717, I am commenting out the similar line in ClusteredVerifiableParameterProviderSystemIT

# Summary

[NIFI-9751](https://issues.apache.org/jira/browse/NIFI-9751)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
