### PR TITLE
NIFI-10373 Set managed version for AWS SDK 1 and 2

### DIFF
--- a/minifi/minifi-c2/minifi-c2-cache/minifi-c2-cache-s3/pom.xml
+++ b/minifi/minifi-c2/minifi-c2-cache/minifi-c2-cache-s3/pom.xml
@@ -34,7 +34,6 @@ limitations under the License.
         <dependency>
              <groupId>com.amazonaws</groupId>
              <artifactId>aws-java-sdk-s3</artifactId>
-             <version>${aws.sdk.version}</version>
              <exclusions>
                  <exclusion>
                      <groupId>commons-logging</groupId>

--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -41,7 +41,6 @@ limitations under the License.
     </modules>
     <properties>
         <system.rules.version>1.19.0</system.rules.version>
-        <aws.sdk.version>1.12.267</aws.sdk.version>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
     </properties>
 

--- a/nifi-commons/nifi-property-protection-aws/pom.xml
+++ b/nifi-commons/nifi-property-protection-aws/pom.xml
@@ -21,9 +21,6 @@
         <version>1.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-property-protection-aws</artifactId>
-    <properties>
-        <aws.sdk.version>2.17.106</aws.sdk.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -46,12 +43,10 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
-            <version>${aws.sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kms</artifactId>
-            <version>${aws.sdk.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>
@@ -66,7 +61,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>secretsmanager</artifactId>
-            <version>${aws.sdk.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>

--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -199,4 +199,9 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
         <cve>CVE-2021-43045</cve>
     </suppress>
+    <suppress>
+        <notes>CVE-2022-31159 applies to AWS S3 library not the SWF libraries</notes>
+        <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-swf\-libraries@.*$</packageUrl>
+        <cve>CVE-2022-31159</cve>
+    </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/pom.xml
@@ -26,34 +26,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- keep AWS 1.x until NIFI-8287 -->
-        <aws-java-sdk-version>1.12.267</aws-java-sdk-version>
         <!-- keep KCL 1.x until NIFI-8531 (blocked by NIFI-8287) -->
         <aws-kinesis-client-library-version>1.14.8</aws-kinesis-client-library-version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${aws-java-sdk-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-core</artifactId>
-                <version>${aws-java-sdk-version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <modules>
         <module>nifi-aws-processors</module>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-aws/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-aws/pom.xml
@@ -28,20 +28,4 @@
         <module>nifi-registry-aws-assembly</module>
         <module>nifi-registry-aws-extensions</module>
     </modules>
-
-    <properties>
-        <aws-java-sdk-version>2.5.9</aws-java-sdk-version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>${aws-java-sdk-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
+        <com.amazonaws.version>1.12.299</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.17.270</software.amazon.awssdk.version>
         <gson.version>2.9.1</gson.version>
         <kotlin.version>1.7.10</kotlin.version>
         <okhttp.version>4.10.0</okhttp.version>
@@ -515,6 +517,36 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>${com.amazonaws.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>${com.amazonaws.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bundle</artifactId>
+                <version>${com.amazonaws.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${software.amazon.awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
# Summary

[NIFI-10373](https://issues.apache.org/jira/browse/NIFI-10373) Sets a common managed version of AWS SDK version 1 and 2 in the root Maven configuration. This approach eliminates different versions in sub-projects and modules. Some components still rely on AWS SDK 1, so both SDK versions must be maintained. Additional changes include suppressing a false positive dependency vulnerability for `aws-sdk-swf-libraries`.

- AWS SDK 1 set to version 1.12.299
- AWS SDK 2 set to version 2.17.270

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
