### PR TITLE
NIFI-10488 Fix NullPointerException on updating empty ParameterContext property with NiFi Toolkit

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/SetParam.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/SetParam.java
@@ -33,6 +33,7 @@ import org.apache.nifi.web.api.entity.ParameterEntity;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -88,7 +89,7 @@ public class SetParam extends AbstractUpdateParamContextCommand<VoidResult> {
             throw new IllegalArgumentException("A parameter value is required when creating a new parameter");
         }
 
-        if (existingParam.isPresent() && paramValue.equals(existingParam.get().getValue())) {
+        if (existingParam.isPresent() && Objects.equals(existingParam.get().getValue(), paramValue)) {
             throw new IllegalArgumentException(String.format("Parameter value supplied for parameter [%s] is the same as its current value", paramName));
         }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/SetParam.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/SetParam.java
@@ -88,7 +88,7 @@ public class SetParam extends AbstractUpdateParamContextCommand<VoidResult> {
             throw new IllegalArgumentException("A parameter value is required when creating a new parameter");
         }
 
-        if (existingParam.isPresent() && existingParam.get().getValue().equals(paramValue)) {
+        if (existingParam.isPresent() && paramValue.equals(existingParam.get().getValue())) {
             throw new IllegalArgumentException(String.format("Parameter value supplied for parameter [%s] is the same as its current value", paramName));
         }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10488](https://issues.apache.org/jira/browse/NIFI-10488)

CLI throws an error when we are trying to set an empty property:
```
ERROR: Error executing command 'set-param' : null 
```
Command to test with:
```
./cli.sh nifi set-param -u http://localhost:8080/ -pcid 32d572a1-0183-1000-a811-ab916612b4af -pn emptyParam -pv newvalue
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
