### PR TITLE
NIFI-10517 Update Flyway-Core to 8.5.13

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <jax.rs.api.version>2.1</jax.rs.api.version>
         <spring.boot.version>2.7.2</spring.boot.version>
-        <flyway.version>8.4.2</flyway.version>
+        <flyway.version>8.5.13</flyway.version>
         <flyway.tests.version>7.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <groovy.eclipse.compiler.version>3.4.0-01</groovy.eclipse.compiler.version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10517](https://issues.apache.org/jira/browse/NIFI-10517) The reasoning: Update Flyway-Core to 8.5.13 from 8.4.2 to remediate the following CVEs: [CVE-2022-26520 ](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26520)and [CVE-2022-21724](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21724)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10517) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
