### PR TITLE
NiFi-10533: Update org.apache.commons.commons-configuration2 to 2.8.0 For NiFi Ranger

### DIFF
--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.1.1</version>
+            <version>2.8.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10533](https://issues.apache.org/jira/browse/NIFI-10533)
Update org.apache.commons.commons-configuration2 to 2.8.0 For NiFi Ranger from version 2.1.1. The move to version 2.8.0 remediates the following CVEs:

[CVE-2022-23437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23437)

[CVE-2022-23302](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23302)

[CVE-2022-22971{}](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22971)

[CVE-2022-22968{}](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22968)

[CVE-2022-22950{}](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22950)

[CVE-2020-15250{}](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

[CVE-2019-17571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17571)

[CVE-2018-8088](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088)

[CVE-2018-1275](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1275)

[CVE-2018-1271](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1271)

[CVE-2018-1257](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1257)

[CVE-2016-5007](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5007)

[CVE-2012-0881](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-0881)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10533) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
