### PR TITLE
NIFI-10513: Added capture non-record fields to JsonTreeRowRecordReader

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -129,13 +129,13 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
             if (strategy == StartingFieldStrategy.NESTED_FIELD) {
                 while (jsonParser.nextToken() != null) {
                     if (nestedFieldName.equals(jsonParser.getCurrentName())) {
+                        logger.debug("Parsing starting at nested field [{}]", nestedFieldName);
                         break;
                     }
                     if (captureFieldPredicate != null) {
                         captureCurrentField(captureFieldPredicate);
                     }
                 }
-                logger.debug("Parsing starting at nested field [{}]", nestedFieldName);
             }
 
             JsonToken token = jsonParser.nextToken();

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -51,7 +51,6 @@ import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 public abstract class AbstractJsonRowRecordReader implements RecordReader {
-    private static final String ARRAY_OR_OBJECT_TYPE = "array or object type field";
 
     private final ComponentLog logger;
     private final Supplier<DateFormat> LAZY_DATE_FORMAT;

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
@@ -61,10 +61,10 @@ public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,
                                    final String dateFormat, final String timeFormat, final String timestampFormat,
                                    final StartingFieldStrategy startingFieldStrategy, final String startingFieldName,
-                                   final SchemaApplicationStrategy schemaApplicationStrategy, final BiPredicate<String, String> capturePredicate)
+                                   final SchemaApplicationStrategy schemaApplicationStrategy, final BiPredicate<String, String> captureFieldsPredicate)
             throws IOException, MalformedRecordException {
 
-        super(in, logger, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, capturePredicate);
+        super(in, logger, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, captureFieldsPredicate);
         if (startingFieldStrategy == StartingFieldStrategy.NESTED_FIELD && schemaApplicationStrategy == SchemaApplicationStrategy.WHOLE_JSON) {
             this.schema = getSelectedSchema(schema, startingFieldName);
         } else {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
@@ -37,31 +37,34 @@ import org.apache.nifi.serialization.record.util.DataTypeUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
+
+    static final BiPredicate<String, String> FALSE_BI_PREDICATE = (s1, s2) -> false;
 
     private final RecordSchema schema;
 
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,
                                    final String dateFormat, final String timeFormat, final String timestampFormat) throws IOException, MalformedRecordException {
-        this(in, logger, schema, dateFormat, timeFormat, timestampFormat, null, null, null);
+        this(in, logger, schema, dateFormat, timeFormat, timestampFormat, null, null, null, FALSE_BI_PREDICATE);
     }
 
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,
                                    final String dateFormat, final String timeFormat, final String timestampFormat,
                                    final StartingFieldStrategy startingFieldStrategy, final String startingFieldName,
-                                   final SchemaApplicationStrategy schemaApplicationStrategy)
+                                   final SchemaApplicationStrategy schemaApplicationStrategy, final BiPredicate<String, String> capturePredicate)
             throws IOException, MalformedRecordException {
 
-        super(in, logger, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName);
+        super(in, logger, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, capturePredicate);
         if (startingFieldStrategy == StartingFieldStrategy.NESTED_FIELD && schemaApplicationStrategy == SchemaApplicationStrategy.WHOLE_JSON) {
             this.schema = getSelectedSchema(schema, startingFieldName);
         } else {
@@ -79,7 +82,7 @@ public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
                 return getChildSchemaFromField(optionalRecordField.get());
             } else {
                 for (RecordField field : currentSchema.getFields()) {
-                    if (field.getDataType() instanceof  ArrayDataType || field.getDataType() instanceof RecordDataType) {
+                    if (field.getDataType() instanceof ArrayDataType || field.getDataType() instanceof RecordDataType) {
                         schemas.add(getChildSchemaFromField(field));
                     }
                 }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonTreeRowRecordReader.java
@@ -49,22 +49,20 @@ import java.util.function.Supplier;
 
 public class JsonTreeRowRecordReader extends AbstractJsonRowRecordReader {
 
-    static final BiPredicate<String, String> FALSE_BI_PREDICATE = (s1, s2) -> false;
-
     private final RecordSchema schema;
 
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,
                                    final String dateFormat, final String timeFormat, final String timestampFormat) throws IOException, MalformedRecordException {
-        this(in, logger, schema, dateFormat, timeFormat, timestampFormat, null, null, null, FALSE_BI_PREDICATE);
+        this(in, logger, schema, dateFormat, timeFormat, timestampFormat, null, null, null, null);
     }
 
     public JsonTreeRowRecordReader(final InputStream in, final ComponentLog logger, final RecordSchema schema,
                                    final String dateFormat, final String timeFormat, final String timestampFormat,
                                    final StartingFieldStrategy startingFieldStrategy, final String startingFieldName,
-                                   final SchemaApplicationStrategy schemaApplicationStrategy, final BiPredicate<String, String> captureFieldsPredicate)
+                                   final SchemaApplicationStrategy schemaApplicationStrategy, final BiPredicate<String, String> captureFieldPredicate)
             throws IOException, MalformedRecordException {
 
-        super(in, logger, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, captureFieldsPredicate);
+        super(in, logger, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, captureFieldPredicate);
         if (startingFieldStrategy == StartingFieldStrategy.NESTED_FIELD && schemaApplicationStrategy == SchemaApplicationStrategy.WHOLE_JSON) {
             this.schema = getSelectedSchema(schema, startingFieldName);
         } else {

--- a/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
+++ b/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
@@ -75,6 +75,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 
 @PrimaryNodeOnly
 @TriggerSerially
@@ -220,6 +222,8 @@ public class QuerySalesforceObject extends AbstractProcessor {
     private static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final String TIME_FORMAT = "HH:mm:ss.SSSX";
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ";
+    private static final String CURSOR_URL = "nextRecordsUrl";
+    private static final BiPredicate<String, String> CAPTURE_PREDICATE = (fieldName, fieldValue) -> CURSOR_URL.equals(fieldName);
 
     private volatile SalesforceToRecordSchemaConverter salesForceToRecordSchemaConverter;
     private volatile SalesforceRestService salesforceRestService;
@@ -330,6 +334,10 @@ public class QuerySalesforceObject extends AbstractProcessor {
                 ageFilterUpper
         );
 
+        AtomicReference<String> nextRecordsUrl = new AtomicReference<>();
+
+        do {
+
         FlowFile flowFile = session.create();
 
         Map<String, String> originalAttributes = flowFile.getAttributes();
@@ -337,69 +345,85 @@ public class QuerySalesforceObject extends AbstractProcessor {
 
         AtomicInteger recordCountHolder = new AtomicInteger();
 
-        flowFile = session.write(flowFile, out -> {
-            try (
-                    InputStream querySObjectResultInputStream = salesforceRestService.query(querySObject);
-                    JsonTreeRowRecordReader jsonReader = new JsonTreeRowRecordReader(
-                            querySObjectResultInputStream,
-                            getLogger(),
-                            convertedSalesforceSchema.recordSchema,
-                            DATE_FORMAT,
-                            TIME_FORMAT,
-                            DATE_TIME_FORMAT,
-                            StartingFieldStrategy.NESTED_FIELD,
-                            STARTING_FIELD_NAME,
-                            SchemaApplicationStrategy.SELECTED_PART
-                    );
 
-                    RecordSetWriter writer = writerFactory.createWriter(
-                            getLogger(),
-                            writerFactory.getSchema(
-                                    originalAttributes,
-                                    convertedSalesforceSchema.recordSchema
-                            ),
-                            out,
-                            originalAttributes
-                    )
-            ) {
-                writer.beginRecordSet();
 
-                Record querySObjectRecord;
-                while ((querySObjectRecord = jsonReader.nextRecord()) != null) {
-                    writer.write(querySObjectRecord);
+            flowFile = session.write(flowFile, out -> {
+                try (
+                        InputStream querySObjectResultInputStream = getResultInputStream(nextRecordsUrl, querySObject);
+
+                        JsonTreeRowRecordReader jsonReader = new JsonTreeRowRecordReader(
+                                querySObjectResultInputStream,
+                                getLogger(),
+                                convertedSalesforceSchema.recordSchema,
+                                DATE_FORMAT,
+                                TIME_FORMAT,
+                                DATE_TIME_FORMAT,
+                                StartingFieldStrategy.NESTED_FIELD,
+                                STARTING_FIELD_NAME,
+                                SchemaApplicationStrategy.SELECTED_PART,
+                                CAPTURE_PREDICATE
+                        );
+
+                        RecordSetWriter writer = writerFactory.createWriter(
+                                getLogger(),
+                                writerFactory.getSchema(
+                                        originalAttributes,
+                                        convertedSalesforceSchema.recordSchema
+                                ),
+                                out,
+                                originalAttributes
+                        )
+                ) {
+                    writer.beginRecordSet();
+
+                    Record querySObjectRecord;
+                    while ((querySObjectRecord = jsonReader.nextRecord()) != null) {
+                        writer.write(querySObjectRecord);
+                    }
+
+                    WriteResult writeResult = writer.finishRecordSet();
+
+                    Map<String, String> storedFields = jsonReader.getCapturedFields();
+
+                    nextRecordsUrl.set(storedFields.getOrDefault(CURSOR_URL, null));
+
+                    attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
+                    attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
+                    attributes.putAll(writeResult.getAttributes());
+
+                    recordCountHolder.set(writeResult.getRecordCount());
+
+                    if (ageFilterUpper != null) {
+                        Map<String, String> newState = new HashMap<>(state.toMap());
+                        newState.put(LAST_AGE_FILTER, ageFilterUpper);
+                        updateState(context, newState);
+                    }
+                } catch (SchemaNotFoundException e) {
+                    throw new ProcessException("Couldn't create record writer", e);
+                } catch (MalformedRecordException e) {
+                    throw new ProcessException("Couldn't read records from input", e);
                 }
+            });
 
-                WriteResult writeResult = writer.finishRecordSet();
+            int recordCount = recordCountHolder.get();
 
-                attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
-                attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
-                attributes.putAll(writeResult.getAttributes());
+            if (!createZeroRecordFlowFiles && recordCount == 0) {
+                session.remove(flowFile);
+            } else {
+                flowFile = session.putAllAttributes(flowFile, attributes);
+                session.transfer(flowFile, REL_SUCCESS);
 
-                recordCountHolder.set(writeResult.getRecordCount());
-
-                if (ageFilterUpper != null) {
-                    Map<String, String> newState = new HashMap<>(state.toMap());
-                    newState.put(LAST_AGE_FILTER, ageFilterUpper);
-                    updateState(context, newState);
-                }
-            } catch (SchemaNotFoundException e) {
-                throw new ProcessException("Couldn't create record writer", e);
-            } catch (MalformedRecordException e) {
-                throw new ProcessException("Couldn't read records from input", e);
+                session.adjustCounter("Records Processed", recordCount, false);
+                getLogger().info("Successfully written {} records for {}", recordCount, flowFile);
             }
-        });
+        } while (nextRecordsUrl.get() != null);
+    }
 
-        int recordCount = recordCountHolder.get();
-
-        if (!createZeroRecordFlowFiles && recordCount == 0) {
-            session.remove(flowFile);
-        } else {
-            flowFile = session.putAllAttributes(flowFile, attributes);
-            session.transfer(flowFile, REL_SUCCESS);
-
-            session.adjustCounter("Records Processed", recordCount, false);
-            getLogger().info("Successfully written {} records for {}", recordCount, flowFile);
+    private InputStream getResultInputStream(AtomicReference<String> nextRecordsUrl, String querySObject) {
+        if (nextRecordsUrl.get() == null) {
+            return salesforceRestService.query(querySObject);
         }
+        return salesforceRestService.queryNextRecords(nextRecordsUrl.get());
     }
 
     private ConvertedSalesforceSchema getConvertedSalesforceSchema(String sObject, String fields) {

--- a/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/util/SalesforceRestService.java
+++ b/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/util/SalesforceRestService.java
@@ -69,6 +69,21 @@ public class SalesforceRestService {
         return request(request);
     }
 
+    public InputStream queryNextRecords(String uri) {
+        String url = baseUrl + uri;
+
+        HttpUrl httpUrl = HttpUrl.get(url).newBuilder()
+                .build();
+
+        Request request = new Request.Builder()
+                .addHeader("Authorization", "Bearer " + accessTokenProvider.get())
+                .url(httpUrl)
+                .get()
+                .build();
+
+        return request(request);
+    }
+
     private InputStream request(Request request) {
         Response response = null;
         try {

--- a/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/util/SalesforceRestService.java
+++ b/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/util/SalesforceRestService.java
@@ -69,8 +69,8 @@ public class SalesforceRestService {
         return request(request);
     }
 
-    public InputStream queryNextRecords(String uri) {
-        String url = baseUrl + uri;
+    public InputStream getNextRecords(String nextRecordsUrl) {
+        String url = baseUrl + nextRecordsUrl;
 
         HttpUrl httpUrl = HttpUrl.get(url).newBuilder()
                 .build();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
@@ -76,7 +76,6 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
     private volatile StartingFieldStrategy startingFieldStrategy;
     private volatile SchemaApplicationStrategy schemaApplicationStrategy;
 
-
     public static final PropertyDescriptor STARTING_FIELD_STRATEGY = new PropertyDescriptor.Builder()
             .name("starting-field-strategy")
             .displayName("Starting Field Strategy")
@@ -165,6 +164,7 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
     public RecordReader createRecordReader(final Map<String, String> variables, final InputStream in, final long inputLength, final ComponentLog logger)
             throws IOException, MalformedRecordException, SchemaNotFoundException {
         final RecordSchema schema = getSchema(variables, in, null);
-        return new JsonTreeRowRecordReader(in, logger, schema, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, schemaApplicationStrategy);
+        return new JsonTreeRowRecordReader(in, logger, schema, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName,
+                schemaApplicationStrategy, null);
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -1067,7 +1067,7 @@ class TestJsonTreeRowRecordReader {
                 }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accounts", null);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accounts");
     }
 
     @Test
@@ -1086,7 +1086,7 @@ class TestJsonTreeRowRecordReader {
                 }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "account", null);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "account");
     }
 
     @Test
@@ -1109,14 +1109,14 @@ class TestJsonTreeRowRecordReader {
                     }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accountIds", null);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accountIds");
     }
 
     @Test
     void testStartFromSimpleFieldReturnsEmptyJson() throws IOException, MalformedRecordException {
         String jsonPath = "src/test/resources/json/single-element-nested.json";
 
-        testReadRecords(jsonPath, Collections.emptyList(), StartingFieldStrategy.NESTED_FIELD, "name", null);
+        testReadRecords(jsonPath, Collections.emptyList(), StartingFieldStrategy.NESTED_FIELD, "name");
     }
 
     @Test
@@ -1127,7 +1127,7 @@ class TestJsonTreeRowRecordReader {
         List<Object> expected = Collections.emptyList();
 
         testReadRecords(jsonPath, expectedRecordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "notfound", SchemaApplicationStrategy.SELECTED_PART, null);
+                "notfound", SchemaApplicationStrategy.SELECTED_PART);
     }
 
     @Test
@@ -1151,7 +1151,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, expectedRecordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "accounts", SchemaApplicationStrategy.SELECTED_PART, null);
+                "accounts", SchemaApplicationStrategy.SELECTED_PART);
     }
 
     @Test
@@ -1177,7 +1177,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "account", SchemaApplicationStrategy.WHOLE_JSON, null);
+                "account", SchemaApplicationStrategy.WHOLE_JSON);
     }
 
     @Test
@@ -1207,7 +1207,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "accounts", SchemaApplicationStrategy.WHOLE_JSON, null);
+                "accounts", SchemaApplicationStrategy.WHOLE_JSON);
     }
 
     @Test
@@ -1244,7 +1244,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "nestedLevel2Record", SchemaApplicationStrategy.WHOLE_JSON, null);
+                "nestedLevel2Record", SchemaApplicationStrategy.WHOLE_JSON);
     }
 
     @Test
@@ -1308,14 +1308,13 @@ class TestJsonTreeRowRecordReader {
     private void testReadRecords(String jsonPath,
                                  List<Object> expected,
                                  StartingFieldStrategy strategy,
-                                 String startingFieldName,
-                                 BiPredicate<String, String> capturePredicate)
+                                 String startingFieldName)
             throws IOException, MalformedRecordException {
 
         final File jsonFile = new File(jsonPath);
         try (InputStream jsonStream = new ByteArrayInputStream(FileUtils.readFileToByteArray(jsonFile))) {
             RecordSchema schema = inferSchema(jsonStream, strategy, startingFieldName);
-            testReadRecords(jsonStream, schema, expected, strategy, startingFieldName, SchemaApplicationStrategy.SELECTED_PART, capturePredicate);
+            testReadRecords(jsonStream, schema, expected, strategy, startingFieldName, SchemaApplicationStrategy.SELECTED_PART);
         }
     }
 
@@ -1331,13 +1330,12 @@ class TestJsonTreeRowRecordReader {
                                  List<Object> expected,
                                  StartingFieldStrategy strategy,
                                  String startingFieldName,
-                                 SchemaApplicationStrategy schemaApplicationStrategy,
-                                 BiPredicate<String, String> capturePredicate
+                                 SchemaApplicationStrategy schemaApplicationStrategy
     ) throws IOException, MalformedRecordException {
 
         final File jsonFile = new File(jsonPath);
         try (InputStream jsonStream = new ByteArrayInputStream(FileUtils.readFileToByteArray(jsonFile))) {
-            testReadRecords(jsonStream, schema, expected, strategy, startingFieldName, schemaApplicationStrategy, capturePredicate);
+            testReadRecords(jsonStream, schema, expected, strategy, startingFieldName, schemaApplicationStrategy);
         }
     }
 
@@ -1373,12 +1371,11 @@ class TestJsonTreeRowRecordReader {
                                  List<Object> expected,
                                  StartingFieldStrategy strategy,
                                  String startingFieldName,
-                                 SchemaApplicationStrategy schemaApplicationStrategy,
-                                 BiPredicate<String, String> capturePredicate)
+                                 SchemaApplicationStrategy schemaApplicationStrategy)
             throws IOException, MalformedRecordException {
 
         try (JsonTreeRowRecordReader reader = new JsonTreeRowRecordReader(jsonStream, mock(ComponentLog.class), schema, dateFormat, timeFormat, timestampFormat,
-                strategy, startingFieldName, schemaApplicationStrategy, capturePredicate)) {
+                strategy, startingFieldName, schemaApplicationStrategy, null)) {
             List<Object> actual = new ArrayList<>();
             Record record;
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -1262,6 +1262,7 @@ class TestJsonTreeRowRecordReader {
         expectedCapturedFields.put("id", "1");
         expectedCapturedFields.put("zipCode", "11111");
         expectedCapturedFields.put("country", "USA");
+        expectedCapturedFields.put("job", null);
         Set<String> fieldsToCapture = expectedCapturedFields.keySet();
         BiPredicate<String, String> capturePredicate = (fieldName, fieldValue) -> fieldsToCapture.contains(fieldName);
         String startingFieldName = "accounts";
@@ -1272,18 +1273,24 @@ class TestJsonTreeRowRecordReader {
                 new RecordField("balance", RecordFieldType.DOUBLE.getDataType())
         ));
 
+        SimpleRecordSchema jobRecordSchema = new SimpleRecordSchema(Arrays.asList(
+                new RecordField("salary", RecordFieldType.INT.getDataType()),
+                new RecordField("position", RecordFieldType.STRING.getDataType())
+        ));
+
         SimpleRecordSchema recordSchema = new SimpleRecordSchema(Arrays.asList(
                 new RecordField("id", RecordFieldType.INT.getDataType()),
                 new RecordField("accounts", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.RECORD.getRecordDataType(accountRecordSchema))),
                 new RecordField("name", RecordFieldType.STRING.getDataType()),
                 new RecordField("address", RecordFieldType.STRING.getDataType()),
                 new RecordField("city", RecordFieldType.STRING.getDataType()),
+                new RecordField("job", RecordFieldType.RECORD.getRecordDataType(jobRecordSchema)),
                 new RecordField("state", RecordFieldType.STRING.getDataType()),
                 new RecordField("zipCode", RecordFieldType.STRING.getDataType()),
                 new RecordField("country", RecordFieldType.STRING.getDataType())
         ));
 
-        try (InputStream in = new FileInputStream("src/test/resources/json/single-element-nested-array-middle.json")) {
+        try (InputStream in = new FileInputStream("src/test/resources/json/capture-fields.json")) {
             JsonTreeRowRecordReader reader = new JsonTreeRowRecordReader(
                     in, mock(ComponentLog.class), recordSchema,
                     dateFormat, timeFormat, timestampFormat,

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -57,7 +57,6 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.nifi.json.JsonTreeRowRecordReader.FALSE_BI_PREDICATE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -95,14 +94,6 @@ class TestJsonTreeRowRecordReader {
         accountFields.add(new RecordField("balance", RecordFieldType.DOUBLE.getDataType()));
 
         return new SimpleRecordSchema(accountFields);
-    }
-
-    private RecordSchema getSchema() {
-        final DataType accountType = RecordFieldType.RECORD.getRecordDataType(getAccountSchema());
-        final List<RecordField> fields = getDefaultFields();
-        fields.add(new RecordField("account", accountType));
-        fields.remove(new RecordField("balance", RecordFieldType.DOUBLE.getDataType()));
-        return new SimpleRecordSchema(fields);
     }
 
     @Test
@@ -1076,7 +1067,7 @@ class TestJsonTreeRowRecordReader {
                 }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accounts", FALSE_BI_PREDICATE);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accounts", null);
     }
 
     @Test
@@ -1095,7 +1086,7 @@ class TestJsonTreeRowRecordReader {
                 }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "account", FALSE_BI_PREDICATE);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "account", null);
     }
 
     @Test
@@ -1118,14 +1109,14 @@ class TestJsonTreeRowRecordReader {
                     }})
         );
 
-        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accountIds", FALSE_BI_PREDICATE);
+        testReadRecords(jsonPath, expected, StartingFieldStrategy.NESTED_FIELD, "accountIds", null);
     }
 
     @Test
     void testStartFromSimpleFieldReturnsEmptyJson() throws IOException, MalformedRecordException {
         String jsonPath = "src/test/resources/json/single-element-nested.json";
 
-        testReadRecords(jsonPath, Collections.emptyList(), StartingFieldStrategy.NESTED_FIELD, "name", FALSE_BI_PREDICATE);
+        testReadRecords(jsonPath, Collections.emptyList(), StartingFieldStrategy.NESTED_FIELD, "name", null);
     }
 
     @Test
@@ -1136,7 +1127,7 @@ class TestJsonTreeRowRecordReader {
         List<Object> expected = Collections.emptyList();
 
         testReadRecords(jsonPath, expectedRecordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "notfound", SchemaApplicationStrategy.SELECTED_PART, FALSE_BI_PREDICATE);
+                "notfound", SchemaApplicationStrategy.SELECTED_PART, null);
     }
 
     @Test
@@ -1160,7 +1151,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, expectedRecordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "accounts", SchemaApplicationStrategy.SELECTED_PART, FALSE_BI_PREDICATE);
+                "accounts", SchemaApplicationStrategy.SELECTED_PART, null);
     }
 
     @Test
@@ -1186,7 +1177,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "account", SchemaApplicationStrategy.WHOLE_JSON, FALSE_BI_PREDICATE);
+                "account", SchemaApplicationStrategy.WHOLE_JSON, null);
     }
 
     @Test
@@ -1216,7 +1207,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "accounts", SchemaApplicationStrategy.WHOLE_JSON, FALSE_BI_PREDICATE);
+                "accounts", SchemaApplicationStrategy.WHOLE_JSON, null);
     }
 
     @Test
@@ -1253,7 +1244,7 @@ class TestJsonTreeRowRecordReader {
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,
-                "nestedLevel2Record", SchemaApplicationStrategy.WHOLE_JSON, FALSE_BI_PREDICATE);
+                "nestedLevel2Record", SchemaApplicationStrategy.WHOLE_JSON, null);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/capture-fields.json
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/capture-fields.json
@@ -1,0 +1,20 @@
+{
+	"id": 1,
+	"accounts": [{
+		"id": 42,
+		"balance": 4750.89
+	}, {
+		"id": 43,
+		"balance": 48212.38
+	}],
+	"name": "John Doe",
+	"address": "123 My Street",
+	"city": "My City",
+	"job" : {
+		"salary": 115431,
+		"position": "acountant"
+	},
+	"state": "MS",
+	"zipCode": "11111",
+	"country": "USA"
+}


### PR DESCRIPTION
…r, added pagination to QuerySalesforceObject

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10513](https://issues.apache.org/jira/browse/NIFI-10513)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10513) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
