### PR TITLE
NIFI-10549: Remove group name wildcard from assembly for nifi-ranger-resources

### DIFF
--- a/nifi-assembly/src/main/assembly/ranger.xml
+++ b/nifi-assembly/src/main/assembly/ranger.xml
@@ -43,7 +43,7 @@
                 <exclude>*:nifi-property-protection-factory</exclude>
                 <exclude>*:nifi-resources</exclude>
                 <exclude>*:nifi-docs</exclude>
-                <exclude>*:org.apache.nifi:nifi-ranger-resources:jar</exclude>
+                <exclude>org.apache.nifi:nifi-ranger-resources:jar</exclude>
 
                 <!-- exclude jaxb/activation/annotation libs from lib, they'll be included in the java11 subdir -->
                 <!-- TODO: remove these once minimum Java version is 11 -->


### PR DESCRIPTION
# Summary

[NIFI-10549](https://issues.apache.org/jira/browse/NIFI-10549)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
