### PR TITLE
NIFI-10558 Update Ranger modules to skip tests on AArch64

### DIFF
--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-plugin/pom.xml
@@ -212,6 +212,18 @@
     </dependencies>
 
     <profiles>
+        <!-- Disable tests on AArch64 which does not have necessary platform-specific libraries -->
+        <profile>
+            <id>disable-ranger-tests</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
         <!-- Includes hadoop-aws for accessing HDFS with an s3a:// filesystem -->
         <profile>
             <id>include-hadoop-aws</id>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -90,6 +90,7 @@
         <module>nifi-cybersecurity-bundle</module>
         <module>nifi-parquet-bundle</module>
         <module>nifi-extension-utils</module>
+        <module>nifi-ranger-bundle</module>
         <module>nifi-redis-bundle</module>
         <module>nifi-metrics-reporting-bundle</module>
         <module>nifi-spark-bundle</module>
@@ -172,39 +173,6 @@
             </activation>
             <modules>
                 <module>nifi-grpc-bundle</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>include-ranger</id>
-            <!-- This profile handles the inclusion of ranger artifacts. Currently, ranger
-            uses JNA libraries that require x86 components, so it is platform dependent. -->
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <modules>
-                <module>nifi-ranger-bundle</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>include-ranger-x86</id>
-            <activation>
-                <os>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-            <modules>
-                <module>nifi-ranger-bundle</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>include-ranger-amd64</id>
-            <activation>
-                <os>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
-            <modules>
-                <module>nifi-ranger-bundle</module>
             </modules>
         </profile>
     </profiles>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
@@ -291,6 +291,18 @@
     </dependencies>
 
     <profiles>
+        <!-- Disable tests on AArch64 which does not have necessary platform-specific libraries -->
+        <profile>
+            <id>disable-ranger-tests</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
         <!-- Includes hadoop-aws for accessing HDFS with an s3a:// filesystem -->
         <profile>
             <id>include-hadoop-aws</id>

--- a/nifi-registry/nifi-registry-extensions/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/pom.xml
@@ -26,39 +26,6 @@
 
     <modules>
         <module>nifi-registry-aws</module>
+        <module>nifi-registry-ranger</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>include-ranger</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <modules>
-                <module>nifi-registry-ranger</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>include-ranger-x86</id>
-            <activation>
-                <os>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-            <modules>
-                <module>nifi-registry-ranger</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>include-ranger-amd64</id>
-            <activation>
-                <os>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
-            <modules>
-                <module>nifi-registry-ranger</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-10558](https://issues.apache.org/jira/browse/NIFI-10558) Updates the Apache Ranger module configuration for NiFi and NiFi Registry to build modules in the standard process but skip tests on AArch64.

This change preserves the ability to build on ARM64, introduced for NIFI-9813 in #6216, but avoids running tests that will not work without platform-specific JNA-based dependencies.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
