### PR TITLE
NIFI-10560 Exclude Elasticsearch and Solr Auto Config from Registry

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/NiFiRegistryApiApplication.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/NiFiRegistryApiApplication.java
@@ -22,7 +22,10 @@ import org.apache.nifi.registry.hook.Event;
 import org.apache.nifi.registry.hook.EventType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
@@ -41,6 +44,12 @@ import java.util.Properties;
  *
  * WebMvcAutoConfiguration is excluded because our web app is using Jersey in place of SpringMVC
  */
+@EnableAutoConfiguration(
+        exclude = {
+                ElasticsearchRestClientAutoConfiguration.class,
+                SolrAutoConfiguration.class
+        }
+)
 @SpringBootApplication
 public class NiFiRegistryApiApplication extends SpringBootServletInitializer {
 


### PR DESCRIPTION
# Summary

[NIFI-10560](https://issues.apache.org/jira/browse/NIFI-10560) Excludes the `ElasticsearchRestClientAutoConfiguration` and `SolrAutoConfiguration` classes from the Spring Boot configuration. These exclusions avoid runtime class reference issues when building and running NiFi Registry with the Apache Ranger plugin.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
