### PR TITLE
NIFI-10563 Add commons-lang3 dependency to nifi-bootstrap

### DIFF
--- a/nifi-assembly/src/main/assembly/ranger.xml
+++ b/nifi-assembly/src/main/assembly/ranger.xml
@@ -64,6 +64,7 @@
                 <include>org.apache.nifi:nifi-ranger-resources:jar</include>
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.slf4j:jcl-over-slf4j</include>
+                <include>org.apache.commons:commons-lang3</include>
             </includes>
         </dependencySet>
         <!-- Write out scripts from nifi-ranger-resources to ext/ranger/scripts -->

--- a/nifi-bootstrap/pom.xml
+++ b/nifi-bootstrap/pom.xml
@@ -91,6 +91,10 @@ language governing permissions and limitations under the License. -->
             <version>1.18.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>


### PR DESCRIPTION
# Summary

[NIFI-10563](https://issues.apache.org/jira/browse/NIFI-10563) Adds a direct dependency on `commons-lang3` to `nifi-bootstrap` based on direct references to `StringUtils` in several classes. Additional changes include updating the Ranger assembly configuration to include `commons-lang3` in the installation libraries directory.

These changes are necessary to avoid runtime class path issues when building with the `include-ranger` profile, which impacts the primary NiFi assembly configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
