### PR TITLE
NIFI-10569 Add Maximum Threads property to HandleHttpRequest

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/HandleHttpRequestTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/HandleHttpRequestTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.http.HttpContextMap;
+import org.apache.nifi.remote.io.socket.NetworkUtils;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HandleHttpRequestTest {
+
+    private static final String CONTEXT_MAP_ID = HttpContextMap.class.getSimpleName();
+
+    private static final String MINIMUM_THREADS = "8";
+
+    @Mock
+    HttpContextMap httpContextMap;
+
+    TestRunner runner;
+
+    @BeforeEach
+    void setRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(HandleHttpRequest.class);
+
+        when(httpContextMap.getIdentifier()).thenReturn(CONTEXT_MAP_ID);
+        runner.addControllerService(CONTEXT_MAP_ID, httpContextMap);
+        runner.enableControllerService(httpContextMap);
+    }
+
+    @AfterEach
+    void shutdown() {
+        runner.shutdown();
+    }
+
+    @Test
+    void testSetRequiredProperties() {
+        runner.setProperty(HandleHttpRequest.HTTP_CONTEXT_MAP, CONTEXT_MAP_ID);
+
+        runner.assertValid();
+    }
+
+    @Test
+    void testRun() {
+        runner.setProperty(HandleHttpRequest.HTTP_CONTEXT_MAP, CONTEXT_MAP_ID);
+        runner.setProperty(HandleHttpRequest.MAXIMUM_THREADS, MINIMUM_THREADS);
+
+        final int port = NetworkUtils.getAvailableTcpPort();
+        runner.setProperty(HandleHttpRequest.PORT, Integer.toString(port));
+
+        runner.run();
+
+        runner.assertTransferCount(HandleHttpRequest.REL_SUCCESS, 0);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-10569](https://issues.apache.org/jira/browse/NIFI-10569) Adds a new `Maximum Threads` property to the `HandleHttpRequest` Processor, enabling configuration of the internal Jetty server thread pool.

The new property follows the pattern of the property added for `ListenHTTP` in [NIFI-8263](https://issues.apache.org/jira/browse/NIFI-8263). The default value is `200`, which aligns with the current internal default that Jetty uses in absence of a specific number. The Jetty Thread Pool sets a minimum of 8 threads, so the allowable range for the value is between 8 and 1000, matching `ListenHTTP`. The introduction of a configured Thread Pool also provides the opportunity to name threads using the Processor name and Processor identifier.

Additional changes include a simple unit test class to set minimum required properties and start the Processor without handling any requests. The integration test method `testCleanup` does not appear to run in reliable way, and more recent integration test methods verify similar capabilities, so changes include removing the `testCleanup` method.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
