### PR TITLE
NIFI-10577 Fix Sensitive Checkbox rendering for Fetch Parameters

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/parameter-provider.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/parameter-provider.css
@@ -325,74 +325,12 @@ span.parameter-provider-referencing-component-name {
     width: 332px;
 }
 
-#selectable-parameters-table .slick-cell-checkboxsel {
-    padding: 1px 2px 5px 4px;
-}
-
-#selectable-parameters-table .slick-cell-checkboxsel.selected {
-    padding: 0px 2px 6px 4px;
-}
-
 #selectable-parameters-table .slick-column-name input {
     margin: 5px 3px 3px 4px;
 }
 
 #selectable-parameters-table .slick-pane-left .slick-viewport {
     overflow-x: hidden;
-}
-
-#selectable-parameters-table input[type="checkbox"] {
-    margin-top: 2px;
-    width: 0;
-}
-
-#selectable-parameters-table input[type="checkbox"]:focus {
-    box-shadow: none;
-    border: none;
-}
-
-#selectable-parameters-table .slick-column-name input[type="checkbox"] {
-    margin-top: 5px;
-}
-
-#selectable-parameters-table .slick-column-name input[checked="checked"]:before {
-    margin-top: 2px;
-}
-
-#selectable-parameters-table input[type="checkbox"]:before {
-    content: url(../images/inputCheckbox.png);
-    cursor: pointer;
-    clip-path: polygon(0% -16%, 50% -16%, 50% 104%, 0% 104%);
-    position: absolute;
-    margin-left: 1px;
-    margin-top: 3px;
-}
-
-#selectable-parameters-table input[checked="checked"]:before {
-    content: url(../images/inputCheckbox.png);
-    cursor: pointer;
-    clip-path: polygon(50% -16%, 100% -16%, 100% 116%, 50% 116%);
-    margin-left: -11px;
-    margin-top: 3px;
-}
-
-#selectable-parameters-table input[type="checkbox"].disabled:before {
-    content: url(../images/inputCheckbox.png);
-    opacity: .5;
-    cursor: not-allowed;
-    clip-path: polygon(0% -16%, 50% -16%, 50% 104%, 0% 104%);
-    position: absolute;
-    margin-left: 1px;
-    margin-top: 3px;
-}
-
-#selectable-parameters-table input[checked="checked"].disabled:before {
-    content: url(../images/inputCheckbox.png);
-    opacity: .5;
-    cursor: not-allowed;
-    clip-path: polygon(50% -16%, 100% -16%, 100% 116%, 50% 116%);
-    margin-left: -11px;
-    margin-top: 3px;
 }
 
 #parameter-groups-table .slick-pane-top .slick-viewport-top .grid-canvas-top,
@@ -406,12 +344,6 @@ span.parameter-provider-referencing-component-name {
 
 #selectable-parameters-table .slick-pane-top .slick-viewport-top .slick-cell.l1:not(.selected) .table-cell {
     margin-top: 5px;
-}
-
-#fetched-parameters-listing .slick-cell-checkboxsel {
-    background: #f0f0f0;
-    border-right-color: silver;
-    border-right-style: solid;
 }
 
 .slick-columnpicker {
@@ -493,4 +425,12 @@ button.selectable-parameters-buttons:hover {
     color: #775351;
     max-width: calc(100% - 230px);
     z-index: 999;
+}
+
+#selectable-parameters-table .slick-cell-checkbox.selected {
+    padding-top: 1px;
+}
+
+.slick-cell-checkbox .nf-checkbox {
+    margin-top: 5px;
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-parameter-provider.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-parameter-provider.js
@@ -2427,23 +2427,23 @@
             if (dataContext) {
                 if (dataContext.status === 'REMOVED' || dataContext.status === 'MISSING_BUT_REFERENCED') {
                     // disable checkboxes
-                    return "<input type='checkbox' class='disabled unchecked-input-disabled' disabled><label for='selector'></label>";
+                    return "<div class='disabled nf-checkbox checkbox-unchecked'></div>";
                 }
 
                 if (_.isEmpty(dataContext.parameterStatus) || _.isEmpty(dataContext.parameterStatus.parameter.parameter.referencingComponents)) {
                     if (dataContext.sensitivity === SENSITIVE) {
-                        return "<input type='checkbox' checked='checked' class='checked-input-enabled'><label for='selector'></label>";
+                        return "<div class='checked-input-enabled nf-checkbox checkbox-checked'></div>";
                     } else {
-                        return "<input type='checkbox' class='unchecked-input-enabled'><label for='selector'></label>";
+                        return "<div class='unchecked-input-enabled nf-checkbox checkbox-unchecked'></div>";
                     }
                 }
 
                 if (!_.isEmpty(dataContext.parameterStatus.parameter.parameter.referencingComponents)) {
                     // disable checkboxes
                     if (dataContext.sensitivity === SENSITIVE) {
-                        return "<input type='checkbox' checked='checked' class='disabled checked-input-disabled' disabled><label for='selector'></label>";
+                        return "<div class='disabled nf-checkbox checkbox-unchecked'></div>";
                     } else {
-                        return "<input type='checkbox' class='disabled unchecked-input-disabled' disabled><label for='selector'></label>";
+                        return "<div class='disabled nf-checkbox checkbox-checked'></div>";
                     }
                 }
 
@@ -2474,7 +2474,7 @@
             width: 30,
             resizable: false,
             sortable: false,
-            cssClass: 'slick-cell-checkboxsel',
+            cssClass: 'slick-cell-checkbox',
             hideSelectAllCheckbox: false,
             formatter: checkboxSelectionFormatter
         }


### PR DESCRIPTION
# Summary

[NIFI-10577](https://issues.apache.org/jira/browse/NIFI-10577) Fixes the Sensitive status checkbox rendering on Firefox in the Fetch Parameters dialog for Parameter Providers.

Changes include replacing the input elements and `:before` pseudo-element selectors with the `nf-checkbox` styling approached used in other components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
