### PR TITLE
NIFI-10578 Fix minifi-c2 unsecure integrations tests

### DIFF
--- a/minifi/minifi-c2/README.md
+++ b/minifi/minifi-c2/README.md
@@ -38,7 +38,7 @@ When using the `CacheConfigurationProvider`, by default, the server will look fo
 
 The pattern can be configured in [./conf/minifi-c2-context.xml](./minifi-c2-assembly/src/main/resources/conf/minifi-c2-context.xml) and the default value (${class}/config) will replace ${class} with the class query parameter and then look for CLASS/config.CONTENT_TYPE.vVERSION in the directory structure.
 
-Ex: http://localhost:10080/c2/config?class=raspi&version=1 with an Accept header that matches text/yml would result in [./files/raspi3/config.text.yml.v1](./minifi-c2-assembly/src/main/resources/files/raspi3/config.text.yml.v1) and omitting the version parameter would look for the highest version number in the directory.
+Ex: http://localhost:10090/c2/config?class=raspi&version=1 with an Accept header that matches text/yml would result in [./files/raspi3/config.text.yml.v1](./minifi-c2-assembly/src/main/resources/files/raspi3/config.text.yml.v1) and omitting the version parameter would look for the highest version number in the directory.
 
 The version resolution is cached in memory to accommodate many devices polling periodically.  The cache duration can be configured with additional arguments in  [./conf/minifi-c2-context.xml](../minifi-integration-tests/src/test/resources/c2/hierarchical/c2-edge2/conf/minifi-c2-context.xml#L55) that call the [overloaded constructor.](./minifi-c2-service/src/main/java/org/apache/nifi/minifi/c2/service/ConfigService.java#L81)
 

--- a/minifi/minifi-c2/minifi-c2-docker/dockerhub/Dockerfile
+++ b/minifi/minifi-c2/minifi-c2-docker/dockerhub/Dockerfile
@@ -48,7 +48,7 @@ RUN chown -R c2:c2 $MINIFI_C2_HOME
 USER c2
 
 #Default http port
-EXPOSE 10080
+EXPOSE 10090
 
 # Startup MiNiFi C2
 CMD $MINIFI_C2_HOME/bin/c2.sh

--- a/minifi/minifi-c2/minifi-c2-docker/dockermaven/Dockerfile
+++ b/minifi/minifi-c2/minifi-c2-docker/dockermaven/Dockerfile
@@ -38,7 +38,7 @@ RUN chown -R c2:c2 $MINIFI_C2_HOME
 USER c2
 
 #Default http port
-EXPOSE 10080
+EXPOSE 10090
 
 # Startup MiNiFi c2
 CMD $MINIFI_C2_HOME/bin/c2.sh run

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestUnsecure.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestUnsecure.java
@@ -36,7 +36,7 @@ public abstract class AbstractTestUnsecure {
     protected String c2Url;
 
     public static String getUnsecureConfigUrl(Container container) {
-        DockerPort dockerPort = container.port(10080);
+        DockerPort dockerPort = container.port(10090);
         return "http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort() + "/c2/config";
     }
 

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/c2-unsecure-delegating/conf/minifi-c2-context.xml
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/c2-unsecure-delegating/conf/minifi-c2-context.xml
@@ -42,7 +42,7 @@
                         </bean>
                     </constructor-arg>
                     <constructor-arg>
-                        <value>http://c2-upstream:10080</value>
+                        <value>http://c2-upstream:10090</value>
                     </constructor-arg>
                 </bean>
             </list>

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/docker-compose-DelegatingProviderUnsecureTest.yml
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/docker-compose-DelegatingProviderUnsecureTest.yml
@@ -19,14 +19,14 @@ services:
   c2-upstream:
     image: apacheminific2:${minifi.c2.version}
     ports:
-      - "10080"
+      - "10090"
     hostname: c2-upstream
     volumes:
       - ./c2/files:/opt/minifi-c2/minifi-c2-${minifi.c2.version}/files
   c2:
     image: apacheminific2:${minifi.c2.version}
     ports:
-      - "10080"
+      - "10090"
     hostname: c2
     volumes:
       - ./c2-unsecure-delegating/conf/minifi-c2-context.xml:/opt/minifi-c2/minifi-c2-${minifi.c2.version}/conf/minifi-c2-context.xml

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/docker-compose-FileSystemProviderUnsecureTest.yml
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/docker-compose-FileSystemProviderUnsecureTest.yml
@@ -19,7 +19,7 @@ services:
   c2:
     image: apacheminific2:${minifi.c2.version}
     ports:
-      - "10080"
+      - "10090"
     hostname: c2
     volumes:
       - ./c2/files:/opt/minifi-c2/minifi-c2-${minifi.c2.version}/files

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/docker-compose-NiFiRestConfigurationProviderUnsecureTest.yml
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/docker-compose-NiFiRestConfigurationProviderUnsecureTest.yml
@@ -19,7 +19,7 @@ services:
   c2:
     image: apacheminific2:${minifi.c2.version}
     ports:
-      - "10080"
+      - "10090"
     hostname: c2
     volumes:
       - ./c2-unsecure-rest/conf/minifi-c2-context.xml:/opt/minifi-c2/minifi-c2-${minifi.c2.version}/conf/minifi-c2-context.xml

--- a/minifi/minifi-c2/minifi-c2-jetty/src/main/java/org/apache/nifi/minifi/c2/jetty/JettyServer.java
+++ b/minifi/minifi-c2/minifi-c2-jetty/src/main/java/org/apache/nifi/minifi/c2/jetty/JettyServer.java
@@ -56,7 +56,7 @@ public class JettyServer {
         }
 
         Server server;
-        int port = Integer.parseInt(properties.getProperty("minifi.c2.server.port", "10080"));
+        int port = Integer.parseInt(properties.getProperty("minifi.c2.server.port", "10090"));
         if (properties.isSecure()) {
             SslContextFactory sslContextFactory = properties.getSslContextFactory();
             HttpConfiguration config = new HttpConfiguration();

--- a/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/c2-edge2/conf/c2.properties
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/c2-edge2/conf/c2.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-minifi.c2.server.port=10080
+minifi.c2.server.port=10090
 
 minifi.c2.server.secure=false
 minifi.c2.server.keystore=./conf/keystore.jks

--- a/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge2/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge2/bootstrap.conf
@@ -53,7 +53,7 @@ nifi.minifi.notifier.ingestors=org.apache.nifi.minifi.bootstrap.configuration.in
 # Hostname on which to pull configurations from
 nifi.minifi.notifier.ingestors.pull.http.hostname=c2-edge2
 # Port on which to pull configurations from
-nifi.minifi.notifier.ingestors.pull.http.port=10080
+nifi.minifi.notifier.ingestors.pull.http.port=10090
 # Path to pull configurations from
 nifi.minifi.notifier.ingestors.pull.http.path=/c2/config
 # Query string to pull configurations with

--- a/minifi/minifi-integration-tests/src/test/resources/docker-compose-c2-hierarchical.yml
+++ b/minifi/minifi-integration-tests/src/test/resources/docker-compose-c2-hierarchical.yml
@@ -66,7 +66,7 @@ services:
       dockerfile: Dockerfile.minific2.test
     image: apacheminific2-test
     ports:
-      - "10080"
+      - "10090"
     hostname: c2-edge2
     volumes:
       - ./c2/hierarchical/c2-edge2/conf/c2.properties:/opt/minifi-c2/minifi-c2-${minifi.c2.version}/conf/c2.properties


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10578](https://issues.apache.org/jira/browse/NIFI-10578)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
