### PR TITLE
NIFI-10584: Only including dependent values in manifest when they are non-null

### DIFF
--- a/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/StandardRuntimeManifestBuilder.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/StandardRuntimeManifestBuilder.java
@@ -426,12 +426,12 @@ public class StandardRuntimeManifestBuilder implements RuntimeManifestBuilder {
             propertyDependency.setPropertyName(dependency.getPropertyName());
             propertyDependency.setPropertyDisplayName(dependency.getPropertyDisplayName());
 
-            final List<String> values = new ArrayList<>();
             final DependentValues dependentValues = dependency.getDependentValues();
             if (dependentValues != null && dependentValues.getValues() != null) {
+                final List<String> values = new ArrayList();
                 values.addAll(dependentValues.getValues());
+                propertyDependency.setDependentValues(values);
             }
-            propertyDependency.setDependentValues(values);
             propertyDependencies.add(propertyDependency);
         }
         return propertyDependencies;


### PR DESCRIPTION
NIFI-10584:
- Only including dependent values in manifest when they are non-null.