### PR TITLE
NIFI-10586 Prioritize ssh-rsa algorithm in SFTP Processors

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHConfigProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHConfigProvider.java
@@ -73,7 +73,6 @@ public class StandardSSHConfigProvider implements SSHConfigProvider {
             config.prioritizeSshRsaKeyAlgorithm();
         }
 
-        config.prioritizeSshRsaKeyAlgorithm();
         return config;
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHConfigProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHConfigProvider.java
@@ -67,6 +67,13 @@ public class StandardSSHConfigProvider implements SSHConfigProvider {
         getOptionalProperty(context, KEY_EXCHANGE_ALGORITHMS_ALLOWED).ifPresent(property -> config.setKeyExchangeFactories(getFilteredValues(property, config.getKeyExchangeFactories())));
         getOptionalProperty(context, MESSAGE_AUTHENTICATION_CODES_ALLOWED).ifPresent(property -> config.setMACFactories(getFilteredValues(property, config.getMACFactories())));
 
+        final String keyAlgorithmsAllowed = context.getProperty(KEY_ALGORITHMS_ALLOWED).evaluateAttributeExpressions().getValue();
+        if (keyAlgorithmsAllowed == null) {
+            // Prioritize ssh-rsa when Key Algorithms Allowed is not specified
+            config.prioritizeSshRsaKeyAlgorithm();
+        }
+
+        config.prioritizeSshRsaKeyAlgorithm();
         return config;
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ssh/StandardSSHConfigProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ssh/StandardSSHConfigProviderTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StandardSSHConfigProviderTest {
-    private static final Config DEFAULT_CONFIG = new DefaultConfig();
+    private static final Config DEFAULT_CONFIG;
 
     private static final String FIRST_ALLOWED_CIPHER = "aes128-ctr";
 
@@ -65,6 +65,12 @@ public class StandardSSHConfigProviderTest {
     private static final int KEEP_ALIVE_DISABLED_INTERVAL = 0;
 
     private static final String IDENTIFIER = UUID.randomUUID().toString();
+
+    static {
+        final DefaultConfig prioritizedConfig = new DefaultConfig();
+        prioritizedConfig.prioritizeSshRsaKeyAlgorithm();
+        DEFAULT_CONFIG = prioritizedConfig;
+    }
 
     @Mock
     private PropertyContext context;


### PR DESCRIPTION
# Summary

[NIFI-10586](https://issues.apache.org/jira/browse/NIFI-10586) Prioritizes the `ssh-rsa` Key Algorithm in SFTP Processors when the `Key Algorithms Allowed` property is not configured.

This approach provides the widest degree of compatibility in the default configuration, following changes in SSHJ 0.33.0. The default SSHJ configuration supports `ssh-rsa` as well as `rsa-sha2-256` and `rsa-sha2-512`, but this change prioritizes the legacy algorithm for better compatibility. SSHJ 0.33.0 also supports trying all configured RSA algorithms, which allows SSHJ to communicate with servers that have disabled the `ssh-rsa` algorithm.
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
