### PR TITLE
NIFI-10592-Fix flaky tests caused by the nondeterministic order of HashMap

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/test/java/org/apache/nifi/reporting/azure/loganalytics/TestAzureLogAnalyticsProvenanceReportingTask.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/test/java/org/apache/nifi/reporting/azure/loganalytics/TestAzureLogAnalyticsProvenanceReportingTask.java
@@ -26,7 +26,7 @@ import javax.json.JsonObjectBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,12 +64,12 @@ public class TestAzureLogAnalyticsProvenanceReportingTask {
         final Map<String, Object> config = Collections.emptyMap();
         final JsonBuilderFactory factory = Json.createBuilderFactory(config);
         final JsonObjectBuilder builder = factory.createObjectBuilder();
-        Map<String, String> values = new HashMap<String, String>();
+        Map<String, String> values = new LinkedHashMap<String, String>();
         values.put("TestKeyString1", "StringValue1");
         values.put("TestKeyString2", "StringValue2");
         AzureLogAnalyticsProvenanceReportingTask.addField(builder, factory, "TestKeyString", values, true);
         javax.json.JsonObject actualJson = builder.build();
-        String expectedjsonString = "{\"TestKeyString\":{\"TestKeyString2\":\"StringValue2\",\"TestKeyString1\":\"StringValue1\"}}";
+        String expectedjsonString = "{\"TestKeyString\":{\"TestKeyString1\":\"StringValue1\",\"TestKeyString2\":\"StringValue2\"}}";
         JsonObject expectedJson = new Gson().fromJson(expectedjsonString, JsonObject.class);
         assertEquals(expectedJson.toString(), actualJson.toString());
     }

--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -53,7 +53,7 @@ import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -80,12 +80,12 @@ public class TestPrometheusRecordSink {
         );
         RecordSchema recordSchema = new SimpleRecordSchema(recordFields);
 
-        Map<String, Object> row1 = new HashMap<>();
+        Map<String, Object> row1 = new LinkedHashMap<>();
         row1.put("field1", 15);
         row1.put("field2", BigDecimal.valueOf(12.34567D));
         row1.put("field3", "Hello");
 
-        Map<String, Object> row2 = new HashMap<>();
+        Map<String, Object> row2 = new LinkedHashMap<>();
         row2.put("field1", 6);
         row2.put("field2", BigDecimal.valueOf(0.1234567890123456789D));
         row2.put("field3", "World!");
@@ -95,7 +95,7 @@ public class TestPrometheusRecordSink {
                 new MapRecord(recordSchema, row2)
         ));
 
-        Map<String, String> attributes = new HashMap<>();
+        Map<String, String> attributes = new LinkedHashMap<>();
         attributes.put("a", "Hello");
         WriteResult writeResult = sink.sendData(recordSet, attributes, true);
         assertNotNull(writeResult);
@@ -104,8 +104,10 @@ public class TestPrometheusRecordSink {
 
 
         final String content = getMetrics();
-        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
-        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
+        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n") ||
+                   content.contains("field1{field3=\"World!\",} 6.0\nfield1{field3=\"Hello\",} 15.0\n"));
+        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n") ||
+                   content.contains("field2{field3=\"World!\",} 0.12345678901234568\nfield2{field3=\"Hello\",} 12.34567\n"));
 
         try {
             sink.onStopped();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/test/java/org/apache/nifi/distributed/cache/server/map/DistributedMapCacheTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/test/java/org/apache/nifi/distributed/cache/server/map/DistributedMapCacheTest.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -149,7 +149,7 @@ public class DistributedMapCacheTest {
         for (int i = 0; (i < 3); ++i) {
             client.put(key + i, value + i, serializer, serializer);
         }
-        final Set<String> keys = new HashSet<>(Arrays.asList("keySubMap0", "keySubMap1", "keySubMap2"));
+        final Set<String> keys = new LinkedHashSet<>(Arrays.asList("keySubMap0", "keySubMap1", "keySubMap2"));
         final Map<String, String> subMap = client.subMap(keys, serializer, deserializer);
         assertEquals(3, subMap.size());
         for (int i = 0; (i < 3); ++i) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10592](https://issues.apache.org/jira/browse/NIFI-10592)

The tests below were found flaky because of the use of HashMaps and HashSet. The orders of elements in the HashMaps and HashSet are not the same every time being called. In this case, LinkedHashMap and LinkedHashSet is applied to replace Hash in order to ensure the orders are not changing. 

- `org.apache.nifi.reporting.prometheus.TestPrometheusRecordSink.testSendData`
- `org.apache.nifi.reporting.azure.loganalytics.TestAzureLogAnalyticsProvenanceReportingTask.testAddField2`
- `org.apache.nifi.distributed.cache.server.map.DistributedMapCacheTest.testSubMap`

It matters to fix this flaky test as it may cause potential issues due to the uncertainty of orders from HashMaps and HashSet rather than the program itself.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn install -pl nifi-nar-bundles -am -DskipTests`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17
  
Test:
 - `mvn -pl nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.reporting.prometheus.TestPrometheusRecordSink#testSendData`

 - `mvn -pl nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.reporting.azure.loganalytics.TestAzureLogAnalyticsProvenanceReportingTask#testAddField2`

- `mvn -pl nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.distributed.cache.server.map.DistributedMapCacheTest#testSubMap`

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files