### PR TITLE
NIFI-10603: fix showing the referencing components border in the fetch parameters dialog

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-parameter-provider.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-parameter-provider.js
@@ -2549,14 +2549,15 @@
 
                     // only populate referencing components if this parameter is different than the last selected
                     if (lastSelectedParameterId === null || lastSelectedParameterId !== parameter.id) {
+                        if ($('#selectable-parameters-table').is(':visible')) {
+                            populateReferencingComponents(parameter.parameterStatus)
+                                .then(function () {
+                                    updateReferencingComponentsBorder($('#fetch-parameter-referencing-components-container'));
 
-                        populateReferencingComponents(parameter.parameterStatus)
-                            .then(function () {
-                                updateReferencingComponentsBorder($('#fetch-parameter-referencing-components-container'));
-
-                                // update the last selected id
-                                lastSelectedParameterId = parameter.id;
-                            });
+                                    // update the last selected id
+                                    lastSelectedParameterId = parameter.id;
+                                });
+                        }
                     }
                 }
             }


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10603](https://issues.apache.org/jira/browse/NIFI-10603)

In the Fetch Parameters dialog, sometimes the referencing components border shows when there is no content. The referencing components should only be populated and update the border for the currently selected parameter.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
