### PR TITLE
NIFI-10627 - VersionedPort missing getter

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/flow/VersionedPort.java
+++ b/nifi-api/src/main/java/org/apache/nifi/flow/VersionedPort.java
@@ -57,6 +57,10 @@ public class VersionedPort extends VersionedComponent {
         return ((allowRemoteAccess != null) && allowRemoteAccess);
     }
 
+    public Boolean getAllowRemoteAccess() {
+        return allowRemoteAccess;
+    }
+
     public void setAllowRemoteAccess(Boolean allowRemoteAccess) {
         this.allowRemoteAccess = allowRemoteAccess;
     }


### PR DESCRIPTION
# Summary
- Add missing getter to class VersionedPort

# Tracking

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
