### PR TITLE
NIFI-10576 - ParquetRecordSetWriter doesn't write avro schema to attribute

### DIFF
--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/ParquetRecordSetWriter.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/ParquetRecordSetWriter.java
@@ -107,7 +107,7 @@ public class ParquetRecordSetWriter extends SchemaRegistryRecordSetWriter implem
                 throw new SchemaNotFoundException("Failed to compile Avro Schema", e);
             }
 
-            return new WriteParquetResult(avroSchema, out, parquetConfig, logger);
+            return new WriteParquetResult(avroSchema, recordSchema, getSchemaAccessWriter(recordSchema, variables), out, parquetConfig, logger);
 
         } catch (final SchemaNotFoundException e) {
             throw new ProcessException("Could not determine the Avro Schema to use for writing the content", e);

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
@@ -46,7 +46,8 @@ public class WriteParquetResult extends AbstractRecordSetWriter {
     private SchemaAccessWriter accessWriter;
     private RecordSchema recordSchema;
 
-    public WriteParquetResult(final Schema avroSchema, final RecordSchema recordSchema, final SchemaAccessWriter accessWriter, final OutputStream out, final ParquetConfig parquetConfig, final ComponentLog componentLogger) throws IOException {
+    public WriteParquetResult(final Schema avroSchema, final RecordSchema recordSchema, final SchemaAccessWriter accessWriter, final OutputStream out,
+                              final ParquetConfig parquetConfig, final ComponentLog componentLogger) throws IOException {
         super(out);
         this.schema = avroSchema;
         this.componentLogger = componentLogger;

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
@@ -31,7 +31,6 @@ import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.OutputFile;
 
-import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -57,8 +56,7 @@ public class WriteParquetResult extends AbstractRecordSetWriter {
         final Configuration conf = new Configuration();
         final OutputFile outputFile = new NifiParquetOutputFile(out);
 
-        final AvroParquetWriter.Builder<GenericRecord> writerBuilder =
-                AvroParquetWriter.<GenericRecord>builder(outputFile).withSchema(avroSchema);
+        final AvroParquetWriter.Builder<GenericRecord> writerBuilder = AvroParquetWriter.<GenericRecord>builder(outputFile).withSchema(avroSchema);
         applyCommonConfig(writerBuilder, conf, parquetConfig);
         parquetWriter = writerBuilder.build();
     }

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
@@ -23,12 +23,15 @@ import org.apache.nifi.avro.AvroTypeUtil;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.parquet.stream.NifiParquetOutputFile;
 import org.apache.nifi.parquet.utils.ParquetConfig;
+import org.apache.nifi.schema.access.SchemaAccessWriter;
 import org.apache.nifi.serialization.AbstractRecordSetWriter;
 import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.OutputFile;
 
+import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -41,17 +44,21 @@ public class WriteParquetResult extends AbstractRecordSetWriter {
     private final Schema schema;
     private final ParquetWriter<GenericRecord> parquetWriter;
     private final ComponentLog componentLogger;
+    private SchemaAccessWriter accessWriter;
+    private RecordSchema recordSchema;
 
-    public WriteParquetResult(final Schema schema, final OutputStream out, final ParquetConfig parquetConfig, final ComponentLog componentLogger) throws IOException {
+    public WriteParquetResult(final Schema avroSchema, final RecordSchema recordSchema, final SchemaAccessWriter accessWriter, final OutputStream out, final ParquetConfig parquetConfig, final ComponentLog componentLogger) throws IOException {
         super(out);
-        this.schema = schema;
+        this.schema = avroSchema;
         this.componentLogger = componentLogger;
+        this.accessWriter = accessWriter;
+        this.recordSchema = recordSchema;
 
         final Configuration conf = new Configuration();
         final OutputFile outputFile = new NifiParquetOutputFile(out);
 
         final AvroParquetWriter.Builder<GenericRecord> writerBuilder =
-                AvroParquetWriter.<GenericRecord>builder(outputFile).withSchema(schema);
+                AvroParquetWriter.<GenericRecord>builder(outputFile).withSchema(avroSchema);
         applyCommonConfig(writerBuilder, conf, parquetConfig);
         parquetWriter = writerBuilder.build();
     }
@@ -61,6 +68,11 @@ public class WriteParquetResult extends AbstractRecordSetWriter {
         final GenericRecord genericRecord = AvroTypeUtil.createAvroRecord(record, schema);
         parquetWriter.write(genericRecord);
         return Collections.emptyMap();
+    }
+
+    @Override
+    protected Map<String, String> onFinishRecordSet() throws IOException {
+        return accessWriter.getAttributes(recordSchema);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/record/WriteParquetResult.java
@@ -70,7 +70,7 @@ public class WriteParquetResult extends AbstractRecordSetWriter {
     }
 
     @Override
-    protected Map<String, String> onFinishRecordSet() throws IOException {
+    protected Map<String, String> onFinishRecordSet() {
         return accessWriter.getAttributes(recordSchema);
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NiFi-10576](https://issues.apache.org/jira/browse/NiFi-10576)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NiFi-10576`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NiFi-10576`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
