### PR TITLE
NIFI-10637 fixing flaky test in TestParseCEF

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
@@ -393,7 +393,7 @@ public class ParseCEF extends AbstractProcessor {
             }
 
             final Locale testLocale = Locale.forLanguageTag(input);
-            final Locale[] availableLocales = Locale.getAvailableLocales();
+            
 
             // Check if the provided Locale is valid by checking against the first value of the array (i.e. "null" locale)
             if ("".equals(testLocale.toString())) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
@@ -393,7 +393,6 @@ public class ParseCEF extends AbstractProcessor {
             }
 
             final Locale testLocale = Locale.forLanguageTag(input);
-            
 
             // Check if the provided Locale is valid by checking against the first value of the array (i.e. "null" locale)
             if ("".equals(testLocale.toString())) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
@@ -396,7 +396,7 @@ public class ParseCEF extends AbstractProcessor {
             final Locale[] availableLocales = Locale.getAvailableLocales();
 
             // Check if the provided Locale is valid by checking against the first value of the array (i.e. "null" locale)
-            if (availableLocales[0].equals(testLocale)) {
+            if ("".equals(testLocale.toString())) {
                 // Locale matches the "null" locale so it is treated as invalid
                 return new ValidationResult.Builder().subject(subject).input(input).valid(false)
                         .explanation(input + " is not a valid locale format.").build();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10637](https://issues.apache.org/jira/browse/NIFI-10637)
Following the problem in the issue NIFI-10637. I dived deep to the class "ValidateLocale" where the validator has been determined valid or not.
After several printouts and checking log files, we found that the available locales is a deterministic list. 

```
final Locale[] availableLocales = Locale.getAvailableLocales();
```
However, the if condition in this class looks like this:
```
if (availableLocales[0].equals(testLocale)) {
                // Locale matches the "null" locale so it is treated as invalid
                return new ValidationResult.Builder().subject(subject).input(input).valid(false)
                        .explanation(input + " is not a valid locale format.").build();
            }
```
The purpose of this if statement is to determine if the testLocale is empty. However, as I said before, the availableLocales is a given list and the first element is not the zero. So I changed the code to this:

```
if ("".equals(testLocale.toString())) {
                // Locale matches the "null" locale so it is treated as invalid
                return new ValidationResult.Builder().subject(subject).input(input).valid(false)
                        .explanation(input + " is not a valid locale format.").build();
            }

```
By changing this, the if statement can correctly work and the bug has been fixed. It is not flaky anymore and can pass the NonDex's check.
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
