### PR TITLE
NIFI-10621 Allow ExecuteGroovyScript classpath properties to accept commas or semicolons

### DIFF
--- a/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -131,7 +131,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
             .name("groovyx-additional-classpath")
             .displayName("Additional classpath")
             .required(false)
-            .description("Classpath list separated by semicolon. You can use masks like `*`, `*.jar` in file name.")
+            .description("Classpath list separated by semicolon or comma. You can use masks like `*`, `*.jar` in file name.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();

--- a/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/util/Files.java
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/util/Files.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public class Files {
 
     /**
-     * Classpath list separated by semicolon. You can use masks like `*`, `*.jar` in file name.
+     * Classpath list separated by semicolon or comma. You can use masks like `*`, `*.jar` in file name.
      *
      * @return file list defined by classpath parameter
      */
@@ -39,7 +39,7 @@ public class Files {
             return Collections.emptySet();
         }
         Set<File> files = new HashSet<>();
-        for (String cp : classpath.split("\\s*;\\s*")) {
+        for (String cp : classpath.split("\\s*[;,]\\s*")) {
             files.addAll(listPathFiles(cp));
         }
         return files;


### PR DESCRIPTION
ExecuteGroovyScript's "Additional classpath" property treats commas and semicolons as delimiters

# Summary

[NIFI-10621](https://issues.apache.org/jira/browse/NIFI-10621)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
