### PR TITLE
NIFI-10567 Correct Sensitive Dynamic Property handling for flow.xml

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ControllerServiceLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/service/ControllerServiceLoader.java
@@ -24,25 +24,14 @@ import org.apache.nifi.controller.serialization.FlowFromDOMFactory;
 import org.apache.nifi.encrypt.PropertyEncryptor;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.logging.LogLevel;
-import org.apache.nifi.reporting.BulletinRepository;
 import org.apache.nifi.util.BundleUtils;
-import org.apache.nifi.util.DomUtils;
 import org.apache.nifi.web.api.dto.BundleDTO;
 import org.apache.nifi.web.api.dto.ControllerServiceDTO;
-import org.apache.nifi.xml.processing.ProcessingException;
-import org.apache.nifi.xml.processing.parsers.StandardDocumentProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,58 +40,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class ControllerServiceLoader {
 
     private static final Logger logger = LoggerFactory.getLogger(ControllerServiceLoader.class);
-
-    public static List<ControllerServiceNode> loadControllerServices(final FlowController controller, final InputStream serializedStream, final ProcessGroup parentGroup,
-        final PropertyEncryptor encryptor, final BulletinRepository bulletinRepo, final boolean autoResumeState, final FlowEncodingVersion encodingVersion) throws IOException {
-
-        try (final InputStream in = new BufferedInputStream(serializedStream)) {
-            final StandardDocumentProvider documentProvider = new StandardDocumentProvider();
-
-            documentProvider.setErrorHandler(new org.xml.sax.ErrorHandler() {
-
-                @Override
-                public void fatalError(final SAXParseException err) throws SAXException {
-                    logger.error("Config file line " + err.getLineNumber() + ", col " + err.getColumnNumber() + ", uri " + err.getSystemId() + " :message: " + err.getMessage());
-                    if (logger.isDebugEnabled()) {
-                        logger.error("Error Stack Dump", err);
-                    }
-                    throw err;
-                }
-
-                @Override
-                public void error(final SAXParseException err) throws SAXParseException {
-                    logger.error("Config file line " + err.getLineNumber() + ", col " + err.getColumnNumber() + ", uri " + err.getSystemId() + " :message: " + err.getMessage());
-                    if (logger.isDebugEnabled()) {
-                        logger.error("Error Stack Dump", err);
-                    }
-                    throw err;
-                }
-
-                @Override
-                public void warning(final SAXParseException err) throws SAXParseException {
-                    logger.warn(" Config file line " + err.getLineNumber() + ", uri " + err.getSystemId() + " : message : " + err.getMessage());
-                    if (logger.isDebugEnabled()) {
-                        logger.warn("Warning stack dump", err);
-                    }
-                    throw err;
-                }
-            });
-
-            final Document document = documentProvider.parse(in);
-            final Element controllerServices = document.getDocumentElement();
-            final List<Element> serviceElements = DomUtils.getChildElementsByTagName(controllerServices, "controllerService");
-
-            final Map<ControllerServiceNode, Element> controllerServiceMap = ControllerServiceLoader.loadControllerServices(serviceElements, controller, parentGroup, encryptor, encodingVersion);
-            enableControllerServices(controllerServiceMap, controller, encryptor, autoResumeState, encodingVersion);
-            return new ArrayList<>(controllerServiceMap.keySet());
-        } catch (final ProcessingException e) {
-            throw new IOException("Parsing Controller Services failed", e);
-        }
-    }
 
     public static Map<ControllerServiceNode, Element> loadControllerServices(final List<Element> serviceElements, final FlowController controller,
                                                                              final ProcessGroup parentGroup, final PropertyEncryptor encryptor, final FlowEncodingVersion encodingVersion) {
@@ -227,11 +169,20 @@ public class ControllerServiceLoader {
         node.pauseValidationTrigger();
         try {
             node.setAnnotationData(dto.getAnnotationData());
-            final Set<String> sensitiveDynamicPropertyNames = dto.getSensitiveDynamicPropertyNames();
-            node.setProperties(dto.getProperties(), false, sensitiveDynamicPropertyNames == null ? Collections.emptySet() : sensitiveDynamicPropertyNames);
+            final Set<String> sensitiveDynamicPropertyNames = getSensitiveDynamicPropertyNames(dto.getSensitiveDynamicPropertyNames(), node);
+            node.setProperties(dto.getProperties(), false, sensitiveDynamicPropertyNames);
         } finally {
             node.resumeValidationTrigger();
         }
     }
 
+    private static Set<String> getSensitiveDynamicPropertyNames(final Set<String> parsedSensitivePropertyNames, final ControllerServiceNode controllerServiceNode) {
+        final Set<String> sensitivePropertyNames = parsedSensitivePropertyNames == null ? Collections.emptySet() : parsedSensitivePropertyNames;
+        return sensitivePropertyNames.stream().filter(
+                propertyName -> {
+                    final PropertyDescriptor propertyDescriptor = controllerServiceNode.getPropertyDescriptor(propertyName);
+                    return propertyDescriptor.isDynamic();
+                }
+        ).collect(Collectors.toSet());
+    }
 }


### PR DESCRIPTION
# Summary

[NIFI-10567](https://issues.apache.org/jira/browse/NIFI-10567) Corrects the parsing of Sensitive Dynamic Properties read from the XML version of the flow configuration, in absence of the JSON version.

The issue surfaces when upgrading to NiFi 1.17.0 or 1.18.0 from a version older than 1.16.0. The issue also requires the presence of a Parameter Context with a Sensitive value assigned to a component with a Sensitive Property. Upgrading from 1.16.0 and following is not a problem. Deleting the `flow.json.gz` configuration also triggers the problematic behavior.

The following steps can be used to reproduce the problem on NiFi 1.18.0:

1. Create a new Process Group
2. Create and assign a new Parameter Context
3. Create a Sensitive Parameter Value in the Parameter Context
4. Create a Processor with a Sensitive Property
5. Assign the Sensitive Parameter Value to the Processor Sensitive Property
6. Stop NiFi
7. Delete `flow.json.gz`
8. Start NiFi

After those steps, the Processor will be marked as invalid with an error indicating that Sensitive Dynamic Properties are configured but not supported.

The changes correct the behavior of the XML synchronizer to filter Sensitive Property Names based on the dynamic status indicated when calling `getPropertyDescriptor()` on the associated component. Additional changes include the removal of an unused method from `ControllerServiceLoader` and non-applicable exceptions from several related methods.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
