### PR TITLE
NIFI-10647: Update README.md to reflect current

### DIFF
--- a/nifi-assembly/README.md
+++ b/nifi-assembly/README.md
@@ -23,7 +23,7 @@ Apache NiFi is an easy to use, powerful, and reliable system to process and dist
 - [Getting Help](#getting-help)
 - [Requirements](#requirements)
 - [License](#license)
-- [Export Control] (#export-control)
+- [Export Control](#export-control)
 
 ## Features
 
@@ -51,7 +51,11 @@ Apache NiFi was made for dataflow. It supports highly configurable directed grap
 To start NiFi:
 - [linux/osx] execute bin/nifi.sh start
 - [windows] execute bin/run-nifi.bat
-- Direct your browser to http://localhost:8080/nifi/
+- Obtain the generated username and password from logs/nifi-app.log
+  - [linux/osx] For example: `cat logs/nifi-app.log | grep Generated`
+- Direct your browser to https://localhost:8443/nifi/
+- Use the generated username and password to login
+
 
 ## Getting Help
 If you have questions, you can reach out to our mailing list: dev@nifi.apache.org


### PR DESCRIPTION
Updated "Getting Stated" section to bring it up to Ni-Fi 1.14's default port, HTTPS usage, and username/password. Fixed broken link to Export Control.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10647](https://issues.apache.org/jira/browse/NIFI-10647) 

Fix outdated README.md bundled with Ni-Fi current versions to provide the right default URL and username/password. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-10647`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-10647`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
