### PR TITLE
NIFI-10658 Upgrade GitHub Actions to current versions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: Manage stale PRs
+name: pull-request-review
 
 on:
   # Run every day at midnight 00:00
@@ -26,19 +26,18 @@ permissions:
 jobs:
   stale:
     permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >
-            We're marking this PR as stale due to lack of updates in the past few months.
-            If after another couple of weeks the stale label has not been removed this PR will be closed.
-            This stale marker and eventual auto close does not indicate a judgement of the PR just
+            Automated review is marking this PR as stale due to lack of updates in the past four months.
+            This PR will be closed in 15 days if the stale label is not removed.
+            This stale label and automated closure does not indicate a judgement of the PR, just
             lack of reviewer bandwidth and helps us keep the PR queue more manageable.  If you would
-            like this PR re-opened you can do so and a committer can remove the stale tag.  Or you can
+            like this PR re-opened you can do so and a committer can remove the stale label.  Or you can
             open a new PR.  Try to help review other PRs to increase PR review bandwidth which in
             turn helps yours.
           days-before-stale: 120

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -62,9 +62,9 @@ jobs:
     name: Ubuntu Java 17
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 17
@@ -87,7 +87,7 @@ jobs:
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Troubleshooting Logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ubuntu-17-troubleshooting-logs
           path: |
@@ -102,9 +102,9 @@ jobs:
     name: Ubuntu Java 11
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Java 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -127,7 +127,7 @@ jobs:
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Troubleshooting Logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ubuntu-latest-troubleshooting-logs
           path: |
@@ -142,9 +142,9 @@ jobs:
     name: MacOS Java 8
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 8
@@ -167,7 +167,7 @@ jobs:
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Troubleshooting Logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-latest-troubleshooting-logs
           path: |


### PR DESCRIPTION
# Summary

[NIFI-10658](https://issues.apache.org/jira/browse/NIFI-10658) Upgrades GitHub Actions in `system-test` and `stale` workflows to the current versions. This resolves GitHub deprecation warnings related to using actions that depend on Node.js 12.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
