### PR TITLE
NIFI-10668 Persist proxy password in remote process group

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/flow/VersionedProcessGroup.java
+++ b/nifi-api/src/main/java/org/apache/nifi/flow/VersionedProcessGroup.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class  VersionedProcessGroup extends VersionedComponent {
+public class VersionedProcessGroup extends VersionedComponent {
 
     private Set<VersionedProcessGroup> processGroups = new HashSet<>();
     private Set<VersionedRemoteProcessGroup> remoteProcessGroups = new HashSet<>();

--- a/nifi-api/src/main/java/org/apache/nifi/flow/VersionedRemoteProcessGroup.java
+++ b/nifi-api/src/main/java/org/apache/nifi/flow/VersionedRemoteProcessGroup.java
@@ -32,6 +32,7 @@ public class VersionedRemoteProcessGroup extends VersionedComponent {
     private String proxyHost;
     private Integer proxyPort;
     private String proxyUser;
+    private String proxyPassword;
 
     private Set<VersionedRemoteGroupPort> inputPorts;
     private Set<VersionedRemoteGroupPort> outputPorts;
@@ -155,6 +156,14 @@ public class VersionedRemoteProcessGroup extends VersionedComponent {
 
     public void setProxyUser(String proxyUser) {
         this.proxyUser = proxyUser;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -2918,6 +2918,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
         rpg.setProxyHost(proposed.getProxyHost());
         rpg.setProxyPort(proposed.getProxyPort());
         rpg.setProxyUser(proposed.getProxyUser());
+        rpg.setProxyPassword(decrypt(proposed.getProxyPassword(), syncOptions.getPropertyDecryptor()));
         rpg.setTransportProtocol(SiteToSiteTransportProtocol.valueOf(proposed.getTransportProtocol()));
         rpg.setYieldDuration(proposed.getYieldDuration());
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
@@ -782,6 +782,7 @@ public class NiFiRegistryFlowMapper {
         rpg.setProxyHost(remoteGroup.getProxyHost());
         rpg.setProxyPort(remoteGroup.getProxyPort());
         rpg.setProxyUser(remoteGroup.getProxyUser());
+        rpg.setProxyPassword(encrypt(remoteGroup.getProxyPassword()));
         rpg.setTargetUri(remoteGroup.getTargetUri());
         rpg.setTargetUris(remoteGroup.getTargetUris());
         rpg.setTransportProtocol(remoteGroup.getTransportProtocol().name());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
@@ -782,7 +782,9 @@ public class NiFiRegistryFlowMapper {
         rpg.setProxyHost(remoteGroup.getProxyHost());
         rpg.setProxyPort(remoteGroup.getProxyPort());
         rpg.setProxyUser(remoteGroup.getProxyUser());
-        rpg.setProxyPassword(encrypt(remoteGroup.getProxyPassword()));
+        if (flowMappingOptions.isMapSensitiveConfiguration()) {
+            rpg.setProxyPassword(encrypt(remoteGroup.getProxyPassword()));
+        }
         rpg.setTargetUri(remoteGroup.getTargetUri());
         rpg.setTargetUris(remoteGroup.getTargetUris());
         rpg.setTransportProtocol(remoteGroup.getTransportProtocol().name());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10668](https://issues.apache.org/jira/browse/NIFI-10668)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
