### PR TITLE
NIFI-XX Fixed Possible Array Ordering Permutations Problem in Tests

### DIFF
--- a/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/util/JASN1ReadRecordTester.java
+++ b/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/util/JASN1ReadRecordTester.java
@@ -24,6 +24,7 @@ import org.apache.nifi.jasn1.RecordSchemaProvider;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.MockComponentLog;
 
@@ -32,6 +33,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.LinkedList;
+import java.util.Collections;
+import java.util.Comparator;
 
 import static org.apache.nifi.jasn1.util.RecordTestUtil.assertRecordsEqual;
 import static org.junit.Assert.assertEquals;
@@ -69,7 +73,13 @@ public interface JASN1ReadRecordTester {
             RecordSchema expectedSchema = expectedSchemaProvider.apply(actual);
 
             assertRecordsEqual(expected, actual);
-            assertEquals(expectedSchema, actualSchema);
+            LinkedList<RecordField>  expectedSchemaList = new LinkedList<>(expectedSchema.getFields());
+            LinkedList<RecordField>  actualSchemaList = new LinkedList<>(actualSchema.getFields());
+            Comparator<RecordField> compareById = (RecordField o1, RecordField o2) -> o1.getFieldName().compareTo( o2.getFieldName() );   
+            Collections.sort(actualSchemaList,compareById);
+            Collections.sort(expectedSchemaList, compareById);
+            assertEquals(expectedSchemaList.toString(), actualSchemaList.toString());
+            
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-XXX](https://issues.apache.org/jira/browse/NIFI-10630)
Following the problem of flakiness that occurred in the project
`nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services`
test file
`org.apache.nifi.jasn1.TestJASN1RecordReaderWithComplexTypes`
with below three tests
```
testBasicTypes
testRecursive
testInheritance
```
All three above test use the same file, `JASN1ReadRecordTester` as tester.
The test flakiness is due to comparisons between two ArrayList outputs from Class
`SimpleRecordSchema` which use ArrayList to store one of the parameter `List<RecordField>`

However, ArrayList does not guarantee entry orders, its object is an unordered set of name/value pairs, and internal permutations may occur in the output as a String.

## Brief changelog

Since the class `SimpleRecordSchema` is a shared Library of the entire NIFI project, so I don't want to touch it.
And the List is stored with Object `RecordField` so a typical sort is not working. And I use `Collections `and `Comparator` to reorder the whole list before comparing them.
Thus the added lines seem excessive.

## Verifying this change

This test avoids different orders of ArrayList strings that cause flaky errors.
Since I didn't touch any Source code, it should be no impact on the project.
And it passed the local test that the guidelines mentioned.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
