### PR TITLE
NIFI-10716 Upgrade Flume from 1.10.1 to 1.11.0

### DIFF
--- a/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-processors/pom.xml
@@ -24,7 +24,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <flume.version>1.10.1</flume.version>
+        <flume.version>1.11.0</flume.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
# Summary

[NIFI-10716](https://issues.apache.org/jira/browse/NIFI-10716) Upgrades Apache Flume dependencies to 1.11.0 to address CVE-2022-42468. The upgrade avoids potential vulnerability exposure through configuration of a JMS Source with an unsafe provider URL.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
