### PR TITLE
NIFI-10717 fix inconsistent tests

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/inheritance/MissingComponentsCheck.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/inheritance/MissingComponentsCheck.java
@@ -22,6 +22,7 @@ import org.apache.nifi.controller.FlowController;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MissingComponentsCheck implements FlowInheritabilityCheck {
     @Override
@@ -34,7 +35,7 @@ public class MissingComponentsCheck implements FlowInheritabilityCheck {
         existingMissingComponents.removeAll(proposedFlow.getMissingComponents());
 
         if (existingMissingComponents.size() > 0) {
-            final String missingIds = StringUtils.join(existingMissingComponents, ",");
+            final String missingIds = StringUtils.join(existingMissingComponents.stream().sorted().collect(Collectors.toList()), ",");
             return FlowInheritability.notInheritable("Current flow has missing components that are not considered missing in the proposed flow (" + missingIds + ")");
         }
 
@@ -42,7 +43,7 @@ public class MissingComponentsCheck implements FlowInheritabilityCheck {
         proposedMissingComponents.removeAll(existingFlow.getMissingComponents());
 
         if (proposedMissingComponents.size() > 0) {
-            final String missingIds = StringUtils.join(proposedMissingComponents, ",");
+            final String missingIds = StringUtils.join(proposedMissingComponents.stream().sorted().collect(Collectors.toList()), ",");
             return FlowInheritability.notInheritable("Proposed flow has missing components that are not considered missing in the current flow (" + missingIds + ")");
         }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10717](https://issues.apache.org/jira/browse/NIFI-10717)
Those two tests (`testSynchronizeFlowWhenExistingMissingComponentsAreDifferent` and `testSynchronizeFlowWhenProposedMissingComponentsAreDifferent`) in TestFlowController are flaky and may fail in certain circumstances since the ordering of missingComponenents is not consistent. To ensure the ordering, I convert the set to a sorted list and then map them to a string.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
