### PR TITLE
Fix flaky test in TestGetHDFSFileInfo

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -153,6 +153,11 @@
             <version>1.19.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
@@ -35,6 +35,8 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -379,7 +381,7 @@ public class TestGetHDFSFileInfo {
         mff.assertAttributeNotExists("hdfs.status");
 
         final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupAllToAttributes.json")));
-        mff.assertAttributeEquals("hdfs.full.tree", expected);
+        JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test


### PR DESCRIPTION
`testRecursiveGroupAllToAttributes` is detected flaky by [Nondex](https://github.com/TestingResearchIllinois/NonDex) since the attribute "hdfs.full.tree" is a JSON Object and is not always written in a deterministic order. Instead of comparing the string of the attribute and the expected one, I used `jsonassert` to compare the two JSON objects. 