### PR TITLE
NIFI-10738 - Updated SNMP tests to retry when BindException occurs.

### DIFF
--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
@@ -50,13 +50,13 @@ public class SNMPSocketSupport {
                 .build();
     }
 
-    protected Snmp createSnmpManagerInstance(final Function<SNMPConfiguration, Snmp> runnable, final int retries) {
+    protected Snmp createSnmpManagerInstanceWithRetries(final Function<SNMPConfiguration, Snmp> runnable, final int retries) {
         int attempts = 0;
         while (attempts < retries) {
             try {
                 return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
             } catch (Exception e) {
-                if (e instanceof BindException) {
+                if (isBindException(e)) {
                     attempts++;
                     if (attempts == retries) {
                         throw e;
@@ -69,13 +69,13 @@ public class SNMPSocketSupport {
         throw new IllegalStateException("Failed to bind ports for SNMP manager");
     }
 
-    protected Target createTargetInstance(final Function<SNMPConfiguration, Target> runnable, final int retries) {
+    protected Target createTargetInstanceWithRetries(final Function<SNMPConfiguration, Target> runnable, final int retries) {
         int attempts = 0;
         while (attempts < retries) {
             try {
                 return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
             } catch (Exception e) {
-                if (e instanceof BindException) {
+                if (isBindException(e)) {
                     attempts++;
                     if (attempts == retries) {
                         throw e;
@@ -86,5 +86,13 @@ public class SNMPSocketSupport {
             }
         }
         throw new IllegalStateException("Failed to bind ports for SNMP target");
+    }
+
+    private boolean isBindException(final Throwable throwable) {
+        Throwable rootCause = throwable;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        return rootCause instanceof BindException;
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
@@ -32,7 +32,7 @@ import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFact
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PASSPHRASE;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PROTOCOL;
 
-public class SNMPTtest {
+public class SNMPSocketSupport {
 
     protected static final int RETRIES = 3;
 
@@ -51,31 +51,37 @@ public class SNMPTtest {
                 .build();
     }
 
-    protected Snmp createSnmpManagerInstance(final Function<SNMPConfiguration, Snmp> runnable, final int retries) throws BindException {
+    protected Snmp createSnmpManagerInstance(final Function<SNMPConfiguration, Snmp> runnable, final int retries) {
         int attempts = 0;
-        while(attempts < retries) {
+        while (attempts < retries) {
             try {
                 return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
             } catch (Exception e) {
                 if (e instanceof BindException) {
                     attempts++;
+                    if (attempts == retries) {
+                        throw e;
+                    }
                 }
             }
         }
-        throw new BindException();
+        return null;
     }
 
-    protected Target createTargetInstance(final Function<SNMPConfiguration, Target> runnable, final int retries) throws BindException {
+    protected Target createTargetInstance(final Function<SNMPConfiguration, Target> runnable, final int retries) {
         int attempts = 0;
-        while(attempts < retries) {
+        while (attempts < retries) {
             try {
                 return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
             } catch (Exception e) {
                 if (e instanceof BindException) {
                     attempts++;
+                    if (attempts == retries) {
+                        throw e;
+                    }
                 }
             }
         }
-        throw new BindException();
+        return null;
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
@@ -21,7 +21,6 @@ import org.apache.nifi.snmp.configuration.SNMPConfiguration;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.security.SecurityLevel;
-
 import java.net.BindException;
 import java.util.function.Function;
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
@@ -18,8 +18,6 @@ package org.apache.nifi.snmp.factory.core;
 
 import org.apache.nifi.remote.io.socket.NetworkUtils;
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
-import org.snmp4j.Snmp;
-import org.snmp4j.Target;
 import org.snmp4j.security.SecurityLevel;
 import java.net.BindException;
 import java.util.function.Function;
@@ -50,7 +48,7 @@ public class SNMPSocketSupport {
                 .build();
     }
 
-    protected Snmp createSnmpManagerInstanceWithRetries(final Function<SNMPConfiguration, Snmp> runnable, final int retries) {
+    protected <T> T createInstanceWithRetries(final Function<SNMPConfiguration, T> runnable, final int retries) {
         int attempts = 0;
         while (attempts < retries) {
             try {
@@ -67,25 +65,6 @@ public class SNMPSocketSupport {
             }
         }
         throw new IllegalStateException("Failed to bind ports for SNMP manager");
-    }
-
-    protected Target createTargetInstanceWithRetries(final Function<SNMPConfiguration, Target> runnable, final int retries) {
-        int attempts = 0;
-        while (attempts < retries) {
-            try {
-                return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
-            } catch (Exception e) {
-                if (isBindException(e)) {
-                    attempts++;
-                    if (attempts == retries) {
-                        throw e;
-                    }
-                } else {
-                    throw e;
-                }
-            }
-        }
-        throw new IllegalStateException("Failed to bind ports for SNMP target");
     }
 
     private boolean isBindException(final Throwable throwable) {

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPSocketSupport.java
@@ -61,10 +61,12 @@ public class SNMPSocketSupport {
                     if (attempts == retries) {
                         throw e;
                     }
+                } else {
+                    throw e;
                 }
             }
         }
-        return null;
+        throw new IllegalStateException("Failed to bind ports for SNMP manager");
     }
 
     protected Target createTargetInstance(final Function<SNMPConfiguration, Target> runnable, final int retries) {
@@ -78,9 +80,11 @@ public class SNMPSocketSupport {
                     if (attempts == retries) {
                         throw e;
                     }
+                } else {
+                    throw e;
                 }
             }
         }
-        return null;
+        throw new IllegalStateException("Failed to bind ports for SNMP target");
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPTtest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPTtest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.snmp.factory.core;
 
 import org.apache.nifi.remote.io.socket.NetworkUtils;
@@ -9,12 +25,12 @@ import org.snmp4j.security.SecurityLevel;
 import java.net.BindException;
 import java.util.function.Function;
 
+import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PASSPHRASE;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PROTOCOL;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PASSPHRASE;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PROTOCOL;
-import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
 
 public class SNMPTtest {
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPTtest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPTtest.java
@@ -1,0 +1,65 @@
+package org.apache.nifi.snmp.factory.core;
+
+import org.apache.nifi.remote.io.socket.NetworkUtils;
+import org.apache.nifi.snmp.configuration.SNMPConfiguration;
+import org.snmp4j.Snmp;
+import org.snmp4j.Target;
+import org.snmp4j.security.SecurityLevel;
+
+import java.net.BindException;
+import java.util.function.Function;
+
+import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
+import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PASSPHRASE;
+import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PROTOCOL;
+import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PASSPHRASE;
+import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PROTOCOL;
+import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
+
+public class SNMPTtest {
+
+    protected static final int RETRIES = 3;
+
+    protected SNMPConfiguration getSnmpConfiguration(int managerPort, String targetPort) {
+        return new SNMPConfiguration.Builder()
+                .setRetries(RETRIES)
+                .setManagerPort(managerPort)
+                .setTargetHost(LOCALHOST)
+                .setTargetPort(targetPort)
+                .setSecurityLevel(SecurityLevel.authPriv.name())
+                .setSecurityName(SECURITY_NAME)
+                .setAuthProtocol(AUTH_PROTOCOL)
+                .setAuthPassphrase(AUTH_PASSPHRASE)
+                .setPrivacyProtocol(PRIV_PROTOCOL)
+                .setPrivacyPassphrase(PRIV_PASSPHRASE)
+                .build();
+    }
+
+    protected Snmp createSnmpManagerInstance(final Function<SNMPConfiguration, Snmp> runnable, final int retries) throws BindException {
+        int attempts = 0;
+        while(attempts < retries) {
+            try {
+                return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
+            } catch (Exception e) {
+                if (e instanceof BindException) {
+                    attempts++;
+                }
+            }
+        }
+        throw new BindException();
+    }
+
+    protected Target createTargetInstance(final Function<SNMPConfiguration, Target> runnable, final int retries) throws BindException {
+        int attempts = 0;
+        while(attempts < retries) {
+            try {
+                return runnable.apply(getSnmpConfiguration(NetworkUtils.getAvailableUdpPort(), String.valueOf(NetworkUtils.getAvailableUdpPort())));
+            } catch (Exception e) {
+                if (e instanceof BindException) {
+                    attempts++;
+                }
+            }
+        }
+        throw new BindException();
+    }
+}

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -19,14 +19,11 @@ package org.apache.nifi.snmp.factory.core;
 import org.apache.nifi.remote.io.socket.NetworkUtils;
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
 import org.apache.nifi.util.StringUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.security.SecurityLevel;
-
-import java.net.BindException;
 
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +38,7 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
     private static final int RETRIES = 3;
 
     @Test
-    void testFactoryCreatesV1V2Configuration() throws BindException {
+    void testFactoryCreatesV1V2Configuration() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
         final Target target = createTargetInstance(snmpFactory::createTargetInstance, 5);
 
@@ -53,11 +50,11 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
     }
 
     @Test
-    void testFactoryCreatesSnmpManager() throws BindException {
+    void testFactoryCreatesSnmpManager() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
         final Snmp snmpManager = createSnmpManagerInstance(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();
-        Assertions.assertNotNull(address);
+        assertNotNull(address);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -28,7 +28,7 @@ import org.snmp4j.security.SecurityLevel;
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -40,7 +40,7 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesV1V2Configuration() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
-        final Target target = createTargetInstanceWithRetries(snmpFactory::createTargetInstance, 5);
+        final Target target = createInstanceWithRetries(snmpFactory::createTargetInstance, 5);
 
         assertThat(target, instanceOf(CommunityTarget.class));
         assertNotNull(target.getAddress().toString());
@@ -52,7 +52,7 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesSnmpManager() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
-        final Snmp snmpManager = createSnmpManagerInstanceWithRetries(snmpFactory::createSnmpManagerInstance, 5);
+        final Snmp snmpManager = createInstanceWithRetries(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();
         assertNotNull(address);
     }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -27,14 +27,12 @@ import org.snmp4j.Target;
 import org.snmp4j.security.SecurityLevel;
 
 import java.net.BindException;
-import java.util.regex.Pattern;
 
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -40,7 +40,7 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesV1V2Configuration() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
-        final Target target = createTargetInstance(snmpFactory::createTargetInstance, 5);
+        final Target target = createTargetInstanceWithRetries(snmpFactory::createTargetInstance, 5);
 
         assertThat(target, instanceOf(CommunityTarget.class));
         assertNotNull(target.getAddress().toString());
@@ -52,7 +52,7 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesSnmpManager() {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
-        final Snmp snmpManager = createSnmpManagerInstance(snmpFactory::createSnmpManagerInstance, 5);
+        final Snmp snmpManager = createSnmpManagerInstanceWithRetries(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();
         assertNotNull(address);
     }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class V1V2cSNMPFactoryTest extends SNMPTtest {
+class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
 
     private static final int RETRIES = 3;
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -43,7 +43,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesTarget() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
-        final Target target = createTargetInstance(snmpFactory::createTargetInstance, 5);
+        final Target target = createTargetInstanceWithRetries(snmpFactory::createTargetInstance, 5);
         assertThat(target, instanceOf(UserTarget.class));
         assertNotNull(target.getAddress().toString());
         assertEquals(RETRIES, target.getRetries());
@@ -54,7 +54,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesSnmpManager() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
-        final Snmp snmpManager = createSnmpManagerInstance(snmpFactory::createSnmpManagerInstance, 5);
+        final Snmp snmpManager = createSnmpManagerInstanceWithRetries(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();
         USM usm = (USM) SecurityModels.getInstance().getSecurityModel(new Integer32(3));
         assertNotNull(address);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -28,7 +28,8 @@ import org.snmp4j.security.USM;
 import org.snmp4j.smi.Integer32;
 import org.snmp4j.smi.OctetString;
 
-import java.util.regex.Pattern;
+import java.net.BindException;
+import java.util.function.Function;
 
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PASSPHRASE;
@@ -39,43 +40,33 @@ import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFact
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class V3SNMPFactoryTest {
+class V3SNMPFactoryTest extends SNMPTtest {
 
-    private static final int RETRIES = 3;
     private static final int EXPECTED_SECURITY_LEVEL = 3;
 
     @Test
-    void testFactoryCreatesTarget() {
+    void testFactoryCreatesTarget() throws BindException {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
-        final int managerPort = NetworkUtils.getAvailableUdpPort();
-        final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());
-        final SNMPConfiguration snmpConfiguration = getSnmpConfiguration(managerPort, targetPort);
-
-        final Target target = snmpFactory.createTargetInstance(snmpConfiguration);
-
+        final Target target = createTargetInstance(snmpFactory::createTargetInstance, 5);
         assertThat(target, instanceOf(UserTarget.class));
-        assertEquals(LOCALHOST + "/" + targetPort, target.getAddress().toString());
+        assertNotNull(target.getAddress().toString());
         assertEquals(RETRIES, target.getRetries());
         assertEquals(EXPECTED_SECURITY_LEVEL, target.getSecurityLevel());
         assertEquals(SECURITY_NAME, target.getSecurityName().toString());
     }
 
     @Test
-    void testFactoryCreatesSnmpManager() {
+    void testFactoryCreatesSnmpManager() throws BindException {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
-        final int managerPort = NetworkUtils.getAvailableUdpPort();
-        final String targetPort = String.valueOf(NetworkUtils.getAvailableUdpPort());
-        final SNMPConfiguration snmpConfiguration = getSnmpConfiguration(managerPort, targetPort);
-
-        final Snmp snmpManager = snmpFactory.createSnmpManagerInstance(snmpConfiguration);
-
+        final Snmp snmpManager = createSnmpManagerInstance(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();
         USM usm = (USM) SecurityModels.getInstance().getSecurityModel(new Integer32(3));
-        assertTrue(Pattern.compile("0.+?0/" + managerPort).matcher(address).matches());
+        assertNotNull(address);
         assertTrue(usm.hasUser(null, new OctetString("SHAAES128")));
     }
 
@@ -90,20 +81,4 @@ class V3SNMPFactoryTest {
         verify(snmpFactory).createTargetInstance(snmpConfiguration);
         verify(snmpFactory).createSnmpManagerInstance(snmpConfiguration);
     }
-
-    private SNMPConfiguration getSnmpConfiguration(int managerPort, String targetPort) {
-        return new SNMPConfiguration.Builder()
-                .setRetries(RETRIES)
-                .setManagerPort(managerPort)
-                .setTargetHost(LOCALHOST)
-                .setTargetPort(targetPort)
-                .setSecurityLevel(SecurityLevel.authPriv.name())
-                .setSecurityName(SECURITY_NAME)
-                .setAuthProtocol(AUTH_PROTOCOL)
-                .setAuthPassphrase(AUTH_PASSPHRASE)
-                .setPrivacyProtocol(PRIV_PROTOCOL)
-                .setPrivacyPassphrase(PRIV_PASSPHRASE)
-                .build();
-    }
-
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class V3SNMPFactoryTest extends SNMPTtest {
+class V3SNMPFactoryTest extends SNMPSocketSupport {
 
     private static final int EXPECTED_SECURITY_LEVEL = 3;
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -27,7 +27,6 @@ import org.snmp4j.security.USM;
 import org.snmp4j.smi.Integer32;
 import org.snmp4j.smi.OctetString;
 
-import java.net.BindException;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -42,7 +41,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     private static final int EXPECTED_SECURITY_LEVEL = 3;
 
     @Test
-    void testFactoryCreatesTarget() throws BindException {
+    void testFactoryCreatesTarget() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
         final Target target = createTargetInstance(snmpFactory::createTargetInstance, 5);
         assertThat(target, instanceOf(UserTarget.class));
@@ -53,7 +52,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     }
 
     @Test
-    void testFactoryCreatesSnmpManager() throws BindException {
+    void testFactoryCreatesSnmpManager() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
         final Snmp snmpManager = createSnmpManagerInstance(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -43,7 +43,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesTarget() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
-        final Target target = createTargetInstanceWithRetries(snmpFactory::createTargetInstance, 5);
+        final Target target = createInstanceWithRetries(snmpFactory::createTargetInstance, 5);
         assertThat(target, instanceOf(UserTarget.class));
         assertNotNull(target.getAddress().toString());
         assertEquals(RETRIES, target.getRetries());
@@ -54,7 +54,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     @Test
     void testFactoryCreatesSnmpManager() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
-        final Snmp snmpManager = createSnmpManagerInstanceWithRetries(snmpFactory::createSnmpManagerInstance, 5);
+        final Snmp snmpManager = createInstanceWithRetries(snmpFactory::createSnmpManagerInstance, 5);
         final String address = snmpManager.getMessageDispatcher().getTransportMappings().iterator().next().getListenAddress().toString();
         USM usm = (USM) SecurityModels.getInstance().getSecurityModel(new Integer32(3));
         assertNotNull(address);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -22,20 +22,12 @@ import org.junit.jupiter.api.Test;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.UserTarget;
-import org.snmp4j.security.SecurityLevel;
 import org.snmp4j.security.SecurityModels;
 import org.snmp4j.security.USM;
 import org.snmp4j.smi.Integer32;
 import org.snmp4j.smi.OctetString;
 
 import java.net.BindException;
-import java.util.function.Function;
-
-import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
-import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PASSPHRASE;
-import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.AUTH_PROTOCOL;
-import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PASSPHRASE;
-import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.PRIV_PROTOCOL;
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10738](https://issues.apache.org/jira/browse/NIFI-10738)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10738) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-10738`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-10738`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
