### PR TITLE
NIFI-10740 Upgrade Spring Security from 5.7.4 to 5.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <snakeyaml.version>1.33</snakeyaml.version>
         <netty.4.version>4.1.84.Final</netty.4.version>
         <spring.version>5.3.23</spring.version>
-        <spring.security.version>5.7.4</spring.security.version>
+        <spring.security.version>5.7.5</spring.security.version>
         <swagger.annotations.version>1.6.6</swagger.annotations.version>
         <h2.version>2.1.214</h2.version>
         <zookeeper.version>3.8.0</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-10740](https://issues.apache.org/jira/browse/NIFI-10740) Upgrades Spring Security from 5.7.4 to [5.7.5](https://github.com/spring-projects/spring-security/releases/tag/5.7.5) to address several request filtering bugs.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
