### PR TITLE
NIFI-10713 Add Deprecation Warning for PGP in EncryptContent

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncryptContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncryptContent.java
@@ -77,7 +77,7 @@ import org.bouncycastle.openpgp.PGPEncryptedData;
 @SideEffectFree
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
-@Tags({"encryption", "decryption", "password", "JCE", "OpenPGP", "PGP", "GPG", "KDF", "Argon2", "Bcrypt", "Scrypt", "PBKDF2", "salt", "iv"})
+@Tags({"encryption", "decryption", "password", "JCE", "KDF", "Argon2", "Bcrypt", "Scrypt", "PBKDF2", "salt", "iv"})
 @CapabilityDescription("Encrypts or Decrypts a FlowFile using either symmetric encryption with a raw key or password " +
         "and randomly generated salt, or asymmetric encryption using a public and secret key.")
 @SystemResourceConsideration(resource = SystemResource.CPU)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncryptContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncryptContent.java
@@ -48,6 +48,8 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -214,6 +216,9 @@ public class EncryptContent extends AbstractProcessor {
 
     public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
             .description("Any FlowFile that cannot be encrypted or decrypted will be routed to failure").build();
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(EncryptContent.class);
+
     private List<PropertyDescriptor> properties;
 
     private Set<Relationship> relationships;
@@ -324,6 +329,11 @@ public class EncryptContent extends AbstractProcessor {
         final String keyHex = context.getProperty(RAW_KEY_HEX).getValue();
         final boolean encrypt = context.getProperty(MODE).getValue().equalsIgnoreCase(ENCRYPT_MODE);
         if (isPGPAlgorithm(algorithm)) {
+            deprecationLogger.warn("{}[id={}] OpenPGP support is deprecated: see EncryptContentPGP and DecryptContentPGP",
+                    getClass().getSimpleName(),
+                    getIdentifier()
+            );
+
             final String publicKeyring = context.getProperty(PUBLIC_KEYRING).getValue();
             final String publicUserId = context.getProperty(PUBLIC_KEY_USERID).getValue();
             final String privateKeyring = context.getProperty(PRIVATE_KEYRING).getValue();


### PR DESCRIPTION
# Summary

[NIFI-10713](https://issues.apache.org/jira/browse/NIFI-10713) Adds a deprecation warning to the `EncryptContent` Processor as part of custom validation when the Processor is configured with PGP properties.

OpenPGP support is implemented in the following Processors, providing better performance and additional features:

- EncryptContentPGP
- DecryptContentPGP
- SignContentPGP
- VerifyContentPGP

The warning mentions `EncryptContentPGP` and `DecryptContentPGP` as those Processors provide direct replacement for the PGP capabilities in `EncryptContent`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
