### PR TITLE
NIFI-10749 Correct Windows NPM Cache for GitHub Workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -261,16 +261,12 @@ jobs:
           git config --global core.longpaths true
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Get NPM Cache Directory
-        id: npm-cache-directory
-        run: |
-          echo "::set-output name=directory::$(npm config get cache)"
       - name: Cache Node Modules
         uses: actions/cache@v3
         with:
           path: |
-            ${{ steps.npm-cache-directory.outputs.directory }}
-            **/node_modules
+            ~\AppData\npm-cache
+            **\node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 8
         uses: actions/setup-java@v3


### PR DESCRIPTION
# Summary

[NIFI-10749](https://issues.apache.org/jira/browse/NIFI-10749) Corrects the Windows NPM cache configuration for GitHub workflow actions.

The changes remove the custom step to get the NPM cache directory and instead rely on the default NPM cache location for Windows, which is the current user's home directory, followed by `\AppData\npm-cache`.

The corrected behavior can be observed in the `Post Cache Node Modules` step indicating that the cache contains saved files.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
