### PR TITLE
NIFI-10702 Clear server list on connection error in SMB processors

### DIFF
--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>smbj</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
@@ -545,6 +545,7 @@ public class GetSmbFile extends AbstractProcessor {
         } catch (Exception e) {
             logger.error("Could not establish smb connection because of error {}", new Object[]{e});
             context.yield();
+            smbClient.getServerList().unregister(hostname);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
@@ -401,6 +401,7 @@ public class PutSmbFile extends AbstractProcessor {
         } catch (Exception e) {
             session.transfer(flowFiles, REL_FAILURE);
             logger.error("Could not establish smb connection because of error {}", new Object[]{e});
+            smbClient.getServerList().unregister(hostname);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/PutSmbFileTest.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/PutSmbFileTest.java
@@ -21,6 +21,7 @@ import com.hierynomus.mssmb2.SMB2ShareAccess;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.auth.AuthenticationContext;
 import com.hierynomus.smbj.connection.Connection;
+import com.hierynomus.smbj.server.ServerList;
 import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskEntry;
 import com.hierynomus.smbj.share.DiskShare;
@@ -59,6 +60,7 @@ public class PutSmbFileTest {
     private DiskShare diskShare;
     private DiskEntry diskEntry;
     private File smbfile;
+    private ServerList serverList;
     private ByteArrayOutputStream baOutputStream;
 
     private final static String HOSTNAME = "smbhostname";
@@ -80,9 +82,12 @@ public class PutSmbFileTest {
         diskShare = mock(DiskShare.class);
         diskEntry = mock(DiskEntry.class);
         smbfile = mock(File.class);
+        serverList = mock(ServerList.class);
         baOutputStream = new ByteArrayOutputStream();
 
         when(smbClient.connect(any(String.class))).thenReturn(connection);
+        when(smbClient.getServerList()).thenReturn(serverList);
+
         when(connection.authenticate(any(AuthenticationContext.class))).thenReturn(session);
         when(session.connectShare(SHARE)).thenReturn(diskShare);
         when(diskShare.openFile(

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>smbj</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
@@ -129,6 +129,7 @@ public class SmbjClientProviderService extends AbstractControllerService impleme
             getLogger().debug("Closing stale connection and trying to create a new one for share " + getServiceLocation());
 
             closeConnection(connection);
+            unregisterHost();
 
             connection = smbClient.connect(hostname, port);
             return connectToShare(connection);
@@ -158,6 +159,10 @@ public class SmbjClientProviderService extends AbstractControllerService impleme
         }
 
         return new SmbjClientService(session, (DiskShare) share, getServiceLocation());
+    }
+
+    private void unregisterHost() {
+        smbClient.getServerList().unregister(hostname);
     }
 
     private void closeConnection(Connection connection) {

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
@@ -121,9 +121,10 @@ public class SmbjClientProviderService extends AbstractControllerService impleme
 
     @Override
     public SmbClientService getClient() throws IOException {
-        Connection connection = smbClient.connect(hostname, port);
+        Connection connection = null;
 
         try {
+            connection = smbClient.connect(hostname, port);
             return connectToShare(connection);
         } catch (IOException e) {
             getLogger().debug("Closing stale connection and trying to create a new one for share " + getServiceLocation());

--- a/nifi-nar-bundles/nifi-smb-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/pom.xml
@@ -48,10 +48,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>net.engio</groupId>
                 <artifactId>mbassador</artifactId>
                 <version>1.3.2</version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10702](https://issues.apache.org/jira/browse/NIFI-10702)



### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
