### PR TITLE
NIFI-10770: Removing fetch parameters on startup

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -203,14 +203,6 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
             verifyNoConnectionsWithDataRemoved(existingDataFlow, proposedFlow, controller, flowComparison);
 
             synchronizeFlow(controller, existingDataFlow, proposedFlow, affectedComponents);
-
-            for (final ParameterProviderNode parameterProviderNode : flowManager.getAllParameterProviders()) {
-                try {
-                    parameterProviderNode.fetchParameters();
-                } catch (final Exception e) {
-                    logger.warn("Failed to fetch parameters for provider {}: {}", new Object[] { parameterProviderNode.getName(), e.getMessage() }, e);
-                }
-            }
         } finally {
             // We have to call toExistingSet() here because some of the components that existed in the active set may no longer exist,
             // so attempting to start them will fail.


### PR DESCRIPTION

# Summary

[NIFI-10770](https://issues.apache.org/jira/browse/NIFI-10770) This removes an unnecessary call to fetch parameters upon startup, which can lead to confusing warnings if services are still ENABLING.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
