### PR TITLE
NIFI-10067 enable use of script, dynamic_templates and _bulk headers for PutElasticsearchJson/Record processors

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/README.md
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/README.md
@@ -67,6 +67,30 @@ done
 - [Elasticsearch Client Service](nifi-elasticsearch-client-service)
 - [Elasticsearch REST API Processors](nifi-elasticsearch-restapi-processors)
 
+## Running on Mac
+
+Testcontainers support for "Mac OS X - Docker for Mac" is currently [best-efforts](https://www.testcontainers.org/supported_docker_environment/).
+
+It may be necessary to do the following to run the tests successfully:
+
+- Link the Docker Unix Socket to the standard location
+
+    ```sh
+    sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock
+    ```
+
+- Set the `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` environment variable
+
+    ```sh
+    export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+    ```
+
+## Running in IDEs
+
+- Edit "Run Configurations" to:
+  - enable Testcontainers via the system property, i.e. `-Delasticsearch.testcontainers.enabled=true`
+  - set the `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` environment variable if required
+
 ## Misc
 
 Integration Tests with Testcontainers currently only uses the `amd64` Docker Images.

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
@@ -341,10 +341,20 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
     /**
      * Check whether an index exists.
      *
-     * @param index The index to target, if omitted then all indices will be updated.
+     * @param index The index to check.
      * @param requestParameters A collection of URL request parameters. Optional.
      */
     boolean exists(final String index, final Map<String, String> requestParameters);
+
+    /**
+     * Check whether a document exists.
+     *
+     * @param index The index that holds the document.
+     * @param type The document type. Optional. Will not be used in future versions of Elasticsearch.
+     * @param id The document ID
+     * @param requestParameters A collection of URL request parameters. Optional.
+     */
+    boolean documentExists(final String index, final String type, final String id, final Map<String, String> requestParameters);
 
     /**
      * Get a document by ID.

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
@@ -34,7 +34,8 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
     PropertyDescriptor HTTP_HOSTS = new PropertyDescriptor.Builder()
             .name("el-cs-http-hosts")
             .displayName("HTTP Hosts")
-            .description("A comma-separated list of HTTP hosts that host Elasticsearch query nodes.")
+            .description("A comma-separated list of HTTP hosts that host Elasticsearch query nodes. " +
+                    "Note that the Host is included in requests as a header (typically including domain and port, e.g. elasticsearch:9200).")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationRequest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationRequest.java
@@ -31,13 +31,21 @@ public class IndexOperationRequest {
     private final String id;
     private final Map<String, Object> fields;
     private final Operation operation;
+    private final Map<String, Object> script;
+    private final Map<String, Object> dynamicTemplates;
+    private final Map<String, String> headerFields;
 
-    public IndexOperationRequest(final String index, final String type, final String id, final Map<String, Object> fields, final Operation operation) {
+    public IndexOperationRequest(final String index, final String type, final String id, final Map<String, Object> fields,
+                                 final Operation operation, final Map<String, Object> script, final Map<String, Object> dynamicTemplates,
+                                 final Map<String, String> headerFields) {
         this.index = index;
         this.type = type;
         this.id = id;
         this.fields = fields;
         this.operation = operation;
+        this.script = script;
+        this.dynamicTemplates = dynamicTemplates;
+        this.headerFields = headerFields;
     }
 
     public String getIndex() {
@@ -58,6 +66,18 @@ public class IndexOperationRequest {
 
     public Operation getOperation() {
         return operation;
+    }
+
+    public Map<String, Object> getScript() {
+        return script;
+    }
+
+    public Map<String, Object> getDynamicTemplates() {
+        return dynamicTemplates;
+    }
+
+    public Map<String, String> getHeaderFields() {
+        return headerFields;
     }
 
     public enum Operation {
@@ -81,10 +101,6 @@ public class IndexOperationRequest {
                     .filter(o -> o.getValue().equalsIgnoreCase(value)).findFirst()
                     .orElseThrow(() -> new IllegalArgumentException(String.format("Unknown Index Operation %s", value)));
         }
-
-        public static String[] allValues() {
-            return Arrays.stream(Operation.values()).map(Operation::getValue).sorted().toArray(String[]::new);
-        }
     }
 
     @Override
@@ -95,6 +111,9 @@ public class IndexOperationRequest {
                 ", id='" + id + '\'' +
                 ", fields=" + fields +
                 ", operation=" + operation +
+                ", script=" + script +
+                ", dynamicTemplates=" + dynamicTemplates +
+                ", headerFields=" + headerFields +
                 '}';
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationRequest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationRequest.java
@@ -32,18 +32,21 @@ public class IndexOperationRequest {
     private final Map<String, Object> fields;
     private final Operation operation;
     private final Map<String, Object> script;
+
+    private final boolean scriptedUpsert;
     private final Map<String, Object> dynamicTemplates;
     private final Map<String, String> headerFields;
 
     public IndexOperationRequest(final String index, final String type, final String id, final Map<String, Object> fields,
-                                 final Operation operation, final Map<String, Object> script, final Map<String, Object> dynamicTemplates,
-                                 final Map<String, String> headerFields) {
+                                 final Operation operation, final Map<String, Object> script, final boolean scriptedUpsert,
+                                 final Map<String, Object> dynamicTemplates, final Map<String, String> headerFields) {
         this.index = index;
         this.type = type;
         this.id = id;
         this.fields = fields;
         this.operation = operation;
         this.script = script;
+        this.scriptedUpsert = scriptedUpsert;
         this.dynamicTemplates = dynamicTemplates;
         this.headerFields = headerFields;
     }
@@ -70,6 +73,10 @@ public class IndexOperationRequest {
 
     public Map<String, Object> getScript() {
         return script;
+    }
+
+    public boolean isScriptedUpsert() {
+        return scriptedUpsert;
     }
 
     public Map<String, Object> getDynamicTemplates() {
@@ -112,6 +119,7 @@ public class IndexOperationRequest {
                 ", fields=" + fields +
                 ", operation=" + operation +
                 ", script=" + script +
+                ", scriptedUpsert=" + scriptedUpsert +
                 ", dynamicTemplates=" + dynamicTemplates +
                 ", headerFields=" + headerFields +
                 '}';

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/TestElasticSearchClientService.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/TestElasticSearchClientService.java
@@ -88,6 +88,11 @@ public class TestElasticSearchClientService extends AbstractControllerService im
     }
 
     @Override
+    public boolean documentExists(String index, String type, String id, Map<String, String> requestParameters) {
+        return true;
+    }
+
+    @Override
     public Map<String, Object> get(String index, String type, String id, Map<String, String> requestParameters) {
         return data;
     }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearch_IT.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearch_IT.java
@@ -31,7 +31,7 @@ abstract class AbstractElasticsearch_IT extends AbstractElasticsearchITBase {
     static final List<String> TEST_INDICES =
             Arrays.asList("user_details", "complex", "nested", "bulk_a", "bulk_b", "bulk_c", "error_handler", "messages");
 
-    ElasticSearchClientServiceImpl service;
+    ElasticSearchClientService service;
 
     @BeforeEach
     void before() throws Exception {

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
@@ -26,7 +26,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.controller.VerifiableControllerService;
 import org.apache.nifi.elasticsearch.AuthorizationScheme;
 import org.apache.nifi.elasticsearch.DeleteOperationResponse;
 import org.apache.nifi.elasticsearch.ElasticSearchClientService;
@@ -43,8 +42,10 @@ import org.apache.nifi.ssl.StandardSSLContextService;
 import org.apache.nifi.util.MockConfigurationContext;
 import org.apache.nifi.util.MockControllerServiceLookup;
 import org.apache.nifi.util.MockVariableRegistry;
+import org.apache.nifi.util.StringUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -70,12 +71,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
     @AfterEach
     void after() throws Exception {
-        service.onDisabled();
+        ((ElasticSearchClientServiceImpl) service).onDisabled();
     }
 
     private Map<PropertyDescriptor, String> getClientServiceProperties() {
@@ -85,7 +87,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
 
     @Test
     void testVerifySuccess() {
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -110,7 +112,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
     }
 
     private void assertVerifySniffer() {
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -131,7 +133,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         runner.setProperty(service, ElasticSearchClientService.API_KEY, apiKey.getValue());
         runner.enableControllerService(service);
 
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -146,7 +148,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         runner.disableControllerService(service);
         runner.setProperty(service, ElasticSearchClientService.HTTP_HOSTS, "invalid");
 
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -175,7 +177,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
             // expected, ignore
         }
 
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -196,7 +198,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         runner.setProperty(service, ElasticSearchClientService.USERNAME, "invalid");
         runner.setProperty(service, ElasticSearchClientService.PASSWORD, "not-real");
 
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -222,7 +224,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         runner.setProperty(service, ElasticSearchClientService.API_KEY, "not-real");
         runner.enableControllerService(service);
 
-        final List<ConfigVerificationResult> results = ((VerifiableControllerService) service).verify(
+        final List<ConfigVerificationResult> results = service.verify(
                 new MockConfigurationContext(service, getClientServiceProperties(), runner.getProcessContext().getControllerServiceLookup(), new MockVariableRegistry()),
                 runner.getLogger(),
                 Collections.emptyMap()
@@ -617,7 +619,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
             assertNotNull(doc);
         } finally {
             // replace the deleted doc
-            service.add(new IndexOperationRequest(INDEX, type, "1", originalDoc, IndexOperationRequest.Operation.Index), null);
+            service.add(new IndexOperationRequest(INDEX, type, "1", originalDoc, IndexOperationRequest.Operation.Index, null, null, null), null);
             waitForIndexRefresh(); // (affects later tests using _search or _bulk)
         }
     }
@@ -734,7 +736,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
 
         // index with nulls
         suppressNulls(false);
-        IndexOperationResponse response = service.bulk(Collections.singletonList(new IndexOperationRequest("nulls", type, "1", doc, IndexOperationRequest.Operation.Index)), null);
+        IndexOperationResponse response = service.bulk(Collections.singletonList(new IndexOperationRequest("nulls", type, "1", doc, IndexOperationRequest.Operation.Index, null, null, null)), null);
         assertNotNull(response);
         assertTrue(response.getTook() > 0);
         waitForIndexRefresh();
@@ -744,7 +746,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
 
         // suppress nulls
         suppressNulls(true);
-        response = service.bulk(Collections.singletonList(new IndexOperationRequest("nulls", type, "2", doc, IndexOperationRequest.Operation.Index)), null);
+        response = service.bulk(Collections.singletonList(new IndexOperationRequest("nulls", type, "2", doc, IndexOperationRequest.Operation.Index, null, null, null)), null);
         assertNotNull(response);
         assertTrue(response.getTook() > 0);
         waitForIndexRefresh();
@@ -773,12 +775,12 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
             final String index = x % 2 == 0 ? "bulk_a": "bulk_b";
             payload.add(new IndexOperationRequest(index, type, String.valueOf(x), new HashMap<String, Object>(){{
                 put("msg", "test");
-            }}, IndexOperationRequest.Operation.Index));
+            }}, IndexOperationRequest.Operation.Index, null, null, null));
         }
         for (int x = 0; x < 5; x++) {
             payload.add(new IndexOperationRequest("bulk_c", type, String.valueOf(x), new HashMap<String, Object>(){{
                 put("msg", "test");
-            }}, IndexOperationRequest.Operation.Index));
+            }}, IndexOperationRequest.Operation.Index, null, null, null));
         }
         final IndexOperationResponse response = service.bulk(payload, createParameters("refresh", "true"));
         assertNotNull(response);
@@ -801,27 +803,29 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         assertEquals(10, indexB.intValue());
         assertEquals(5, indexC.intValue());
 
-        final Long total = service.count(query, "bulk_*", type, null);
+        final Long total = service.count(query, "bulk_a,bulk_b,bulk_c", type, null);
         assertNotNull(total);
         assertEquals(25, total.intValue());
     }
 
     @Test
-    void testBulkRequestParameters() {
+    void testBulkRequestParametersAndBulkHeaders() {
         final List<IndexOperationRequest> payload = new ArrayList<>();
         for (int x = 0; x < 20; x++) {
             final String index = x % 2 == 0 ? "bulk_a": "bulk_b";
-            payload.add(new IndexOperationRequest(index, type, String.valueOf(x), new MapBuilder().of("msg", "test").build(), IndexOperationRequest.Operation.Index));
+            payload.add(new IndexOperationRequest(index, type, String.valueOf(x), new MapBuilder().of("msg", "test").build(),
+                    IndexOperationRequest.Operation.Index, null, null, Collections.singletonMap("retry_on_conflict", "3")));
         }
         for (int x = 0; x < 5; x++) {
-            payload.add(new IndexOperationRequest("bulk_c", type, String.valueOf(x), new MapBuilder().of("msg", "test").build(), IndexOperationRequest.Operation.Index));
+            payload.add(new IndexOperationRequest("bulk_c", type, String.valueOf(x), new MapBuilder().of("msg", "test").build(),
+                    IndexOperationRequest.Operation.Index, null, null, null));
         }
         final IndexOperationResponse response = service.bulk(payload, createParameters("refresh", "true"));
         assertNotNull(response);
         assertTrue(response.getTook() > 0);
 
         /*
-         * Now, check to ensure that both indexes got populated and refreshed appropriately.
+         * Now, check to ensure that all indices got populated and refreshed appropriately.
          */
         final String query = "{ \"query\": { \"match_all\": {}}}";
         final Long indexA = service.count(query, "bulk_a", type, null);
@@ -842,54 +846,113 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
     }
 
     @Test
+    void testUnknownBulkHeader() {
+        final IndexOperationRequest failingRequest = new IndexOperationRequest("bulk_c", type, "1", new MapBuilder().of("msg", "test").build(),
+                IndexOperationRequest.Operation.Index, null, null, Collections.singletonMap("not_exist", "true"));
+        final ElasticsearchException ee = assertThrows(ElasticsearchException.class, () -> service.add(failingRequest, null));
+        assertInstanceOf(ResponseException.class, ee.getCause());
+        assertTrue(ee.getCause().getMessage().contains("Action/metadata line [1] contains an unknown parameter [not_exist]"));
+    }
+
+    @Test
+    void testDynamicTemplates() {
+        assumeFalse(getElasticMajorVersion() == 6, "Requires Elasticsearch > 6");
+
+        final List<IndexOperationRequest> payload = Collections.singletonList(
+                new IndexOperationRequest("dynamo", type, "1", new MapBuilder().of("msg", "test", "hello", "world").build(),
+                        IndexOperationRequest.Operation.Index, null, new MapBuilder().of("hello", "test_text").build(), null)
+        );
+
+        final IndexOperationResponse response = service.bulk(payload, createParameters("refresh", "true"));
+        assertNotNull(response);
+        assertTrue(response.getTook() > 0);
+
+        /*
+         * Now, check the dynamic_template was applied
+         */
+        final Map<String, Object> fieldMapping = getIndexFieldMapping(type);
+        assertEquals(1, fieldMapping.size());
+        assertEquals("text", fieldMapping.get("type"));
+    }
+
+    @Test
     void testUpdateAndUpsert() throws InterruptedException {
         final String TEST_ID = "update-test";
-        final Map<String, Object> doc = new HashMap<>();
-        doc.put("msg", "Buongiorno, mondo");
-        service.add(new IndexOperationRequest(INDEX, type, TEST_ID, doc, IndexOperationRequest.Operation.Index), createParameters("refresh", "true"));
-        Map<String, Object> result = service.get(INDEX, type, TEST_ID, null);
-        assertEquals(doc, result, "Not the same");
-
-        final Map<String, Object> updates = new HashMap<>();
-        updates.put("from", "john.smith");
-        final Map<String, Object> merged = new HashMap<>();
-        merged.putAll(updates);
-        merged.putAll(doc);
-        IndexOperationRequest request = new IndexOperationRequest(INDEX, type, TEST_ID, updates, IndexOperationRequest.Operation.Update);
-        service.add(request, createParameters("refresh", "true"));
-        result = service.get(INDEX, type, TEST_ID, null);
-        assertTrue(result.containsKey("from"));
-        assertTrue(result.containsKey("msg"));
-        assertEquals(merged, result, "Not the same after update.");
-
         final String UPSERTED_ID = "upsert-ftw";
-        final Map<String, Object> upsertItems = new HashMap<>();
-        upsertItems.put("upsert_1", "hello");
-        upsertItems.put("upsert_2", 1);
-        upsertItems.put("upsert_3", true);
-        request = new IndexOperationRequest(INDEX, type, UPSERTED_ID, upsertItems, IndexOperationRequest.Operation.Upsert);
-        service.add(request, createParameters("refresh", "true"));
-        result = service.get(INDEX, type, UPSERTED_ID, null);
-        assertEquals(upsertItems, result);
+        final String UPSERT_SCRIPT_ID = "upsert-script";
+        try {
+            final Map<String, Object> doc = new HashMap<>();
+            doc.put("msg", "Buongiorno, mondo");
+            doc.put("counter", 1);
+            service.add(new IndexOperationRequest(INDEX, type, TEST_ID, doc, IndexOperationRequest.Operation.Index, null, null, null), createParameters("refresh", "true"));
+            Map<String, Object> result = service.get(INDEX, type, TEST_ID, null);
+            assertEquals(doc, result, "Not the same");
 
-        final List<IndexOperationRequest> deletes = new ArrayList<>();
-        deletes.add(new IndexOperationRequest(INDEX, type, TEST_ID, null, IndexOperationRequest.Operation.Delete));
-        deletes.add(new IndexOperationRequest(INDEX, type, UPSERTED_ID, null, IndexOperationRequest.Operation.Delete));
-        assertFalse(service.bulk(deletes, createParameters("refresh", "true")).hasErrors());
-        waitForIndexRefresh(); // wait 1s for index refresh (doesn't prevent GET but affects later tests using _search or _bulk)
-        ElasticsearchException ee = assertThrows(ElasticsearchException.class, () -> service.get(INDEX, type, TEST_ID, null) );
-        assertTrue(ee.isNotFound());
-        ee = assertThrows(ElasticsearchException.class, () -> service.get(INDEX, type, UPSERTED_ID, null));
-        assertTrue(ee.isNotFound());
+            final Map<String, Object> updates = new HashMap<>();
+            updates.put("from", "john.smith");
+            final Map<String, Object> merged = new HashMap<>();
+            merged.putAll(updates);
+            merged.putAll(doc);
+            IndexOperationRequest request = new IndexOperationRequest(INDEX, type, TEST_ID, updates, IndexOperationRequest.Operation.Update, null, null, null);
+            service.add(request, createParameters("refresh", "true"));
+            result = service.get(INDEX, type, TEST_ID, null);
+            assertTrue(result.containsKey("from"));
+            assertTrue(result.containsKey("counter"));
+            assertTrue(result.containsKey("msg"));
+            assertEquals(merged, result, "Not the same after update.");
+
+            final Map<String, Object> upsertItems = new HashMap<>();
+            upsertItems.put("upsert_1", "hello");
+            upsertItems.put("upsert_2", 1);
+            upsertItems.put("upsert_3", true);
+            request = new IndexOperationRequest(INDEX, type, UPSERTED_ID, upsertItems, IndexOperationRequest.Operation.Upsert, null, null, null);
+            service.add(request, createParameters("refresh", "true"));
+            result = service.get(INDEX, type, UPSERTED_ID, null);
+            assertEquals(upsertItems, result);
+
+            final Map<String, Object> upsertDoc = new HashMap<>();
+            upsertDoc.put("msg", "Only if doesn't already exist");
+            final Map<String, Object> script = new HashMap<>();
+            script.put("source", "ctx._source.counter += params.count");
+            script.put("lang", "painless");
+            script.put("params", Collections.singletonMap("count", 2));
+            // apply script to existing document
+            request = new IndexOperationRequest(INDEX, type, TEST_ID, upsertDoc, IndexOperationRequest.Operation.Upsert, script, null, null);
+            service.add(request, createParameters("refresh", "true"));
+            result = service.get(INDEX, type, TEST_ID, null);
+            assertEquals(doc.get("msg"), result.get("msg"));
+            assertEquals(3, result.get("counter"));
+            // index document that doesn't already exist (don't apply script)
+            request = new IndexOperationRequest(INDEX, type, UPSERT_SCRIPT_ID, upsertDoc, IndexOperationRequest.Operation.Upsert, script, null, null);
+            service.add(request, createParameters("refresh", "true"));
+            result = service.get(INDEX, type, UPSERT_SCRIPT_ID, null);
+            assertEquals(upsertDoc, result);
+        } finally {
+            final List<IndexOperationRequest> deletes = new ArrayList<>();
+            deletes.add(new IndexOperationRequest(INDEX, type, TEST_ID, null, IndexOperationRequest.Operation.Delete, null, null, null));
+            deletes.add(new IndexOperationRequest(INDEX, type, UPSERTED_ID, null, IndexOperationRequest.Operation.Delete, null, null, null));
+            deletes.add(new IndexOperationRequest(INDEX, type, UPSERT_SCRIPT_ID, null, IndexOperationRequest.Operation.Delete, null, null, null));
+            assertFalse(service.bulk(deletes, createParameters("refresh", "true")).hasErrors());
+            waitForIndexRefresh(); // wait 1s for index refresh (doesn't prevent GET but affects later tests using _search or _bulk)
+            ElasticsearchException ee = assertThrows(ElasticsearchException.class, () -> service.get(INDEX, type, TEST_ID, null));
+            assertTrue(ee.isNotFound());
+            ee = assertThrows(ElasticsearchException.class, () -> service.get(INDEX, type, UPSERTED_ID, null));
+            assertTrue(ee.isNotFound());
+            ee = assertThrows(ElasticsearchException.class, () -> service.get(INDEX, type, UPSERT_SCRIPT_ID, null));
+            assertTrue(ee.isNotFound());
+        }
     }
 
     @SuppressWarnings("unchecked")
     @Test
     void testGetBulkResponsesWithErrors() {
         final List<IndexOperationRequest> ops = Arrays.asList(
-                new IndexOperationRequest(INDEX, type, "1", new MapBuilder().of("msg", "one", "intField", 1).build(), IndexOperationRequest.Operation.Index), // OK
-                new IndexOperationRequest(INDEX, type, "2", new MapBuilder().of("msg", "two", "intField", 1).build(), IndexOperationRequest.Operation.Create), // already exists
-                new IndexOperationRequest(INDEX, type, "1", new MapBuilder().of("msg", "one", "intField", "notaninteger").build(), IndexOperationRequest.Operation.Index) // can't parse int field
+                new IndexOperationRequest(INDEX, type, "1", new MapBuilder().of("msg", "one", "intField", 1).build(),
+                        IndexOperationRequest.Operation.Index, null, null, null), // OK
+                new IndexOperationRequest(INDEX, type, "2", new MapBuilder().of("msg", "two", "intField", 1).build(),
+                        IndexOperationRequest.Operation.Create, null, null, null), // already exists
+                new IndexOperationRequest(INDEX, type, "1", new MapBuilder().of("msg", "one", "intField", "notaninteger").build(),
+                        IndexOperationRequest.Operation.Index, null, null, null) // can't parse int field
         );
         final IndexOperationResponse response = service.bulk(ops, createParameters("refresh", "true"));
         assertTrue(response.hasErrors());
@@ -954,5 +1017,29 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         inputStream.close();
         final Map<String, String> ret = MAPPER.readValue(new String(result, StandardCharsets.UTF_8), new TypeReference<Map<String, String>>() {});
         return Pair.of(ret.get("id"), ret.get("api_key"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getIndexFieldMapping(final String type) {
+        final String index = "dynamo";
+        final String field = "hello";
+
+        final Request request = new Request("GET",
+                String.format("%s/%s/_mapping%s/field/%s", elasticsearchHost, index, StringUtils.isBlank(type) ? "" : "/" + type, field)
+        );
+        try {
+            final Response response = testDataManagementClient.performRequest(request);
+            final InputStream inputStream = response.getEntity().getContent();
+            final byte[] result = IOUtils.toByteArray(inputStream);
+            inputStream.close();
+            final Map<String, Object> parsed = (Map<String, Object>) MAPPER.readValue(new String(result, StandardCharsets.UTF_8), Map.class);
+            final Map<String, Object> parsedIndex = (Map<String, Object>) parsed.get(index);
+            final Map<String, Object> parsedMappings = (Map<String, Object>) (StringUtils.isBlank(type)
+                    ? parsedIndex.get("mappings")
+                    : ((Map<String, Object>) parsedIndex.get("mappings")).get(type));
+            return (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) parsedMappings.get(field)).get("mapping")).get(field);
+        } catch (final IOException ioe) {
+            throw new IllegalStateException(String.format("Error getting field mappings %s [%s]", index, field), ioe);
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/resources/setup-6.script
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/resources/setup-6.script
@@ -15,7 +15,7 @@
 
 #create mapping
 PUT:user_details/:{ "mappings":{"_doc":{ "properties":{ "email":{"type":"keyword"},"phone":{"type": "keyword"},"accessKey":{"type": "keyword"}}}}}
-PUT:messages/:{ "mappings":{"_doc":{ "properties":{ "msg":{"type":"keyword"}}}}}
+PUT:messages/:{ "mappings":{"_doc":{ "properties":{ "msg":{"type":"keyword"}, "counter":{"type":"short"}}}}}
 PUT:complex/:{"mappings":{"_doc":{"properties":{"msg":{"type":"keyword"},"subField":{"type":"nested","properties":{"longField":{"type":"long"},"dateField":{"type":"date"}}}}}}}
 PUT:nested/:{"mappings":{"_doc":{"properties":{"msg":{"type":"keyword"},"subField":{"type":"nested","properties":{"longField":{"type":"long"},"dateField":{"type":"date"},"deeper":{"type":"nested","properties":{"secretz":{"type":"keyword"},"deepest":{"type":"nested","properties":{"super_secret":{"type":"keyword"}}}}}}}}}}}
 PUT:bulk_a/:{ "mappings":{"_doc":{ "properties":{ "msg":{"type":"keyword"}}}}}

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/resources/setup-7.script
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/resources/setup-7.script
@@ -15,12 +15,13 @@
 
 #create mapping
 PUT:user_details/:{ "mappings":{ "properties":{ "email":{"type":"keyword"},"phone":{"type": "keyword"},"accessKey":{"type": "keyword"}}}}
-PUT:messages/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
+PUT:messages/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}, "counter":{"type":"short"}}}}
 PUT:complex/:{"mappings":{ "properties":{"msg":{"type":"keyword"},"subField":{"type":"nested","properties":{"longField":{"type":"long"},"dateField":{"type":"date"}}}}}}
 PUT:nested/:{"mappings":{ "properties":{"msg":{"type":"keyword"},"subField":{"type":"nested","properties":{"longField":{"type":"long"},"dateField":{"type":"date"},"deeper":{"type":"nested","properties":{"secretz":{"type":"keyword"},"deepest":{"type":"nested","properties":{"super_secret":{"type":"keyword"}}}}}}}}}}
 PUT:bulk_a/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
 PUT:bulk_b/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
 PUT:bulk_c/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
+PUT:dynamo/:{ "mappings":{ "dynamic_templates": [{ "test_text": { "mapping": { "type": "text" } } }], "properties":{ "msg":{"type":"keyword"}}}}
 PUT:error_handler:{ "mappings": { "properties": { "msg": { "type": "keyword" }, "intField": { "type": "integer" }}}}
 PUT:no_source/:{ "mappings":{ "_source": { "enabled": false }, "properties":{ "msg":{"type":"keyword"}}}}
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/resources/setup-8.script
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/resources/setup-8.script
@@ -15,12 +15,13 @@
 
 #create mapping
 PUT:user_details/:{ "mappings":{ "properties":{ "email":{"type":"keyword"},"phone":{"type": "keyword"},"accessKey":{"type": "keyword"}}}}
-PUT:messages/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
+PUT:messages/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}, "counter":{"type":"short"}}}}
 PUT:complex/:{"mappings":{ "properties":{"msg":{"type":"keyword"},"subField":{"type":"nested","properties":{"longField":{"type":"long"},"dateField":{"type":"date"}}}}}}
 PUT:nested/:{"mappings":{ "properties":{"msg":{"type":"keyword"},"subField":{"type":"nested","properties":{"longField":{"type":"long"},"dateField":{"type":"date"},"deeper":{"type":"nested","properties":{"secretz":{"type":"keyword"},"deepest":{"type":"nested","properties":{"super_secret":{"type":"keyword"}}}}}}}}}}
 PUT:bulk_a/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
 PUT:bulk_b/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
 PUT:bulk_c/:{ "mappings":{ "properties":{ "msg":{"type":"keyword"}}}}
+PUT:dynamo/:{ "mappings":{ "dynamic_templates": [{ "test_text": { "mapping": { "type": "text" } } }], "properties":{ "msg":{"type":"keyword"}}}}
 PUT:error_handler:{ "mappings": { "properties": { "msg": { "type": "keyword" }, "intField": { "type": "integer" }}}}
 PUT:no_source/:{ "mappings":{ "_source": { "enabled": false }, "properties":{ "msg":{"type":"keyword"}}}}
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractByQueryElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractByQueryElasticsearch.java
@@ -137,7 +137,7 @@ public abstract class AbstractByQueryElasticsearch extends AbstractProcessor imp
                     ? context.getProperty(QUERY_ATTRIBUTE).evaluateAttributeExpressions(input).getValue()
                     : null;
 
-            final OperationResponse or = performOperation(clientService.get(), query, index, type, getUrlQueryParameters(context, input));
+            final OperationResponse or = performOperation(clientService.get(), query, index, type, getDynamicProperties(context, input));
 
             if (input == null) {
                 input = session.create();

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPaginatedJsonQueryElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPaginatedJsonQueryElasticsearch.java
@@ -120,7 +120,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearch extends AbstractJs
             if (!newQuery && paginationType == PaginationType.SCROLL) {
                 response = clientService.get().scroll(queryJson);
             } else {
-                final Map<String, String> requestParameters = getUrlQueryParameters(context, input);
+                final Map<String, String> requestParameters = getDynamicProperties(context, input);
                 if (paginationType == PaginationType.SCROLL) {
                     requestParameters.put("scroll", paginatedJsonQueryParameters.getKeepAlive());
                 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/GetElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/GetElasticsearch.java
@@ -180,7 +180,7 @@ public class GetElasticsearch extends AbstractProcessor implements Elasticsearch
             final String type = context.getProperty(TYPE).evaluateAttributeExpressions(attributes).getValue();
             final String id = context.getProperty(ID).evaluateAttributeExpressions(attributes).getValue();
             try {
-                final Map<String, String> requestParameters = new HashMap<>(getUrlQueryParameters(context, attributes));
+                final Map<String, String> requestParameters = new HashMap<>(getDynamicProperties(context, attributes));
                 requestParameters.putIfAbsent("_source", "false");
                 verifyClientService.get(index, type, id, requestParameters);
                 documentExistsResult.outcome(ConfigVerificationResult.Outcome.SUCCESSFUL)
@@ -233,7 +233,7 @@ public class GetElasticsearch extends AbstractProcessor implements Elasticsearch
             }
 
             final StopWatch stopWatch = new StopWatch(true);
-            final Map<String, Object> doc = clientService.get().get(index, type, id, getUrlQueryParameters(context, input));
+            final Map<String, Object> doc = clientService.get().get(index, type, id, getDynamicProperties(context, input));
 
             final Map<String, String> attributes = new HashMap<>(4, 1);
             attributes.put("filename", id);

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/GetElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/GetElasticsearch.java
@@ -182,15 +182,12 @@ public class GetElasticsearch extends AbstractProcessor implements Elasticsearch
             try {
                 final Map<String, String> requestParameters = new HashMap<>(getDynamicProperties(context, attributes));
                 requestParameters.putIfAbsent("_source", "false");
-                verifyClientService.get(index, type, id, requestParameters);
-                documentExistsResult.outcome(ConfigVerificationResult.Outcome.SUCCESSFUL)
-                        .explanation(String.format("Document [%s] exists in index [%s]", id, index));
-            } catch (final ElasticsearchException ee) {
-                if (ee.isNotFound()) {
+                if (verifyClientService.documentExists(index, type, id, requestParameters)) {
+                    documentExistsResult.outcome(ConfigVerificationResult.Outcome.SUCCESSFUL)
+                            .explanation(String.format("Document [%s] exists in index [%s]", id, index));
+                } else {
                     documentExistsResult.outcome(ConfigVerificationResult.Outcome.SUCCESSFUL)
                             .explanation(String.format("Document [%s] does not exist in index [%s]", id, index));
-                } else {
-                    handleDocumentExistsCheckException(ee, documentExistsResult, verificationLogger, index, id);
                 }
             } catch (final Exception ex) {
                 handleDocumentExistsCheckException(ex, documentExistsResult, verificationLogger, index, id);

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/JsonQueryElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/JsonQueryElasticsearch.java
@@ -72,7 +72,7 @@ public class JsonQueryElasticsearch extends AbstractJsonQueryElasticsearch<JsonQ
                 queryJsonParameters.getQuery(),
                 queryJsonParameters.getIndex(),
                 queryJsonParameters.getType(),
-                getUrlQueryParameters(context, input)
+                getDynamicProperties(context, input)
         );
         if (input != null) {
             session.getProvenanceReporter().send(

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJson.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJson.java
@@ -20,6 +20,7 @@ package org.apache.nifi.processors.elasticsearch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
+import org.apache.nifi.annotation.behavior.DynamicProperties;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SystemResource;
@@ -38,6 +39,7 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StringUtils;
 
@@ -61,13 +63,22 @@ import java.util.stream.Collectors;
                 description = "The error message if there is an issue parsing the FlowFile, sending the parsed document to Elasticsearch or parsing the Elasticsearch response"),
         @WritesAttribute(attribute = "elasticsearch.bulk.error", description = "The _bulk response if there was an error during processing the document within Elasticsearch.")
 })
-@DynamicProperty(
-        name = "The name of a URL query parameter to add",
-        value = "The value of the URL query parameter",
-        expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
-        description = "Adds the specified property name/value as a query parameter in the Elasticsearch URL used for processing. " +
-                "These parameters will override any matching parameters in the _bulk request body. " +
-                "If FlowFiles are batched, only the first FlowFile in the batch is used to evaluate property values.")
+@DynamicProperties({
+        @DynamicProperty(
+                name = "The name of the Bulk request header",
+                value = "The value of the Bulk request header",
+                expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
+                description = "Prefix: " + AbstractPutElasticsearch.BULK_HEADER_PREFIX +
+                        " - adds the specified property name/value as a Bulk request header in the Elasticsearch Bulk API body used for processing. " +
+                        "These parameters will override any matching parameters in the _bulk request body."),
+        @DynamicProperty(
+                name = "The name of a URL query parameter to add",
+                value = "The value of the URL query parameter",
+                expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
+                description = "Adds the specified property name/value as a query parameter in the Elasticsearch URL used for processing. " +
+                        "These parameters will override any matching parameters in the _bulk request body. " +
+                        "If FlowFiles are batched, only the first FlowFile in the batch is used to evaluate property values.")
+})
 @SystemResourceConsideration(
         resource = SystemResource.MEMORY,
         description = "The Batch of FlowFiles will be stored in memory until the bulk operation is performed.")
@@ -86,6 +97,25 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .addValidator(StandardValidators.ATTRIBUTE_KEY_VALIDATOR)
+            .build();
+
+    static final PropertyDescriptor SCRIPT = new PropertyDescriptor.Builder()
+            .name("put-es-json-script")
+            .displayName("Script")
+            .description("The script for the document update/upsert. Only applies to Update/Upsert operations. " +
+                    "Must be parsable as JSON Object. " +
+                    "If left blank, the FlowFile content will be used for document update/upsert")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .build();
+
+    static final PropertyDescriptor DYNAMIC_TEMPLATES = new PropertyDescriptor.Builder()
+            .name("put-es-json-dynamic_templates")
+            .displayName("Script")
+            .description("The dynamic_templates for the document. Must be parsable as a JSON Object. " +
+                    "Requires Elasticsearch 7+")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
     static final PropertyDescriptor CHARSET = new PropertyDescriptor.Builder()
@@ -125,7 +155,7 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         .build();
 
     static final List<PropertyDescriptor> DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
-        ID_ATTRIBUTE, INDEX_OP, INDEX, TYPE, BATCH_SIZE, CHARSET, CLIENT_SERVICE,
+        ID_ATTRIBUTE, INDEX_OP, INDEX, TYPE, SCRIPT, DYNAMIC_TEMPLATES, BATCH_SIZE, CHARSET, CLIENT_SERVICE,
         LOG_ERROR_RESPONSES, OUTPUT_ERROR_RESPONSES, OUTPUT_ERROR_DOCUMENTS, NOT_FOUND_IS_SUCCESSFUL
     ));
     static final Set<Relationship> BASE_RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
@@ -168,62 +198,14 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         final List<FlowFile> originals = new ArrayList<>(flowFiles.size());
         final List<IndexOperationRequest> operations = new ArrayList<>(flowFiles.size());
 
-        for (FlowFile input : flowFiles) {
-            final String indexOp = context.getProperty(INDEX_OP).evaluateAttributeExpressions(input).getValue();
-            final String index = context.getProperty(INDEX).evaluateAttributeExpressions(input).getValue();
-            final String type = context.getProperty(TYPE).evaluateAttributeExpressions(input).getValue();
-            final String id = StringUtils.isNotBlank(idAttribute) && StringUtils.isNotBlank(input.getAttribute(idAttribute)) ? input.getAttribute(idAttribute) : null;
-
-            final String charset = context.getProperty(CHARSET).evaluateAttributeExpressions(input).getValue();
-
-            try (final InputStream inStream = session.read(input)) {
-                final byte[] result = IOUtils.toByteArray(inStream);
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> contentMap = objectMapper.readValue(new String(result, charset), Map.class);
-
-                final IndexOperationRequest.Operation o = IndexOperationRequest.Operation.forValue(indexOp);
-                operations.add(new IndexOperationRequest(index, type, id, contentMap, o));
-
-                originals.add(input);
-            } catch (final IOException ioe) {
-                getLogger().error("Could not read FlowFile content valid JSON.", ioe);
-                input = session.putAttribute(input, "elasticsearch.put.error", ioe.getMessage());
-                session.penalize(input);
-                session.transfer(input, REL_FAILURE);
-            } catch (final Exception ex) {
-                getLogger().error("Could not index documents.", ex);
-                input = session.putAttribute(input, "elasticsearch.put.error", ex.getMessage());
-                session.penalize(input);
-                session.transfer(input, REL_FAILURE);
-            }
+        for (final FlowFile input : flowFiles) {
+            addOperation(operations, originals, idAttribute, context, session, input);
         }
 
         if (!originals.isEmpty()) {
             try {
                 final List<FlowFile> errorDocuments = indexDocuments(operations, originals, context, session);
-                session.transfer(errorDocuments, REL_FAILED_DOCUMENTS);
-                errorDocuments.forEach(e ->
-                        session.getProvenanceReporter().send(
-                                e,
-                                clientService.get().getTransitUrl(
-                                        context.getProperty(INDEX).evaluateAttributeExpressions(e).getValue(),
-                                        context.getProperty(TYPE).evaluateAttributeExpressions(e).getValue()
-                                ),
-                                "Elasticsearch _bulk operation error"
-                        )
-                );
-
-                final List<FlowFile> successfulDocuments = originals.stream().filter(f -> !errorDocuments.contains(f)).collect(Collectors.toList());
-                session.transfer(successfulDocuments, REL_SUCCESS);
-                successfulDocuments.forEach(s ->
-                        session.getProvenanceReporter().send(
-                                s,
-                                clientService.get().getTransitUrl(
-                                        context.getProperty(INDEX).evaluateAttributeExpressions(s).getValue(),
-                                        context.getProperty(TYPE).evaluateAttributeExpressions(s).getValue()
-                                )
-                        )
-                );
+                handleResponse(context, session, errorDocuments, originals);
             } catch (final ElasticsearchException ese) {
                 final String msg = String.format("Encountered a server-side problem with Elasticsearch. %s",
                         ese.isElastic() ? "Routing to retry." : "Routing to failure");
@@ -244,8 +226,56 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         }
     }
 
+    private void addOperation(final List<IndexOperationRequest> operations, final List<FlowFile> originals, final String idAttribute,
+                              final ProcessContext context, final ProcessSession session, FlowFile input) {
+        final String indexOp = context.getProperty(INDEX_OP).evaluateAttributeExpressions(input).getValue();
+        final String index = context.getProperty(INDEX).evaluateAttributeExpressions(input).getValue();
+        final String type = context.getProperty(TYPE).evaluateAttributeExpressions(input).getValue();
+        final String id = StringUtils.isNotBlank(idAttribute) && StringUtils.isNotBlank(input.getAttribute(idAttribute)) ? input.getAttribute(idAttribute) : null;
+
+        final Map<String, Object> scriptMap = getMapFromAttribute(SCRIPT, context, input);
+        final Map<String, Object> dynamicTemplatesMap = getMapFromAttribute(DYNAMIC_TEMPLATES, context, input);
+
+        final Map<String, String> dynamicProperties = getDynamicProperties(context, input);
+        final Map<String, String> bulkHeaderFields = getBulkHeaderParameters(dynamicProperties);
+
+        final String charset = context.getProperty(CHARSET).evaluateAttributeExpressions(input).getValue();
+
+        try (final InputStream inStream = session.read(input)) {
+            final byte[] result = IOUtils.toByteArray(inStream);
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> contentMap = objectMapper.readValue(new String(result, charset), Map.class);
+
+            final IndexOperationRequest.Operation o = IndexOperationRequest.Operation.forValue(indexOp);
+            operations.add(new IndexOperationRequest(index, type, id, contentMap, o, scriptMap, dynamicTemplatesMap, bulkHeaderFields));
+
+            originals.add(input);
+        } catch (final IOException ioe) {
+            getLogger().error("Could not read FlowFile content valid JSON.", ioe);
+            input = session.putAttribute(input, "elasticsearch.put.error", ioe.getMessage());
+            session.penalize(input);
+            session.transfer(input, REL_FAILURE);
+        } catch (final Exception ex) {
+            getLogger().error("Could not index documents.", ex);
+            input = session.putAttribute(input, "elasticsearch.put.error", ex.getMessage());
+            session.penalize(input);
+            session.transfer(input, REL_FAILURE);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getMapFromAttribute(final PropertyDescriptor propertyDescriptor, final ProcessContext context, final FlowFile input) {
+        final String dynamicTemplates = context.getProperty(propertyDescriptor).evaluateAttributeExpressions(input).getValue();
+        try {
+            return StringUtils.isNotBlank(dynamicTemplates) ? MAPPER.readValue(dynamicTemplates, Map.class) : Collections.emptyMap();
+        } catch (final JsonProcessingException jpe) {
+            throw new ProcessException(propertyDescriptor.getDisplayName() + " must be a String parsable into a JSON Object", jpe);
+        }
+    }
+
     private List<FlowFile> indexDocuments(final List<IndexOperationRequest> operations, final List<FlowFile> originals, final ProcessContext context, final ProcessSession session) throws IOException {
-        final IndexOperationResponse response = clientService.get().bulk(operations, getUrlQueryParameters(context, originals.get(0)));
+        final Map<String, String> dynamicProperties = getDynamicProperties(context, originals.get(0));
+        final IndexOperationResponse response = clientService.get().bulk(operations, getRequestURLParameters(dynamicProperties));
 
         final Map<Integer, Map<String, Object>> errors = findElasticsearchResponseErrors(response);
         final List<FlowFile> errorDocuments = outputErrors ? new ArrayList<>(errors.size()) : Collections.emptyList();
@@ -269,5 +299,31 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         }
 
         return errorDocuments;
+    }
+
+    private void handleResponse(final ProcessContext context, final ProcessSession session, final List<FlowFile> errorDocuments, final List<FlowFile> originals) {
+        session.transfer(errorDocuments, REL_FAILED_DOCUMENTS);
+        errorDocuments.forEach(e ->
+                session.getProvenanceReporter().send(
+                        e,
+                        clientService.get().getTransitUrl(
+                                context.getProperty(INDEX).evaluateAttributeExpressions(e).getValue(),
+                                context.getProperty(TYPE).evaluateAttributeExpressions(e).getValue()
+                        ),
+                        "Elasticsearch _bulk operation error"
+                )
+        );
+
+        final List<FlowFile> successfulDocuments = originals.stream().filter(f -> !errorDocuments.contains(f)).collect(Collectors.toList());
+        session.transfer(successfulDocuments, REL_SUCCESS);
+        successfulDocuments.forEach(s ->
+                session.getProvenanceReporter().send(
+                        s,
+                        clientService.get().getTransitUrl(
+                                context.getProperty(INDEX).evaluateAttributeExpressions(s).getValue(),
+                                context.getProperty(TYPE).evaluateAttributeExpressions(s).getValue()
+                        )
+                )
+        );
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -17,6 +17,8 @@
 
 package org.apache.nifi.processors.elasticsearch;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.nifi.annotation.behavior.DynamicProperties;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SystemResource;
@@ -86,12 +88,21 @@ import java.util.concurrent.atomic.AtomicLong;
         @WritesAttribute(attribute = "elasticsearch.put.error.count", description = "The number of records that generated errors in the Elasticsearch _bulk API."),
         @WritesAttribute(attribute = "elasticsearch.put.success.count", description = "The number of records that were successfully processed by the Elasticsearch _bulk API.")
 })
-@DynamicProperty(
-        name = "The name of a URL query parameter to add",
-        value = "The value of the URL query parameter",
-        expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
-        description = "Adds the specified property name/value as a query parameter in the Elasticsearch URL used for processing. " +
-                "These parameters will override any matching parameters in the _bulk request body")
+@DynamicProperties({
+        @DynamicProperty(
+                name = "The name of the Bulk request header",
+                value = "The value of the Bulk request header",
+                expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
+                description = "Prefix: " + AbstractPutElasticsearch.BULK_HEADER_PREFIX +
+                        " - adds the specified property name/value as a Bulk request header in the Elasticsearch Bulk API body used for processing. " +
+                        "These parameters will override any matching parameters in the _bulk request body."),
+        @DynamicProperty(
+                name = "The name of a URL query parameter to add",
+                value = "The value of the URL query parameter",
+                expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
+                description = "Adds the specified property name/value as a query parameter in the Elasticsearch URL used for processing. " +
+                        "These parameters will override any matching parameters in the _bulk request body")
+})
 @SystemResourceConsideration(
         resource = SystemResource.MEMORY,
         description = "The Batch of Records will be stored in memory until the bulk operation is performed.")
@@ -190,6 +201,26 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
 
+    static final PropertyDescriptor SCRIPT_RECORD_PATH = new PropertyDescriptor.Builder()
+            .name("put-es-record-script-path")
+            .displayName("script Record Path")
+            .description("A RecordPath pointing to a field in the record(s) that contains the script for the document update/upsert. " +
+                    "Only applies to Update/Upsert operations. Field must be Map-type compatible (e.g. a Map or a Record) " +
+                    "or a String parsable into a JSON Object")
+            .addValidator(new RecordPathValidator())
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    static final PropertyDescriptor DYNAMIC_TEMPLATES_RECORD_PATH = new PropertyDescriptor.Builder()
+            .name("put-es-record-dynamic-templates-path")
+            .displayName("Dynamic Templates Record Path")
+            .description("A RecordPath pointing to a field in the record(s) that contains the dynamic_templates for the document. " +
+                    "Field must be Map-type compatible (e.g. a Map or Record) or a String parsable into a JSON Object. " +
+                    "Requires Elasticsearch 7+")
+            .addValidator(new RecordPathValidator())
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
     static final PropertyDescriptor RETAIN_AT_TIMESTAMP_FIELD = new PropertyDescriptor.Builder()
         .name("put-es-record-retain-at-timestamp-field")
         .displayName("Retain @timestamp (Record Path)")
@@ -268,8 +299,8 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
     static final List<PropertyDescriptor> DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
         INDEX_OP, INDEX, TYPE, AT_TIMESTAMP, CLIENT_SERVICE, RECORD_READER, BATCH_SIZE, ID_RECORD_PATH, RETAIN_ID_FIELD,
         INDEX_OP_RECORD_PATH, INDEX_RECORD_PATH, TYPE_RECORD_PATH, AT_TIMESTAMP_RECORD_PATH, RETAIN_AT_TIMESTAMP_FIELD,
-        DATE_FORMAT, TIME_FORMAT, TIMESTAMP_FORMAT, LOG_ERROR_RESPONSES, OUTPUT_ERROR_RESPONSES, RESULT_RECORD_WRITER,
-        NOT_FOUND_IS_SUCCESSFUL
+        SCRIPT_RECORD_PATH, DYNAMIC_TEMPLATES_RECORD_PATH, DATE_FORMAT, TIME_FORMAT, TIMESTAMP_FORMAT, LOG_ERROR_RESPONSES,
+        OUTPUT_ERROR_RESPONSES, RESULT_RECORD_WRITER, NOT_FOUND_IS_SUCCESSFUL
     ));
     static final Set<Relationship> BASE_RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             REL_SUCCESS, REL_FAILURE, REL_RETRY, REL_FAILED_RECORDS, REL_SUCCESSFUL_RECORDS
@@ -325,27 +356,8 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
             return;
         }
 
-        final String indexOp = context.getProperty(INDEX_OP).evaluateAttributeExpressions(input).getValue();
-        final String index = context.getProperty(INDEX).evaluateAttributeExpressions(input).getValue();
-        final String type  = context.getProperty(TYPE).evaluateAttributeExpressions(input).getValue();
-        final String atTimestamp  = context.getProperty(AT_TIMESTAMP).evaluateAttributeExpressions(input).getValue();
+        final IndexOperationParameters indexOperationParameters = new IndexOperationParameters(context, input);
 
-        final String indexOpPath = context.getProperty(INDEX_OP_RECORD_PATH).evaluateAttributeExpressions(input).getValue();
-        final String idPath = context.getProperty(ID_RECORD_PATH).evaluateAttributeExpressions(input).getValue();
-        final String indexPath = context.getProperty(INDEX_RECORD_PATH).evaluateAttributeExpressions(input).getValue();
-        final String typePath = context.getProperty(TYPE_RECORD_PATH).evaluateAttributeExpressions(input).getValue();
-        final String atTimestampPath = context.getProperty(AT_TIMESTAMP_RECORD_PATH).evaluateAttributeExpressions(input).getValue();
-
-        final RecordPath ioPath = indexOpPath != null ? recordPathCache.getCompiled(indexOpPath) : null;
-        final RecordPath path = StringUtils.isNotBlank(idPath) ? recordPathCache.getCompiled(idPath) : null;
-        final RecordPath iPath = indexPath != null ? recordPathCache.getCompiled(indexPath) : null;
-        final RecordPath tPath = typePath != null ? recordPathCache.getCompiled(typePath) : null;
-        final RecordPath atPath = StringUtils.isNotBlank(atTimestampPath) ? recordPathCache.getCompiled(atTimestampPath) : null;
-
-        final boolean retainId = context.getProperty(RETAIN_ID_FIELD).evaluateAttributeExpressions(input).asBoolean();
-        final boolean retainTimestamp = context.getProperty(RETAIN_AT_TIMESTAMP_FIELD).evaluateAttributeExpressions(input).asBoolean();
-
-        final int batchSize = context.getProperty(BATCH_SIZE).evaluateAttributeExpressions(input).asInteger();
         final List<FlowFile> resultRecords = new ArrayList<>();
 
         final AtomicLong erroredRecords = new AtomicLong(0);
@@ -363,35 +375,17 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
 
             Record record;
             while ((record = recordSet.next()) != null) {
-                final String idx = getFromRecordPath(record, iPath, index, false);
-                indices.add(idx);
-                final String t = getFromRecordPath(record, tPath, type, false);
-                if (StringUtils.isNotBlank(t)) {
-                    types.add(t);
-                }
-                final IndexOperationRequest.Operation o = IndexOperationRequest.Operation.forValue(getFromRecordPath(record, ioPath, indexOp, false));
-                final String id = getFromRecordPath(record, path, null, retainId);
-                final Object timestamp = getTimestampFromRecordPath(record, atPath, atTimestamp, retainTimestamp);
-
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> contentMap = (Map<String, Object>) DataTypeUtils
-                        .convertRecordFieldtoObject(record, RecordFieldType.RECORD.getRecordDataType(record.getSchema()));
-                formatDateTimeFields(contentMap, record);
-                if (timestamp != null) {
-                    contentMap.putIfAbsent("@timestamp", timestamp);
-                }
-
-                operationList.add(new IndexOperationRequest(idx, t, id, contentMap, o));
+                addOperation(operationList, record, indexOperationParameters, indices, types);
                 originals.add(record);
 
-                if (operationList.size() == batchSize || !recordSet.isAnotherRecord()) {
-                    operate(operationList, originals, reader, context, session, input, resultRecords, erroredRecords, successfulRecords);
+                if (operationList.size() == indexOperationParameters.getBatchSize() || !recordSet.isAnotherRecord()) {
+                    operate(operationList, originals, reader, session, input, indexOperationParameters.getRequestParameters(), resultRecords, erroredRecords, successfulRecords);
                     batches++;
                 }
             }
 
             if (!operationList.isEmpty()) {
-                operate(operationList, originals, reader, context, session, input, resultRecords, erroredRecords, successfulRecords);
+                operate(operationList, originals, reader, session, input, indexOperationParameters.getRequestParameters(), resultRecords, erroredRecords, successfulRecords);
                 batches++;
             }
         } catch (final ElasticsearchException ese) {
@@ -431,13 +425,45 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         session.transfer(input, REL_SUCCESS);
     }
 
+    private void addOperation(final List<IndexOperationRequest> operationList, final Record record, final IndexOperationParameters indexOperationParameters,
+                              final Set<String> indices, final Set<String> types) {
+        final String index = getFromRecordPath(record, indexOperationParameters.getIndexPath(), true, indexOperationParameters.getDefaultIndex(), false);
+        indices.add(index);
+        final String type = getFromRecordPath(record, indexOperationParameters.getTypePath(), true, indexOperationParameters.getDefaultType(), false);
+        if (StringUtils.isNotBlank(type)) {
+            types.add(type);
+        }
+        final String op = getFromRecordPath(record, indexOperationParameters.getIndexOpPath(), true, indexOperationParameters.getDefaultIndexOp(), false);
+        final IndexOperationRequest.Operation indexOp = IndexOperationRequest.Operation.forValue(op);
+        final String id = getFromRecordPath(record, indexOperationParameters.getIdPath(), true, null, indexOperationParameters.isRetainId());
+        final Object atTimestamp = getTimestampFromRecordPath(record, indexOperationParameters.getAtTimestampPath(),
+                indexOperationParameters.getDefaultAtTimestamp(), indexOperationParameters.isRetainTimestamp());
+        final Map<String, Object> script = getMapFromRecordPath(record, indexOperationParameters.getScriptPath());
+        final Map<String, Object> dynamicTemplates = getMapFromRecordPath(record, indexOperationParameters.getDynamicTypesPath());
+
+        final Map<String, String> bulkHeaderFields = new HashMap<>(indexOperationParameters.getBulkHeaderRecordPaths().size(), 1);
+        for (final Map.Entry<String, RecordPath> entry : indexOperationParameters.getBulkHeaderRecordPaths().entrySet()) {
+            bulkHeaderFields.put(entry.getKey(), getFromRecordPath(record, entry.getValue(), false, null, false));
+        }
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> contentMap = (Map<String, Object>) DataTypeUtils
+                .convertRecordFieldtoObject(record, RecordFieldType.RECORD.getRecordDataType(record.getSchema()));
+        formatDateTimeFields(contentMap, record);
+        if (atTimestamp != null) {
+            contentMap.putIfAbsent("@timestamp", atTimestamp);
+        }
+
+        operationList.add(new IndexOperationRequest(index, type, id, contentMap, indexOp, script, dynamicTemplates, bulkHeaderFields));
+    }
+
     private void operate(final List<IndexOperationRequest> operationList, final List<Record> originals, final RecordReader reader,
-                         final ProcessContext context, final ProcessSession session, final FlowFile input,
+                         final ProcessSession session, final FlowFile input, final Map<String, String> requestParameters,
                          final List<FlowFile> resultRecords, final AtomicLong erroredRecords, final AtomicLong successfulRecords)
             throws IOException, SchemaNotFoundException, MalformedRecordException {
 
         final BulkOperation bundle = new BulkOperation(operationList, originals, reader.getSchema());
-        final ResponseDetails responseDetails = indexDocuments(bundle, context, session, input);
+        final ResponseDetails responseDetails = indexDocuments(bundle, session, input, requestParameters);
 
         if (responseDetails.getErrored() != null) {
             resultRecords.add(responseDetails.getErrored());
@@ -461,8 +487,9 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         results.clear();
     }
 
-    private ResponseDetails indexDocuments(final BulkOperation bundle, final ProcessContext context, final ProcessSession session, final FlowFile input) throws IOException, SchemaNotFoundException {
-        final IndexOperationResponse response = clientService.get().bulk(bundle.getOperationList(), getUrlQueryParameters(context, input));
+    private ResponseDetails indexDocuments(final BulkOperation bundle, final ProcessSession session, final FlowFile input,
+                                           final Map<String, String> requestParameters) throws IOException, SchemaNotFoundException {
+        final IndexOperationResponse response = clientService.get().bulk(bundle.getOperationList(), requestParameters);
 
         final Map<Integer, Map<String, Object>> errors = findElasticsearchResponseErrors(response);
         if (!errors.isEmpty()) {
@@ -541,19 +568,19 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         }
     }
 
-    private String getFromRecordPath(final Record record, final RecordPath path, final String fallback,
-                                     final boolean retain) {
+    private String getFromRecordPath(final Record record, final RecordPath path, final boolean strictString,
+                                     final String fallback, final boolean retain) {
         if (path == null) {
             return fallback;
         }
 
         final RecordPathResult result = path.evaluate(record);
         final Optional<FieldValue> value = result.getSelectedFields().findFirst();
-        if (value.isPresent() && value.get().getValue() != null) {
+        if (value.isPresent() && value.get().getValue() != null && DataTypeUtils.isStringTypeCompatible(value.get().getValue())) {
             final FieldValue fieldValue = value.get();
-            if (!fieldValue.getField().getDataType().getFieldType().equals(RecordFieldType.STRING) ) {
+            if (strictString && !fieldValue.getField().getDataType().getFieldType().equals(RecordFieldType.STRING)) {
                 throw new ProcessException(
-                    String.format("Field referenced by %s must be a string.", path.getPath())
+                    String.format("Field referenced by %s must be a string", path.getPath())
                 );
             }
 
@@ -564,6 +591,38 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
             return fieldValue.toString();
         } else {
             return fallback;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getMapFromRecordPath(final Record record, final RecordPath path) {
+        if (path == null) {
+            return Collections.emptyMap();
+        }
+
+        final RecordPathResult result = path.evaluate(record);
+        final Optional<FieldValue> value = result.getSelectedFields().findFirst();
+        if (value.isPresent() && value.get().getValue() != null) {
+            final FieldValue fieldValue = value.get();
+            final Map<String, Object> map;
+            if (DataTypeUtils.isMapTypeCompatible(fieldValue.getValue())) {
+                map = DataTypeUtils.toMap(fieldValue.getValue(), path.getPath());
+            } else {
+                try {
+                    map = MAPPER.readValue(fieldValue.getValue().toString(), Map.class);
+                } catch (final JsonProcessingException jpe) {
+                    getLogger().error("Unable to parse field {} as Map", path.getPath(), jpe);
+                    throw new ProcessException(
+                            String.format("Field referenced by %s must be Map-type compatible or a String parsable into a JSON Object", path.getPath())
+                    );
+                }
+            }
+
+            fieldValue.updateValue(null);
+
+            return map;
+        } else {
+            return Collections.emptyMap();
         }
     }
 
@@ -683,4 +742,130 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
             return successCount;
         }
     }
+
+    private class IndexOperationParameters {
+        private final String defaultIndexOp;
+        private final String defaultIndex;
+        private final String defaultType;
+        private final String defaultAtTimestamp;
+
+        private final RecordPath indexOpPath;
+        private final RecordPath idPath;
+        private final RecordPath indexPath;
+        private final RecordPath typePath;
+        private final RecordPath atTimestampPath;
+        private final RecordPath scriptPath;
+        private final RecordPath dynamicTypesPath;
+
+        private final Map<String, String> requestParameters;
+        private final Map<String, RecordPath> bulkHeaderRecordPaths;
+
+        private final boolean retainId;
+        private final boolean retainTimestamp;
+        private final int batchSize;
+
+        IndexOperationParameters(final ProcessContext context, final FlowFile input) {
+            defaultIndexOp = context.getProperty(INDEX_OP).evaluateAttributeExpressions(input).getValue();
+            defaultIndex = context.getProperty(INDEX).evaluateAttributeExpressions(input).getValue();
+            defaultType = context.getProperty(TYPE).evaluateAttributeExpressions(input).getValue();
+            defaultAtTimestamp = context.getProperty(AT_TIMESTAMP).evaluateAttributeExpressions(input).getValue();
+
+            indexOpPath = compileRecordPathFromProperty(context, INDEX_OP_RECORD_PATH, input);
+            idPath = compileRecordPathFromProperty(context, ID_RECORD_PATH, input);
+            indexPath = compileRecordPathFromProperty(context, INDEX_RECORD_PATH, input);
+            typePath = compileRecordPathFromProperty(context, TYPE_RECORD_PATH, input);
+            atTimestampPath = compileRecordPathFromProperty(context, AT_TIMESTAMP_RECORD_PATH, input);
+            scriptPath = compileRecordPathFromProperty(context, SCRIPT_RECORD_PATH, input);
+            dynamicTypesPath = compileRecordPathFromProperty(context, DYNAMIC_TEMPLATES_RECORD_PATH, input);
+
+            final Map<String, String> dynamicProperties = getDynamicProperties(context, input);
+            requestParameters = getRequestURLParameters(dynamicProperties);
+
+            final Map<String, String> bulkHeaderParameterPaths = getBulkHeaderParameters(dynamicProperties);
+            bulkHeaderRecordPaths = new HashMap<>(bulkHeaderParameterPaths.size(), 1);
+            for (final Map.Entry<String, String> entry : bulkHeaderParameterPaths.entrySet()) {
+                if (StringUtils.isNotBlank(entry.getValue())) {
+                    final RecordPath rp = recordPathCache.getCompiled(entry.getValue());
+                    if (rp != null) {
+                        bulkHeaderRecordPaths.put(entry.getKey(), rp);
+                    }
+                }
+            }
+
+            retainId = context.getProperty(RETAIN_ID_FIELD).evaluateAttributeExpressions(input).asBoolean();
+            retainTimestamp = context.getProperty(RETAIN_AT_TIMESTAMP_FIELD).evaluateAttributeExpressions(input).asBoolean();
+            batchSize = context.getProperty(BATCH_SIZE).evaluateAttributeExpressions(input).asInteger();
+        }
+
+        private RecordPath compileRecordPathFromProperty(final ProcessContext context, final PropertyDescriptor property, final FlowFile input) {
+            final String recordPathProperty = context.getProperty(property).evaluateAttributeExpressions(input).getValue();
+            return StringUtils.isNotBlank(recordPathProperty) ? recordPathCache.getCompiled(recordPathProperty) : null;
+        }
+
+        public String getDefaultIndexOp() {
+            return defaultIndexOp;
+        }
+
+        public String getDefaultIndex() {
+            return defaultIndex;
+        }
+
+        public String getDefaultType() {
+            return defaultType;
+        }
+
+        public String getDefaultAtTimestamp() {
+            return defaultAtTimestamp;
+        }
+
+        public RecordPath getIndexOpPath() {
+            return indexOpPath;
+        }
+
+        public RecordPath getIdPath() {
+            return idPath;
+        }
+
+        public RecordPath getIndexPath() {
+            return indexPath;
+        }
+
+        public RecordPath getTypePath() {
+            return typePath;
+        }
+
+        public RecordPath getAtTimestampPath() {
+            return atTimestampPath;
+        }
+
+        public RecordPath getScriptPath() {
+            return scriptPath;
+        }
+
+        public RecordPath getDynamicTypesPath() {
+            return dynamicTypesPath;
+        }
+
+        public Map<String, String> getRequestParameters() {
+            return requestParameters;
+        }
+
+        public Map<String, RecordPath> getBulkHeaderRecordPaths() {
+            return bulkHeaderRecordPaths;
+        }
+
+        public boolean isRetainId() {
+            return retainId;
+        }
+
+        public boolean isRetainTimestamp() {
+            return retainTimestamp;
+        }
+
+        public int getBatchSize() {
+            return batchSize;
+        }
+    }
+
+
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/UpdateByQueryElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/UpdateByQueryElasticsearch.java
@@ -36,7 +36,8 @@ import java.util.Map;
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
 @Tags({ "elastic", "elasticsearch", "elasticsearch5", "elasticsearch6", "elasticsearch7", "elasticsearch8", "update", "query"})
 @CapabilityDescription("Update documents in an Elasticsearch index using a query. The query can be loaded from a flowfile body " +
-        "or from the Query parameter.")
+        "or from the Query parameter. The loaded Query can contain any JSON accepted by Elasticsearch's _update_by_query API, " +
+        "for example a \"query\" object to identify what documents are to be updated, plus a \"script\" to define the updates to perform.")
 @DynamicProperty(
         name = "The name of a URL query parameter to add",
         value = "The value of the URL query parameter",

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/resources/docs/org.apache.nifi.processors.elasticsearch.PutElasticsearchJson/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/resources/docs/org.apache.nifi.processors.elasticsearch.PutElasticsearchJson/additionalDetails.html
@@ -38,7 +38,92 @@
 <p>
     The index, operation and (optional) type fields are configured with default values.
     The ID (optional unless the operation is "index") can be set as an attribute on the FlowFile(s).
-    The following is an example of a document exercising all of these features:
 </p>
+
+<h3>Dynamic Templates</h3>
+<p>
+    Index and Create operations can use Dynamic Templates. The Dynamic Templates property must be parsable as a JSON object.
+</p>
+<h4>Example - Index with Dynamic Templates</h4>
+<pre>
+    {
+        "message": "Hello, world"
+    }
+</pre>
+<p>The Dynamic Templates property below would be parsable:</p>
+<pre>{"message": "keyword_lower"}</pre>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "index" : {"_id" : "1", "_index" : "test", "dynamic_templates" : {"message" : "keyword_lower"}} }
+    { "doc" : {"message" : "Hello, world"} }
+</pre>
+
+<h3>Update/Upsert Scripts</h3>
+<p>
+    Update and Upsert operations can use a script. Scripts must contain all the elements required by Elasticsearch, e.g. source and lang.
+    The Script property must be parsable as a JSON object.
+</p>
+<p>
+    If a script is defined for an upset, the Flowfile content will be used as the upsert fields in the Elasticsearch action.
+    If no script is defined, the FlowFile content will be used as the update doc (or doc_as_upsert for upsert operations).
+</p>
+<h4>Example - Update without Script</h4>
+<pre>
+    {
+        "message": "Hello, world",
+        "from": "john.smith"
+    }
+</pre>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "update" : {"_id" : "1", "_index" : "test"} }
+    { "doc" : {"message" : "Hello, world", "from" : "john.smith"} }
+</pre>
+<h4>Example - Upsert with Script</h4>
+<pre>
+    {
+        "counter": 1
+    }
+</pre>
+<p>The script property below would be parsable:</p>
+<pre>{"source": "ctx._source.counter += params.param1", "lang": "painless", "params": {"param1": 1}}</pre>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "update" : {"_id" : "1", "_index" : "test"} }
+    { "script" : { "source": "ctx._source.counter += params.param1", "lang" : "painless", "params" : {"param1" : 1}}, "upsert" : {"counter" : 1}}
+</pre>
+
+<h3>Bulk Action Header Fields</h3>
+<p>
+    Dynamic Properties can be defined on the processor with <i>BULK:</i> prefixes.
+    Users must ensure that only known Bulk action fields are sent to Elasticsearch for the relevant index operation defined for the FlowFile,
+    Elasticsearch will reject invalid combinations of index operation and Bulk action fields.
+</p>
+<h4>Example - Update with Retry on Conflict</h4>
+<pre>
+    {
+        "message": "Hello, world",
+        "from": "john.smith"
+    }
+</pre>
+<p>With the Dynamic Property below:</p>
+<ul>
+    <li>BULK:retry_on_conflict = 3</li>
+</ul>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "update" : {"_id" : "1", "_index" : "test", "retry_on_conflict" : "3"} }
+    { "doc" : {"message" : "Hello, world", "from" : "john.smith"} }
+</pre>
+
+<h3>Index Operations</h3>
+<p>Valid values for "operation" are:</p>
+<ul>
+    <li>create</li>
+    <li>delete</li>
+    <li>index</li>
+    <li>update</li>
+    <li>upsert</li>
+</ul>
 </body>
 </html>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/resources/docs/org.apache.nifi.processors.elasticsearch.PutElasticsearchRecord/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/resources/docs/org.apache.nifi.processors.elasticsearch.PutElasticsearchRecord/additionalDetails.html
@@ -37,6 +37,8 @@
     not too large for it to handle. When failures do occur, this processor is capable of attempting to write the records
     that failed to an output record writer so that only failed records can be processed downstream or replayed.
 </p>
+
+<h3>Per-Record Actions</h3>
 <p>
     The index, operation and (optional) type fields are configured with default values that can be overridden using
     record path operations that find an index or type value in the record set.
@@ -44,8 +46,9 @@
     the record set.
     An "@timestamp" field can be added to the data either using a default or by extracting it from the record set.
     This is useful if the documents are being indexed into an Elasticsearch Data Stream.
-    The following is an example of a document exercising all of these features:
 </p>
+<h4>Example - per-record actions</h4>
+<p>The following is an example of a document exercising all of these features:</p>
 <pre>
     {
         "metadata": {
@@ -77,6 +80,101 @@
     <li>metadata/operation</li>
     <li>/ts</li>
 </ul>
+
+<h3>Dynamic Templates</h3>
+<p>
+    Index and Create operations can use Dynamic Templates from the Record, record path operations can be configured to
+    find the Dynamic Templates from the record set. Dynamic Templates fields in Records must either be a Map,
+    child Record or a string that can be parsable as a JSON object.
+</p>
+<h4>Example - Index with Dynamic Templates</h4>
+<pre>
+    {
+        "message": "Hello, world",
+        "dynamic_templates": "{\"message\": \"keyword_lower\"}"
+    }
+</pre>
+<p>The record path operation below would extract the relevant Dynamic Templates:</p>
+<ul>
+    <li>/dynamic_templates</li>
+</ul>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "index" : {"_id" : "1", "_index" : "test", "dynamic_templates" : {"message" : "keyword_lower"}} }
+    { "doc" : {"message" : "Hello, world"} }
+</pre>
+
+<h3>Update/Upsert Scripts</h3>
+<p>
+    Update and Upsert operations can use a script from the Record, record path operations can be configured to
+    find the script from the record set. Scripts must contain all the elements required by Elasticsearch, e.g. source and lang.
+    Script fields in Records must either be a Map, child Record or a string that can be parsable as a JSON object.
+</p>
+<p>
+    If a script is defined for an upset, any fields remaining in the Record will be used as the upsert fields in the Elasticsearch action.
+    If no script is defined, all Record fields will be used as the update doc (or doc_as_upsert for upsert operations).
+</p>
+<h4>Example - Update without Script</h4>
+<pre>
+    {
+        "message": "Hello, world",
+        "from": "john.smith"
+    }
+</pre>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "update" : {"_id" : "1", "_index" : "test"} }
+    { "doc" : {"message" : "Hello, world", "from" : "john.smith"} }
+</pre>
+<h4>Example - Upsert with Script</h4>
+<pre>
+    {
+        "counter": 1,
+        "script" {
+            "source": "ctx._source.counter += params.param1",
+            "lang": "painless",
+            "params": {
+                "param1": 1
+            }
+        }
+    }
+</pre>
+<p>The record path operation below would extract the relevant script:</p>
+<ul>
+    <li>/script</li>
+</ul>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "update" : {"_id" : "1", "_index" : "test"} }
+    { "script" : { "source": "ctx._source.counter += params.param1", "lang" : "painless", "params" : {"param1" : 1}}, "upsert" : {"counter" : 1}}
+</pre>
+
+<h3>Bulk Action Header Fields</h3>
+<p>
+    Dynamic Properties can be defined on the processor with <i>BULK:</i> prefixes. The value of the Dynamic Property
+    is a record path operation to find the field value from the record set.
+    Users must ensure that only known Bulk action fields are sent to Elasticsearch for the relevant index operation defined for the Record,
+    Elasticsearch will reject invalid combinations of index operation and Bulk action fields.
+</p>
+<h4>Example - Update with Retry on Conflict</h4>
+<pre>
+    {
+        "message": "Hello, world",
+        "from": "john.smith",
+        "retry": 3
+    }
+</pre>
+<p>The Dynamic Property and record path operation below would extract the relevant field:</p>
+<ul>
+    <li>BULK:retry_on_conflict = /retry</li>
+</ul>
+<p>Would create Elasticsearch action:</p>
+<pre>
+    { "update" : {"_id" : "1", "_index" : "test", "retry_on_conflict" : 3} }
+    { "doc" : {"message" : "Hello, world", "from" : "john.smith"} }
+</pre>
+
+<h3>Index Operations</h3>
 <p>Valid values for "operation" are:</p>
 <ul>
     <li>create</li>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/GetElasticsearchTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/GetElasticsearchTest.groovy
@@ -29,7 +29,6 @@ import static groovy.json.JsonOutput.toJson
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.is
 import static org.hamcrest.MatcherAssert.assertThat
-
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.groovy
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.elasticsearch
 
 import org.apache.nifi.elasticsearch.IndexOperationRequest
 import org.apache.nifi.elasticsearch.IndexOperationResponse
+import org.apache.nifi.processor.exception.ProcessException
 import org.apache.nifi.processors.elasticsearch.mock.MockBulkLoadClientService
 import org.apache.nifi.provenance.ProvenanceEventType
 import org.apache.nifi.util.TestRunner
@@ -30,6 +31,7 @@ import static groovy.json.JsonOutput.toJson
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertInstanceOf
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
@@ -75,10 +77,16 @@ class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutElasticse
             int indexCount = items.findAll { it.index == "test_index" }.size()
             int typeCount = items.findAll { it.type == "test_type" }.size()
             int opCount = items.findAll { it.operation == IndexOperationRequest.Operation.Index }.size()
+            int emptyScriptCount = items.findAll { it.script.isEmpty() }.size()
+            int emptyDynamicTemplatesCount = items.findAll { it.script.isEmpty() }.size()
+            int emptyHeaderFields = items.findAll { it.headerFields.isEmpty() }.size()
             assertEquals(1, nullIdCount)
             assertEquals(1, indexCount)
             assertEquals(1, typeCount)
             assertEquals(1, opCount)
+            assertEquals(1, emptyScriptCount)
+            assertEquals(1, emptyDynamicTemplatesCount)
+            assertEquals(1, emptyHeaderFields)
         }
 
         basicTest(failure, retry, success, evalClosure)
@@ -122,10 +130,16 @@ class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutElasticse
     }
 
     @Test
-    void simpleTestWithDocIdAndRequestParameters() {
+    void simpleTestWithDocIdAndRequestParametersAndBulkHeaders() {
         runner.setProperty("refresh", "true")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "routing", "1")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "version", '${version}')
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "empty", '${empty}')
         runner.setProperty("slices", '${slices}')
+        runner.setProperty("another", '${blank}')
         runner.setVariable("slices", "auto")
+        runner.setVariable("blank", " ")
+        runner.setVariable("version", "external")
         runner.assertValid()
 
         def evalParametersClosure = { Map<String, String> params ->
@@ -141,10 +155,17 @@ class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutElasticse
             int indexCount = items.findAll { it.index == "test_index" }.size()
             int typeCount = items.findAll { it.type == "test_type" }.size()
             int opCount = items.findAll { it.operation == IndexOperationRequest.Operation.Index }.size()
+            int headerFieldsCount = items.findAll { !it.headerFields.isEmpty() }.size()
             assertEquals(1, idCount)
             assertEquals(1, indexCount)
             assertEquals(1, typeCount)
             assertEquals(1, opCount)
+            assertEquals(1, headerFieldsCount)
+
+            def headerFields = items.get(0).headerFields
+            assertEquals(2, headerFields.size())
+            assertEquals("1", headerFields.get("routing"))
+            assertEquals("external", headerFields.get("version"))
         }
 
         clientService.evalClosure = evalClosure
@@ -153,9 +174,13 @@ class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutElasticse
     }
 
     @Test
-    void simpleTestWithRequestParametersFlowFileEL() {
+    void simpleTestWithRequestParametersAndBulkHeadersFlowFileEL() {
         runner.setProperty("refresh", "true")
         runner.setProperty("slices", '${slices}')
+        runner.setVariable("blank", " ")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "routing", "1")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "version", '${version}')
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "empty", '${empty}')
         runner.assertValid()
 
         def evalParametersClosure = { Map<String, String> params ->
@@ -168,12 +193,48 @@ class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutElasticse
 
         def evalClosure = { List<IndexOperationRequest> items ->
             int nullIdCount = items.findAll { it.id == null }.size()
+            int headerFieldsCount = items.findAll { !it.headerFields.isEmpty() }.size()
             assertEquals(1, nullIdCount)
+            assertEquals(1, headerFieldsCount)
+
+            def headerFields = items.get(0).headerFields
+            assertEquals(2, headerFields.size())
+            assertEquals("1", headerFields.get("routing"))
+            assertEquals("external", headerFields.get("version"))
         }
 
         clientService.evalClosure = evalClosure
 
-        basicTest(0, 0, 1, [slices: "auto", "doc_id": ""])
+        basicTest(0, 0, 1, [slices: "auto", version: "external", blank: " ", "doc_id": ""])
+    }
+
+    @Test
+    void simpleTestWithScriptAndDynamicTemplates() {
+        runner.setProperty(PutElasticsearchJson.SCRIPT, prettyPrint(toJson(
+                [ _source: "some script", language: "painless" ]
+        )))
+        runner.setProperty(PutElasticsearchJson.DYNAMIC_TEMPLATES, prettyPrint(toJson(
+                [ my_field: "keyword", your_field: [type: "text", keyword: [type: "text"]]]
+        )))
+
+        def evalClosure = { List<IndexOperationRequest> items ->
+            int scriptCount = items.findAll { it.script == [ _source: "some script", language: "painless" ] }.size()
+            int dynamicTemplatesCount = items.findAll { it.dynamicTemplates == [ my_field: "keyword", your_field: [type: "text", keyword: [type: "text"]]] }.size()
+            assertEquals(1, scriptCount)
+            assertEquals(1, dynamicTemplatesCount)
+        }
+
+        basicTest(0, 0, 1, evalClosure)
+
+        runner.clearTransferState()
+
+        runner.setProperty(PutElasticsearchJson.SCRIPT, "not-json")
+        runner.removeProperty(PutElasticsearchJson.DYNAMIC_TEMPLATES)
+
+        runner.enqueue(flowFileContents)
+        final AssertionError ae = assertThrows(AssertionError.class, runner.&run)
+        assertInstanceOf(ProcessException.class, ae.getCause())
+        assertEquals(PutElasticsearchJson.SCRIPT.getDisplayName() + " must be a String parsable into a JSON Object", ae.getCause().getMessage())
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
@@ -74,13 +74,15 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
         type: "record",
         fields: [
             [ name: "msg", type: "string" ],
-            [ name: "from", type: "string" ]
+            [ name: "from", type: "string" ],
+            [ name: "routing", type: "string" ],
+            [ name: "version", type: "string" ]
         ]
     ]))
 
     static final List<Map<String, String>> flowFileContentMaps = [
-            [ msg: "Hello, world", from: "john.smith" ],
-            [ msg: "Hi, back at ya!", from: "jane.doe" ]
+            [ msg: "Hello, world", from: "john.smith", routing: "1", version: " " ],
+            [ msg: "Hi, back at ya!", from: "jane.doe", version: "external" ]
     ]
 
     static final String flowFileContents = prettyPrint(toJson(flowFileContentMaps))
@@ -126,10 +128,16 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
             int indexCount = items.findAll { it.index == "test_index" }.size()
             int typeCount = items.findAll { it.type == "test_type" }.size()
             int opCount = items.findAll { it.operation == IndexOperationRequest.Operation.Index }.size()
+            int emptyScriptCount = items.findAll { it.script.isEmpty() }.size()
+            int emptyDynamicTemplatesCount = items.findAll { it.script.isEmpty() }.size()
+            int emptyHeaderFields = items.findAll { it.headerFields.isEmpty() }.size()
             assertEquals(2, timestampDefaultCount)
             assertEquals(2, indexCount)
             assertEquals(2, typeCount)
             assertEquals(2, opCount)
+            assertEquals(2, emptyScriptCount)
+            assertEquals(2, emptyDynamicTemplatesCount)
+            assertEquals(2, emptyHeaderFields)
         }
 
         basicTest(failure, retry, success, evalClosure)
@@ -188,10 +196,16 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
     }
 
     @Test
-    void simpleTestWithRequestParameters() {
+    void simpleTestWithRequestParametersAndBulkHeaders() {
         runner.setProperty("refresh", "true")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "routing", "/routing")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "version", '${version}')
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "empty", '${empty}')
         runner.setProperty("slices", '${slices}')
+        runner.setProperty("another", '${blank}')
         runner.setVariable("slices", "auto")
+        runner.setVariable("blank", " ")
+        runner.setVariable("version", "/version")
         runner.assertValid()
 
         def evalParametersClosure = { Map<String, String> params ->
@@ -202,13 +216,26 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
 
         clientService.evalParametersClosure = evalParametersClosure
 
-        basicTest(0, 0, 1)
+        def evalClosure = { List<IndexOperationRequest> items ->
+            int headerFieldsCount = items.findAll { !it.headerFields.isEmpty() }.size()
+            int routingCount = items.findAll { it.headerFields.get("routing") == "1" }.size()
+            int versionCount = items.findAll { it.headerFields.get("version") == "external" }.size()
+            assertEquals(2, headerFieldsCount)
+            assertEquals(1, routingCount)
+            assertEquals(1, versionCount)
+        }
+
+        basicTest(0, 0, 1, evalClosure)
     }
 
     @Test
-    void simpleTestWithRequestParametersFlowFileEL() {
+    void simpleTestWithRequestParametersAndBulkHeadersFlowFileEL() {
         runner.setProperty("refresh", "true")
         runner.setProperty("slices", '${slices}')
+        runner.setVariable("blank", " ")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "routing", "/routing")
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "version", '${version}')
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "empty", '${empty}')
         runner.assertValid()
 
         def evalParametersClosure = { Map<String, String> params ->
@@ -219,7 +246,18 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
 
         clientService.evalParametersClosure = evalParametersClosure
 
-        basicTest(0, 0, 1, ["schema.name": "simple", slices: "auto"])
+        def evalClosure = { List<IndexOperationRequest> items ->
+            int headerFieldsCount = items.findAll { !it.headerFields.isEmpty() }.size()
+            int routingCount = items.findAll { it.headerFields.get("routing") == "1" }.size()
+            int versionCount = items.findAll { it.headerFields.get("version") == "external" }.size()
+            assertEquals(2, headerFieldsCount)
+            assertEquals(1, routingCount)
+            assertEquals(1, versionCount)
+        }
+
+        clientService.evalClosure = evalClosure
+
+        basicTest(0, 0, 1, ["schema.name": "simple", version: "/version", slices: "auto", blank: " "])
     }
 
     @Test
@@ -263,17 +301,24 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
                 [ name: "ts", type: [ type: "long", logicalType: "timestamp-millis" ] ],
                 [ name: "date", type: [ type: "int", logicalType: "date" ] ],
                 [ name: "time", type: [ type: "int", logicalType: "time-millis" ] ],
-                [ name: "code", type: "long" ]
+                [ name: "code", type: "long" ],
+                [ name: "script", type: [ type: "map", values: "string" ] ],
+                [ name: "script_record", type: [ type: "record", name: "nested", fields: [
+                        [ name: "source", type: "string" ], [ name: "language", type: "string" ]
+                ] ] ],
+                [ name: "dynamic_templates", type: "string" ]
             ]
         ]))
 
+        def script = [ source: "some script", language: "painless" ]
+        def dynamicTemplates = [ my_field: "keyword", your_field: [type: "text", keyword: [type: "text"]]]
         def flowFileContents = prettyPrint(toJson([
             [ id: "rec-1", op: "index", index: "bulk_a", type: "message", msg: "Hello", ts: Timestamp.valueOf(LOCAL_DATE_TIME).toInstant().toEpochMilli() ],
             [ id: "rec-2", op: "index", index: "bulk_b", type: "message", msg: "Hello" ],
             [ id: "rec-3", op: "index", index: "bulk_a", type: "message", msg: "Hello" ],
             [ id: "rec-4", op: "index", index: "bulk_b", type: "message", msg: "Hello" ],
-            [ id: "rec-5", op: "index", index: "bulk_a", type: "message", msg: "" ],
-            [ id: "rec-6", op: "create", index: "bulk_b", type: "message", msg: null ]
+            [ id: "rec-5", op: "index", index: "bulk_a", type: "message", msg: "", script: script, dynamic_templates: null],
+            [ id: "rec-6", op: "create", index: "bulk_b", type: "message", msg: null, script: null, dynamic_templates: prettyPrint(toJson(dynamicTemplates)) ]
         ]))
 
         def evalClosure = { List<IndexOperationRequest> items ->
@@ -290,6 +335,10 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
             int timestampDefault = items.findAll { it.fields.get("@timestamp") == "test_timestamp" }.size()
             int ts = items.findAll { it.fields.get("ts") != null }.size()
             int id = items.findAll { it.fields.get("id") != null }.size()
+            int emptyScript = items.findAll { it.script.isEmpty() }.size()
+            int s = items.findAll { it.script == script }.size()
+            int emptyDynamicTemplates = items.findAll { it.dynamicTemplates.isEmpty() }.size()
+            int dt = items.findAll { it.dynamicTemplates == dynamicTemplates }.size()
             items.each {
                 assertNotNull(it.id)
                 assertTrue(it.id.startsWith("rec-"))
@@ -307,6 +356,10 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
             assertEquals(5, timestampDefault)
             assertEquals(0, ts)
             assertEquals(0, id)
+            assertEquals(5, emptyScript)
+            assertEquals(1, s)
+            assertEquals(5, emptyDynamicTemplates)
+            assertEquals(1, dt)
         }
 
         clientService.evalClosure = evalClosure
@@ -319,6 +372,8 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
         runner.setProperty(PutElasticsearchRecord.INDEX_RECORD_PATH, "/index")
         runner.setProperty(PutElasticsearchRecord.TYPE_RECORD_PATH, "/type")
         runner.setProperty(PutElasticsearchRecord.AT_TIMESTAMP_RECORD_PATH, "/ts")
+        runner.setProperty(PutElasticsearchRecord.SCRIPT_RECORD_PATH, "/script")
+        runner.setProperty(PutElasticsearchRecord.DYNAMIC_TEMPLATES_RECORD_PATH, "/dynamic_templates")
         runner.enqueue(flowFileContents, [
             "schema.name": "recordPathTest"
         ])
@@ -339,7 +394,7 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
                 [ id: "rec-3", op: null, index: null, type: null, msg: "Hello" ],
                 [ id: "rec-4", op: null, index: null, type: null, msg: "Hello" ],
                 [ id: "rec-5", op: "update", index: null, type: null, msg: "Hello" ],
-                [ id: "rec-6", op: null, index: "bulk_b", type: "message", msg: "Hello" ]
+                [ id: "rec-6", op: null, index: "bulk_b", type: "message", msg: "Hello", script_record: script ]
         ]))
 
         evalClosure = { List<IndexOperationRequest> items ->
@@ -355,6 +410,8 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
             int dateCount = items.findAll { it.fields.get("date") != null }.size()
             def idCount = items.findAll { it.fields.get("id") != null }.size()
             def defaultCoercedTimestampCount = items.findAll { it.fields.get("@timestamp") == 100L }.size()
+            int emptyScriptCount = items.findAll { it.script.isEmpty() }.size()
+            int scriptCount = items.findAll { it.script == script }.size()
             assertEquals(5, testTypeCount)
             assertEquals(1, messageTypeCount)
             assertEquals(5, testIndexCount)
@@ -365,6 +422,8 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
             assertEquals(5, defaultCoercedTimestampCount)
             assertEquals(1, dateCount)
             assertEquals(6, idCount)
+            assertEquals(5, emptyScriptCount)
+            assertEquals(1, scriptCount)
         }
 
         clientService.evalClosure = evalClosure
@@ -375,6 +434,7 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
         runner.setProperty(PutElasticsearchRecord.AT_TIMESTAMP_RECORD_PATH, "/date")
         runner.setProperty(PutElasticsearchRecord.DATE_FORMAT, "dd/MM/yyyy")
         runner.setProperty(PutElasticsearchRecord.RETAIN_AT_TIMESTAMP_FIELD, "true")
+        runner.setProperty(PutElasticsearchRecord.SCRIPT_RECORD_PATH, "/script_record")
         runner.enqueue(flowFileContents, [
             "schema.name": "recordPathTest",
             "operation": "index"
@@ -537,6 +597,73 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
         runner.enqueue(flowFileContents, [
                 "schema.name": "recordPathTest",
                 "will_be_empty": "/empty"
+        ])
+        runner.run()
+        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
+
+        runner.clearTransferState()
+
+        flowFileContents = prettyPrint(toJson([
+                [ id: "rec-1", op: "index", index: "bulk_a", type: "message", msg: "Hello", dynamic_templates: "" ]
+        ]))
+
+        runner.enqueue(flowFileContents, [
+                "schema.name": "recordPathTest"
+        ])
+        runner.run()
+        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 1)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
+        def failure = runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILURE)[0]
+        failure.assertAttributeEquals("elasticsearch.put.error", String.format("Field referenced by %s must be Map-type compatible or a String parsable into a JSON Object","/dynamic_templates"))
+
+        runner.clearTransferState()
+
+        flowFileContents = prettyPrint(toJson([
+                [ id: "rec-1", op: "index", index: "bulk_a", type: "message" ],
+                [ id: null, op: "create", index: "bulk_a", msg: "Hello" ],
+                [ id: "rec-3", op: null, type: "message", msg: "Hello" ],
+                [ id: "rec-4", index: null, type: "message", msg: "Hello" ],
+                [ op: "create", index: "bulk_a", type: null, msg: "Hello" ],
+                [ id: "rec-6", op: "create", index: "bulk_a", type: "message", msg: null ]
+        ]))
+
+        clientService.evalClosure = { List<IndexOperationRequest> items ->
+            int idNotNull = items.findAll { it.id != null }.size()
+            int opIndex = items.findAll { it.operation == IndexOperationRequest.Operation.Index }.size()
+            int opCreate = items.findAll { it.operation == IndexOperationRequest.Operation.Create }.size()
+            int indexA = items.findAll { it.index == "bulk_a" }.size()
+            int indexC = items.findAll { it.index == "bulk_c" }.size()
+            int typeMessage = items.findAll { it.type == "message" }.size()
+            int typeBlah = items.findAll { it.type == "blah" }.size()
+            assertEquals(4, idNotNull)
+            assertEquals(3, opIndex)
+            assertEquals(3, opCreate)
+            assertEquals(4, indexA)
+            assertEquals(2, indexC)
+            assertEquals(4, typeMessage)
+            assertEquals(2, typeBlah)
+        }
+
+        runner.setProperty(PutElasticsearchRecord.INDEX_OP, "index")
+        runner.setProperty(PutElasticsearchRecord.INDEX_OP_RECORD_PATH, "/op")
+        runner.setProperty(PutElasticsearchRecord.TYPE, "blah")
+        runner.setProperty(PutElasticsearchRecord.TYPE_RECORD_PATH, "/type")
+        runner.setProperty(PutElasticsearchRecord.INDEX, "bulk_c")
+        runner.setProperty(PutElasticsearchRecord.INDEX_RECORD_PATH, "/index")
+        runner.setProperty(PutElasticsearchRecord.ID_RECORD_PATH, "/id")
+        runner.setProperty(PutElasticsearchRecord.RETAIN_ID_FIELD, "false")
+        runner.removeProperty(PutElasticsearchRecord.AT_TIMESTAMP_RECORD_PATH)
+        runner.enqueue(flowFileContents, [
+                "schema.name": "recordPathTest"
         ])
         runner.run()
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1)
@@ -822,5 +949,12 @@ class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElastic
                     e -> ProvenanceEventType.SEND == e.getEventType() && e.getDetails() == "1 Elasticsearch _bulk operation batch(es) [2 error(s), 3 success(es)]"
                 }).count()
         )
+    }
+
+    @Test
+    void testInvalidBulkHeaderProperty() {
+        runner.assertValid()
+        runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "routing", "not-record-path")
+        runner.assertNotValid()
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/TestElasticsearchClientService.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/TestElasticsearchClientService.groovy
@@ -23,15 +23,12 @@ import org.apache.nifi.controller.AbstractControllerService
 import org.apache.nifi.controller.ConfigurationContext
 import org.apache.nifi.elasticsearch.DeleteOperationResponse
 import org.apache.nifi.elasticsearch.ElasticSearchClientService
-import org.apache.nifi.elasticsearch.ElasticsearchException
 import org.apache.nifi.elasticsearch.IndexOperationRequest
 import org.apache.nifi.elasticsearch.IndexOperationResponse
 import org.apache.nifi.elasticsearch.SearchResponse
 import org.apache.nifi.elasticsearch.UpdateOperationResponse
 import org.apache.nifi.logging.ComponentLog
 import org.apache.nifi.processors.elasticsearch.mock.MockElasticsearchException
-import org.elasticsearch.client.Response
-import org.elasticsearch.client.ResponseException
 
 class TestElasticsearchClientService extends AbstractControllerService implements ElasticSearchClientService {
     private boolean returnAggs

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/TestElasticsearchClientService.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/TestElasticsearchClientService.groovy
@@ -112,6 +112,11 @@ class TestElasticsearchClientService extends AbstractControllerService implement
     }
 
     @Override
+    boolean documentExists(String index, String type, String id, Map<String, String> requestParameters) {
+        return true
+    }
+
+    @Override
     Map<String, Object> get(String index, String type, String id, Map<String, String> requestParameters) {
         common(throwErrorInGet || throwNotFoundInGet, requestParameters)
         return [ "msg": "one" ]

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/mock/AbstractMockElasticsearchClient.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/mock/AbstractMockElasticsearchClient.groovy
@@ -83,6 +83,11 @@ class AbstractMockElasticsearchClient extends AbstractControllerService implemen
     }
 
     @Override
+    boolean documentExists(String index, String type, String id, Map<String, String> requestParameters) {
+        return true
+    }
+
+    @Override
     Map<String, Object> get(String index, String type, String id, Map<String, String> requestParameters) {
         return null
     }


### PR DESCRIPTION
# Summary

[NIFI-10067](https://issues.apache.org/jira/browse/NIFI-10067) enable use of script when updating documents in Elasticsearch via PutElasticsearchJson or PutElasticsearchRecord

[NIFI-3262](https://issues.apache.org/jira/browse/NIFI-3262) enable use of dynamic_templates in Elasticsearch _bulk operations

NIFI-3262 enable use of bulk header fields in Elasticsearch _bulk operations via BULK: dynamic headers in PutElasticsearchJson and PutElasticsearchRecord

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- [x] Documentation formatting appears as expected in rendered files
