### PR TITLE
NIFI-10774 fix flaky tests in TestGetHDFSFileInfo

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -153,6 +153,11 @@
             <version>1.19.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
@@ -35,6 +35,8 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -379,7 +381,7 @@ public class TestGetHDFSFileInfo {
         mff.assertAttributeNotExists("hdfs.status");
 
         final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupAllToAttributes.json")));
-        mff.assertAttributeEquals("hdfs.full.tree", expected);
+        JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -564,7 +566,7 @@ public class TestGetHDFSFileInfo {
                 mff.assertAttributeEquals("hdfs.permissions", "rwxr-xr-x");
                 mff.assertAttributeNotExists("hdfs.status");
                 final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupDirToAttributes-mydir.json")));
-                mff.assertAttributeEquals("hdfs.full.tree", expected);
+                JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
             }else if (mff.getAttribute("hdfs.objectName").equals("dir1")) {
                 matchCount++;
                 mff.assertAttributeEquals("hdfs.path", "/some/home/mydir");
@@ -579,7 +581,7 @@ public class TestGetHDFSFileInfo {
                 mff.assertAttributeEquals("hdfs.permissions", "rwxr-xr-x");
                 mff.assertAttributeNotExists("hdfs.status");
                 final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupDirToAttributes-dir1.json")));
-                mff.assertAttributeEquals("hdfs.full.tree", expected);
+                JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
             }else if (mff.getAttribute("hdfs.objectName").equals("dir2")) {
                 matchCount++;
                 mff.assertAttributeEquals("hdfs.path", "/some/home/mydir");
@@ -594,7 +596,7 @@ public class TestGetHDFSFileInfo {
                 mff.assertAttributeEquals("hdfs.permissions", "rwxr-xr-x");
                 mff.assertAttributeNotExists("hdfs.status");
                 final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupDirToAttributes-dir2.json")));
-                mff.assertAttributeEquals("hdfs.full.tree", expected);
+                JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
             }else if (mff.getAttribute("hdfs.objectName").equals("regDir")) {
                 matchCount++;
                 mff.assertAttributeEquals("hdfs.path", "/some/home/mydir/dir1");
@@ -609,7 +611,7 @@ public class TestGetHDFSFileInfo {
                 mff.assertAttributeEquals("hdfs.permissions", "rwxr-xr-x");
                 mff.assertAttributeNotExists("hdfs.status");
                 final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupDirToAttributes-regDir.json")));
-                mff.assertAttributeEquals("hdfs.full.tree", expected);
+                JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
             }else if (mff.getAttribute("hdfs.objectName").equals("regDir2")) {
                 matchCount++;
                 mff.assertAttributeEquals("hdfs.path", "/some/home/mydir/dir2");
@@ -624,7 +626,7 @@ public class TestGetHDFSFileInfo {
                 mff.assertAttributeEquals("hdfs.permissions", "rwxr-xr-x");
                 mff.assertAttributeNotExists("hdfs.status");
                 final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRecursiveGroupDirToAttributes-regDir2.json")));
-                mff.assertAttributeEquals("hdfs.full.tree", expected);
+                JSONAssert.assertEquals(mff.getAttribute("hdfs.full.tree"), expected, JSONCompareMode.NON_EXTENSIBLE);
             }else {
                runner.assertNotValid();
             }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
@@ -303,7 +303,9 @@ public class TestGetHDFSFileInfo {
         runner.assertTransferCount(GetHDFSFileInfo.REL_NOT_FOUND, 0);
 
         final MockFlowFile mff = runner.getFlowFilesForRelationship(GetHDFSFileInfo.REL_SUCCESS).get(0);
-        mff.assertContentEquals(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRunWithPermissionsExceptionContent.json"));
+        final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/TestGetHDFSFileInfo/testRunWithPermissionsExceptionContent.json")));
+        String content = new String(mff.getData());
+        JSONAssert.assertEquals(content, expected, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10774](https://issues.apache.org/jira/browse/NIFI-10774)
`testRecursiveGroupAllToAttributes` is detected flaky by [Nondex](https://github.com/TestingResearchIllinois/NonDex) since the attribute "hdfs.full.tree" is a JSON Object and is not always written in a deterministic order. Instead of comparing the string of the attribute and the expected one, I used `jsonassert` to compare the two JSON objects. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
