### PR TITLE
NIFI-10780 Improve ListenSyslog and ListenTCP Event Queuing

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/EventDroppedException.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-event-transport/src/main/java/org/apache/nifi/event/transport/EventDroppedException.java
@@ -17,15 +17,15 @@
 package org.apache.nifi.event.transport;
 
 /**
- * Event Exception indicating issues when transporting events
+ * Event Dropped Exception indicating when a handler drops one or more events
  */
-public class EventException extends RuntimeException {
+public class EventDroppedException extends EventException {
     /**
      * Event Exception
      *
      * @param message Message
      */
-    public EventException(final String message) {
+    public EventDroppedException(final String message) {
         super(message);
     }
 
@@ -35,7 +35,7 @@ public class EventException extends RuntimeException {
      * @param message Message
      * @param cause Throwable cause
      */
-    public EventException(final String message, final Throwable cause) {
+    public EventDroppedException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-10780](https://issues.apache.org/jira/browse/NIFI-10780) Improves `ListenSyslog` and `ListenTCP` handling of queued messages when reaching the maximum configured queue size. Changes to the supporting `ByteArrayMessageChannelHandler` allow the handler to retry queuing messages as long as the Processor is running.

The changes update `ByteArrayMessageChannelHandler` to call `BlockingQueue.offer()` with a 500 ms timeout, instead of `BlockingQueue.add()`, which throws an `IllegalStateException` when attempt to add to a full queue. The handler loop checks the shutting down status of the managing `EventExecutor` to stop trying and throw an exception when the framework instructs the Processor to shutdown the listening event server.

Additional changes include adjusting the `NettyEventServer` to call `ChannelFuture.await()` instead of `ChannelFuture.syncUninterruptibly()` for the `Channel.close()` operation. This is necessary so that the `shutdown()` method proceeds to call `shutdownGracefully()`, which informs handlers that the executor is shutting down.

Queue failures can occur when the Processor is being stopped, the queue is full, and the listening event server is attempting to add a message to the queue. This scenario will result in throwing a new `EventDroppedException`, logged at the warning level.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
