### PR TITLE
NIFI-10703 - Updated VersionedDataflow to support MaxEventDrivenThrea…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
@@ -39,7 +39,7 @@ public class VersionedDataflow {
     private Set<VersionedTemplate> templates;
     private VersionedProcessGroup rootGroup;
 
-    final static int DEFAULT_MAX_EVENT_DRIVEN_THREAD_COUNT = 1;
+    private final static int DEFAULT_MAX_EVENT_DRIVEN_THREAD_COUNT = 1;
 
     public VersionedFlowEncodingVersion getEncodingVersion() {
         return encodingVersion;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class VersionedDataflow {
     private VersionedFlowEncodingVersion encodingVersion;
     private int maxTimerDrivenThreadCount;
-    private int maxEventDrivenThreadCount = 1;
+    private int maxEventDrivenThreadCount;
     private List<VersionedFlowRegistryClient> registries;
     private List<VersionedParameterContext> parameterContexts;
     private List<VersionedParameterProvider> parameterProviders;
@@ -38,6 +38,8 @@ public class VersionedDataflow {
     private List<VersionedReportingTask> reportingTasks;
     private Set<VersionedTemplate> templates;
     private VersionedProcessGroup rootGroup;
+
+    final static int DEFAULT_MAX_EVENT_DRIVEN_THREAD_COUNT = 1;
 
     public VersionedFlowEncodingVersion getEncodingVersion() {
         return encodingVersion;
@@ -56,7 +58,7 @@ public class VersionedDataflow {
     }
 
     public int getMaxEventDrivenThreadCount() {
-        return maxEventDrivenThreadCount;
+        return maxEventDrivenThreadCount < 1 ? DEFAULT_MAX_EVENT_DRIVEN_THREAD_COUNT : maxEventDrivenThreadCount;
     }
 
     public void setMaxEventDrivenThreadCount(final int maxEventDrivenThreadCount) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
@@ -30,6 +30,7 @@ import java.util.Set;
 public class VersionedDataflow {
     private VersionedFlowEncodingVersion encodingVersion;
     private int maxTimerDrivenThreadCount;
+    private int maxEventDrivenThreadCount;
     private List<VersionedFlowRegistryClient> registries;
     private List<VersionedParameterContext> parameterContexts;
     private List<VersionedParameterProvider> parameterProviders;
@@ -52,6 +53,14 @@ public class VersionedDataflow {
 
     public void setMaxTimerDrivenThreadCount(final int maxTimerDrivenThreadCount) {
         this.maxTimerDrivenThreadCount = maxTimerDrivenThreadCount;
+    }
+
+    public int getMaxEventDrivenThreadCount() {
+        return maxEventDrivenThreadCount;
+    }
+
+    public void setMaxEventDrivenThreadCount(final int maxEventDrivenThreadCount) {
+        this.maxEventDrivenThreadCount = maxEventDrivenThreadCount;
     }
 
     public List<VersionedFlowRegistryClient> getRegistries() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/flow/VersionedDataflow.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class VersionedDataflow {
     private VersionedFlowEncodingVersion encodingVersion;
     private int maxTimerDrivenThreadCount;
-    private int maxEventDrivenThreadCount;
+    private int maxEventDrivenThreadCount = 1;
     private List<VersionedFlowRegistryClient> registries;
     private List<VersionedParameterContext> parameterContexts;
     private List<VersionedParameterProvider> parameterProviders;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1591,7 +1591,7 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
      */
     private void setMaxThreadCount(final int maxThreadCount, final FlowEngine engine, final AtomicInteger maxThreads) {
         if (maxThreadCount < 1) {
-            throw new IllegalArgumentException("Cannot set max number of threads to less than 2");
+            throw new IllegalArgumentException("Cannot set max number of threads to less than 1");
         }
 
         maxThreads.getAndSet(maxThreadCount);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedDataflowMapper.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedDataflowMapper.java
@@ -82,6 +82,7 @@ public class VersionedDataflowMapper {
         final VersionedDataflow dataflow = new VersionedDataflow();
         dataflow.setEncodingVersion(ENCODING_VERSION);
         dataflow.setMaxTimerDrivenThreadCount(flowController.getMaxTimerDrivenThreadCount());
+        dataflow.setMaxEventDrivenThreadCount(flowController.getMaxEventDrivenThreadCount());
         dataflow.setControllerServices(mapControllerServices());
         dataflow.setParameterContexts(mapParameterContexts());
         dataflow.setRegistries(mapRegistries());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -378,7 +378,7 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
 
             if (versionedFlow != null) {
                 controller.setMaxTimerDrivenThreadCount(versionedFlow.getMaxTimerDrivenThreadCount());
-                controller.setMaxEventDrivenThreadCount(versionedFlow.getMaxTimerDrivenThreadCount());
+                controller.setMaxEventDrivenThreadCount(versionedFlow.getMaxEventDrivenThreadCount());
                 ProcessGroup rootGroup = controller.getFlowManager().getRootGroup();
 
                 final Map<String, VersionedParameterContext> versionedParameterContextMap = new HashMap<>();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -378,6 +378,7 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
 
             if (versionedFlow != null) {
                 controller.setMaxTimerDrivenThreadCount(versionedFlow.getMaxTimerDrivenThreadCount());
+                controller.setMaxEventDrivenThreadCount(versionedFlow.getMaxTimerDrivenThreadCount());
                 ProcessGroup rootGroup = controller.getFlowManager().getRootGroup();
 
                 final Map<String, VersionedParameterContext> versionedParameterContextMap = new HashMap<>();


### PR DESCRIPTION
…dCount


* Knowing that this property/feature is planned to be deprecated, it still exists in NiFi 1.18.0 but currently doesn't work as expected. This PR should fix that for the time being before it's officially removed.


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10703](https://issues.apache.org/jira/browse/NIFI-10703)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10703) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-10703`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-10703`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
