### PR TITLE
NIFI-10798 Add Deprecation Logging for Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Apache NiFi was made for dataflow. It supports highly configurable directed grap
   - Pluggable fine-grained role-based authentication/authorization
   - Multiple teams can manage and share specific portions of the flow
 
+## Minimum Recommendations
+* JDK 11.0.16
+* Apache Maven 3.8.6
+
 ## Minimum Requirements
 * JDK 8 Update 251
 * Apache Maven 3.6.0

--- a/minifi/minifi-bootstrap/pom.xml
+++ b/minifi/minifi-bootstrap/pom.xml
@@ -51,6 +51,10 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-expression-language</artifactId>
         </dependency>
         <dependency>

--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/command/StartRunner.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/command/StartRunner.java
@@ -43,6 +43,9 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.nifi.bootstrap.util.OSUtils;
+import org.apache.nifi.bootstrap.util.RuntimeVersionProvider;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.minifi.bootstrap.MiNiFiParameters;
 import org.apache.nifi.minifi.bootstrap.RunMiNiFi;
 import org.apache.nifi.minifi.bootstrap.ShutdownHook;
@@ -59,6 +62,8 @@ import org.apache.nifi.util.Tuple;
 
 public class StartRunner implements CommandRunner {
     private static final int STARTUP_WAIT_SECONDS = 60;
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(StartRunner.class);
 
     private final CurrentPortProvider currentPortProvider;
     private final BootstrapFileProvider bootstrapFileProvider;
@@ -108,6 +113,11 @@ public class StartRunner implements CommandRunner {
         if (port != null) {
             CMD_LOGGER.info("Apache MiNiFi is already running, listening to Bootstrap on port {}", port);
             return;
+        }
+
+        final int javaMajorVersion = RuntimeVersionProvider.getMajorVersion();
+        if (RuntimeVersionProvider.isMajorVersionDeprecated(javaMajorVersion)) {
+            deprecationLogger.warn("Support for Java {} is deprecated. Java {} is the minimum recommended version", javaMajorVersion, RuntimeVersionProvider.getMinimumMajorVersion());
         }
 
         File prevLockFile = bootstrapFileProvider.getLockFile();

--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/service/MiNiFiExecCommandProvider.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/service/MiNiFiExecCommandProvider.java
@@ -18,7 +18,6 @@
 package org.apache.nifi.minifi.bootstrap.service;
 
 import static org.apache.nifi.minifi.bootstrap.RunMiNiFi.CONF_DIR_KEY;
-import static org.apache.nifi.minifi.bootstrap.RunMiNiFi.DEFAULT_LOGGER;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +26,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
-import org.apache.nifi.bootstrap.util.OSUtils;
+import org.apache.nifi.bootstrap.util.RuntimeVersionProvider;
 
 public class MiNiFiExecCommandProvider {
 
@@ -146,9 +145,8 @@ public class MiNiFiExecCommandProvider {
 
     private List<String> getJava11Files(File libDir) {
         List<String> java11Files = new ArrayList();
-        String runtimeJavaVersion = System.getProperty("java.version");
-        DEFAULT_LOGGER.info("Runtime Java version: {}", runtimeJavaVersion);
-        if (OSUtils.parseJavaVersion(runtimeJavaVersion) >= 11) {
+        final int javaMajorVersion = RuntimeVersionProvider.getMajorVersion();
+        if (javaMajorVersion >= 11) {
             /* If running on Java 11 or greater, add the JAXB/activation/annotation libs to the classpath.
              *
              * TODO: Once the minimum Java version requirement of NiFi is 11, this processing should be removed.

--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -52,6 +52,11 @@ limitations under the License.
                 <version>1.19.0-SNAPSHOT</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-deprecation-log</artifactId>
+                <version>1.19.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.nifi.minifi</groupId>
                 <artifactId>minifi-bootstrap</artifactId>
                 <version>1.19.0-SNAPSHOT</version>

--- a/nifi-bootstrap/pom.xml
+++ b/nifi-bootstrap/pom.xml
@@ -32,6 +32,11 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>1.19.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-bootstrap-utils</artifactId>
             <version>1.19.0-SNAPSHOT</version>
         </dependency>

--- a/nifi-commons/nifi-bootstrap-utils/src/main/java/org/apache/nifi/bootstrap/util/OSUtils.java
+++ b/nifi-commons/nifi-bootstrap-utils/src/main/java/org/apache/nifi/bootstrap/util/OSUtils.java
@@ -75,7 +75,7 @@ public final class OSUtils {
      * @param version the Java version string
      * @return the major version as an int
      */
-    public static int parseJavaVersion(final String version) {
+    static int parseJavaVersion(final String version) {
         String majorVersion;
         if (version.startsWith("1.")) {
             majorVersion = version.substring(2, 3);

--- a/nifi-commons/nifi-bootstrap-utils/src/main/java/org/apache/nifi/bootstrap/util/RuntimeVersionProvider.java
+++ b/nifi-commons/nifi-bootstrap-utils/src/main/java/org/apache/nifi/bootstrap/util/RuntimeVersionProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.bootstrap.util;
+
+/**
+ * Java Runtime Version Provider with information on supported and deprecated versions
+ */
+public class RuntimeVersionProvider {
+
+    private static final String JAVA_VERSION_PROPERTY = "java.version";
+
+    private static final int DEPRECATED_JAVA_VERSION = 8;
+
+    private static final int MINIMUM_JAVA_VERSION = 11;
+
+    /**
+     * Get major version from java.version System property
+     *
+     * @return Major Version
+     */
+    public static int getMajorVersion() {
+        final String javaVersion = System.getProperty(JAVA_VERSION_PROPERTY);
+        return OSUtils.parseJavaVersion(javaVersion);
+    }
+
+    /**
+     * Get minimum supported major version
+     *
+     * @return Minimum Major Version
+     */
+    public static int getMinimumMajorVersion() {
+        return MINIMUM_JAVA_VERSION;
+    }
+
+    /**
+     * Is major version deprecated
+     *
+     * @param majorVersion Java major version
+     * @return Deprecated status
+     */
+    public static boolean isMajorVersionDeprecated(final int majorVersion) {
+        return majorVersion == DEPRECATED_JAVA_VERSION;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-bootstrap/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-bootstrap/pom.xml
@@ -35,5 +35,10 @@
             <artifactId>nifi-bootstrap-utils</artifactId>
             <version>1.19.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>1.19.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-10798](https://issues.apache.org/jira/browse/NIFI-10798) Adds a deprecation log warning when starting NiFi, MiNiFi, or Registry on Java 8.

The warning message indicates that support for Java 8 is deprecated, and that Java 11 is the minimum recommended version.

This deprecation log provides a general warning for the future removal of Java 8 in subsequent major releases.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
