### PR TITLE
NIFI-10776 add NONE and PKI AuthorizationSchemes for ElasticSearchClientService

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/README.md
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/README.md
@@ -41,6 +41,27 @@ An example using a non-Docker version of Elasticsearch:
 
 `mvn -Pintegration-tests --fail-at-end -Delasticsearch.testcontainers.enabled=false -Delasticsearch.elastic_user.password=s3cret1234 clean install`
 
+## Bash Script Example
+
+Execute the following script from the `nifi-elasticsearch-bundle` directory:
+
+```bash
+mvn --fail-at-end -Pcontrib-check clean install
+
+es_versions=(elasticsearch6 elasticsearch7 elasticsearch8)
+it_modules=(nifi-elasticsearch-client-service nifi-elasticsearch-restapi-processors)
+for v in "${es_versions[@]}"; do
+    for m in "${it_modules[@]}"; do
+        pushd "${m}"
+        if ! mvn -P "integration-tests,${v}" --fail-at-end failsafe:integration-test failsafe:verify; then
+            echo; echo; echo "Integration Tests failed for ${v} in ${m}, see Maven logs for details"
+            exit 1
+        fi
+        popd
+    done
+done
+```
+
 ## Modules with Integration Tests (using Testcontainers)
 
 - [Elasticsearch Client Service](nifi-elasticsearch-client-service)
@@ -50,6 +71,8 @@ An example using a non-Docker version of Elasticsearch:
 
 Integration Tests with Testcontainers currently only uses the `amd64` Docker Images.
 
-`elasticsearch6` is known to **not** work with `arm64` machines (e.g. Mac M1/M2), but other Elasticsearch images (e.g. 7.x and 8.x) appear to work.
+`elasticsearch6` is known to experience some problems with `arm64` machines (e.g. Mac M1/M2),
+but other Elasticsearch images (e.g. 7.x and 8.x) appear to work. Settings have been altered for the Elasticsearch
+containers in order to try and enable them on different architectures, but there may still be some inconsistencies.
 
 Explicit `arm64` architecture support may be added in future where the Elasticsearch images exist.

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/AuthorizationScheme.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/AuthorizationScheme.java
@@ -19,6 +19,8 @@ package org.apache.nifi.elasticsearch;
 import org.apache.nifi.components.DescribedValue;
 
 public enum AuthorizationScheme implements DescribedValue {
+    NONE("None", "No authorization scheme (not recommended)."),
+    PKI("PKI", "2-way TLS/PKI certificate authorization scheme."),
     BASIC("Basic", "Basic authorization scheme."),
     API_KEY("API Key", "API key authorization scheme.");
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
@@ -58,7 +58,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
     PropertyDescriptor AUTHORIZATION_SCHEME = new PropertyDescriptor.Builder()
             .name("authorization-scheme")
             .displayName("Authorization Scheme")
-            .description("Authorization Scheme used for authenticating to Elasticsearch using the HTTP Authorization header.")
+            .description("Authorization Scheme used for (optionally) authenticating to Elasticsearch.")
             .allowableValues(AuthorizationScheme.class)
             .defaultValue(AuthorizationScheme.BASIC.getValue())
             .required(true)

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.elasticsearch.unit;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.elasticsearch.AuthorizationScheme;
+import org.apache.nifi.elasticsearch.ElasticSearchClientService;
+import org.apache.nifi.elasticsearch.ElasticSearchClientServiceImpl;
+import org.apache.nifi.elasticsearch.TestControllerServiceProcessor;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.ssl.SSLContextService;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ElasticSearchClientServiceImplTest {
+    private TestRunner runner;
+
+    private ElasticSearchClientServiceImpl service;
+
+    private static final String HOST = "http://localhost:9200";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        runner = TestRunners.newTestRunner(TestControllerServiceProcessor.class);
+        service = new ElasticSearchClientServiceImpl();
+        runner.addControllerService("Client Service", service);
+        runner.setProperty(TestControllerServiceProcessor.CLIENT_SERVICE, "Client Service");
+        runner.setProperty(service, ElasticSearchClientService.HTTP_HOSTS, HOST);
+    }
+
+    @Test
+    void testTransitUrl() {
+        final String index = "test";
+        final String type = "no-type";
+
+        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.NONE.getValue());
+        runner.enableControllerService(service);
+
+        assertEquals(String.format("%s/%s/%s", HOST, index, type), service.getTransitUrl(index, type));
+        assertEquals(String.format("%s/%s", HOST, index), service.getTransitUrl(index, null));
+    }
+
+    @Test
+    void testValidateBasicAuth() {
+        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.BASIC.getValue());
+        runner.setProperty(service, ElasticSearchClientService.USERNAME, "elastic");
+        runner.setProperty(service, ElasticSearchClientService.PASSWORD, "password");
+        runner.assertValid(service);
+
+        runner.removeProperty(service, ElasticSearchClientService.PASSWORD);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.BASIC, ElasticSearchClientService.PASSWORD);
+
+        runner.removeProperty(service, ElasticSearchClientService.USERNAME);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.BASIC, ElasticSearchClientService.USERNAME);
+
+        runner.setProperty(service, ElasticSearchClientService.PASSWORD, "password");
+        runner.removeProperty(service, ElasticSearchClientService.USERNAME);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.BASIC, ElasticSearchClientService.USERNAME);
+    }
+
+    @Test
+    void testValidateApiKeyAuth() {
+        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.API_KEY.getValue());
+        runner.setProperty(service, ElasticSearchClientService.API_KEY_ID, "api-key-id");
+        runner.setProperty(service, ElasticSearchClientService.API_KEY, "api-key");
+        runner.assertValid(service);
+
+        runner.removeProperty(service, ElasticSearchClientService.API_KEY_ID);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.API_KEY, ElasticSearchClientService.API_KEY_ID);
+
+        runner.removeProperty(service, ElasticSearchClientService.API_KEY);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.API_KEY, ElasticSearchClientService.API_KEY);
+
+        runner.setProperty(service, ElasticSearchClientService.API_KEY_ID, "api-key-id");
+        runner.removeProperty(service, ElasticSearchClientService.API_KEY);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.API_KEY, ElasticSearchClientService.API_KEY);
+    }
+
+    @Test
+    void testValidatePkiAuth() throws InitializationException {
+        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.PKI.getValue());
+
+        final SSLContextService sslService = mock(SSLContextService.class);
+        when(sslService.getIdentifier()).thenReturn("ssl-context");
+        runner.addControllerService("ssl-context", sslService);
+        runner.setProperty(service, ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE, "ssl-context");
+        when(sslService.isKeyStoreConfigured()).thenReturn(true);
+        runner.assertValid(service);
+        verify(sslService, atMostOnce()).isKeyStoreConfigured();
+        reset(sslService);
+
+        when(sslService.isKeyStoreConfigured()).thenReturn(false);
+        final AssertionFailedError ise = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
+        assertEquals(String.format(
+                "Expected Controller Service to be valid but it is invalid due to: '%s' is invalid because if '%s' is '%s' then '%s' must specify a Keystore for 2-way TLS encryption.",
+                ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE.getName(),
+                ElasticSearchClientService.AUTHORIZATION_SCHEME.getDisplayName(),
+                AuthorizationScheme.PKI.getDisplayName(),
+                ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE.getDisplayName()
+        ), ise.getMessage());
+        verify(sslService, atMostOnce()).isKeyStoreConfigured();
+        reset(sslService);
+
+        runner.removeProperty(service, ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE);
+        assertAuthorizationSchemePropertyValidationErrorMessage(AuthorizationScheme.PKI, ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE);
+        verify(sslService, atMostOnce()).isKeyStoreConfigured();
+        reset(sslService);
+    }
+
+    @Test
+    void testValidateNoAuth() {
+        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.NONE.getValue());
+        runner.assertValid(service);
+
+        runner.setProperty(service, ElasticSearchClientService.USERNAME, "elastic");
+        assertNoneAuthorizationSchemeValidationMessage(Collections.singletonList(ElasticSearchClientService.USERNAME.getDisplayName()));
+
+        runner.setProperty(service, ElasticSearchClientService.USERNAME, "elastic");
+        runner.setProperty(service, ElasticSearchClientService.PASSWORD, "password");
+        runner.setProperty(service, ElasticSearchClientService.API_KEY_ID, "api-key-id");
+        runner.setProperty(service, ElasticSearchClientService.API_KEY, "api-key");
+        assertNoneAuthorizationSchemeValidationMessage(
+                Arrays.asList(ElasticSearchClientService.USERNAME.getDisplayName(), ElasticSearchClientService.PASSWORD.getDisplayName(),
+                        ElasticSearchClientService.API_KEY_ID.getDisplayName(),ElasticSearchClientService.API_KEY.getDisplayName())
+        );
+    }
+
+    private void assertAuthorizationSchemePropertyValidationErrorMessage(final AuthorizationScheme scheme, final PropertyDescriptor subject) {
+        final AssertionFailedError ise = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
+        assertEquals(String.format("Expected Controller Service to be valid but it is invalid due to: '%s' is invalid because if '%s' is '%s' then '%s' must be set.",
+                subject.getName(),
+                ElasticSearchClientService.AUTHORIZATION_SCHEME.getDisplayName(),
+                scheme.getDisplayName(),
+                subject.getDisplayName()
+        ), ise.getMessage());
+    }
+
+    private void assertNoneAuthorizationSchemeValidationMessage(final List<String> present) {
+        final AssertionFailedError ise = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
+        assertEquals(String.format("Expected Controller Service to be valid but it is invalid due to: '%s' is invalid because if '%s' is '%s' then %s cannot be set.",
+                ElasticSearchClientService.AUTHORIZATION_SCHEME.getName(),
+                ElasticSearchClientService.AUTHORIZATION_SCHEME.getDisplayName(),
+                AuthorizationScheme.NONE.getDisplayName(),
+                present
+        ), ise.getMessage());
+    }
+}

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -86,6 +86,7 @@ language governing permissions and limitations under the License. -->
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
+                <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
                 <elasticsearch_docker_image>8.5.0</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>


### PR DESCRIPTION
# Summary

[NIFI-10776](https://issues.apache.org/jira/browse/NIFI-10776) add NONE and PKI AuthorizationSchemes for ElasticSearchClientService

Fix the ElasticSearchClientService integration-tests for Elasticsearch 6.x/7.x

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
