### PR TITLE
NIFI-10826 Separate Maven Compile and Verify in ci-workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,14 +25,36 @@ env:
     -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
-  MAVEN_BUILD_COMMAND: >-
-    mvn package verify
-    -V
+  COMPILE_MAVEN_OPTS: >-
+    -Xmx3g
+    -Dhttp.keepAlive=false
+    -Dmaven.wagon.http.pool=false
+  MAVEN_COMPILE_COMMAND: >-
+    mvn compile
+    --threads 2C
+    --show-version
+    --no-snapshot-updates
+    --no-transfer-progress
+    --fail-fast
+    -pl -:nifi-assembly
+    -pl -:nifi-kafka-connector-assembly
+    -pl -:nifi-kafka-connector-tests
+    -pl -:nifi-toolkit-encrypt-config
+    -pl -:nifi-toolkit-admin
+    -pl -:nifi-toolkit-tls
+    -pl -:nifi-toolkit-assembly
+    -pl -:nifi-registry-assembly
+    -pl -:nifi-registry-toolkit-assembly
+    -pl -:nifi-runtime-manifest
+    -pl -:nifi-runtime-manifest-test
+  MAVEN_VERIFY_COMMAND: >-
+    mvn verify
+    --show-version
+    --no-snapshot-updates
+    --no-transfer-progress
+    --fail-fast
     -D dir-only
     -D disableXmlReport
-    -nsu
-    -ntp
-    -ff
   MAVEN_BUILD_PROFILES: >-
     -P include-grpc
     -P skip-nifi-bin-assembly
@@ -107,7 +129,13 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
           cache: 'maven'
-      - name: Maven Build
+      - name: Maven Compile
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.COMPILE_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMPILE_COMMAND }}
+      - name: Maven Verify
         env:
           NIFI_CI_LOCALE: >-
             -Duser.language=en
@@ -121,7 +149,7 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >
-          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_VERIFY_COMMAND }}
           ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
@@ -162,7 +190,13 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
           cache: 'maven'
-      - name: Maven Build
+      - name: Maven Compile
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.COMPILE_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMPILE_COMMAND }}
+      - name: Maven Verify
         env:
           NIFI_CI_LOCALE: >-
             -Duser.language=hi
@@ -176,7 +210,7 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >
-          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_VERIFY_COMMAND }}
           ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
@@ -217,7 +251,13 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
-      - name: Maven Build
+      - name: Maven Compile
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.COMPILE_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMPILE_COMMAND }}
+      - name: Maven Verify
         env:
           NIFI_CI_LOCALE: >-
             -Duser.language=ja
@@ -231,7 +271,7 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >-
-          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_VERIFY_COMMAND }}
           ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
@@ -274,7 +314,13 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Maven Build
+      - name: Maven Compile
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.COMPILE_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMPILE_COMMAND }}
+      - name: Maven Verify
         env:
           NIFI_CI_LOCALE: >-
             -Duser.language=fr
@@ -288,7 +334,7 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
         run: >-
-          ${{ env.MAVEN_BUILD_COMMAND }}
+          ${{ env.MAVEN_VERIFY_COMMAND }}
           ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports

--- a/nifi-h2/nifi-h2-database/pom.xml
+++ b/nifi-h2/nifi-h2-database/pom.xml
@@ -33,11 +33,25 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/pom.xml
@@ -93,7 +93,7 @@
                 <executions>
                     <execution>
                         <id>unpack-rest-api-doc</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
@@ -118,7 +118,7 @@
                 <executions>
                     <execution>
                         <id>copy-rest-api-doc</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
# Summary

[NIFI-10826](https://issues.apache.org/jira/browse/NIFI-10826) Separates Maven compilation and verification into separate build steps within the GitHub ci-workflow configuration.

The updated ci-workflow includes a Maven Compile step that calls `mvn compile` with two threads per core and excludes several assembly that are not necessary for initial compilation. The subsequent Maven Verify step calls `mvn verify` with existing arguments to run standard unit tests.

Additional changes include adjusting the lifecycle phase for `nifi-h2-database` to be invoked during compilation, and shifting NiFi Registry documentation unpacking to the `prepare-package` phase where it is needed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
