### PR TITLE
NIFI-10837 fixing flaky test in TestXMLReader

### DIFF
--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReaderProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReaderProcessor.java
@@ -57,7 +57,8 @@ public class TestXMLReaderProcessor extends AbstractProcessor {
              final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger())) {
             Record record;
             while ((record = reader.nextRecord()) != null) {
-                records.add(record.toString());
+                String str="MapRecord[{COUNTRY="+record.getValue("COUNTRY").toString()+", ATTR_ID="+record.getValue("ATTR_ID").toString()+", NAME="+record.getValue("NAME").toString()+", AGE="+record.getValue("AGE").toString()+"}]";
+                records.add(str);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReaderProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReaderProcessor.java
@@ -57,7 +57,7 @@ public class TestXMLReaderProcessor extends AbstractProcessor {
              final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger())) {
             Record record;
             while ((record = reader.nextRecord()) != null) {
-                String str="MapRecord[{COUNTRY="+record.getValue("COUNTRY").toString()+", ATTR_ID="+record.getValue("ATTR_ID").toString()+", NAME="+record.getValue("NAME").toString()+", AGE="+record.getValue("AGE").toString()+"}]";
+                String str = "MapRecord[{COUNTRY="+record.getValue("COUNTRY").toString()+", ATTR_ID="+record.getValue("ATTR_ID").toString()+", NAME="+record.getValue("NAME").toString()+", AGE="+record.getValue("AGE").toString()+"}]";
                 records.add(str);
             }
         } catch (Exception e) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10837](https://issues.apache.org/jira/browse/NIFI-10837)
Following the problem in the issue NIFI-10837. I dived deep to the class "TestXMLReaderProcessor" where the record has been transfer to String and stored in records.
After several printouts and checking log files and view the code in Record interface, we found that we can actually get the value and field of each record. 

The reason assertion can't pass is that the record is implemented as hashmap. When record.toString(), the order of the data is non-deterministic.

Since the record.toString() return a string variable, I did not really want to change too many codes. And the onTrigger function only put the string variable to records List. So I create a String variable to make the record in a specific format. As I said before, we can get value of the record by given function record.getValue("field")
```
String str="MapRecord[{COUNTRY="+record.getValue("COUNTRY").toString()+", ATTR_ID="+record.getValue("ATTR_ID").toString()+", NAME="+record.getValue("NAME").toString()+", AGE="+record.getValue("AGE").toString()+"}]";

```
By changing this, the compile can pass and the bug has been fixed. It is not flaky anymore and can pass the NonDex's check.
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files