### PR TITLE
NIFI-10608 Copying Process Group now includes non-processor referenced controller services

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/SnippetUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/SnippetUtils.java
@@ -354,6 +354,16 @@ public final class SnippetUtils {
                 });
         }
 
+        // include services referenced by processor group but not by any processors
+        for (ControllerServiceNode csNode : group.getControllerServices(false)) {
+            if (csNode != null) {
+                ControllerServiceDTO serviceDto = dtoFactory.createControllerServiceDto(csNode);
+                if (allServicesReferenced.add(serviceDto)) {
+                    contents.getControllerServices().add(serviceDto);
+                }
+            }
+        }
+
         // Map child process group ID to the child process group for easy lookup
         final Map<String, ProcessGroupDTO> childGroupMap = contents.getProcessGroups().stream()
             .collect(Collectors.toMap(ComponentDTO::getId, childGroupDto -> childGroupDto));


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10608](https://issues.apache.org/jira/browse/NIFI-10608)

Copying a processor group used to miss controller services if controller service had not been referenced to a processor.
This resolves that.

To show fix:
create new PG -> right click -> Configure -> Controller Sevices -> Add any controller service (AvroReader for example)
copy PG
copied PG -> right click -> Configure -> Controller Services -> (new controller service is now listed/ i.e. AvroReader will be listed)

Prior to this the new controller service/Avro Reader would not be listed for the copied PG.

This same issue was also present when making templates (i.e. the template would miss controller service that had not been referenced to a processor).  This is now resolved for templates as well.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
