### PR TITLE
[NIFI-10754] Initial check in of new getUri NIFI Expression Language …

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
@@ -91,6 +91,7 @@ fragment EXP : ('e'|'E') ('+'|'-')? ('0'..'9')+ ;
 
 TRUE	: 'true';
 FALSE	: 'false';
+NULL    : 'null';
 
 //
 // FUNCTION NAMES

--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionLexer.g
@@ -111,6 +111,7 @@ UUID : 'UUID';
 HOSTNAME : 'hostname';	// requires boolean arg: prefer FQDN
 NOW	: 'now';
 THREAD : 'thread';
+GET_URI : 'getUri';
 
 
 // 0 arg functions

--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
@@ -137,7 +137,8 @@ booleanLiteral : TRUE | FALSE;
 zeroArgStandaloneFunction : (IP | UUID | NOW | NEXT_INT | HOSTNAME | THREAD | RANDOM) LPAREN! RPAREN!;
 oneArgStandaloneFunction : ((TO_LITERAL | MATH | GET_STATE_VALUE)^ LPAREN! anyArg RPAREN!) |
                            (HOSTNAME^ LPAREN! booleanLiteral RPAREN!);
-standaloneFunction : zeroArgStandaloneFunction | oneArgStandaloneFunction;
+threeOrFourOrFiveOrSevenArgStandaloneFunction : GET_URI^ LPAREN! anyArg COMMA! anyArg COMMA! anyArg (COMMA! anyArg (COMMA! anyArg (COMMA! anyArg COMMA! anyArg)?)?)? RPAREN!;
+standaloneFunction : zeroArgStandaloneFunction | oneArgStandaloneFunction | threeOrFourOrFiveOrSevenArgStandaloneFunction;
 
 attributeRefOrFunctionCall	: (attributeRef | standaloneFunction | parameterReference);
 

--- a/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
+++ b/nifi-commons/nifi-expression-language/src/main/antlr3/org/apache/nifi/attribute/expression/language/antlr/AttributeExpressionParser.g
@@ -106,7 +106,7 @@ booleanFunctionRef : zeroArgBool | oneArgBool | multiArgBool;
 numberFunctionRef : zeroArgNum | oneArgNum | zeroOrTwoArgNum | oneOrTwoArgNum | zeroOrOneOrTwoArgNum;
 
 anyArg : WHOLE_NUMBER | DECIMAL | numberFunctionRef | STRING_LITERAL | zeroArgString | oneArgString | twoArgString | fiveArgString | booleanLiteral | zeroArgBool | oneArgBool | multiArgBool
-                | expression | parameterReference;
+                | expression | parameterReference | NULL;
 
 stringArg : STRING_LITERAL | zeroArgString | oneArgString | twoArgString | expression;
 functionRef : stringFunctionRef | booleanFunctionRef | numberFunctionRef;
@@ -137,8 +137,8 @@ booleanLiteral : TRUE | FALSE;
 zeroArgStandaloneFunction : (IP | UUID | NOW | NEXT_INT | HOSTNAME | THREAD | RANDOM) LPAREN! RPAREN!;
 oneArgStandaloneFunction : ((TO_LITERAL | MATH | GET_STATE_VALUE)^ LPAREN! anyArg RPAREN!) |
                            (HOSTNAME^ LPAREN! booleanLiteral RPAREN!);
-threeOrFourOrFiveOrSevenArgStandaloneFunction : GET_URI^ LPAREN! anyArg COMMA! anyArg COMMA! anyArg (COMMA! anyArg (COMMA! anyArg (COMMA! anyArg COMMA! anyArg)?)?)? RPAREN!;
-standaloneFunction : zeroArgStandaloneFunction | oneArgStandaloneFunction | threeOrFourOrFiveOrSevenArgStandaloneFunction;
+sevenArgStandaloneFunction : GET_URI^ LPAREN! anyArg COMMA! anyArg COMMA! anyArg COMMA! anyArg COMMA! anyArg COMMA! anyArg COMMA! anyArg RPAREN!;
+standaloneFunction : zeroArgStandaloneFunction | oneArgStandaloneFunction | sevenArgStandaloneFunction;
 
 attributeRefOrFunctionCall	: (attributeRef | standaloneFunction | parameterReference);
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
@@ -153,6 +153,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionLexer.TO_MICROS;
@@ -220,6 +221,7 @@ import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpre
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.NOT;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.NOT_NULL;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.NOW;
+import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.NULL;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.OR;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.PAD_LEFT;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.PAD_RIGHT;
@@ -1205,6 +1207,8 @@ public class ExpressionCompiler {
             case TRUE:
             case FALSE:
                 return buildBooleanEvaluator(tree);
+            case NULL:
+                return newStringLiteralEvaluator(null);
             case UUID: {
                 return addToken(new UuidEvaluator(), "uuid");
             }
@@ -1271,11 +1275,10 @@ public class ExpressionCompiler {
                 return eval;
             }
             case GET_URI: {
-                @SuppressWarnings("unchecked")
-                Evaluator<String> [] uriArgs = Stream.iterate(0, i -> i + 1)
+                List<Evaluator<String>> uriArgs = Stream.iterate(0, i -> i + 1)
                         .limit(tree.getChildCount())
                         .map(num -> toStringEvaluator(buildEvaluator(tree.getChild(num))))
-                        .toArray(Evaluator[]::new);
+                        .collect(Collectors.toList());
                 return addToken(new GetUriEvaluator(uriArgs), "getUri");
             }
             default:

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
@@ -117,6 +117,7 @@ import org.apache.nifi.attribute.expression.language.evaluation.functions.ToStri
 import org.apache.nifi.attribute.expression.language.evaluation.functions.ToUpperEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.EvaluateELStringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.TrimEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.functions.GetUriEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.UrlDecodeEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.UrlEncodeEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.functions.UuidEvaluator;
@@ -152,6 +153,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionLexer.TO_MICROS;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionLexer.TO_NANOS;
@@ -187,6 +189,7 @@ import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpre
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.FROM_RADIX;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.GET_DELIMITED_FIELD;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.GET_STATE_VALUE;
+import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.GET_URI;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.GREATER_THAN;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.GREATER_THAN_OR_EQUAL;
 import static org.apache.nifi.attribute.expression.language.antlr.AttributeExpressionParser.HASH;
@@ -1266,6 +1269,14 @@ public class ExpressionCompiler {
                 final GetStateVariableEvaluator eval = new GetStateVariableEvaluator(stringEvaluator);
                 evaluators.add(eval);
                 return eval;
+            }
+            case GET_URI: {
+                @SuppressWarnings("unchecked")
+                Evaluator<String> [] uriArgs = Stream.iterate(0, i -> i + 1)
+                        .limit(tree.getChildCount())
+                        .map(num -> toStringEvaluator(buildEvaluator(tree.getChild(num))))
+                        .toArray(Evaluator[]::new);
+                return addToken(new GetUriEvaluator(uriArgs), "getUri");
             }
             default:
                 throw new AttributeExpressionLanguageParsingException("Unexpected token: " + tree.toString());

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetUriEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetUriEvaluator.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.attribute.expression.language.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
@@ -26,47 +25,34 @@ import org.apache.nifi.attribute.expression.language.exception.AttributeExpressi
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class GetUriEvaluator extends StringEvaluator {
 
-    private final Evaluator<String>[] uriArgs;
+    private final List<Evaluator<String>> uriArgs;
 
-    public GetUriEvaluator(Evaluator<String>[] uriArgs) {
+    public GetUriEvaluator(List<Evaluator<String>> uriArgs) {
         this.uriArgs = uriArgs;
     }
 
     @Override
     public QueryResult<String> evaluate(EvaluationContext evaluationContext) {
-        List<String> args = Arrays.stream(uriArgs)
+        List<String> args = uriArgs.stream()
                 .map(uriArg -> uriArg.evaluate(evaluationContext).getValue())
-                .map(string -> StringUtils.isBlank(string) ? null : string)
                 .collect(Collectors.toList());
 
         try {
-            switch (args.size()) {
-                case 3:
-                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2)).toString());
-                case 4:
-                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2), args.get(3)).toString());
-                case 5:
-                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2), args.get(3), args.get(4)).toString());
-                case 7:
-                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2),
-                            Integer.parseInt(args.get(3)), args.get(4), args.get(5), args.get(6)).toString());
-                default:
-                    throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with " + args.size() + " argument(s)");
+            if (args.size() == 7) {
+                return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2),
+                        Integer.parseInt(args.get(3)), args.get(4), args.get(5), args.get(6)).toString());
             }
+            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with " + args.size() + " argument(s)");
         } catch (NumberFormatException nfe) {
             throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument '"
                     + args.get(3) + "' which is not a number", nfe);
-        } catch (URISyntaxException e) {
-            args = args.stream()
-                    .map(arg -> arg == null ? "''" : arg)
-                    .collect(Collectors.toList());
-            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument(s) " + args, e);
+        } catch (URISyntaxException use) {
+            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument(s) " + args, use);
         }
     }
 

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetUriEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetUriEvaluator.java
@@ -44,18 +44,30 @@ public class GetUriEvaluator extends StringEvaluator {
 
         try {
             if (args.size() == 7) {
-                return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2),
-                        Integer.parseInt(args.get(3)), args.get(4), args.get(5), args.get(6)).toString());
+                final String scheme = args.get(0);
+                final String userInfo = args.get(1);
+                final String host = args.get(2);
+                final int port = getPort(args.get(3));
+                final String path = args.get(4);
+                final String query = args.get(5);
+                final String fragment = args.get(6);
+                final URI uri = new URI(scheme, userInfo, host, port, path, query, fragment);
+                return new StringQueryResult(uri.toString());
             }
             throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with " + args.size() + " argument(s)");
-        } catch (NumberFormatException nfe) {
-            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument '"
-                    + args.get(3) + "' which is not a number", nfe);
         } catch (URISyntaxException use) {
             throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument(s) " + args, use);
         }
     }
 
+    private int getPort(String portArg) {
+        try {
+            return Integer.parseInt(portArg);
+        } catch (NumberFormatException nfe) {
+            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument '"
+                    + portArg + "' which is not a number", nfe);
+        }
+    }
     @Override
     public Evaluator<?> getSubjectEvaluator() {
         return null;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetUriEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/GetUriEvaluator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.attribute.expression.language.evaluation.functions;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.attribute.expression.language.EvaluationContext;
+import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
+import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
+import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GetUriEvaluator extends StringEvaluator {
+
+    private final Evaluator<String>[] uriArgs;
+
+    public GetUriEvaluator(Evaluator<String>[] uriArgs) {
+        this.uriArgs = uriArgs;
+    }
+
+    @Override
+    public QueryResult<String> evaluate(EvaluationContext evaluationContext) {
+        List<String> args = Arrays.stream(uriArgs)
+                .map(uriArg -> uriArg.evaluate(evaluationContext).getValue())
+                .map(string -> StringUtils.isBlank(string) ? null : string)
+                .collect(Collectors.toList());
+
+        try {
+            switch (args.size()) {
+                case 3:
+                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2)).toString());
+                case 4:
+                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2), args.get(3)).toString());
+                case 5:
+                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2), args.get(3), args.get(4)).toString());
+                case 7:
+                    return new StringQueryResult(new URI(args.get(0), args.get(1), args.get(2),
+                            Integer.parseInt(args.get(3)), args.get(4), args.get(5), args.get(6)).toString());
+                default:
+                    throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with " + args.size() + " argument(s)");
+            }
+        } catch (NumberFormatException nfe) {
+            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument '"
+                    + args.get(3) + "' which is not a number", nfe);
+        } catch (URISyntaxException e) {
+            args = args.stream()
+                    .map(arg -> arg == null ? "''" : arg)
+                    .collect(Collectors.toList());
+            throw new AttributeExpressionLanguageException("Could not evaluate 'getUri' function with argument(s) " + args, e);
+        }
+    }
+
+    @Override
+    public Evaluator<?> getSubjectEvaluator() {
+        return null;
+    }
+}

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/StringLiteralEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/literals/StringLiteralEvaluator.java
@@ -27,40 +27,44 @@ public class StringLiteralEvaluator extends StringEvaluator {
     private final String value;
 
     public StringLiteralEvaluator(final String value) {
-        // need to escape characters after backslashes
-        final StringBuilder sb = new StringBuilder();
-        boolean lastCharIsBackslash = false;
-        for (int i = 0; i < value.length(); i++) {
-            final char c = value.charAt(i);
+        if(value == null) {
+            this.value = null;
+        } else {
+            // need to escape characters after backslashes
+            final StringBuilder sb = new StringBuilder();
+            boolean lastCharIsBackslash = false;
+            for (int i = 0; i < value.length(); i++) {
+                final char c = value.charAt(i);
 
-            if (lastCharIsBackslash) {
-                switch (c) {
-                    case 'n':
-                        sb.append("\n");
-                        break;
-                    case 'r':
-                        sb.append("\r");
-                        break;
-                    case '\\':
-                        sb.append("\\");
-                        break;
-                    case 't':
-                        sb.append("\\t");
-                        break;
-                    default:
-                        sb.append("\\").append(c);
-                        break;
+                if (lastCharIsBackslash) {
+                    switch (c) {
+                        case 'n':
+                            sb.append("\n");
+                            break;
+                        case 'r':
+                            sb.append("\r");
+                            break;
+                        case '\\':
+                            sb.append("\\");
+                            break;
+                        case 't':
+                            sb.append("\\t");
+                            break;
+                        default:
+                            sb.append("\\").append(c);
+                            break;
+                    }
+
+                    lastCharIsBackslash = false;
+                } else if (c == '\\') {
+                    lastCharIsBackslash = true;
+                } else {
+                    sb.append(c);
                 }
-
-                lastCharIsBackslash = false;
-            } else if (c == '\\') {
-                lastCharIsBackslash = true;
-            } else {
-                sb.append(c);
             }
-        }
 
-        this.value = sb.toString();
+            this.value = sb.toString();
+        }
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2401,23 +2401,23 @@ public class TestQuery {
 
     @Test
     void testGetUri() {
-        verifyEquals("${getUri('mailto', 'dev@nifi.apache.org', '')}", null, "mailto:dev@nifi.apache.org");
-        verifyEquals("${getUri('http', 'nifi.apache.org', '/path/data', 'frag1')}",
-                null, "http://nifi.apache.org/path/data#frag1");
-        verifyEquals("${getUri('https', 'admin:admin@nifi.apache.org:1234', '/path/data ', 'key=value&key2=value2', 'frag1')}",
-                null, "https://admin:admin@nifi.apache.org:1234/path/data%20?key=value&key2=value2#frag1");
         verifyEquals("${getUri('https', 'admin:admin', 'nifi.apache.org', '1234', '/path/data ', 'key=value &key2=value2', 'frag1')}",
                 null, "https://admin:admin@nifi.apache.org:1234/path/data%20?key=value%20&key2=value2#frag1");
+        verifyEquals("${getUri('https', null, 'nifi.apache.org', 8443, '/docs.html', null, null)}",
+                null, "https://nifi.apache.org:8443/docs.html");
+        verifyEquals("${getUri('http', null, 'nifi.apache.org', -1, '/docs.html', null, null)}",
+                null, "http://nifi.apache.org/docs.html");
 
         assertInvalid("${getUri()}");
         assertInvalid("${getUri('http://nifi.apache.org:1234/path/data?key=value&key2=value2#frag1')}");
         assertInvalid("${getUri('https', 'admin:admin')}");
+        assertInvalid("${getUri('mailto', 'dev@nifi.apache.org', '')}");
+        assertInvalid("${getUri('http', 'nifi.apache.org', '/path/data', 'frag1')}");
+        assertInvalid("${getUri('https', 'admin:admin@nifi.apache.org:1234', '/path/data ', 'key=value&key2=value2', 'frag1')}");
 
         AttributeExpressionLanguageException thrown = assertThrows(AttributeExpressionLanguageException.class,
                 () -> verifyEquals("${getUri('https', 'admin:admin', 'nifi.apache.org', 'notANumber', '/path/data ', 'key=value&key2=value2', 'frag1')}", null, ""));
         Assertions.assertEquals("Could not evaluate 'getUri' function with argument 'notANumber' which is not a number", thrown.getMessage());
-        thrown = assertThrows(AttributeExpressionLanguageException.class, () -> verifyEquals("${getUri('mailto', '', '')}", null, ""));
-        Assertions.assertEquals("Could not evaluate 'getUri' function with argument(s) [mailto, '', '']", thrown.getMessage());
     }
 
     private void verifyEquals(final String expression, final Map<String, String> attributes, final Object expectedResult) {

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -2616,6 +2616,52 @@ names begin with the letter `a`.
 
 
 
+
+[.function]
+=== getUri
+
+*Description*: [.description]#Returns a URI compliant with RFC 2396. This includes encoding non-US-ASCII characters and quoting illegal characters with octets. This expression utilizes the java.net.URI API in order to build a  URI. The exact API will depend on the version of Java you are running. The Java 8 API can be found here: link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[https://docs.oracle.com/javase/8/docs/api/java/net/URI.html^].
+  As detailed in the API, a URI consists of nine components represented with the following types.#
+|============================================================================
+| Component | Type
+| `scheme` | `String`
+| `scheme-specific-part` | `String`
+| `authority` | `String`
+| `user-info` | `String`
+| `host` | `String`
+| `port` | `int`
+| `path` | `String`
+| `query` | `String`
+| `fragment` | `String`
+|============================================================================
+
+See the API for more details on character categories, encoding and quoting.
+
+*Subject Type*: [.subjectless]#No Subject#
+
+*Arguments*: There are four forms of calling this expression either with the following three, four, five or seven arguments.
+
+- [.argName]#_scheme_#, [.argName]#_scheme-specific part_#, [.argName]#_fragment_#
+- [.argName]#_scheme_#, [.argName]#_host_#, [.argName]#_path_#, [.argName]#_fragment_#
+- [.argName]#_scheme_#, [.argName]#_authority_#, [.argName]#_path_#, [.argName]#_query_#, [.argName]#_fragment_#
+- [.argName]#_scheme_#, [.argName]#_userinfo_#, [.argName]#_host_#, [.argName]#_port_#, [.argName]#_path_#, [.argName]#_query_#, [.argName]#_fragment_#
+
+*NOTE:* Any component of the new URI may be left undefined by passing empty string ('') for the corresponding parameter or, in the case of the port parameter, by passing -1.
+
+*Return Type*: [.returnType]#String#
+
+*Examples*
+The following examples detail how each form of the expression can be called:
+
+|============================================================================
+| Expression | Returns
+| `${getUri('mailto', 'dev@nifi.apache.org', '')` | `mailto:dev@nifi.apache.org`
+| `${getUri('http', 'nifi.apache.org', '/path/data', 'frag1')}` | `http://nifi.apache.org/path/data#frag1`
+| `${getUri('https', 'admin:admin@nifi.apache.org:1234', '/path/data ', 'key=value&key2=value2', 'frag1')}` | `https://admin:admin@nifi.apache.org:1234/path/data%20?key=value&key2=value2#frag1`
+| `${getUri('https', 'admin:admin', 'nifi.${getUri('https', 'admin:admin', 'nifi.apache.org', '1234', '/path/data ', 'key=value &key2=value2', 'frag1')}` | `https://admin:admin@nifi.apache.org:1234/path/data%20?key=value%20&key2=value2#frag1`
+|============================================================================
+
+
 [[multi]]
 == Evaluating Multiple Attributes
 

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -2639,26 +2639,22 @@ See the API for more details on character categories, encoding and quoting.
 
 *Subject Type*: [.subjectless]#No Subject#
 
-*Arguments*: There are four forms of calling this expression either with the following three, four, five or seven arguments.
+*Arguments*: This expression takes seven arguments.
 
-- [.argName]#_scheme_#, [.argName]#_scheme-specific part_#, [.argName]#_fragment_#
-- [.argName]#_scheme_#, [.argName]#_host_#, [.argName]#_path_#, [.argName]#_fragment_#
-- [.argName]#_scheme_#, [.argName]#_authority_#, [.argName]#_path_#, [.argName]#_query_#, [.argName]#_fragment_#
 - [.argName]#_scheme_#, [.argName]#_userinfo_#, [.argName]#_host_#, [.argName]#_port_#, [.argName]#_path_#, [.argName]#_query_#, [.argName]#_fragment_#
 
-*NOTE:* Any component of the new URI may be left undefined by passing empty string ('') for the corresponding parameter or, in the case of the port parameter, by passing -1.
+*NOTE:* Any component of the new URI may be left undefined by passing [.argName]#_null_# for the corresponding parameter or, in the case of the port parameter, by passing [.argName]#_-1_#.
 
 *Return Type*: [.returnType]#String#
 
 *Examples*
-The following examples detail how each form of the expression can be called:
+The following examples detail how this expression can be called:
 
 |============================================================================
 | Expression | Returns
-| `${getUri('mailto', 'dev@nifi.apache.org', '')` | `mailto:dev@nifi.apache.org`
-| `${getUri('http', 'nifi.apache.org', '/path/data', 'frag1')}` | `http://nifi.apache.org/path/data#frag1`
-| `${getUri('https', 'admin:admin@nifi.apache.org:1234', '/path/data ', 'key=value&key2=value2', 'frag1')}` | `https://admin:admin@nifi.apache.org:1234/path/data%20?key=value&key2=value2#frag1`
 | `${getUri('https', 'admin:admin', 'nifi.${getUri('https', 'admin:admin', 'nifi.apache.org', '1234', '/path/data ', 'key=value &key2=value2', 'frag1')}` | `https://admin:admin@nifi.apache.org:1234/path/data%20?key=value%20&key2=value2#frag1`
+|`${getUri('https', null, 'nifi.apache.org', 8443, '/docs.html', null, null)}`|`https://nifi.apache.org:8443/docs.html`
+|`${getUri('http', null, 'nifi.apache.org', -1, '/docs.html', null, null)}`|`http://nifi.apache.org/docs.html`
 |============================================================================
 
 


### PR DESCRIPTION
…function.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10754](https://issues.apache.org/jira/browse/NIFI-10754)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
