### PR TITLE
NIFI-10849 Change Maven compile to test-compile in GitHub ci-workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -30,12 +30,15 @@ env:
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
   MAVEN_COMPILE_COMMAND: >-
-    mvn compile
+    mvn test-compile
     --threads 2C
     --show-version
     --no-snapshot-updates
     --no-transfer-progress
     --fail-fast
+    -pl -:minifi-c2-integration-tests
+    -pl -:minifi-integration-tests
+    -pl -:minifi-assembly
     -pl -:nifi-assembly
     -pl -:nifi-kafka-connector-assembly
     -pl -:nifi-kafka-connector-tests
@@ -47,6 +50,10 @@ env:
     -pl -:nifi-registry-toolkit-assembly
     -pl -:nifi-runtime-manifest
     -pl -:nifi-runtime-manifest-test
+    -pl -:nifi-stateless-assembly
+    -pl -:nifi-stateless-processor-tests
+    -pl -:nifi-stateless-system-test-suite
+    -pl -:nifi-system-test-suite
   MAVEN_VERIFY_COMMAND: >-
     mvn verify
     --show-version


### PR DESCRIPTION
# Summary

[NIFI-10849](https://issues.apache.org/jira/browse/NIFI-10849) Changes the GitHub ci-workflow to run Maven `test-compile` instead of `compile` for the Maven Compile step. The change shifts more of the automated build process to run with multiple threads while maintaining the distinction between compilation and testing. This change provides some performance optimization on runners with multiple cores.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
