### PR TITLE
NIFI-10188 Add jaxws-api for ConsumeEWS on Java 11

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -95,6 +95,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- jaxws-api required for ews-java-api on Java 11 and later -->
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/ConsumeEWSTest.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/ConsumeEWSTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.email;
+
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConsumeEWSTest {
+
+    private static final String LOCALHOST_URL = "http://localhost:65000";
+
+    TestRunner runner;
+
+    @BeforeEach
+    void setRunner() {
+        runner = TestRunners.newTestRunner(ConsumeEWS.class);
+    }
+
+    @Test
+    void testRequiredProperties() {
+        runner.setProperty(ConsumeEWS.USER, String.class.getSimpleName());
+        runner.setProperty(ConsumeEWS.PASSWORD, String.class.getName());
+
+        runner.assertValid();
+    }
+
+    @Test
+    void testRunFailure() {
+        runner.setProperty(ConsumeEWS.USER, String.class.getSimpleName());
+        runner.setProperty(ConsumeEWS.PASSWORD, String.class.getName());
+        runner.setProperty(ConsumeEWS.USE_AUTODISCOVER, Boolean.FALSE.toString());
+        runner.setProperty(ConsumeEWS.EWS_URL, LOCALHOST_URL);
+
+        assertThrows(AssertionError.class, runner::run);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-10188](https://issues.apache.org/jira/browse/NIFI-10188) Adds the `jaxws-api` dependency to `nifi-email-processors` to avoid `NoClassDefFoundError` failures for `javax.xml.ws.http.HTTPException` with the `ConsumeEWS` Processor on Java 11 and Java 17.

The Microsoft `ews-java-api` is no longer maintained and is targeted to Java 8, which includes the `HTTPException` class as part of the standard distribution. Adding the `jaxws-api` dependency allows the new unit test to run without throwing a `NoClassDefFoundError` on Java 11 and 17.

The `ConsumeEWS` Processor should be deprecated in subsequent releases, but this change provides the possibility for successful invocation on Java 11.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
