### PR TITLE
NIFI-10863 Wrapped the debug loggers in InvokeHttp with if statements…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -1299,13 +1299,17 @@ public class InvokeHTTP extends AbstractProcessor {
     }
 
     private void logRequest(ComponentLog logger, Request request) {
-        logger.debug("\nRequest to remote service:\n\t{}\n{}",
-                request.url().url().toExternalForm(), getLogString(request.headers().toMultimap()));
+        if (logger.isDebugEnabled()) {
+            logger.debug("\nRequest to remote service:\n\t{}\n{}",
+                    request.url().url().toExternalForm(), getLogString(request.headers().toMultimap()));
+        }
     }
 
     private void logResponse(ComponentLog logger, URL url, Response response) {
-        logger.debug("\nResponse from remote service:\n\t{}\n{}",
-                url.toExternalForm(), getLogString(response.headers().toMultimap()));
+        if (logger.isDebugEnabled()) {
+            logger.debug("\nResponse from remote service:\n\t{}\n{}",
+                    url.toExternalForm(), getLogString(response.headers().toMultimap()));
+        }
     }
 
     private String getLogString(Map<String, List<String>> map) {


### PR DESCRIPTION
… to prevent them from being called at all if debug logging is disabled.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
