### PR TITLE
NIFI-10865 allow RecordPath's unescapeJson to convert de-serialised JSON Objects into Records

### DIFF
--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
@@ -329,8 +329,15 @@ public class RecordPathCompiler {
                         return new EscapeJson(args[0], absolute);
                     }
                     case "unescapeJson": {
-                        final RecordPathSegment[] args = getArgPaths(argumentListTree, 1, functionName, absolute);
-                        return new UnescapeJson(args[0], absolute);
+                        final int numArgs = argumentListTree.getChildCount();
+
+                        if (numArgs == 1) {
+                            final RecordPathSegment[] args = getArgPaths(argumentListTree, 1, functionName, absolute);
+                            return new UnescapeJson(args[0], null, absolute);
+                        } else {
+                            final RecordPathSegment[] args = getArgPaths(argumentListTree, 2, functionName, absolute);
+                            return new UnescapeJson(args[0], args[1], absolute);
+                        }
                     }
                     case "hash":{
                         final RecordPathSegment[] args = getArgPaths(argumentListTree, 2, functionName, absolute);

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestRecordPath {
 
     private static final String USER_TIMEZONE_PROPERTY = "user.timezone";
@@ -280,7 +281,7 @@ public class TestRecordPath {
         final Record record = new MapRecord(schema, values);
 
         final FieldValue fieldValue = RecordPath.compile("/attributes['city']").evaluate(record).getSelectedFields().findFirst().get();
-        assertTrue(fieldValue.getField().getFieldName().equals("attributes"));
+        assertEquals("attributes", fieldValue.getField().getFieldName());
         assertEquals("New York", fieldValue.getValue());
         assertEquals(record, fieldValue.getParentRecord().get());
     }
@@ -300,7 +301,7 @@ public class TestRecordPath {
         final Record record = new MapRecord(schema, values);
 
         final FieldValue fieldValue = RecordPath.compile("/attributes/.['city']").evaluate(record).getSelectedFields().findFirst().get();
-        assertTrue(fieldValue.getField().getFieldName().equals("attributes"));
+        assertEquals("attributes", fieldValue.getField().getFieldName());
         assertEquals("New York", fieldValue.getValue());
         assertEquals(record, fieldValue.getParentRecord().get());
     }
@@ -1094,21 +1095,24 @@ public class TestRecordPath {
 
         // Special character cases
         values.put("name", "John Doe");
-        assertEquals(
-                "John\nDoe", RecordPath.compile("replaceRegex(/name, '[\\s]', '\\n')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+        assertEquals("John\nDoe", RecordPath.compile("replaceRegex(/name, '[\\s]', '\\n')")
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing whitespace to new line");
 
         values.put("name", "John\nDoe");
         assertEquals("John Doe", RecordPath.compile("replaceRegex(/name, '\\n', ' ')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing new line to whitespace");
 
         values.put("name", "John Doe");
         assertEquals("John\tDoe", RecordPath.compile("replaceRegex(/name, '[\\s]', '\\t')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing whitespace to tab");
 
         values.put("name", "John\tDoe");
         assertEquals("John Doe", RecordPath.compile("replaceRegex(/name, '\\t', ' ')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing tab to whitespace");
 
     }
 
@@ -1126,23 +1130,27 @@ public class TestRecordPath {
         final Record record = new MapRecord(schema, values);
 
         // Quotes
-        // NOTE: At Java code, a single back-slash needs to be escaped with another-back slash, but needn't to do so at NiFi UI.
+        // NOTE: At Java code, a single back-slash needs to be escaped with another-back slash, but needn't do so at NiFi UI.
         //       The test record path is equivalent to replaceRegex(/name, '\'', '"')
         values.put("name", "'John' 'Doe'");
         assertEquals("\"John\" \"Doe\"", RecordPath.compile("replaceRegex(/name, '\\'', '\"')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing quote to double-quote");
 
         values.put("name", "\"John\" \"Doe\"");
         assertEquals("'John' 'Doe'", RecordPath.compile("replaceRegex(/name, '\"', '\\'')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing double-quote to single-quote");
 
         values.put("name", "'John' 'Doe'");
         assertEquals("\"John\" \"Doe\"", RecordPath.compile("replaceRegex(/name, \"'\", \"\\\"\")")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing quote to double-quote, the function arguments are wrapped by double-quote");
 
         values.put("name", "\"John\" \"Doe\"");
         assertEquals("'John' 'Doe'", RecordPath.compile("replaceRegex(/name, \"\\\"\", \"'\")")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing double-quote to single-quote, the function arguments are wrapped by double-quote");
 
     }
 
@@ -1160,15 +1168,17 @@ public class TestRecordPath {
         final Record record = new MapRecord(schema, values);
 
         // Back-slash
-        // NOTE: At Java code, a single back-slash needs to be escaped with another-back slash, but needn't to do so at NiFi UI.
+        // NOTE: At Java code, a single back-slash needs to be escaped with another-back slash, but needn't do so at NiFi UI.
         //       The test record path is equivalent to replaceRegex(/name, '\\', '/')
         values.put("name", "John\\Doe");
         assertEquals("John/Doe", RecordPath.compile("replaceRegex(/name, '\\\\', '/')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing a back-slash to forward-slash");
 
         values.put("name", "John/Doe");
         assertEquals("John\\Doe", RecordPath.compile("replaceRegex(/name, '/', '\\\\')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Replacing a forward-slash to back-slash");
 
     }
 
@@ -1188,11 +1198,13 @@ public class TestRecordPath {
         // Brackets
         values.put("name", "J[o]hn Do[e]");
         assertEquals("J(o)hn Do(e)", RecordPath.compile("replaceRegex(replaceRegex(/name, '\\[', '('), '\\]', ')')")
-                .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Square brackets can be escaped with back-slash");
 
         values.put("name", "J(o)hn Do(e)");
         assertEquals("J[o]hn Do[e]", RecordPath.compile("replaceRegex(replaceRegex(/name, '\\(', '['), '\\)', ']')")
-                        .evaluate(record).getSelectedFields().findFirst().get().getValue());
+                        .evaluate(record).getSelectedFields().findFirst().get().getValue(),
+                "Brackets can be escaped with back-slash");
     }
 
     @Test
@@ -1629,8 +1641,8 @@ public class TestRecordPath {
                 RecordPath.compile("base64Encode(/firstName)").evaluate(record).getSelectedFields().findFirst().get().getValue());
         assertEquals(Base64.getEncoder().encodeToString("Doe".getBytes(StandardCharsets.UTF_8)),
                 RecordPath.compile("base64Encode(/lastName)").evaluate(record).getSelectedFields().findFirst().get().getValue());
-        assertTrue(Arrays.equals(Base64.getEncoder().encode("xyz".getBytes(StandardCharsets.UTF_8)),
-                (byte[]) RecordPath.compile("base64Encode(/b)").evaluate(record).getSelectedFields().findFirst().get().getValue()));
+        assertArrayEquals(Base64.getEncoder().encode("xyz".getBytes(StandardCharsets.UTF_8)),
+                (byte[]) RecordPath.compile("base64Encode(/b)").evaluate(record).getSelectedFields().findFirst().get().getValue());
         List<Object> actualValues = RecordPath.compile("base64Encode(/*)").evaluate(record).getSelectedFields().map(FieldValue::getValue).collect(Collectors.toList());
         IntStream.range(0, 3).forEach(i -> {
             Object expectedObject = expectedValues.get(i);
@@ -1638,7 +1650,7 @@ public class TestRecordPath {
             if (actualObject instanceof String) {
                 assertEquals(expectedObject, actualObject);
             } else if (actualObject instanceof byte[]) {
-                assertTrue(Arrays.equals((byte[]) expectedObject, (byte[]) actualObject));
+                assertArrayEquals((byte[]) expectedObject, (byte[]) actualObject);
             }
         });
     }
@@ -1660,7 +1672,7 @@ public class TestRecordPath {
 
         assertEquals("John", RecordPath.compile("base64Decode(/firstName)").evaluate(record).getSelectedFields().findFirst().get().getValue());
         assertEquals("Doe", RecordPath.compile("base64Decode(/lastName)").evaluate(record).getSelectedFields().findFirst().get().getValue());
-        assertTrue(Arrays.equals("xyz".getBytes(StandardCharsets.UTF_8), (byte[]) RecordPath.compile("base64Decode(/b)").evaluate(record).getSelectedFields().findFirst().get().getValue()));
+        assertArrayEquals("xyz".getBytes(StandardCharsets.UTF_8), (byte[]) RecordPath.compile("base64Decode(/b)").evaluate(record).getSelectedFields().findFirst().get().getValue());
         List<Object> actualValues = RecordPath.compile("base64Decode(/*)").evaluate(record).getSelectedFields().map(FieldValue::getValue).collect(Collectors.toList());
         IntStream.range(0, 3).forEach(i -> {
             Object expectedObject = expectedValues.get(i);
@@ -1668,7 +1680,7 @@ public class TestRecordPath {
             if (actualObject instanceof String) {
                 assertEquals(expectedObject, actualObject);
             } else if (actualObject instanceof byte[]) {
-                assertTrue(Arrays.equals((byte[]) expectedObject, (byte[]) actualObject));
+                assertArrayEquals((byte[]) expectedObject, (byte[]) actualObject);
             }
         });
     }
@@ -1733,8 +1745,8 @@ public class TestRecordPath {
                 new RecordField("json_str", RecordFieldType.STRING.getDataType())
         ));
 
-        // test CHOICE resulting in nested ARRAY of RECORDs
-        final Record recordAddressesArray = new MapRecord(schema,
+        // test CHOICE resulting in nested ARRAY of Records
+        final Record mapAddressesArray = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
                         "{\"firstName\":\"John\",\"age\":30,\"nicknames\":[\"J\",\"Johnny\"],\"addresses\":[{\"address_1\":\"123 Somewhere Street\"},{\"address_1\":\"456 Anywhere Road\"}]}")
@@ -1749,11 +1761,11 @@ public class TestRecordPath {
                             Collections.singletonMap("address_1", "456 Anywhere Road")
                     ));
                 }},
-                RecordPath.compile("unescapeJson(/json_str)").evaluate(recordAddressesArray).getSelectedFields().findFirst().orElseThrow(IllegalStateException::new).getValue()
+                RecordPath.compile("unescapeJson(/json_str)").evaluate(mapAddressesArray).getSelectedFields().findFirst().orElseThrow(IllegalStateException::new).getValue()
         );
 
         // test CHOICE resulting in nested single RECORD
-        final Record recordAddressesSingle = new MapRecord(schema,
+        final Record mapAddressesSingle = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
                         "{\"firstName\":\"John\",\"age\":30,\"nicknames\":[\"J\",\"Johnny\"],\"addresses\":{\"address_1\":\"123 Somewhere Street\"}}")
@@ -1765,7 +1777,35 @@ public class TestRecordPath {
                     put("nicknames", Arrays.asList("J", "Johnny"));
                     put("addresses", Collections.singletonMap("address_1", "123 Somewhere Street"));
                 }},
-                RecordPath.compile("unescapeJson(/json_str)").evaluate(recordAddressesSingle).getSelectedFields().findFirst().orElseThrow(IllegalStateException::new).getValue()
+                RecordPath.compile("unescapeJson(/json_str, 'false')").evaluate(mapAddressesSingle).getSelectedFields().findFirst().orElseThrow(IllegalStateException::new).getValue()
+        );
+
+        // test single Record converted from Map Object
+        final Record recordFromMap = new MapRecord(schema,
+                Collections.singletonMap(
+                        "json_str",
+                        "{\"firstName\":\"John\",\"age\":30}")
+        );
+        assertEquals(
+                DataTypeUtils.toRecord(new HashMap<String, Object>(){{
+                    put("firstName", "John");
+                    put("age", 30);
+                }}, "json_str"),
+                RecordPath.compile("unescapeJson(/json_str, 'true')").evaluate(recordFromMap).getSelectedFields().findFirst().orElseThrow(IllegalStateException::new).getValue()
+        );
+
+        // test collection of Record converted from Map collection
+        final Record recordCollectionFromMaps = new MapRecord(schema,
+                Collections.singletonMap(
+                        "json_str",
+                        "[{\"address_1\":\"123 Somewhere Street\"},{\"address_1\":\"456 Anywhere Road\"}]")
+        );
+        assertEquals(
+                Arrays.asList(
+                        DataTypeUtils.toRecord(Collections.singletonMap("address_1", "123 Somewhere Street"), "json_str"),
+                        DataTypeUtils.toRecord(Collections.singletonMap("address_1", "456 Anywhere Road"), "json_str")
+                ),
+                RecordPath.compile("unescapeJson(/json_str, 'true')").evaluate(recordCollectionFromMaps).getSelectedFields().findFirst().orElseThrow(IllegalStateException::new).getValue()
         );
 
         // test simple String field

--- a/nifi-docs/src/main/asciidoc/record-path-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/record-path-guide.adoc
@@ -893,7 +893,10 @@ The following record path expression would convert the record into an escaped JS
 
 === unescapeJson
 
-Converts a stringified JSON element to a Record, Array or simple field (e.g. String), using the UTF-8 character set. For example, given a schema such as:
+Converts a stringified JSON element to a Record, Array or simple field (e.g. String), using the UTF-8 character set.
+Optionally convert JSON Objects parsed as Maps into Records (defaults to false).
+
+For example, given a schema such as:
 
 ----
 {
@@ -923,6 +926,23 @@ The following record path expression would populate the record with unescaped JS
 |==========================================================
 | RecordPath | Return value
 | `unescapeJson(/json_str)` | {"person": {"name": "John", "age": 30}}"
+|==========================================================
+
+Given a record such as:
+
+----
+{
+  "json_str": "{\"name\":\"John\",\"age\":30}"
+}
+----
+
+The following record path expression would return:
+
+|==========================================================
+| RecordPath | Return value
+| `unescapeJson(/json_str, 'true')` | {"name": "John", "age": 30} (as a Record)
+| `unescapeJson(/json_str, 'false')` | {"name"="John", "age"=30} (as a Map)
+| `unescapeJson(/json_str)` | {"name"="John", "age"=30} (as a Map)
 |==========================================================
 
 Given a record such as:

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -651,23 +651,29 @@
                         <exclude>src/test/resources/TestExtractGrok/apache.log</exclude>
                         <exclude>src/test/resources/TestExtractGrok/simple_text.log</exclude>
                         <exclude>src/test/resources/TestExtractGrok/patterns</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/input/embedded-string.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/person.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/person-address.json</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/input/person-stringified-name.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/person-with-null-array.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/multi-arrays.json</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/output/embedded-string.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-null-array.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-firstname.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-firstname-lastname.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-capital-lastname.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/name-fields-only.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/name-and-mother-same.json</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/output/person-with-name.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-new-city.json</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/schema/embedded-record.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-address.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-name-string.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-name-string-fields.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and1.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and2.json</exclude>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/input/embedded-string.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/input/embedded-string.json
@@ -1,0 +1,4 @@
+{
+  "str": "{\"label\":\"Test!\",\"child\":{\"name\":\"Child record!\"}}",
+  "embedded": null
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/input/person-stringified-name.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/input/person-stringified-name.json
@@ -1,0 +1,4 @@
+{
+	"id": 485,
+	"stringified_name": "{\"last\": \"Doe\", \"first\": \"John\"}"
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/output/embedded-record.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/output/embedded-record.json
@@ -1,0 +1,9 @@
+[ {
+  "str" : "{\"label\":\"Test!\",\"child\":{\"name\":\"Child record!\"}}",
+  "embedded" : {
+    "label" : "Test!",
+    "child" : {
+      "name" : "Child record!"
+    }
+  }
+} ]

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/output/person-with-name.json
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/output/person-with-name.json
@@ -1,0 +1,7 @@
+[ {
+  "id" : 485,
+  "name" : {
+    "last" : "Doe",
+    "first" : "John"
+  }
+} ]

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/embedded-record.avsc
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/embedded-record.avsc
@@ -1,0 +1,39 @@
+{
+  "name": "Parent",
+  "type": "record",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string"
+    },
+    {
+      "name": "embedded",
+      "type": [
+        {
+          "name": "EmbeddedRecord",
+          "type": "record",
+          "fields": [
+            {
+              "name": "label",
+              "type": "string"
+            },
+            {
+              "name": "child",
+              "type": {
+                "name": "ChildRecord",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "null"
+      ]
+    }
+  ]
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc
@@ -1,0 +1,9 @@
+{
+	"name": "personWithNameRecord",
+	"namespace": "nifi",
+	"type": "record",
+	"fields": [
+		{ "name": "id", "type": "int" },
+		{ "name": "stringified_name", "type": "string" }
+	]
+}


### PR DESCRIPTION
# Summary

[NIFI-10865](https://issues.apache.org/jira/browse/NIFI-10865) allow RecordPath's unescapeJson to convert de-serialised JSON Objects into Records

NIFI-10865 allow UpdateRecord to replace the Record root for relative paths, e.g. when a RecordPath function is used to modify selected field(s)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- [x] Documentation formatting appears as expected in rendered files`
