### PR TITLE
NIFI-10871 Skip CSRF processing for replicated HTTP requests

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.StandardAuthenticationEntryPoint;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationFilter;
 import org.apache.nifi.web.security.csrf.CsrfCookieRequestMatcher;
+import org.apache.nifi.web.security.csrf.SkipReplicatedCsrfFilter;
 import org.apache.nifi.web.security.csrf.StandardCookieCsrfTokenRepository;
 import org.apache.nifi.web.security.knox.KnoxAuthenticationFilter;
 import org.apache.nifi.web.security.log.AuthenticationUserFilter;
@@ -109,6 +110,7 @@ public class NiFiWebApiSecurityConfiguration {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(new SkipReplicatedCsrfFilter(), CsrfFilter.class)
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(
                                 new StandardCookieCsrfTokenRepository()

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/csrf/SkipReplicatedCsrfFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/csrf/SkipReplicatedCsrfFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.csrf;
+
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Skip Replicated Cross-Site Request Forgery Filter disables subsequent filtering for matched requests
+ */
+public class SkipReplicatedCsrfFilter extends OncePerRequestFilter {
+    /** RequestReplicator.REQUEST_TRANSACTION_ID_HEADER applied to replicated cluster requests */
+    protected static final String REPLICATED_REQUEST_HEADER = "X-RequestTransactionId";
+
+    /** Requests containing replicated header will be skipped */
+    private static final RequestMatcher REQUEST_MATCHER = new RequestHeaderRequestMatcher(REPLICATED_REQUEST_HEADER);
+
+    /**
+     * Set request attribute to disable standard CSRF Filter when request matches
+     *
+     * @param request HTTP Servlet Request
+     * @param response HTTP Servlet Response
+     * @param filterChain Filter Chain
+     * @throws ServletException Thrown on FilterChain.doFilter()
+     * @throws IOException Thrown on FilterChain.doFilter()
+     */
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain) throws ServletException, IOException {
+        if (REQUEST_MATCHER.matches(request)) {
+            CsrfFilter.skipRequest(request);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/csrf/SkipReplicatedCsrfFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/csrf/SkipReplicatedCsrfFilter.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.web.security.csrf;
 
 import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.util.matcher.AndRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -34,8 +36,11 @@ public class SkipReplicatedCsrfFilter extends OncePerRequestFilter {
     /** RequestReplicator.REQUEST_TRANSACTION_ID_HEADER applied to replicated cluster requests */
     protected static final String REPLICATED_REQUEST_HEADER = "X-RequestTransactionId";
 
-    /** Requests containing replicated header will be skipped */
-    private static final RequestMatcher REQUEST_MATCHER = new RequestHeaderRequestMatcher(REPLICATED_REQUEST_HEADER);
+    /** Requests containing replicated header and not containing authorization cookies will be skipped */
+    private static final RequestMatcher REQUEST_MATCHER = new AndRequestMatcher(
+            new RequestHeaderRequestMatcher(REPLICATED_REQUEST_HEADER),
+            new NegatedRequestMatcher(new CsrfCookieRequestMatcher())
+    );
 
     /**
      * Set request attribute to disable standard CSRF Filter when request matches

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/csrf/SkipReplicatedCsrfFilterTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/csrf/SkipReplicatedCsrfFilterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.csrf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.csrf.CsrfFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SkipReplicatedCsrfFilterTest {
+    private static final String SHOULD_NOT_FILTER = String.format("SHOULD_NOT_FILTER%s", CsrfFilter.class.getName());
+
+    MockHttpServletRequest httpServletRequest;
+
+    MockHttpServletResponse httpServletResponse;
+
+    @Mock
+    FilterChain filterChain;
+
+    SkipReplicatedCsrfFilter filter;
+
+    @BeforeEach
+    void setHandler() {
+        filter = new SkipReplicatedCsrfFilter();
+        httpServletRequest = new MockHttpServletRequest();
+        httpServletResponse = new MockHttpServletResponse();
+    }
+
+    @Test
+    void testDoFilterInternalNotSkipped() throws ServletException, IOException {
+        httpServletRequest.setMethod(HttpMethod.GET.name());
+
+        filter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
+
+        final Object shouldNotFilter = httpServletRequest.getAttribute(SHOULD_NOT_FILTER);
+
+        assertNotEquals(Boolean.TRUE, shouldNotFilter);
+        verify(filterChain).doFilter(eq(httpServletRequest), eq(httpServletResponse));
+    }
+
+    @Test
+    void testDoFilterInternalReplicatedHeaderSkipped() throws ServletException, IOException {
+        httpServletRequest.setMethod(HttpMethod.GET.name());
+        httpServletRequest.addHeader(SkipReplicatedCsrfFilter.REPLICATED_REQUEST_HEADER, UUID.randomUUID().toString());
+
+        filter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
+
+        final Object shouldNotFilter = httpServletRequest.getAttribute(SHOULD_NOT_FILTER);
+
+        assertEquals(Boolean.TRUE, shouldNotFilter);
+        verify(filterChain).doFilter(eq(httpServletRequest), eq(httpServletResponse));
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-10871](https://issues.apache.org/jira/browse/NIFI-10871) Adds a new Servlet Filter to the application Spring Security Filter Chain configuration for skipping Cross-Site Request Forgery processing on HTTP requests replicated between cluster nodes.

The introduction of CSRF mitigation using the standard Spring Security `CsrfFilter` causes the application to generate and set a `__Secure-Request-Token` cookie on HTTP responses. This is not necessary for requests replicated from one cluster node to another. As a result of the current behavior, requests to cluster nodes can return intermittent HTTP 403 responses when a client web browser sends mismatched `__Secure-Request-Token` Cookie and `Request-Token` Header values.

Skipping CSRF token generation for cluster replicated requests avoids introducing a new value for the `__Secure-Request-Token` Cookie, which resolves intermittent HTTP 403 responses in clustered deployments. The new `SkipReplicatedCsrfFilter` matches HTTP requests based on the presence of the custom `X-RequestTransactionId`, which the standard Request Replicator applies to replicated requests.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
