### PR TITLE
NIFI-10875 fixed flaky test

### DIFF
--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
@@ -588,7 +588,7 @@ public class TestQuerySolr {
 
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(QuerySolr.RESULTS).get(0);
         Map<String, String> attributes = flowFile.getAttributes();
-        
+
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_CONNECT);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_COLLECTION);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_QUERY);
@@ -602,7 +602,8 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||  attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||
+            attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));
@@ -625,7 +626,8 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||  attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||
+            attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));
@@ -648,7 +650,8 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||  attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||
+            attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
@@ -588,7 +588,7 @@ public class TestQuerySolr {
 
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(QuerySolr.RESULTS).get(0);
         Map<String, String> attributes = flowFile.getAttributes();
-
+        
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_CONNECT);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_COLLECTION);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_QUERY);
@@ -602,8 +602,12 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||
-            attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("q=*:*"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("qt=/select"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("start=0"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("rows=10"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("facet=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));
@@ -626,8 +630,12 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||
-            attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("q=*:*"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("qt=/select"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("start=0"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("rows=10"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("facet=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));
@@ -650,8 +658,12 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||
-            attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("q=*:*"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("qt=/select"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("start=0"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("rows=10"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("stats=true"));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).contains("facet=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
@@ -588,7 +588,7 @@ public class TestQuerySolr {
 
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(QuerySolr.RESULTS).get(0);
         Map<String, String> attributes = flowFile.getAttributes();
-
+        
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_CONNECT);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_COLLECTION);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_QUERY);
@@ -602,8 +602,7 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-
-        assertEquals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true", attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||  attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));
@@ -626,8 +625,7 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-
-        assertEquals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true", attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||  attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));
@@ -650,8 +648,7 @@ public class TestQuerySolr {
 
         assertEquals(SOLR_CONNECT, attributes.get(QuerySolr.ATTRIBUTE_SOLR_CONNECT));
         assertEquals(DEFAULT_SOLR_CORE, attributes.get(QuerySolr.ATTRIBUTE_SOLR_COLLECTION));
-
-        assertEquals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true", attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY));
+        assertTrue(attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&stats=true&facet=true") ||  attributes.get(QuerySolr.ATTRIBUTE_SOLR_QUERY).equals("q=*:*&qt=/select&start=0&rows=10&facet=true&stats=true"));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_STATUS));
         assertEquals("0", attributes.get(QuerySolr.ATTRIBUTE_SOLR_START));
         assertEquals("10", attributes.get(QuerySolr.ATTRIBUTE_SOLR_ROWS));

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/src/test/java/org/apache/nifi/processors/solr/TestQuerySolr.java
@@ -588,7 +588,7 @@ public class TestQuerySolr {
 
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(QuerySolr.RESULTS).get(0);
         Map<String, String> attributes = flowFile.getAttributes();
-        
+
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_CONNECT);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_COLLECTION);
         flowFile.assertAttributeExists(QuerySolr.ATTRIBUTE_SOLR_QUERY);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10875](https://issues.apache.org/jira/browse/NIFI-10875)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
