### PR TITLE
NIFI-10882 prevent setting of both BASIC and API_KEY Authorization Scheme properties in ElasticSearchClientService

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -144,15 +144,6 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             addAuthorizationPropertiesValidationIssue(results, API_KEY, API_KEY_ID);
         }
 
-        if ((usernameSet || passwordSet) && (apiKeyIdSet || apiKeySet)) {
-            results.add(new ValidationResult.Builder().subject(AuthorizationScheme.API_KEY == authorizationScheme ? USERNAME.getName() : API_KEY_ID.getName()).valid(false)
-                    .explanation(String.format("cannot specify '%s'/'%s' and '%s'/'%s' together.",
-                            USERNAME.getDisplayName(), PASSWORD.getDisplayName(),
-                            API_KEY_ID.getDisplayName(), API_KEY.getDisplayName())
-                    ).build()
-            );
-        }
-
         return results;
     }
 
@@ -258,6 +249,8 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
     }
 
     private RestClient setupClient(final ConfigurationContext context) throws MalformedURLException, InitializationException {
+        final AuthorizationScheme authorizationScheme = AuthorizationScheme.valueOf(context.getProperty(AUTHORIZATION_SCHEME).getValue());
+
         final String hosts = context.getProperty(HTTP_HOSTS).evaluateAttributeExpressions().getValue();
         final String[] hostsSplit = hosts.split(",\\s*");
         this.url = hostsSplit[0];
@@ -270,7 +263,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         final String apiKey = context.getProperty(API_KEY).getValue();
 
         final Integer connectTimeout = context.getProperty(CONNECT_TIMEOUT).asInteger();
-        final Integer readTimeout    = context.getProperty(SOCKET_TIMEOUT).asInteger();
+        final Integer socketTimeout = context.getProperty(SOCKET_TIMEOUT).asInteger();
 
         final ProxyConfigurationService proxyConfigurationService = context.getProperty(PROXY_CONFIGURATION_SERVICE).asControllerService(ProxyConfigurationService.class);
 
@@ -296,11 +289,11 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
                     }
 
                     CredentialsProvider credentialsProvider = null;
-                    if (username != null && password != null) {
+                    if (AuthorizationScheme.BASIC == authorizationScheme && username != null && password != null) {
                         credentialsProvider = addCredentials(null, AuthScope.ANY, username, password);
                     }
 
-                    if (apiKeyId != null && apiKey != null) {
+                    if (AuthorizationScheme.API_KEY == authorizationScheme && apiKeyId != null && apiKey != null) {
                         httpClientBuilder.setDefaultHeaders(Collections.singletonList(createApiKeyAuthorizationHeader(apiKeyId, apiKey)));
                     }
 
@@ -322,7 +315,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
                 })
                 .setRequestConfigCallback(requestConfigBuilder -> {
                     requestConfigBuilder.setConnectTimeout(connectTimeout);
-                    requestConfigBuilder.setSocketTimeout(readTimeout);
+                    requestConfigBuilder.setSocketTimeout(socketTimeout);
                     return requestConfigBuilder;
                 });
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -144,6 +144,15 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             addAuthorizationPropertiesValidationIssue(results, API_KEY, API_KEY_ID);
         }
 
+        if ((usernameSet || passwordSet) && (apiKeyIdSet || apiKeySet)) {
+            results.add(new ValidationResult.Builder().subject(AuthorizationScheme.API_KEY == authorizationScheme ? USERNAME.getName() : API_KEY_ID.getName()).valid(false)
+                    .explanation(String.format("cannot specify '%s'/'%s' and '%s'/'%s' together.",
+                            USERNAME.getDisplayName(), PASSWORD.getDisplayName(),
+                            API_KEY_ID.getDisplayName(), API_KEY.getDisplayName())
+                    ).build()
+            );
+        }
+
         return results;
     }
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
@@ -104,22 +104,6 @@ class ElasticSearchClientServiceImplTest {
     }
 
     @Test
-    void testValidateBasicAndApiKeyAuth() {
-        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.API_KEY.getValue());
-        runner.setProperty(service, ElasticSearchClientService.USERNAME, "username");
-        runner.setProperty(service, ElasticSearchClientService.PASSWORD, "password");
-        runner.setProperty(service, ElasticSearchClientService.API_KEY_ID, "api-key-id");
-        runner.setProperty(service, ElasticSearchClientService.API_KEY, "api-key");
-        runner.assertNotValid(service);
-
-        final AssertionFailedError afe = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
-        assertTrue(afe.getMessage().contains(String.format("cannot specify '%s'/'%s' and '%s'/'%s' together.",
-                ElasticSearchClientService.USERNAME.getDisplayName(), ElasticSearchClientService.PASSWORD.getDisplayName(),
-                ElasticSearchClientService.API_KEY_ID.getDisplayName(), ElasticSearchClientService.API_KEY.getDisplayName()))
-        );
-    }
-
-    @Test
     void testValidatePkiAuth() throws InitializationException {
         runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.PKI.getValue());
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
@@ -104,6 +104,22 @@ class ElasticSearchClientServiceImplTest {
     }
 
     @Test
+    void testValidateBasicAndApiKeyAuth() {
+        runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.API_KEY.getValue());
+        runner.setProperty(service, ElasticSearchClientService.USERNAME, "username");
+        runner.setProperty(service, ElasticSearchClientService.PASSWORD, "password");
+        runner.setProperty(service, ElasticSearchClientService.API_KEY_ID, "api-key-id");
+        runner.setProperty(service, ElasticSearchClientService.API_KEY, "api-key");
+        runner.assertNotValid(service);
+
+        final AssertionFailedError afe = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
+        assertTrue(afe.getMessage().contains(String.format("cannot specify '%s'/'%s' and '%s'/'%s' together.",
+                ElasticSearchClientService.USERNAME.getDisplayName(), ElasticSearchClientService.PASSWORD.getDisplayName(),
+                ElasticSearchClientService.API_KEY_ID.getDisplayName(), ElasticSearchClientService.API_KEY.getDisplayName()))
+        );
+    }
+
+    @Test
     void testValidatePkiAuth() throws InitializationException {
         runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.PKI.getValue());
 


### PR DESCRIPTION
# Summary

[NIFI-10882](https://issues.apache.org/jira/browse/NIFI-10882) prevent setting of both BASIC and API_KEY Authorization Scheme properties in ElasticSearchClientService

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
