### PR TITLE
NIFI-10897 Replace Spring Security Base64 with java.util.Base64

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/kerberos/KerberosService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/kerberos/KerberosService.java
@@ -20,13 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.codec.Base64;
 import org.springframework.security.kerberos.authentication.KerberosServiceAuthenticationProvider;
 import org.springframework.security.kerberos.authentication.KerberosServiceRequestToken;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 
 import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  *
@@ -39,8 +39,10 @@ public class KerberosService {
     public static final String AUTHENTICATION_CHALLENGE_HEADER_NAME = "WWW-Authenticate";
     public static final String AUTHORIZATION_NEGOTIATE = "Negotiate";
 
+    private static final Base64.Decoder decoder = Base64.getDecoder();
+
     private KerberosServiceAuthenticationProvider kerberosServiceAuthenticationProvider;
-    private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
+    private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
     public void setKerberosServiceAuthenticationProvider(KerberosServiceAuthenticationProvider kerberosServiceAuthenticationProvider) {
         this.kerberosServiceAuthenticationProvider = kerberosServiceAuthenticationProvider;
@@ -59,7 +61,7 @@ public class KerberosService {
                 logger.debug("Received Negotiate Header for request " + request.getRequestURL() + ": " + header);
             }
             byte[] base64Token = header.substring(header.indexOf(" ") + 1).getBytes(StandardCharsets.UTF_8);
-            byte[] kerberosTicket = Base64.decode(base64Token);
+            byte[] kerberosTicket = decoder.decode(base64Token);
             KerberosServiceRequestToken authenticationRequest = new KerberosServiceRequestToken(kerberosTicket);
             authenticationRequest.setDetails(authenticationDetailsSource.buildDetails(request));
 


### PR DESCRIPTION
# Summary

[NIFI-10897](https://issues.apache.org/jira/browse/NIFI-10897) Replaces usage of the deprecated Spring Security `Base64` class with the standard `java.util.Base64` decoder. Additional changes include replacing deprecated usage of `FormatUtils.getTimeDuration()` with `FormatUtils.getPreciseTimeDuration()`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
