### PR TITLE
NIFI-10721 No querying for props after successful blob upload

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
@@ -189,8 +189,12 @@ public abstract class AbstractAzureBlobProcessor_v12 extends AbstractProcessor {
         attributes.computeIfAbsent(ATTR_NAME_ETAG, key -> props.get().getETag());
         attributes.computeIfAbsent(ATTR_NAME_BLOBTYPE, key -> props.get().getBlobType().toString());
         attributes.computeIfAbsent(ATTR_NAME_MIME_TYPE, key -> props.get().getContentType());
-        attributes.computeIfAbsent(ATTR_NAME_LANG, key -> props.get().getContentLanguage());
         attributes.computeIfAbsent(ATTR_NAME_TIMESTAMP, key -> String.valueOf(props.get().getLastModified()));
         attributes.computeIfAbsent(ATTR_NAME_LENGTH, key -> String.valueOf(props.get().getBlobSize()));
+        
+        // The LANG attribute is a special case because we allow it to be null.
+        if (!attributes.containsKey(ATTR_NAME_LANG)) {
+            attributes.put(ATTR_NAME_LANG, props.get().getContentLanguage());
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.getProxyOptions;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_BLOBNAME;
@@ -175,12 +176,21 @@ public abstract class AbstractAzureBlobProcessor_v12 extends AbstractProcessor {
     }
 
     protected void applyBlobMetadata(Map<String, String> attributes, BlobClient blobClient) {
-        BlobProperties properties = blobClient.getProperties();
-        attributes.put(ATTR_NAME_ETAG, properties.getETag());
-        attributes.put(ATTR_NAME_BLOBTYPE, properties.getBlobType().toString());
-        attributes.put(ATTR_NAME_MIME_TYPE, properties.getContentType());
-        attributes.put(ATTR_NAME_LANG, properties.getContentLanguage());
-        attributes.put(ATTR_NAME_TIMESTAMP, String.valueOf(properties.getLastModified()));
-        attributes.put(ATTR_NAME_LENGTH, String.valueOf(properties.getBlobSize()));
+        Supplier<BlobProperties> props = new Supplier() {
+            BlobProperties properties;
+            public BlobProperties get() {
+                if (properties == null) {
+                    properties = blobClient.getProperties();
+                }
+                return properties;
+            }
+        };
+
+        attributes.computeIfAbsent(ATTR_NAME_ETAG, key -> props.get().getETag());
+        attributes.computeIfAbsent(ATTR_NAME_BLOBTYPE, key -> props.get().getBlobType().toString());
+        attributes.computeIfAbsent(ATTR_NAME_MIME_TYPE, key -> props.get().getContentType());
+        attributes.computeIfAbsent(ATTR_NAME_LANG, key -> props.get().getContentLanguage());
+        attributes.computeIfAbsent(ATTR_NAME_TIMESTAMP, key -> String.valueOf(props.get().getLastModified()));
+        attributes.computeIfAbsent(ATTR_NAME_LENGTH, key -> String.valueOf(props.get().getBlobSize()));
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
@@ -191,7 +191,7 @@ public abstract class AbstractAzureBlobProcessor_v12 extends AbstractProcessor {
         attributes.computeIfAbsent(ATTR_NAME_MIME_TYPE, key -> props.get().getContentType());
         attributes.computeIfAbsent(ATTR_NAME_TIMESTAMP, key -> String.valueOf(props.get().getLastModified()));
         attributes.computeIfAbsent(ATTR_NAME_LENGTH, key -> String.valueOf(props.get().getBlobSize()));
-        
+
         // The LANG attribute is a special case because we allow it to be null.
         if (!attributes.containsKey(ATTR_NAME_LANG)) {
             attributes.put(ATTR_NAME_LANG, props.get().getContentLanguage());

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.azure.storage;
 
+import com.azure.core.http.rest.Response;
 import com.azure.core.util.Context;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
@@ -23,6 +24,8 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlobType;
+import com.azure.storage.blob.models.BlockBlobItem;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -50,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.azure.core.http.ContentType.APPLICATION_OCTET_STREAM;
 import static com.azure.core.util.FluxUtil.toFluxByteBuffer;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
@@ -161,8 +165,10 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
                 try (InputStream rawIn = session.read(flowFile)) {
                     final BlobParallelUploadOptions blobParallelUploadOptions = new BlobParallelUploadOptions(toFluxByteBuffer(rawIn));
                     blobParallelUploadOptions.setRequestConditions(blobRequestConditions);
-                    blobClient.uploadWithResponse(blobParallelUploadOptions, null, Context.NONE);
-                    applyBlobMetadata(attributes, blobClient);
+                    Response<BlockBlobItem> response = blobClient.uploadWithResponse(blobParallelUploadOptions, null, Context.NONE);
+                    BlockBlobItem blob = response.getValue();
+                    long length = flowFile.getSize();
+                    applyUploadResultAttributes(attributes, blob, BlobType.BLOCK_BLOB, length);
                     if (ignore) {
                         attributes.put(ATTR_NAME_IGNORED, "false");
                     }
@@ -190,5 +196,14 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    private static void applyUploadResultAttributes(final Map<String, String> attributes, final BlockBlobItem blob, final BlobType blobType, final long length) {
+        attributes.put(ATTR_NAME_BLOBTYPE, blobType.toString());
+        attributes.put(ATTR_NAME_ETAG, blob.getETag());
+        attributes.put(ATTR_NAME_LENGTH, String.valueOf(length));
+        attributes.put(ATTR_NAME_TIMESTAMP, String.valueOf(blob.getLastModified()));
+        attributes.put(ATTR_NAME_LANG, null);
+        attributes.put(ATTR_NAME_MIME_TYPE, APPLICATION_OCTET_STREAM);
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
@@ -169,6 +169,7 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
                     BlockBlobItem blob = response.getValue();
                     long length = flowFile.getSize();
                     applyUploadResultAttributes(attributes, blob, BlobType.BLOCK_BLOB, length);
+                    applyBlobMetadata(attributes, blobClient);
                     if (ignore) {
                         attributes.put(ATTR_NAME_IGNORED, "false");
                     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
@@ -71,7 +71,7 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
         runProcessor(BLOB_DATA);
 
         assertSuccess(getContainerName(), BLOB_NAME, BLOB_DATA);
-        assert ((ITProcessor) runner.getProcessor()).blobMetadataApplied;
+        assertTrue(((ITProcessor) runner.getProcessor()).blobMetadataApplied);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
@@ -40,9 +40,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
+    public static class ITProcessor extends PutAzureBlobStorage_v12 {
+        public boolean blobMetadataApplied = false;
+        @Override
+        protected void applyBlobMetadata(Map<String, String> attributes, BlobClient blobClient) {
+            super.applyBlobMetadata(attributes, blobClient);
+            blobMetadataApplied = true;
+        }
+    }
+
     @Override
     protected Class<? extends Processor> getProcessorClass() {
-        return PutAzureBlobStorage_v12.class;
+        return ITProcessor.class;
     }
 
     @BeforeEach
@@ -55,6 +64,14 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
         runProcessor(BLOB_DATA);
 
         assertSuccess(getContainerName(), BLOB_NAME, BLOB_DATA);
+    }
+
+    @Test
+    public void testPutBlobApplyBlobMetadata() throws Exception {
+        runProcessor(BLOB_DATA);
+
+        assertSuccess(getContainerName(), BLOB_NAME, BLOB_DATA);
+        assert ((ITProcessor) runner.getProcessor()).blobMetadataApplied;
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10721](https://issues.apache.org/jira/browse/NIFI-10721)

Description snippet from the issue:

> Since we're in control of all the properties of the blob, there is no reason to query for the properties after success. Using the information we already have will obviate the need for this additional roundtrip.

## Implementation notes

For users who may be extending the processor, the `applyBlobMetadata` is still functioning as an extension point – it's being called, but in the default implementation, it does nothing because the information is already available.

(That is, the call to get blob properties has been made lazy, invoked only if needed.)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
