### PR TITLE
NIFI-10899 Add SameSite Policy to Application Cookies

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/ApplicationCookieName.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/ApplicationCookieName.java
@@ -22,21 +22,35 @@ import org.apache.nifi.web.security.http.SecurityCookieName;
  * Application Cookie Names
  */
 public enum ApplicationCookieName {
-    AUTHORIZATION_BEARER(SecurityCookieName.AUTHORIZATION_BEARER.getName()),
+    /** Authorization Bearer contains signed JSON Web Token and requires Strict Same Site handling */
+    AUTHORIZATION_BEARER(SecurityCookieName.AUTHORIZATION_BEARER.getName(), SameSitePolicy.STRICT),
 
-    LOGOUT_REQUEST_IDENTIFIER("nifi-logout-request-identifier"),
+    /** Cross-Site Request Forgery mitigation token requires Strict Same Site handling */
+    REQUEST_TOKEN(SecurityCookieName.REQUEST_TOKEN.getName(), SameSitePolicy.STRICT),
 
-    OIDC_REQUEST_IDENTIFIER("nifi-oidc-request-identifier"),
+    /** Logout Requests can interact with external identity providers requiring no Same Site restrictions */
+    LOGOUT_REQUEST_IDENTIFIER("__Secure-Logout-Request-Identifier", SameSitePolicy.NONE),
 
-    SAML_REQUEST_IDENTIFIER("nifi-saml-request-identifier");
+    /** OpenID Connect Requests use external identity providers requiring no Same Site restrictions */
+    OIDC_REQUEST_IDENTIFIER("__Secure-OIDC-Request-Identifier", SameSitePolicy.NONE),
+
+    /** SAML Requests use external identity providers requiring no Same Site restrictions */
+    SAML_REQUEST_IDENTIFIER("__Secure-SAML-Request-Identifier", SameSitePolicy.NONE);
 
     private final String cookieName;
 
-    ApplicationCookieName(final String cookieName) {
+    private final SameSitePolicy sameSitePolicy;
+
+    ApplicationCookieName(final String cookieName, final SameSitePolicy sameSitePolicy) {
         this.cookieName = cookieName;
+        this.sameSitePolicy = sameSitePolicy;
     }
 
     public String getCookieName() {
         return cookieName;
+    }
+
+    public SameSitePolicy getSameSitePolicy() {
+        return sameSitePolicy;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/SameSitePolicy.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/SameSitePolicy.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.cookie;
+
+/**
+ * Cookie SameSite attribute policy
+ */
+public enum SameSitePolicy {
+    /** Instructs browsers to limit sending cookies to first-party-initiated requests */
+    STRICT("Strict"),
+
+    /** Instructs browsers to send cookies for both first-party and cross-site requests */
+    NONE("None");
+
+    private final String policy;
+
+    SameSitePolicy(final String policy) {
+        this.policy = policy;
+    }
+
+    public String getPolicy() {
+        return policy;
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieService.java
@@ -43,8 +43,6 @@ public class StandardApplicationCookieService implements ApplicationCookieServic
 
     private static final String DEFAULT_PATH = "/";
 
-    private static final String SAME_SITE_STRICT = "Strict";
-
     private static final boolean SECURE_ENABLED = true;
 
     private static final boolean HTTP_ONLY_ENABLED = true;
@@ -77,7 +75,6 @@ public class StandardApplicationCookieService implements ApplicationCookieServic
     @Override
     public void addSessionCookie(final URI resourceUri, final HttpServletResponse response, final ApplicationCookieName applicationCookieName, final String value) {
         final ResponseCookie.ResponseCookieBuilder responseCookieBuilder = getCookieBuilder(resourceUri, applicationCookieName, value, MAX_AGE_SESSION);
-        responseCookieBuilder.sameSite(SAME_SITE_STRICT);
         setResponseCookie(response, responseCookieBuilder.build());
         logger.debug("Added Session Cookie [{}] URI [{}]", applicationCookieName.getCookieName(), resourceUri);
     }
@@ -110,15 +107,27 @@ public class StandardApplicationCookieService implements ApplicationCookieServic
         logger.debug("Removed Cookie [{}] URI [{}]", applicationCookieName.getCookieName(), resourceUri);
     }
 
-    private ResponseCookie.ResponseCookieBuilder getCookieBuilder(final URI resourceUri,
+    /**
+     * Get Response Cookie Builder with standard properties
+     *
+     * @param resourceUri Resource URI containing path and domain
+     * @param applicationCookieName Application Cookie Name to be used
+     * @param value Cookie value
+     * @param maxAge Max Age
+     * @return Response Cookie Builder
+     */
+    protected ResponseCookie.ResponseCookieBuilder getCookieBuilder(final URI resourceUri,
                                              final ApplicationCookieName applicationCookieName,
                                              final String value,
                                              final Duration maxAge) {
         Objects.requireNonNull(resourceUri, "Resource URI required");
         Objects.requireNonNull(applicationCookieName, "Response Cookie Name required");
+
+        final SameSitePolicy sameSitePolicy = applicationCookieName.getSameSitePolicy();
         return ResponseCookie.from(applicationCookieName.getCookieName(), value)
                 .path(getCookiePath(resourceUri))
                 .domain(resourceUri.getHost())
+                .sameSite(sameSitePolicy.getPolicy())
                 .secure(SECURE_ENABLED)
                 .httpOnly(HTTP_ONLY_ENABLED)
                 .maxAge(maxAge);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieServiceTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieServiceTest.java
@@ -17,13 +17,13 @@
 package org.apache.nifi.web.security.cookie;
 
 import org.apache.nifi.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockCookie;
 
 import javax.servlet.http.Cookie;
@@ -34,14 +34,14 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class StandardApplicationCookieServiceTest {
     private static final String DOMAIN = "localhost.localdomain";
 
@@ -59,7 +59,7 @@ public class StandardApplicationCookieServiceTest {
 
     private static final int REMOVE_MAX_AGE = 0;
 
-    private static final String SAME_SITE_STRICT = "SameSite=Strict";
+    private static final String SAME_SITE = "SameSite";
 
     private static final String COOKIE_VALUE = UUID.randomUUID().toString();
 
@@ -80,7 +80,7 @@ public class StandardApplicationCookieServiceTest {
     @Captor
     private ArgumentCaptor<String> cookieArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setService() {
         service = new StandardApplicationCookieService();
         resourceUri = URI.create(RESOURCE_URI);
@@ -113,7 +113,6 @@ public class StandardApplicationCookieServiceTest {
 
         final String setCookieHeader = cookieArgumentCaptor.getValue();
         assertAddCookieMatches(setCookieHeader, ROOT_PATH, SESSION_MAX_AGE);
-        assertTrue("SameSite not found", setCookieHeader.endsWith(SAME_SITE_STRICT));
     }
 
     @Test
@@ -124,7 +123,6 @@ public class StandardApplicationCookieServiceTest {
 
         final String setCookieHeader = cookieArgumentCaptor.getValue();
         assertAddCookieMatches(setCookieHeader, CONTEXT_PATH, SESSION_MAX_AGE);
-        assertTrue("SameSite not found", setCookieHeader.endsWith(SAME_SITE_STRICT));
     }
 
     @Test
@@ -175,10 +173,11 @@ public class StandardApplicationCookieServiceTest {
     }
 
     private void assertCookieMatches(final String setCookieHeader, final Cookie cookie, final String path) {
-        assertEquals("Cookie Name not matched", COOKIE_NAME.getCookieName(), cookie.getName());
-        assertEquals("Path not matched", path, cookie.getPath());
-        assertEquals("Domain not matched", DOMAIN, cookie.getDomain());
-        assertTrue("HTTP Only not matched", cookie.isHttpOnly());
-        assertTrue("Secure not matched", cookie.getSecure());
+        assertEquals(COOKIE_NAME.getCookieName(), cookie.getName(), "Cookie Name not matched");
+        assertEquals(path, cookie.getPath(), "Path not matched");
+        assertEquals(DOMAIN, cookie.getDomain(), "Domain not matched");
+        assertTrue(cookie.isHttpOnly(), "HTTP Only not matched");
+        assertTrue(cookie.getSecure(), "Secure not matched");
+        assertTrue(setCookieHeader.contains(SAME_SITE), "SameSite not found");
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-10899](https://issues.apache.org/jira/browse/NIFI-10899) Adds the `SameSite` attribute to all application cookies. The current security configuration applies `SameSite=Strict` to the `__Secure-Authorization-Bearer` Cookie, but no other cookies have the `SameSite` policy applied.

The changes implemented add a `SameSitePolicy` enumeration and update the `ApplicationCookieName` enumeration to indicate the policy that will be applied. The implementation applies a `SameSite` attribute to all application cookies to avoid browser warnings and fallback to implicit behavior.

The `__Secure-Authorization-Bearer` and `__Secure-Request-Token` cookies are limited to first-party access, so both of those cookies have the `Strict` policy configured.

The Logout, SAML, and OIDC cookies require a value of `None` for the `SameSite` attribute because authentication and logout involves redirects between NiFi and external identity providers.

Additional changes include adding the `__Secure` [prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#cookie_prefixes) to the the Logout, SAML, and OIDC cookie names .

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
