### PR TITLE
NIFI-10868 Add PutDropbox processor

### DIFF
--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxAttributes.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxAttributes.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.dropbox;
+
+public class DropboxAttributes {
+    public static final String ID = "dropbox.id";
+    public static final String ID_DESC = "The Dropbox identifier of the file";
+
+    public static final String PATH = "path";
+    public static final String PATH_DESC = "The folder path where the file is located";
+
+    public static final String FILENAME = "filename";
+    public static final String FILENAME_DESC = "The name of the file";
+
+    public static final String SIZE = "dropbox.size";
+    public static final String SIZE_DESC = "The size of the file";
+
+    public static final String TIMESTAMP = "dropbox.timestamp";
+    public static final String TIMESTAMP_DESC = "The server modified time, when the file was uploaded to Dropbox";
+
+    public static final String REVISION = "dropbox.revision";
+    public static final String REVISION_DESC = "Revision of the file";
+
+    public static final String ERROR_MESSAGE = "error.message";
+    public static final String ERROR_MESSAGE_DESC = "The error message returned by Dropbox when the fetch of a file fails";
+}

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxFileInfo.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxFileInfo.java
@@ -16,6 +16,13 @@
  */
 package org.apache.nifi.processors.dropbox;
 
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.FILENAME;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.ID;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.PATH;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.REVISION;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.SIZE;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.TIMESTAMP;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,14 +37,6 @@ import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 
 public class DropboxFileInfo implements ListableEntity {
-
-    public static final String ID = "dropbox.id";
-    public static final String PATH = "path";
-    public static final String FILENAME = "filename";
-    public static final String SIZE = "dropbox.size";
-    public static final String TIMESTAMP = "dropbox.timestamp";
-    public static final String REVISION = "dropbox.revision";
-    public static final String URL = "dropbox.url";
 
     private static final RecordSchema SCHEMA;
 
@@ -63,6 +62,7 @@ public class DropboxFileInfo implements ListableEntity {
     private final long size;
     private final long timestamp;
     private final String revision;
+
     private DropboxFileInfo(final Builder builder) {
         this.id = builder.id;
         this.path = builder.path;
@@ -71,8 +71,6 @@ public class DropboxFileInfo implements ListableEntity {
         this.timestamp = builder.timestamp;
         this.revision = builder.revision;
     }
-
-
 
     public String getId() {
         return id;

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxFileInfo.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxFileInfo.java
@@ -37,6 +37,7 @@ public class DropboxFileInfo implements ListableEntity {
     public static final String SIZE = "dropbox.size";
     public static final String TIMESTAMP = "dropbox.timestamp";
     public static final String REVISION = "dropbox.revision";
+    public static final String URL = "dropbox.url";
 
     private static final RecordSchema SCHEMA;
 
@@ -62,7 +63,6 @@ public class DropboxFileInfo implements ListableEntity {
     private final long size;
     private final long timestamp;
     private final String revision;
-
     private DropboxFileInfo(final Builder builder) {
         this.id = builder.id;
         this.path = builder.path;
@@ -71,6 +71,8 @@ public class DropboxFileInfo implements ListableEntity {
         this.timestamp = builder.timestamp;
         this.revision = builder.revision;
     }
+
+
 
     public String getId() {
         return id;

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxFlowFileAttribute.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxFlowFileAttribute.java
@@ -19,12 +19,12 @@ package org.apache.nifi.processors.dropbox;
 import java.util.function.Function;
 
 public enum DropboxFlowFileAttribute {
-    ID(DropboxFileInfo.ID, DropboxFileInfo::getId),
-    PATH(DropboxFileInfo.PATH, DropboxFileInfo::getPath),
-    FILENAME(DropboxFileInfo.FILENAME, DropboxFileInfo::getName),
-    SIZE(DropboxFileInfo.SIZE, fileInfo -> String.valueOf(fileInfo.getSize())),
-    TIMESTAMP(DropboxFileInfo.TIMESTAMP, fileInfo -> String.valueOf(fileInfo.getTimestamp())),
-    REVISION(DropboxFileInfo.REVISION, DropboxFileInfo::getRevision);
+    ID(DropboxAttributes.ID, DropboxFileInfo::getId),
+    PATH(DropboxAttributes.PATH, DropboxFileInfo::getPath),
+    FILENAME(DropboxAttributes.FILENAME, DropboxFileInfo::getName),
+    SIZE(DropboxAttributes.SIZE, fileInfo -> String.valueOf(fileInfo.getSize())),
+    TIMESTAMP(DropboxAttributes.TIMESTAMP, fileInfo -> String.valueOf(fileInfo.getTimestamp())),
+    REVISION(DropboxAttributes.REVISION, DropboxFileInfo::getRevision);
 
     private final String name;
     private final Function<DropboxFileInfo, String> fromFileInfo;

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
@@ -43,12 +43,10 @@ public interface DropboxTrait {
             .required(true)
             .build();
 
-
-
     default DbxClientV2 getDropboxApiClient(ProcessContext context, String identifier) {
         final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
-        String dropboxClientId = format("%s-%s", getClass().getSimpleName(), identifier);
-        OkHttpClient.Builder okHttpClientBuilder = OkHttp3Requestor.defaultOkHttpClientBuilder();
+        final String dropboxClientId = format("%s-%s", getClass().getSimpleName(), identifier);
+        final OkHttpClient.Builder okHttpClientBuilder = OkHttp3Requestor.defaultOkHttpClientBuilder();
 
         if (!Proxy.Type.DIRECT.equals(proxyConfiguration.getProxyType())) {
             okHttpClientBuilder.proxy(proxyConfiguration.createProxy());
@@ -63,14 +61,14 @@ public interface DropboxTrait {
             }
         }
 
-        HttpRequestor httpRequestor = new OkHttp3Requestor(okHttpClientBuilder.build());
-        DbxRequestConfig config = DbxRequestConfig.newBuilder(dropboxClientId)
+        final HttpRequestor httpRequestor = new OkHttp3Requestor(okHttpClientBuilder.build());
+        final DbxRequestConfig config = DbxRequestConfig.newBuilder(dropboxClientId)
                 .withHttpRequestor(httpRequestor)
                 .build();
 
         final DropboxCredentialService credentialService = context.getProperty(CREDENTIAL_SERVICE)
                 .asControllerService(DropboxCredentialService.class);
-        DropboxCredentialDetails credential = credentialService.getDropboxCredential();
+        final DropboxCredentialDetails credential = credentialService.getDropboxCredential();
 
         return new DbxClientV2(config, new DbxCredential(credential.getAccessToken(), -1L,
                 credential.getRefreshToken(), credential.getAppKey(), credential.getAppSecret()));

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
@@ -70,4 +70,8 @@ public interface DropboxTrait {
         return new DbxClientV2(config, new DbxCredential(credential.getAccessToken(), -1L,
                 credential.getRefreshToken(), credential.getAppKey(), credential.getAppSecret()));
     }
+
+    default String convertFolderName(String folderName) {
+        return "/".equals(folderName) ? "" : folderName;
+    }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
@@ -92,13 +92,12 @@ public interface DropboxTrait {
 
     default Map<String, String> createAttributeMap(FileMetadata fileMetadata) {
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put(DropboxFileInfo.ID, fileMetadata.getId());
-        attributes.put(DropboxFileInfo.PATH, getParentPath(fileMetadata.getPathDisplay()));
-        attributes.put(DropboxFileInfo.FILENAME, fileMetadata.getName());
-        attributes.put(DropboxFileInfo.SIZE, valueOf(fileMetadata.getSize()));
-        attributes.put(DropboxFileInfo.REVISION, fileMetadata.getRev());
-        attributes.put(DropboxFileInfo.TIMESTAMP, valueOf(fileMetadata.getServerModified().getTime()));
-        attributes.put(DropboxFileInfo.URL, DROPBOX_HOME_URL + fileMetadata.getPathDisplay());
+        attributes.put(DropboxAttributes.ID, fileMetadata.getId());
+        attributes.put(DropboxAttributes.PATH, getParentPath(fileMetadata.getPathDisplay()));
+        attributes.put(DropboxAttributes.FILENAME, fileMetadata.getName());
+        attributes.put(DropboxAttributes.SIZE, valueOf(fileMetadata.getSize()));
+        attributes.put(DropboxAttributes.REVISION, fileMetadata.getRev());
+        attributes.put(DropboxAttributes.TIMESTAMP, valueOf(fileMetadata.getServerModified().getTime()));
         return attributes;
     }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxTrait.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.processors.dropbox;
 
+import static java.lang.String.format;
+
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.http.HttpRequestor;
 import com.dropbox.core.http.OkHttp3Requestor;
@@ -42,7 +44,10 @@ public interface DropboxTrait {
             .build();
 
 
-    default DbxClientV2 getDropboxApiClient(ProcessContext context, ProxyConfiguration proxyConfiguration, String clientId) {
+
+    default DbxClientV2 getDropboxApiClient(ProcessContext context, String identifier) {
+        final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
+        String dropboxClientId = format("%s-%s", getClass().getSimpleName(), identifier);
         OkHttpClient.Builder okHttpClientBuilder = OkHttp3Requestor.defaultOkHttpClientBuilder();
 
         if (!Proxy.Type.DIRECT.equals(proxyConfiguration.getProxyType())) {
@@ -59,7 +64,7 @@ public interface DropboxTrait {
         }
 
         HttpRequestor httpRequestor = new OkHttp3Requestor(okHttpClientBuilder.build());
-        DbxRequestConfig config = DbxRequestConfig.newBuilder(clientId)
+        DbxRequestConfig config = DbxRequestConfig.newBuilder(dropboxClientId)
                 .withHttpRequestor(httpRequestor)
                 .build();
 

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
@@ -16,8 +16,6 @@
  */
 package org.apache.nifi.processors.dropbox;
 
-import static java.lang.String.format;
-
 import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
 import java.io.InputStream;
@@ -51,7 +49,7 @@ import org.apache.nifi.proxy.ProxySpec;
 @CapabilityDescription("Fetches files from Dropbox. Designed to be used in tandem with ListDropbox.")
 @WritesAttribute(attribute = "error.message", description = "When a FlowFile is routed to 'failure', this attribute is added indicating why the file could "
         + "not be fetched from Dropbox.")
-@SeeAlso(ListDropbox.class)
+@SeeAlso({PutDropbox.class, ListDropbox.class})
 @WritesAttributes(
         @WritesAttribute(attribute = FetchDropbox.ERROR_MESSAGE_ATTRIBUTE, description = "The error message returned by Dropbox when the fetch of a file fails."))
 public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
@@ -83,7 +81,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
                     .description("A FlowFile will be routed here for each File for which fetch was attempted but failed.")
                     .build();
 
-    public static final Set<Relationship> relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             REL_SUCCESS,
             REL_FAILURE
     )));
@@ -98,7 +96,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
@@ -108,9 +106,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) {
-        final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
-        String dropboxClientId = format("%s-%s", getClass().getSimpleName(), getIdentifier());
-        dropboxApiClient = getDropboxApiClient(context, proxyConfiguration, dropboxClientId);
+        dropboxApiClient = getDropboxApiClient(context, getIdentifier());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
@@ -47,11 +47,10 @@ import org.apache.nifi.proxy.ProxySpec;
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"dropbox", "storage", "fetch"})
 @CapabilityDescription("Fetches files from Dropbox. Designed to be used in tandem with ListDropbox.")
-@WritesAttribute(attribute = "error.message", description = "When a FlowFile is routed to 'failure', this attribute is added indicating why the file could "
-        + "not be fetched from Dropbox.")
 @SeeAlso({PutDropbox.class, ListDropbox.class})
 @WritesAttributes(
-        @WritesAttribute(attribute = FetchDropbox.ERROR_MESSAGE_ATTRIBUTE, description = "The error message returned by Dropbox when the fetch of a file fails."))
+        @WritesAttribute(attribute = FetchDropbox.ERROR_MESSAGE_ATTRIBUTE, description = "The error message returned by Dropbox when the fetch of a file fails.")
+)
 public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
 
     public static final String ERROR_MESSAGE_ATTRIBUTE = "error.message";
@@ -111,7 +110,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
 
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
-        FlowFile flowFile = session.get();
+        final FlowFile flowFile = session.get();
         if (flowFile == null) {
             return;
         }
@@ -119,7 +118,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
         String fileIdentifier = context.getProperty(FILE).evaluateAttributeExpressions(flowFile).getValue();
         fileIdentifier = correctFilePath(fileIdentifier);
 
-        FlowFile outFlowFile = flowFile;
+        final FlowFile outFlowFile = flowFile;
         try {
             fetchFile(fileIdentifier, session, outFlowFile);
             session.transfer(outFlowFile, REL_SUCCESS);
@@ -129,7 +128,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
     }
 
     private void fetchFile(String fileId, ProcessSession session, FlowFile outFlowFile) throws DbxException {
-        InputStream dropboxInputStream = dropboxApiClient.files()
+        final InputStream dropboxInputStream = dropboxApiClient.files()
                 .download(fileId)
                 .getInputStream();
         session.importFrom(dropboxInputStream, outFlowFile);
@@ -137,7 +136,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
 
     private void handleError(ProcessSession session, FlowFile flowFile, String fileId, Exception e) {
         getLogger().error("Error while fetching and processing file with id '{}'", fileId, e);
-        FlowFile outFlowFile = session.putAttribute(flowFile, ERROR_MESSAGE_ATTRIBUTE, e.getMessage());
+        final FlowFile outFlowFile = session.putAttribute(flowFile, ERROR_MESSAGE_ATTRIBUTE, e.getMessage());
         session.transfer(outFlowFile, REL_FAILURE);
     }
 

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -267,10 +267,5 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
                 .collect(toList());
     }
 
-    private String getParentPath(String fullPath) {
-        final int idx = fullPath.lastIndexOf("/");
-        final String parentPath = fullPath.substring(0, idx);
-        return "".equals(parentPath) ? "/" : parentPath;
-    }
 
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -18,6 +18,18 @@ package org.apache.nifi.processors.dropbox;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.FILENAME;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.FILENAME_DESC;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.ID;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.ID_DESC;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.PATH;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.PATH_DESC;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.REVISION;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.REVISION_DESC;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.SIZE;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.SIZE_DESC;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.TIMESTAMP;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.TIMESTAMP_DESC;
 
 import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
@@ -69,12 +81,13 @@ import org.apache.nifi.serialization.record.RecordSchema;
         " This Processor is designed to run on Primary Node only in a cluster. If the primary node changes, the new Primary Node will pick up where the" +
         " previous node left off without duplicating all of the data.")
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
-@WritesAttributes({@WritesAttribute(attribute = DropboxFileInfo.ID, description = "The Dropbox identifier of the file"),
-        @WritesAttribute(attribute = DropboxFileInfo.PATH, description = "The folder path where the file is located"),
-        @WritesAttribute(attribute = DropboxFileInfo.FILENAME, description = "The name of the file"),
-        @WritesAttribute(attribute = DropboxFileInfo.SIZE, description = "The size of the file"),
-        @WritesAttribute(attribute = DropboxFileInfo.TIMESTAMP, description = "The server modified time, when the file was uploaded to Dropbox"),
-        @WritesAttribute(attribute = DropboxFileInfo.REVISION, description = "Revision of the file")})
+@WritesAttributes({
+        @WritesAttribute(attribute = ID, description = ID_DESC),
+        @WritesAttribute(attribute = PATH, description = PATH_DESC),
+        @WritesAttribute(attribute = FILENAME, description = FILENAME_DESC),
+        @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = REVISION, description = REVISION_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already. " +
         "What exactly needs to be stored depends on the 'Listing Strategy'.")
 @SeeAlso({FetchDropbox.class, PutDropbox.class})

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -274,7 +274,4 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
         return "".equals(parentPath) ? "/" : parentPath;
     }
 
-    private String convertFolderName(String folderName) {
-        return "/".equals(folderName) ? "" : folderName;
-    }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -80,6 +80,7 @@ import org.apache.nifi.serialization.record.RecordSchema;
 @SeeAlso({FetchDropbox.class, PutDropbox.class})
 @DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "1 min")
 public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implements DropboxTrait {
+
     public static final PropertyDescriptor FOLDER = new PropertyDescriptor.Builder()
             .name("folder")
             .displayName("Folder")
@@ -187,20 +188,20 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
         try {
             Predicate<FileMetadata> metadataFilter = createMetadataFilter(minTimestamp, minAge);
 
-            ListFolderBuilder listFolderBuilder = dropboxApiClient.files().listFolderBuilder(convertFolderName(folderName));
+            final ListFolderBuilder listFolderBuilder = dropboxApiClient.files().listFolderBuilder(convertFolderName(folderName));
             ListFolderResult result = listFolderBuilder
                     .withRecursive(recursive)
                     .start();
 
-            List<FileMetadata> metadataList = new ArrayList<>(filterMetadata(result, metadataFilter));
+            final List<FileMetadata> metadataList = new ArrayList<>(filterMetadata(result, metadataFilter));
 
             while (result.getHasMore()) {
                 result = dropboxApiClient.files().listFolderContinue(result.getCursor());
                 metadataList.addAll(filterMetadata(result, metadataFilter));
             }
 
-            for (FileMetadata metadata : metadataList) {
-                DropboxFileInfo.Builder builder = new DropboxFileInfo.Builder()
+            for (final FileMetadata metadata : metadataList) {
+                final DropboxFileInfo.Builder builder = new DropboxFileInfo.Builder()
                         .id(metadata.getId())
                         .path(getParentPath(metadata.getPathDisplay()))
                         .name(metadata.getName())
@@ -267,8 +268,8 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
     }
 
     private String getParentPath(String fullPath) {
-        int idx = fullPath.lastIndexOf("/");
-        String parentPath = fullPath.substring(0, idx);
+        final int idx = fullPath.lastIndexOf("/");
+        final String parentPath = fullPath.substring(0, idx);
         return "".equals(parentPath) ? "/" : parentPath;
     }
 

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -77,7 +77,7 @@ import org.apache.nifi.serialization.record.RecordSchema;
         @WritesAttribute(attribute = DropboxFileInfo.REVISION, description = "Revision of the file")})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already. " +
         "What exactly needs to be stored depends on the 'Listing Strategy'.")
-@SeeAlso(FetchDropbox.class)
+@SeeAlso({FetchDropbox.class, PutDropbox.class})
 @DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "1 min")
 public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implements DropboxTrait {
     public static final PropertyDescriptor FOLDER = new PropertyDescriptor.Builder()
@@ -148,9 +148,7 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) {
-        final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
-        String dropboxClientId = format("%s-%s", getClass().getSimpleName(), getIdentifier());
-        dropboxApiClient = getDropboxApiClient(context, proxyConfiguration, dropboxClientId);
+        dropboxApiClient = getDropboxApiClient(context, getIdentifier());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.dropbox;
+
+import static java.lang.String.format;
+
+import com.dropbox.core.DbxUploader;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.CommitInfo;
+import com.dropbox.core.v2.files.FileMetadata;
+import com.dropbox.core.v2.files.UploadSessionAppendV2Uploader;
+import com.dropbox.core.v2.files.UploadSessionCursor;
+import com.dropbox.core.v2.files.UploadSessionFinishUploader;
+import com.dropbox.core.v2.files.UploadSessionStartUploader;
+import com.dropbox.core.v2.files.UploadUploader;
+import com.dropbox.core.v2.files.WriteMode;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.apache.nifi.proxy.ProxySpec;
+
+/**
+ * This processor uploads objects to Dropbox.
+ */
+@SeeAlso({ListDropbox.class, FetchDropbox.class})
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@Tags({"dropbox", "storage", "put"})
+@CapabilityDescription("Puts content to a Dropbox folder.")
+@ReadsAttribute(attribute = "filename", description = "Uses the FlowFile's filename as the filename for the Dropbox object.")
+public class PutDropbox extends AbstractProcessor implements DropboxTrait {
+
+    public static final int UPLOAD_FILE_SIZE_LIMIT_IN_BYTES = 150 * 1024 * 1024;
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Files that have been successfully written to Dropbox are transferred to this relationship.")
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("Files that could not be written to Dropbox for some reason are transferred to this relationship.")
+            .build();
+
+    public static final PropertyDescriptor FOLDER = new PropertyDescriptor.Builder()
+            .name("folder")
+            .displayName("Folder")
+            .description("The Dropbox identifier or path of the folder to upload files to. "
+                    + "The folder will be created if it does not exist yet.")
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .required(true)
+            .addValidator(StandardValidators.createRegexMatchingValidator(Pattern.compile("/.*|id:.*")))
+            .defaultValue("/")
+            .build();
+
+    public static final PropertyDescriptor FILE_NAME = new PropertyDescriptor.Builder()
+            .name("file-name")
+            .displayName("File Name")
+            .description("The full name of the file to upload.")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .defaultValue("${filename}")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor UPLOAD_CHUNK_SIZE = new PropertyDescriptor.Builder()
+            .name("upload-chunk-size")
+            .displayName("Upload Chunk Size")
+            .description("The chunk size used to upload files larger than 150 MB in smaller parts (chunks). "
+                    + "It is recommended to specify chunk size as multiples of 4 MB.")
+            .defaultValue("8 MB")
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .addValidator(StandardValidators.createDataSizeBoundsValidator(1, UPLOAD_FILE_SIZE_LIMIT_IN_BYTES))
+            .required(false)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+            CREDENTIAL_SERVICE,
+            FOLDER,
+            FILE_NAME,
+            UPLOAD_CHUNK_SIZE,
+            ProxyConfiguration.createProxyConfigPropertyDescriptor(false, ProxySpec.HTTP_AUTH)
+    ));
+
+    private static final Set<Relationship> relationships;
+
+    static {
+        final Set<Relationship> rels = new HashSet<>();
+        rels.add(REL_SUCCESS);
+        rels.add(REL_FAILURE);
+        relationships = Collections.unmodifiableSet(rels);
+    }
+
+    private DbxClientV2 dropboxApiClient;
+    private DbxUploader dbxUploader;
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
+        String dropboxClientId = format("%s-%s", getClass().getSimpleName(), getIdentifier());
+        dropboxApiClient = getDropboxApiClient(context, proxyConfiguration, dropboxClientId);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        String folder = context.getProperty(FOLDER).evaluateAttributeExpressions().getValue();
+        String filename = context.getProperty(FILE_NAME).evaluateAttributeExpressions(flowFile).getValue();
+
+        FileMetadata uploadedFileMetadata = null;
+
+        long size = flowFile.getSize();
+        String uploadPath = convertFolderName(folder) + "/" + filename;
+
+        if (size > 0) {
+            try (final InputStream rawIn = session.read(flowFile)) {
+                if (size <= getUploadFileSizeLimit()) {
+                    dbxUploader = dropboxApiClient.files()
+                            .upload(uploadPath);
+                    uploadedFileMetadata = ((UploadUploader) dbxUploader).uploadAndFinish(rawIn);
+                } else {
+                    long chunkSize = context.getProperty(UPLOAD_CHUNK_SIZE)
+                            .evaluateAttributeExpressions()
+                            .asDataSize(DataUnit.B)
+                            .longValue();
+
+                    uploadedFileMetadata = uploadLargeFileInChunks(rawIn, size, chunkSize, uploadPath);
+                }
+            } catch (Exception e) {
+                getLogger().error("Exception occurred while uploading file '{}' to Dropbox folder '{}'", filename, folder, e);
+            }
+
+            if (uploadedFileMetadata != null) {
+                session.transfer(flowFile, REL_SUCCESS);
+            } else {
+                session.transfer(flowFile, REL_FAILURE);
+            }
+        }
+    }
+
+    @OnUnscheduled
+    @OnDisabled
+    public synchronized void shutdown() {
+        if (dbxUploader != null) {
+            dbxUploader.close();
+        }
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    protected long getUploadFileSizeLimit() {
+        return UPLOAD_FILE_SIZE_LIMIT_IN_BYTES;
+    }
+
+    private FileMetadata uploadLargeFileInChunks(InputStream rawIn, long size, long uploadChunkSize, String path) throws Exception {
+        dbxUploader = dropboxApiClient
+                .files()
+                .uploadSessionStart();
+        String sessionId = ((UploadSessionStartUploader) dbxUploader)
+                .uploadAndFinish(rawIn, uploadChunkSize)
+                .getSessionId();
+        long uploadedBytes = uploadChunkSize;
+
+        UploadSessionCursor cursor = new UploadSessionCursor(sessionId, uploadedBytes);
+
+        while (size - uploadedBytes > uploadChunkSize) {
+            dbxUploader = dropboxApiClient
+                    .files()
+                    .uploadSessionAppendV2(cursor);
+
+            ((UploadSessionAppendV2Uploader) dbxUploader).uploadAndFinish(rawIn, uploadChunkSize);
+            uploadedBytes += uploadChunkSize;
+            cursor = new UploadSessionCursor(sessionId, uploadedBytes);
+        }
+
+        long remainingBytes = size - uploadedBytes;
+
+        CommitInfo commitInfo = CommitInfo.newBuilder(path)
+                .withMode(WriteMode.ADD)
+                .withClientModified(new Date(System.currentTimeMillis()))
+                .build();
+        dbxUploader = dropboxApiClient
+                .files()
+                .uploadSessionFinish(cursor, commitInfo);
+        return  ((UploadSessionFinishUploader) dbxUploader).uploadAndFinish(rawIn, remainingBytes);
+    }
+}

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -14,3 +14,4 @@
 # limitations under the License.
 org.apache.nifi.processors.dropbox.ListDropbox
 org.apache.nifi.processors.dropbox.FetchDropbox
+org.apache.nifi.processors.dropbox.PutDropbox

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/AbstractDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/AbstractDropboxTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.dropbox;
+
+import static java.lang.String.valueOf;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.FileMetadata;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import org.apache.nifi.dropbox.credentials.service.DropboxCredentialService;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+
+public class AbstractDropboxTest {
+    public static final String TEST_FOLDER = "/testFolder";
+    public static final String FILENAME_1 = "file_name_1";
+    public static final String FILENAME_2 = "file_name_2";
+    public static final String FILE_ID = "id:odTlUvbpIEAAAAAAAAAGGQ";
+    public static final long CREATED_TIME = 1659707000;
+    public static final long SIZE = 125;
+    public static final String REVISION = "5e4ddb1320676a5c29261";
+
+    protected TestRunner testRunner;
+
+    @Mock
+    protected DbxClientV2 mockDropboxClient;
+
+    @Mock
+    private DropboxCredentialService mockCredentialService;
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        mockStandardDropboxCredentialService();
+    }
+
+    protected void assertProvenanceEvent(ProvenanceEventType eventType) {
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(eventType);
+        Set<ProvenanceEventType> actualEventTypes = testRunner.getProvenanceEvents().stream()
+                .map(ProvenanceEventRecord::getEventType)
+                .collect(toSet());
+        assertEquals(expectedEventTypes, actualEventTypes);
+    }
+
+    protected void assertNoProvenanceEvent() {
+        assertTrue(testRunner.getProvenanceEvents().isEmpty());
+    }
+
+    protected void mockStandardDropboxCredentialService() throws InitializationException {
+        String credentialServiceId = "dropbox_credentials";
+        when(mockCredentialService.getIdentifier()).thenReturn(credentialServiceId);
+        testRunner.addControllerService(credentialServiceId, mockCredentialService);
+        testRunner.enableControllerService(mockCredentialService);
+        testRunner.setProperty(FetchDropbox.CREDENTIAL_SERVICE, credentialServiceId);
+    }
+
+    protected FileMetadata createFileMetadata() {
+        return FileMetadata.newBuilder(FILENAME_1, FILE_ID,
+                        new Date(CREATED_TIME),
+                        new Date(CREATED_TIME),
+                        REVISION, SIZE)
+                .withPathDisplay(TEST_FOLDER + "/" + FILENAME_1)
+                .withIsDownloadable(true)
+                .build();
+    }
+
+    protected FileMetadata createFileMetadata(
+            String filename,
+            String parent,
+            String id,
+            long createdTime,
+            boolean isDownloadable) {
+        return FileMetadata.newBuilder(filename, id,
+                        new Date(createdTime),
+                        new Date(createdTime),
+                        REVISION, SIZE)
+                .withPathDisplay(parent + "/" + filename)
+                .withIsDownloadable(isDownloadable)
+                .build();
+    }
+
+    protected FileMetadata createFileMetadata(
+            String filename,
+            String parent,
+            String id,
+            long createdTime) {
+        return createFileMetadata(filename, parent, id, createdTime, true);
+    }
+
+    protected void assertOutFlowFileAttributes(MockFlowFile flowFile) {
+        flowFile.assertAttributeEquals(DropboxAttributes.ID, FILE_ID);
+        flowFile.assertAttributeEquals(DropboxAttributes.REVISION, REVISION);
+        flowFile.assertAttributeEquals(DropboxAttributes.PATH, TEST_FOLDER);
+        flowFile.assertAttributeEquals(DropboxAttributes.SIZE, valueOf(SIZE));
+        flowFile.assertAttributeEquals(DropboxAttributes.TIMESTAMP, valueOf(CREATED_TIME));
+        flowFile.assertAttributeEquals(DropboxAttributes.FILENAME, FILENAME_1);
+    }
+}

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/AbstractDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/AbstractDropboxTest.java
@@ -16,10 +16,9 @@
  */
 package org.apache.nifi.processors.dropbox;
 
-import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.dropbox.core.v2.DbxClientV2;
@@ -40,7 +39,8 @@ public class AbstractDropboxTest {
     public static final String TEST_FOLDER = "/testFolder";
     public static final String FILENAME_1 = "file_name_1";
     public static final String FILENAME_2 = "file_name_2";
-    public static final String FILE_ID = "id:odTlUvbpIEAAAAAAAAAGGQ";
+    public static final String FILE_ID_1 = "id:odTlUvbpIEAAAAAAAAAGGQ";
+    public static final String FILE_ID_2 = "id:bdCQUvbpIEAABBAAAAAGKK";
     public static final long CREATED_TIME = 1659707000;
     public static final long SIZE = 125;
     public static final String REVISION = "5e4ddb1320676a5c29261";
@@ -79,44 +79,50 @@ public class AbstractDropboxTest {
     }
 
     protected FileMetadata createFileMetadata() {
-        return FileMetadata.newBuilder(FILENAME_1, FILE_ID,
+        return FileMetadata.newBuilder(FILENAME_1, FILE_ID_1,
                         new Date(CREATED_TIME),
                         new Date(CREATED_TIME),
                         REVISION, SIZE)
-                .withPathDisplay(TEST_FOLDER + "/" + FILENAME_1)
+                .withPathDisplay(getPath(TEST_FOLDER, FILENAME_1))
                 .withIsDownloadable(true)
                 .build();
     }
 
     protected FileMetadata createFileMetadata(
-            String filename,
+            String id, String filename,
             String parent,
-            String id,
             long createdTime,
             boolean isDownloadable) {
         return FileMetadata.newBuilder(filename, id,
                         new Date(createdTime),
                         new Date(createdTime),
                         REVISION, SIZE)
-                .withPathDisplay(parent + "/" + filename)
+                .withPathDisplay(getPath(parent, filename))
                 .withIsDownloadable(isDownloadable)
                 .build();
     }
 
-    protected FileMetadata createFileMetadata(
+    protected FileMetadata createFileMetadata(String id,
             String filename,
             String parent,
-            String id,
             long createdTime) {
-        return createFileMetadata(filename, parent, id, createdTime, true);
+        return createFileMetadata(id, filename, parent, createdTime, true);
     }
 
     protected void assertOutFlowFileAttributes(MockFlowFile flowFile) {
-        flowFile.assertAttributeEquals(DropboxAttributes.ID, FILE_ID);
-        flowFile.assertAttributeEquals(DropboxAttributes.REVISION, REVISION);
-        flowFile.assertAttributeEquals(DropboxAttributes.PATH, TEST_FOLDER);
-        flowFile.assertAttributeEquals(DropboxAttributes.SIZE, valueOf(SIZE));
-        flowFile.assertAttributeEquals(DropboxAttributes.TIMESTAMP, valueOf(CREATED_TIME));
+        assertOutFlowFileAttributes(flowFile, TEST_FOLDER);
+    }
+
+    protected void assertOutFlowFileAttributes(MockFlowFile flowFile, String folderName) {
+        flowFile.assertAttributeEquals(DropboxAttributes.ID, FILE_ID_1);
         flowFile.assertAttributeEquals(DropboxAttributes.FILENAME, FILENAME_1);
+        flowFile.assertAttributeEquals(DropboxAttributes.PATH, folderName);
+        flowFile.assertAttributeEquals(DropboxAttributes.TIMESTAMP, Long.toString(CREATED_TIME));
+        flowFile.assertAttributeEquals(DropboxAttributes.SIZE, Long.toString(SIZE));
+        flowFile.assertAttributeEquals(DropboxAttributes.REVISION, REVISION);
+    }
+
+    protected String getPath(String folder, String filename) {
+        return "/".equals(folder) ? folder + filename : folder + "/" + filename;
     }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.nifi.dropbox.credentials.service.DropboxCredentialService;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -58,7 +57,7 @@ public class FetchDropboxTest {
     private DbxClientV2 mockDropboxClient;
 
     @Mock
-    private DropboxCredentialService credentialService;
+    private DropboxCredentialService mockCredentialService;
 
     @Mock
     private DbxUserFilesRequests mockDbxUserFilesRequest;
@@ -71,7 +70,7 @@ public class FetchDropboxTest {
     void setUp() throws Exception {
         FetchDropbox testSubject = new FetchDropbox() {
             @Override
-            public DbxClientV2 getDropboxApiClient(ProcessContext context, ProxyConfiguration proxyConfiguration, String clientId) {
+            public DbxClientV2 getDropboxApiClient(ProcessContext context, String id) {
                 return mockDropboxClient;
             }
         };
@@ -139,9 +138,9 @@ public class FetchDropboxTest {
 
     private void mockStandardDropboxCredentialService() throws InitializationException {
         String credentialServiceId = "dropbox_credentials";
-        when(credentialService.getIdentifier()).thenReturn(credentialServiceId);
-        testRunner.addControllerService(credentialServiceId, credentialService);
-        testRunner.enableControllerService(credentialService);
+        when(mockCredentialService.getIdentifier()).thenReturn(credentialServiceId);
+        testRunner.addControllerService(credentialServiceId, mockCredentialService);
+        testRunner.enableControllerService(mockCredentialService);
         testRunner.setProperty(FetchDropbox.CREDENTIAL_SERVICE, credentialServiceId);
     }
 

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.dropbox;
 
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.nifi.processors.dropbox.DropboxAttributes.ERROR_MESSAGE;
 import static org.mockito.Mockito.when;
 
 import com.dropbox.core.DbxDownloader;
@@ -26,15 +27,12 @@ import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.DbxUserFilesRequests;
 import com.dropbox.core.v2.files.FileMetadata;
 import java.io.ByteArrayInputStream;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.nifi.dropbox.credentials.service.DropboxCredentialService;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,33 +41,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class FetchDropboxTest {
-
-    public static final String FILE_ID_1 = "id:odTlUvbpIEAAAAAAAAAGGQ";
-    public static final String FILE_ID_2 = "id:odTlUvbpIEBBBBBBBBBGGQ";
-    public static final String FILENAME = "file_name";
-    public static final String FOLDER = "/testFolder";
-    public static final long SIZE = 125;
-    public static final long CREATED_TIME = 1659707000;
-    public static final String REVISION = "5e4ddb1320676a5c29261";
-
-    private TestRunner testRunner;
-
-    @Mock
-    private DbxClientV2 mockDropboxClient;
-
-    @Mock
-    private DropboxCredentialService mockCredentialService;
+public class FetchDropboxTest extends AbstractDropboxTest {
 
     @Mock
     private DbxUserFilesRequests mockDbxUserFilesRequest;
-
 
     @Mock
     private DbxDownloader<FileMetadata> mockDbxDownloader;
 
     @BeforeEach
-    void setUp() throws Exception {
+    protected void setUp() throws Exception {
         FetchDropbox testSubject = new FetchDropbox() {
             @Override
             public DbxClientV2 getDropboxApiClient(ProcessContext context, String id) {
@@ -80,20 +61,18 @@ public class FetchDropboxTest {
         testRunner = TestRunners.newTestRunner(testSubject);
 
         when(mockDropboxClient.files()).thenReturn(mockDbxUserFilesRequest);
-
-        mockStandardDropboxCredentialService();
+        super.setUp();
     }
 
     @Test
     void testFileIsDownloadedById() throws Exception {
-
         testRunner.setProperty(FetchDropbox.FILE, "${dropbox.id}");
 
-        when(mockDbxUserFilesRequest.download(FILE_ID_1)).thenReturn(mockDbxDownloader);
+        when(mockDbxUserFilesRequest.download(FILE_ID)).thenReturn(mockDbxDownloader);
         when(mockDbxDownloader.getInputStream()).thenReturn(new ByteArrayInputStream("content".getBytes(UTF_8)));
         when(mockDbxDownloader.getResult()).thenReturn(createFileMetadata());
 
-        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID_1);
+        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
 
@@ -101,18 +80,19 @@ public class FetchDropboxTest {
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(FetchDropbox.REL_SUCCESS);
         MockFlowFile ff0 = flowFiles.get(0);
         ff0.assertContentEquals("content");
-        assertOutFlowFileAttributes(ff0, FILE_ID_1);
+        assertOutFlowFileAttributes(ff0);
+        assertProvenanceEvent(ProvenanceEventType.FETCH);
     }
 
     @Test
     void testFileIsDownloadedByPath() throws Exception {
         testRunner.setProperty(FetchDropbox.FILE, "${path}/${filename}");
 
-        when(mockDbxUserFilesRequest.download(FOLDER + "/" + FILENAME)).thenReturn(mockDbxDownloader);
+        when(mockDbxUserFilesRequest.download(TEST_FOLDER + "/" + FILENAME_1)).thenReturn(mockDbxDownloader);
         when(mockDbxDownloader.getInputStream()).thenReturn(new ByteArrayInputStream("contentByPath".getBytes(UTF_8)));
         when(mockDbxDownloader.getResult()).thenReturn(createFileMetadata());
 
-        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID_1);
+        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
 
@@ -120,63 +100,38 @@ public class FetchDropboxTest {
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(FetchDropbox.REL_SUCCESS);
         MockFlowFile ff0 = flowFiles.get(0);
         ff0.assertContentEquals("contentByPath");
-        assertOutFlowFileAttributes(ff0, FILE_ID_1);
+        assertOutFlowFileAttributes(ff0);
+        assertProvenanceEvent(ProvenanceEventType.FETCH);
     }
 
     @Test
     void testFetchFails() throws Exception {
         testRunner.setProperty(FetchDropbox.FILE, "${dropbox.id}");
 
-        when(mockDbxUserFilesRequest.download(FILE_ID_2)).thenThrow(new DbxException("Error in Dropbox"));
+        when(mockDbxUserFilesRequest.download(FILE_ID)).thenThrow(new DbxException("Error in Dropbox"));
 
-        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID_2);
+        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
 
         testRunner.assertAllFlowFilesTransferred(FetchDropbox.REL_FAILURE, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(FetchDropbox.REL_FAILURE);
         MockFlowFile ff0 = flowFiles.get(0);
-        ff0.assertAttributeEquals("error.message", "Error in Dropbox");
-        assertOutFlowFileAttributes(ff0, FILE_ID_2);
-    }
-
-    private void mockStandardDropboxCredentialService() throws InitializationException {
-        String credentialServiceId = "dropbox_credentials";
-        when(mockCredentialService.getIdentifier()).thenReturn(credentialServiceId);
-        testRunner.addControllerService(credentialServiceId, mockCredentialService);
-        testRunner.enableControllerService(mockCredentialService);
-        testRunner.setProperty(FetchDropbox.CREDENTIAL_SERVICE, credentialServiceId);
+        ff0.assertAttributeEquals(ERROR_MESSAGE, "Error in Dropbox");
+        assertOutFlowFileAttributes(ff0);
+        assertNoProvenanceEvent();
     }
 
     private MockFlowFile getMockFlowFile(String fileId) {
         MockFlowFile inputFlowFile = new MockFlowFile(0);
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(DropboxFileInfo.ID, fileId);
-        attributes.put(DropboxFileInfo.REVISION, REVISION);
-        attributes.put(DropboxFileInfo.FILENAME, FILENAME);
-        attributes.put(DropboxFileInfo.PATH, FOLDER);
-        attributes.put(DropboxFileInfo.SIZE, valueOf(SIZE));
-        attributes.put(DropboxFileInfo.TIMESTAMP, valueOf(CREATED_TIME));
+        attributes.put(DropboxAttributes.ID, fileId);
+        attributes.put(DropboxAttributes.REVISION, REVISION);
+        attributes.put(DropboxAttributes.FILENAME, FILENAME_1);
+        attributes.put(DropboxAttributes.PATH, TEST_FOLDER);
+        attributes.put(DropboxAttributes.SIZE, valueOf(SIZE));
+        attributes.put(DropboxAttributes.TIMESTAMP, valueOf(CREATED_TIME));
         inputFlowFile.putAttributes(attributes);
         return inputFlowFile;
-    }
-
-    private void assertOutFlowFileAttributes(MockFlowFile flowFile, String fileId) {
-        flowFile.assertAttributeEquals(DropboxFileInfo.ID, fileId);
-        flowFile.assertAttributeEquals(DropboxFileInfo.REVISION, REVISION);
-        flowFile.assertAttributeEquals(DropboxFileInfo.PATH, FOLDER);
-        flowFile.assertAttributeEquals(DropboxFileInfo.SIZE, valueOf(SIZE));
-        flowFile.assertAttributeEquals(DropboxFileInfo.TIMESTAMP, valueOf(CREATED_TIME));
-        flowFile.assertAttributeEquals(DropboxFileInfo.FILENAME, FILENAME);
-    }
-
-    private FileMetadata createFileMetadata() {
-        return FileMetadata.newBuilder(FILENAME, FILE_ID_1,
-                        new Date(CREATED_TIME),
-                        new Date(CREATED_TIME),
-                        REVISION, SIZE)
-                .withPathDisplay(FOLDER + "/" + FILENAME)
-                .withIsDownloadable(true)
-                .build();
     }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
@@ -50,7 +50,7 @@ public class FetchDropboxTest extends AbstractDropboxTest {
     private DbxDownloader<FileMetadata> mockDbxDownloader;
 
     @BeforeEach
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         FetchDropbox testSubject = new FetchDropbox() {
             @Override
             public DbxClientV2 getDropboxApiClient(ProcessContext context, String id) {
@@ -68,11 +68,11 @@ public class FetchDropboxTest extends AbstractDropboxTest {
     void testFileIsDownloadedById() throws Exception {
         testRunner.setProperty(FetchDropbox.FILE, "${dropbox.id}");
 
-        when(mockDbxUserFilesRequest.download(FILE_ID)).thenReturn(mockDbxDownloader);
+        when(mockDbxUserFilesRequest.download(FILE_ID_1)).thenReturn(mockDbxDownloader);
         when(mockDbxDownloader.getInputStream()).thenReturn(new ByteArrayInputStream("content".getBytes(UTF_8)));
         when(mockDbxDownloader.getResult()).thenReturn(createFileMetadata());
 
-        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID);
+        MockFlowFile inputFlowFile = getMockFlowFile();
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
 
@@ -88,11 +88,11 @@ public class FetchDropboxTest extends AbstractDropboxTest {
     void testFileIsDownloadedByPath() throws Exception {
         testRunner.setProperty(FetchDropbox.FILE, "${path}/${filename}");
 
-        when(mockDbxUserFilesRequest.download(TEST_FOLDER + "/" + FILENAME_1)).thenReturn(mockDbxDownloader);
+        when(mockDbxUserFilesRequest.download(getPath(TEST_FOLDER, FILENAME_1))).thenReturn(mockDbxDownloader);
         when(mockDbxDownloader.getInputStream()).thenReturn(new ByteArrayInputStream("contentByPath".getBytes(UTF_8)));
         when(mockDbxDownloader.getResult()).thenReturn(createFileMetadata());
 
-        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID);
+        MockFlowFile inputFlowFile = getMockFlowFile();
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
 
@@ -108,9 +108,9 @@ public class FetchDropboxTest extends AbstractDropboxTest {
     void testFetchFails() throws Exception {
         testRunner.setProperty(FetchDropbox.FILE, "${dropbox.id}");
 
-        when(mockDbxUserFilesRequest.download(FILE_ID)).thenThrow(new DbxException("Error in Dropbox"));
+        when(mockDbxUserFilesRequest.download(FILE_ID_1)).thenThrow(new DbxException("Error in Dropbox"));
 
-        MockFlowFile inputFlowFile = getMockFlowFile(FILE_ID);
+        MockFlowFile inputFlowFile = getMockFlowFile();
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
 
@@ -122,10 +122,10 @@ public class FetchDropboxTest extends AbstractDropboxTest {
         assertNoProvenanceEvent();
     }
 
-    private MockFlowFile getMockFlowFile(String fileId) {
+    private MockFlowFile getMockFlowFile() {
         MockFlowFile inputFlowFile = new MockFlowFile(0);
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(DropboxAttributes.ID, fileId);
+        attributes.put(DropboxAttributes.ID, FILE_ID_1);
         attributes.put(DropboxAttributes.REVISION, REVISION);
         attributes.put(DropboxAttributes.FILENAME, FILENAME_1);
         attributes.put(DropboxAttributes.PATH, TEST_FOLDER);

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/ListDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/ListDropboxTest.java
@@ -44,7 +44,6 @@ import java.util.stream.StreamSupport;
 import org.apache.nifi.dropbox.credentials.service.DropboxCredentialService;
 import org.apache.nifi.json.JsonRecordSetWriter;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 import org.apache.nifi.util.MockFlowFile;
@@ -76,7 +75,7 @@ public class ListDropboxTest {
     private DbxClientV2 mockDropboxClient;
 
     @Mock
-    private DropboxCredentialService credentialService;
+    private DropboxCredentialService mockCredentialService;
 
     @Mock
     private DbxUserFilesRequests mockDbxUserFilesRequest;
@@ -91,7 +90,7 @@ public class ListDropboxTest {
     void setUp() throws Exception {
         ListDropbox testSubject = new ListDropbox() {
             @Override
-            public DbxClientV2 getDropboxApiClient(ProcessContext context, ProxyConfiguration proxyConfiguration, String clientId) {
+            public DbxClientV2 getDropboxApiClient(ProcessContext context, String id) {
                 return mockDropboxClient;
             }
 
@@ -256,9 +255,9 @@ public class ListDropboxTest {
 
     private void mockStandardDropboxCredentialService() throws Exception {
         String credentialServiceId = "dropbox_credentials";
-        when(credentialService.getIdentifier()).thenReturn(credentialServiceId);
-        testRunner.addControllerService(credentialServiceId, credentialService);
-        testRunner.enableControllerService(credentialService);
+        when(mockCredentialService.getIdentifier()).thenReturn(credentialServiceId);
+        testRunner.addControllerService(credentialServiceId, mockCredentialService);
+        testRunner.enableControllerService(mockCredentialService);
         testRunner.setProperty(ListDropbox.CREDENTIAL_SERVICE, credentialServiceId);
     }
 

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/ListDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/ListDropboxTest.java
@@ -54,8 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ListDropboxTest extends AbstractDropboxTest {
 
-    public static final String FOLDER_ID_1 = "id:11111";
-    public static final String FOLDER_ID_2 = "id:22222";
+    public static final String FOLDER_ID = "id:11111";
     public static final boolean IS_RECURSIVE = true;
     public static final long MIN_TIMESTAMP = 1659707000;
     public static final long OLD_CREATED_TIME = 1657375066;
@@ -124,7 +123,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
         //root is listed when "" is used in Dropbox API
         when(mockDbxUserFilesRequest.listFolderBuilder("")).thenReturn(mockListFolderBuilder);
         when(mockListFolderResult.getEntries()).thenReturn(singletonList(
-                createFileMetadata(FILENAME_1, folderName, FOLDER_ID_1, CREATED_TIME)
+                createFileMetadata(FILE_ID_1, FILENAME_1, folderName, CREATED_TIME)
         ));
 
         testRunner.run();
@@ -132,7 +131,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
         MockFlowFile ff0 = flowFiles.get(0);
-        assertFlowFileAttributes(ff0, folderName);
+        assertOutFlowFileAttributes(ff0, folderName);
     }
 
     @Test
@@ -143,9 +142,9 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         when(mockDbxUserFilesRequest.listFolderBuilder(TEST_FOLDER)).thenReturn(mockListFolderBuilder);
         when(mockListFolderResult.getEntries()).thenReturn(Arrays.asList(
-                createFileMetadata(FILENAME_1, TEST_FOLDER, FOLDER_ID_1, CREATED_TIME),
+                createFileMetadata(FILE_ID_1, FILENAME_1, TEST_FOLDER, CREATED_TIME),
                 createFolderMetadata(),
-                createFileMetadata(FILENAME_2, TEST_FOLDER, FOLDER_ID_2, CREATED_TIME, false)
+                createFileMetadata(FILE_ID_2, FILENAME_2, TEST_FOLDER, CREATED_TIME, false)
         ));
 
         testRunner.run();
@@ -153,7 +152,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
         MockFlowFile ff0 = flowFiles.get(0);
-        assertFlowFileAttributes(ff0, TEST_FOLDER);
+        assertOutFlowFileAttributes(ff0);
     }
 
     @Test
@@ -164,8 +163,8 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         when(mockDbxUserFilesRequest.listFolderBuilder(TEST_FOLDER)).thenReturn(mockListFolderBuilder);
         when(mockListFolderResult.getEntries()).thenReturn(Arrays.asList(
-                createFileMetadata(FILENAME_1, TEST_FOLDER, FOLDER_ID_1, CREATED_TIME),
-                createFileMetadata(FILENAME_2, TEST_FOLDER, FOLDER_ID_2, OLD_CREATED_TIME)
+                createFileMetadata(FILE_ID_1, FILENAME_1, TEST_FOLDER, CREATED_TIME),
+                createFileMetadata(FILE_ID_2, FILENAME_2, TEST_FOLDER, OLD_CREATED_TIME)
         ));
 
         testRunner.run();
@@ -173,7 +172,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
         MockFlowFile ff0 = flowFiles.get(0);
-        assertFlowFileAttributes(ff0, TEST_FOLDER);
+        assertOutFlowFileAttributes(ff0);
     }
 
     @Test
@@ -185,8 +184,8 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         when(mockDbxUserFilesRequest.listFolderBuilder(TEST_FOLDER)).thenReturn(mockListFolderBuilder);
         when(mockListFolderResult.getEntries()).thenReturn(Arrays.asList(
-                createFileMetadata(FILENAME_1, TEST_FOLDER, FOLDER_ID_1, CREATED_TIME),
-                createFileMetadata(FILENAME_2, TEST_FOLDER, FOLDER_ID_2, CREATED_TIME)
+                createFileMetadata(FILE_ID_1, FILENAME_1, TEST_FOLDER, CREATED_TIME),
+                createFileMetadata(FILE_ID_2, FILENAME_2, TEST_FOLDER, CREATED_TIME)
         ));
 
         testRunner.run();
@@ -200,18 +199,9 @@ public class ListDropboxTest extends AbstractDropboxTest {
         assertEquals(expectedFileNames, actualFileNames);
     }
 
-    private void assertFlowFileAttributes(MockFlowFile flowFile, String folderName) {
-        flowFile.assertAttributeEquals(DropboxAttributes.ID, FOLDER_ID_1);
-        flowFile.assertAttributeEquals(DropboxAttributes.FILENAME, FILENAME_1);
-        flowFile.assertAttributeEquals(DropboxAttributes.PATH, folderName);
-        flowFile.assertAttributeEquals(DropboxAttributes.TIMESTAMP, Long.toString(CREATED_TIME));
-        flowFile.assertAttributeEquals(DropboxAttributes.SIZE, Long.toString(SIZE));
-        flowFile.assertAttributeEquals(DropboxAttributes.REVISION, REVISION);
-    }
-
     private Metadata createFolderMetadata() {
-        return FolderMetadata.newBuilder(FOLDER_ID_1)
-                .withPathDisplay(TEST_FOLDER + "/" + FOLDER_ID_1)
+        return FolderMetadata.newBuilder(FOLDER_ID)
+                .withPathDisplay(TEST_FOLDER + "/" + FOLDER_ID)
                 .build();
     }
 

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
@@ -23,7 +23,8 @@ import org.junit.jupiter.api.Test;
 
 public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
 
-    private static final String CONTENT = String.class.getSimpleName();
+    private static final String CONTENT = "content";
+    private static final String CHANGED_CONTENT = "changedContent";
     private static final String NON_EXISTING_FOLDER = "/doesNotExistYet";
 
     @BeforeEach
@@ -74,5 +75,62 @@ public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
 
         testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
         testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testUploadExistingFileFailStrategy()  {
+        testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
+        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.FAIL_RESOLUTION);
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.clearTransferState();
+
+        testRunner.enqueue(CHANGED_CONTENT);
+        testRunner.run();
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 1);
+
+    }
+
+    @Test
+    void testUploadExistingFileOverwriteStrategy()  {
+        testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
+        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.OVERWRITE_RESOLUTION);
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.clearTransferState();
+
+        testRunner.enqueue(CHANGED_CONTENT);
+        testRunner.run();
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+
+    }
+
+    @Test
+    void testUploadExistingFileIgnoreStrategy()  {
+        testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
+        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.IGNORE_RESOLUTION);
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.clearTransferState();
+
+        testRunner.enqueue(CHANGED_CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
     }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
@@ -66,10 +66,10 @@ public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
     }
 
     @Test
-    void testUploadFileToFolderSpecifiedById()  {
-        testRunner.setProperty(PutDropbox.FOLDER, mainFolderId);
+    void testEmptyFileIsUpladed()  {
+        testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
 
-        testRunner.enqueue(CONTENT);
+        testRunner.enqueue("");
         testRunner.run();
 
         testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
@@ -130,7 +130,6 @@ public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
         testRunner.run();
         testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
         testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
-
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.dropbox;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
+
+    private static final String CONTENT = String.class.getSimpleName();
+    private static final String NON_EXISTING_FOLDER = "/doesNotExistYet";
+
+    @BeforeEach
+    public void init() throws Exception {
+        super.init();
+        testRunner.setProperty(PutDropbox.FILE_NAME, "testFile.json");
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        super.teardown();
+        deleteFolderIfExists(NON_EXISTING_FOLDER);
+    }
+
+    @Override
+    protected PutDropbox createTestSubject() {
+        return new PutDropbox();
+    }
+
+    @Test
+    void testUploadFileToExistingDirectory()  {
+        testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testUploadFileCreateFolderWithSubFolders()  {
+        testRunner.setProperty(PutDropbox.FOLDER, NON_EXISTING_FOLDER + "/subFolder1/subFolder2");
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testUploadFileToFolderSpecifiedById()  {
+        testRunner.setProperty(PutDropbox.FOLDER, mainFolderId);
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+    }
+}

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
@@ -85,15 +85,33 @@ public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
         testRunner.enqueue(CONTENT);
         testRunner.run();
 
-        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
         testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
         testRunner.clearTransferState();
 
         testRunner.enqueue(CHANGED_CONTENT);
         testRunner.run();
         testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 0);
         testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 1);
+    }
 
+    @Test
+    void testUploadExistingFileWithSameContentFailStrategy()  {
+        testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
+        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.FAIL_RESOLUTION);
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 0);
+
+        testRunner.clearTransferState();
+
+        testRunner.enqueue(CONTENT);
+        testRunner.run();
+        testRunner.assertTransferCount(PutDropbox.REL_SUCCESS, 0);
+        testRunner.assertTransferCount(PutDropbox.REL_FAILURE, 1);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.dropbox;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dropbox.core.DbxException;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.CommitInfo;
+import com.dropbox.core.v2.files.DbxUserFilesRequests;
+import com.dropbox.core.v2.files.FileMetadata;
+import com.dropbox.core.v2.files.UploadSessionAppendV2Uploader;
+import com.dropbox.core.v2.files.UploadSessionCursor;
+import com.dropbox.core.v2.files.UploadSessionFinishUploader;
+import com.dropbox.core.v2.files.UploadSessionStartResult;
+import com.dropbox.core.v2.files.UploadSessionStartUploader;
+import com.dropbox.core.v2.files.UploadUploader;
+import com.dropbox.core.v2.files.WriteMode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.nifi.dropbox.credentials.service.DropboxCredentialService;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PutDropboxTest {
+
+    public static final String TEST_FOLDER = "/testFolder";
+    public static final String FILENAME_1 = "file_name_1";
+    public static final String FILENAME_2 = "file_name_2";
+    private static final String CONTENT = "1234567890";
+    private static final String LARGE_CONTENT_30B = "123456789012345678901234567890";
+    private static final String SESSION_ID = "sessionId";
+    public static final long CHUNK_SIZE_IN_BYTES = 8;
+    public static final long MAX_FILE_SIZE_IN_BYTES = 15;
+    private TestRunner testRunner;
+
+    @Mock
+    private DbxClientV2 mockDropboxClient;
+
+    @Mock
+    private DropboxCredentialService credentialService;
+
+    @Mock
+    private DbxUserFilesRequests mockDbxUserFilesRequest;
+
+    @Mock
+    private UploadUploader mockUploadUploader;
+
+    @Mock
+    private UploadSessionStartUploader mockUploadSessionStartUploader;
+
+    @Mock
+    private UploadSessionStartResult mockUploadSessionStartResult;
+
+    @Mock
+    private UploadSessionAppendV2Uploader mockUploadSessionAppendV2Uploader;
+
+    @Mock
+    private UploadSessionFinishUploader mockUploadSessionFinishUploader;
+
+    @Mock
+    private FileMetadata mockFileMetadata;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        PutDropbox testSubject = new PutDropbox() {
+            @Override
+            public DbxClientV2 getDropboxApiClient(ProcessContext context, ProxyConfiguration proxyConfiguration, String clientId) {
+                return mockDropboxClient;
+            }
+
+            @Override
+            protected long getUploadFileSizeLimit() {
+                return MAX_FILE_SIZE_IN_BYTES;
+            }
+        };
+
+        testRunner = TestRunners.newTestRunner(testSubject);
+
+        mockStandardDropboxCredentialService();
+
+        testRunner.setProperty(PutDropbox.FOLDER, TEST_FOLDER);
+    }
+
+    @Test
+    void testFolderValidity() {
+        testRunner.setProperty(PutDropbox.FOLDER, "id:odTlUvbpIEAAAAAAAAABmw");
+        testRunner.assertValid();
+        testRunner.setProperty(PutDropbox.FOLDER, "/");
+        testRunner.assertValid();
+        testRunner.setProperty(PutDropbox.FOLDER, "/tempFolder");
+        testRunner.assertValid();
+    }
+
+    @Test
+    void testUploadChunkSizeValidity() {
+        testRunner.setProperty(PutDropbox.UPLOAD_CHUNK_SIZE, "");
+        testRunner.assertNotValid();
+        testRunner.setProperty(PutDropbox.UPLOAD_CHUNK_SIZE, "40 MB");
+        testRunner.assertValid();
+        testRunner.setProperty(PutDropbox.UPLOAD_CHUNK_SIZE, "152 MB");
+        testRunner.assertNotValid();
+        testRunner.setProperty(PutDropbox.UPLOAD_CHUNK_SIZE, "1024");
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    void testFileUploadFileNameFromProperty() throws Exception {
+        testRunner.setProperty(PutDropbox.FILE_NAME, FILENAME_1);
+        mockFileUpload(TEST_FOLDER + "/" + FILENAME_1);
+
+        MockFlowFile mockFlowFile = getMockFlowFile(CONTENT);
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(PutDropbox.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testFileUploadFileNameFromFlowFileAttribute() throws Exception {
+        mockFileUpload(TEST_FOLDER + "/" + FILENAME_2);
+
+        MockFlowFile mockFlowFile = getMockFlowFile(CONTENT);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("filename", FILENAME_2);
+        mockFlowFile.putAttributes(attributes);
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(PutDropbox.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testFileUploadFileToRoot() throws Exception {
+        testRunner.setProperty(PutDropbox.FOLDER, "/");
+        testRunner.setProperty(PutDropbox.FILE_NAME, FILENAME_1);
+
+        mockFileUpload("/" + FILENAME_1);
+
+        MockFlowFile mockFlowFile = getMockFlowFile(CONTENT);
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(PutDropbox.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testFileUploadLargeFile() throws Exception {
+        MockFlowFile mockFlowFile = getMockFlowFile(LARGE_CONTENT_30B);
+
+        testRunner.setProperty(PutDropbox.FILE_NAME, FILENAME_1);
+        testRunner.setProperty(PutDropbox.UPLOAD_CHUNK_SIZE, CHUNK_SIZE_IN_BYTES + " B");
+
+        when(mockDropboxClient.files())
+                .thenReturn(mockDbxUserFilesRequest);
+
+        //start session: 8 bytes uploaded
+        when(mockDbxUserFilesRequest
+                .uploadSessionStart())
+                .thenReturn(mockUploadSessionStartUploader);
+
+        when(mockUploadSessionStartUploader
+                .uploadAndFinish(any(InputStream.class), eq(CHUNK_SIZE_IN_BYTES)))
+                .thenReturn(mockUploadSessionStartResult);
+
+        when(mockUploadSessionStartResult
+                .getSessionId())
+                .thenReturn(SESSION_ID);
+
+        //append session: invoked twice, 2 * 8 bytes uploaded
+        when(mockDbxUserFilesRequest
+                .uploadSessionAppendV2(any(UploadSessionCursor.class)))
+                .thenReturn(mockUploadSessionAppendV2Uploader);
+
+        //finish session: 30 - 8 - 2 * 8 = 6 bytes uploaded
+        CommitInfo commitInfo = CommitInfo.newBuilder(TEST_FOLDER + "/" + FILENAME_1)
+                .withMode(WriteMode.ADD)
+                .withClientModified(new Date(mockFlowFile.getEntryDate()))
+                .build();
+
+        when(mockDbxUserFilesRequest
+                .uploadSessionFinish(any(UploadSessionCursor.class), eq(commitInfo)))
+                .thenReturn(mockUploadSessionFinishUploader);
+
+        when(mockUploadSessionFinishUploader
+                .uploadAndFinish(any(InputStream.class), eq(6L)))
+                .thenReturn(mockFileMetadata);
+
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(PutDropbox.REL_SUCCESS, 1);
+
+        verify(mockUploadSessionAppendV2Uploader, times(2))
+                .uploadAndFinish(any(InputStream.class), eq(CHUNK_SIZE_IN_BYTES));
+    }
+
+    private void mockStandardDropboxCredentialService() throws Exception {
+        String credentialServiceId = "dropbox_credentials";
+        when(credentialService.getIdentifier()).thenReturn(credentialServiceId);
+        testRunner.addControllerService(credentialServiceId, credentialService);
+        testRunner.enableControllerService(credentialService);
+        testRunner.setProperty(PutDropbox.CREDENTIAL_SERVICE, credentialServiceId);
+    }
+
+    private void mockFileUpload(String path) throws DbxException, IOException {
+        when(mockDropboxClient.files())
+                .thenReturn(mockDbxUserFilesRequest);
+
+        when(mockDbxUserFilesRequest
+                .upload(path))
+                .thenReturn(mockUploadUploader);
+
+        when(mockUploadUploader
+                .uploadAndFinish(any(InputStream.class)))
+                .thenReturn(mockFileMetadata);
+    }
+
+    private MockFlowFile getMockFlowFile(String content) {
+        MockFlowFile inputFlowFile = new MockFlowFile(0);
+        inputFlowFile.setData(content.getBytes(UTF_8));
+        return inputFlowFile;
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10868](https://issues.apache.org/jira/browse/NIFI-10868)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-10868`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-10868`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
