### PR TITLE
NIFI-10923 Upgrade Apache SSHD to 2.9.2

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
         <jolt.version>0.1.7</jolt.version>
+        <org.apache.sshd.version>2.9.2</org.apache.sshd.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -303,12 +304,12 @@
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-core</artifactId>
-                <version>2.8.0</version>
+                <version>${org.apache.sshd.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-sftp</artifactId>
-                <version>2.8.0</version>
+                <version>${org.apache.sshd.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -43,6 +43,7 @@
         <groovy.eclipse.compiler.version>3.4.0-01</groovy.eclipse.compiler.version>
         <jaxb.version>2.3.2</jaxb.version>
         <jgit.version>5.13.1.202206130422-r</jgit.version>
+        <org.apache.sshd.version>2.9.2</org.apache.sshd.version>
     </properties>
 
     <dependencyManagement>
@@ -240,6 +241,17 @@
                         <artifactId>jcl-over-slf4j</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- Override transitive SSHD version from JGit -->
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-osgi</artifactId>
+                <version>${org.apache.sshd.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-sftp</artifactId>
+                <version>${org.apache.sshd.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -970,6 +970,8 @@
                                         <exclude>org.bouncycastle:bcpkix-jdk15on</exclude>
                                         <exclude>org.bouncycastle:bcutil-jdk15on</exclude>
                                         <exclude>org.bouncycastle:bcmail-jdk15on</exclude>
+                                        <!-- Exclude SSHD 2.9.1 and earlier due to CVE-2022-45047 -->
+                                        <exclude>org.apache.sshd:*:[,2.9.1]</exclude>
                                     </excludes>
                                     <includes>
                                         <!-- Versions of JSR305 after 3.0.1 are allowed https://github.com/findbugsproject/findbugs/issues/128 -->


### PR DESCRIPTION
# Summary

[NIFI-10923](https://issues.apache.org/jira/browse/NIFI-10923) Upgrades Apache SSHD to 2.9.2 in NiFi Standard Processor tests and NiFi Registry for the JGit library. The changes upgrade Standard Processor tests from version 2.8.0, and upgrade JGit transitive dependencies from version 2.7.0.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
