### PR TITLE
NIFI-10928 Fixed Flaky Test failing with NonDex

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockFlowFile.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockFlowFile.java
@@ -28,11 +28,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.nifi.controller.repository.FlowFileRecord;
 import org.apache.nifi.controller.repository.claim.ContentClaim;
@@ -42,7 +43,7 @@ import org.junit.jupiter.api.Assertions;
 
 public class MockFlowFile implements FlowFileRecord {
 
-    private final Map<String, String> attributes = new HashMap<>();
+    private final Map<String, String> attributes = new LinkedHashMap<>();
 
     private final long id;
     private final long entryDate;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/protocol/http/TestHttpFlowFileServerProtocol.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/protocol/http/TestHttpFlowFileServerProtocol.java
@@ -282,7 +282,7 @@ public class TestHttpFlowFileServerProtocol {
         });
 
         // Commit transaction
-        final int flowFileSent = serverProtocol.commitTransferTransaction(peer, "3229577812");
+        final int flowFileSent = serverProtocol.commitTransferTransaction(peer, "1853411835");
         assertEquals(1, flowFileSent);
 
         // Assert provenance
@@ -378,7 +378,7 @@ public class TestHttpFlowFileServerProtocol {
         );
 
         // Commit transaction
-        final int flowFileSent = serverProtocol.commitTransferTransaction(peer, "3058746557");
+        final int flowFileSent = serverProtocol.commitTransferTransaction(peer, "2295235398");
         assertEquals(2, flowFileSent);
 
         // Assert provenance (SEND and DROP)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToCSV.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToCSV.java
@@ -271,7 +271,7 @@ public class AttributesToCSV extends AbstractProcessor {
     @OnScheduled
     public void onScheduled(ProcessContext context) {
         includeCoreAttributes = context.getProperty(INCLUDE_CORE_ATTRIBUTES).asBoolean();
-        coreAttributes = Arrays.stream(CoreAttributes.values()).map(CoreAttributes::key).collect(Collectors.toSet());
+        coreAttributes = Arrays.stream(CoreAttributes.values()).map(CoreAttributes::key).collect(Collectors.toCollection(LinkedHashSet::new));
         destinationContent = OUTPUT_OVERWRITE_CONTENT.getValue().equals(context.getProperty(DESTINATION).getValue());
         nullValForEmptyString = context.getProperty(NULL_VALUE_FOR_EMPTY_STRING).asBoolean();
         includeSchema = context.getProperty(INCLUDE_SCHEMA).asBoolean();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToCSV.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToCSV.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Set;
@@ -689,7 +690,7 @@ public class TestAttributesToCSV {
         testRunner.setProperty(AttributesToCSV.INCLUDE_SCHEMA, "true");
         testRunner.setProperty(AttributesToCSV.ATTRIBUTES_REGEX, "beach-.*");
 
-        Map<String, String> attrs = new HashMap<String, String>(){{
+        Map<String, String> attrs = new LinkedHashMap<String, String>(){{
             put("beach-name", "Malibu Beach");
             put("beach-location", "California, US");
             put("attribute-should-be-eliminated", "This should not be in CSVData!");
@@ -721,7 +722,7 @@ public class TestAttributesToCSV {
         testRunner.setProperty(AttributesToCSV.INCLUDE_SCHEMA, "true");
         testRunner.setProperty(AttributesToCSV.ATTRIBUTES_REGEX, "beach-.*");
 
-        Map<String, String> attrs = new HashMap<String, String>(){{
+        Map<String, String> attrs = new LinkedHashMap<String, String>(){{
             put("beach-name", "Malibu Beach");
             put("beach-location", "California, US");
             put("attribute-should-be-eliminated", "This should not be in CSVData!");
@@ -754,7 +755,7 @@ public class TestAttributesToCSV {
         testRunner.setProperty(AttributesToCSV.INCLUDE_SCHEMA, "true");
         testRunner.setProperty(AttributesToCSV.ATTRIBUTES_REGEX, "beach-.*");
 
-        Map<String, String> attrs = new HashMap<String, String>(){{
+        Map<String, String> attrs = new LinkedHashMap<String, String>(){{
             put("beach-name", "Malibu Beach");
             put("beach-location", "California, US");
             put("attribute-should-be-eliminated", "This should not be in CSVData!");
@@ -788,7 +789,7 @@ public class TestAttributesToCSV {
         testRunner.setProperty(AttributesToCSV.INCLUDE_SCHEMA, "true");
         testRunner.setProperty(AttributesToCSV.ATTRIBUTES_REGEX, "beach-.*");
 
-        Map<String, String> attrs = new HashMap<String, String>(){{
+        Map<String, String> attrs = new LinkedHashMap<String, String>(){{
             put("beach-name", "Malibu Beach");
             put("beach-location", "California, US");
             put("attribute-should-be-eliminated", "This should not be in CSVData!");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Tests in the testSchemaWithCoreAttribuesToAttribute(), testSchemaToContent(), testSchemaWithCoreAttribuesToContent() and testSchemaToAttribute() under TestAttributesToCSV express non-deterministic behavior and change the order of the attributes. The fix is changing HashMap to LinkedHashMap in the test and Set to LinkedHashSet to ensure deterministic behavior.

[NIFI-10928](https://issues.apache.org/jira/browse/NIFI-10928)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
