### PR TITLE
NIFI-10941 Remove TestNG references

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -838,19 +838,8 @@ limitations under the License.
                 <version>1.6.0</version>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>6.8.8</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>3.0.8</version>
             </dependency>
             <dependency>
                 <groupId>org.spockframework</groupId>

--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -1164,7 +1164,6 @@ The following binary components are provided under the Apache Software License v
         groovy-templates
         groovy-test
         groovy-test-junit5
-        groovy-testng
         groovy-xml
     The following NOTICE information applies:
       Groovy Language
@@ -1969,12 +1968,6 @@ The following binary components are provided under the Apache Software License v
               * https://github.com/metamx/java-util
             * COMMIT TAG:
               * https://github.com/metamx/java-util/commit/826021f
-
-          This product contains a modified version of TestNG 6.8.7
-            * LICENSE:
-              * http://testng.org/license/ (Apache License, Version 2.0)
-            * HOMEPAGE:
-              * http://testng.org/
 
           This product contains a modified version of Metamarkets bytebuffer-collections library
             * LICENSE:

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/pom.xml
@@ -152,11 +152,6 @@
             <artifactId>nifi-mock</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Spock testing dependencies -->
         <dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -220,11 +220,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <version>1.20.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/AbstractTestStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/AbstractTestStateProvider.java
@@ -17,10 +17,10 @@
 
 package org.apache.nifi.controller.state.providers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/local/TestWriteAheadLocalStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/local/TestWriteAheadLocalStateProvider.java
@@ -26,8 +26,8 @@ import org.apache.nifi.components.state.StateProviderInitializationContext;
 import org.apache.nifi.controller.state.StateMapUpdate;
 import org.apache.nifi.controller.state.providers.AbstractTestStateProvider;
 import org.apache.nifi.logging.ComponentLog;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.wali.WriteAheadRepository;
 
 import javax.net.ssl.SSLContext;
@@ -42,7 +42,7 @@ public class TestWriteAheadLocalStateProvider extends AbstractTestStateProvider 
     private StateProvider provider;
     private WriteAheadRepository<StateMapUpdate> wal;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         provider = new WriteAheadLocalStateProvider();
         final Map<PropertyDescriptor, PropertyValue> properties = new HashMap<>();
@@ -92,7 +92,7 @@ public class TestWriteAheadLocalStateProvider extends AbstractTestStateProvider 
         });
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws IOException {
         provider.onComponentRemoved(componentId);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/zookeeper/TestZooKeeperStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/zookeeper/TestZooKeeperStateProvider.java
@@ -27,10 +27,10 @@ import org.apache.nifi.components.state.exception.StateTooLargeException;
 import org.apache.nifi.controller.state.providers.AbstractTestStateProvider;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.util.NiFiProperties;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -42,6 +42,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
 
@@ -63,7 +64,7 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
         defaultProperties.put(ZooKeeperStateProvider.ACCESS_CONTROL, ZooKeeperStateProvider.OPEN_TO_WORLD.getValue());
     }
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         zkServer = new TestingServer(true);
         zkServer.start();
@@ -134,7 +135,7 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
         return NiFiProperties.createBasicNiFiProperties(null, keystoreProps);
     }
 
-    @After
+    @AfterEach
     public void clear() throws IOException {
         try {
             if (provider != null) {
@@ -155,7 +156,8 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
         return provider;
     }
 
-    @Test(timeout = 30000)
+    @Timeout(30)
+    @Test
     public void testStateTooLargeExceptionThrownOnSetState() throws InterruptedException {
         final Map<String, String> state = new HashMap<>();
         final StringBuilder sb = new StringBuilder();
@@ -173,7 +175,7 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
         while (true) {
             try {
                 getProvider().setState(state, componentId);
-                Assert.fail("Expected StateTooLargeException");
+                fail("Expected StateTooLargeException");
             } catch (final StateTooLargeException stle) {
                 // expected behavior.
                 break;
@@ -184,12 +186,13 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
                 // does not succeeed within 30 seconds.
                 Thread.sleep(1000L);
             } catch (final Exception e) {
-                Assert.fail("Expected StateTooLargeException but " + e.getClass() + " was thrown", e);
+                fail("Expected StateTooLargeException but " + e.getClass() + " was thrown", e);
             }
         }
     }
 
-    @Test(timeout = 30000)
+    @Timeout(30)
+    @Test
     public void testStateTooLargeExceptionThrownOnReplace() throws InterruptedException {
         final Map<String, String> state = new HashMap<>();
         final StringBuilder sb = new StringBuilder();
@@ -223,7 +226,8 @@ public class TestZooKeeperStateProvider extends AbstractTestStateProvider {
         assertThrows(StateTooLargeException.class, () -> getProvider().replace(getProvider().getState(componentId), state, componentId));
     }
 
-    @Test(timeout = 5000)
+    @Timeout(30)
+    @Test
     public void testStateTooLargeExceptionThrownOnReplaceSmallJuteMaxbuffer() throws Exception {
         final Map<String, String> initialState = new HashMap<>();
         final String stateValue = UUID.randomUUID().toString();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/server/TestZooKeeperStateServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/server/TestZooKeeperStateServer.java
@@ -25,10 +25,9 @@ import org.apache.zookeeper.client.FourLetterWordMain;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -39,6 +38,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 public class TestZooKeeperStateServer {
 
     private static ZooKeeperStateServer zkServer;
@@ -47,7 +49,7 @@ public class TestZooKeeperStateServer {
     private static Path zkServerConfig;
     private static int clientPort;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException, ConfigException {
         tempDir = Paths.get("target", "TestZooKeeperStateServer");
         dataDir = tempDir.resolve("state");
@@ -74,7 +76,7 @@ public class TestZooKeeperStateServer {
         if (zkServer != null) zkServer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() throws IOException {
         if (zkServer != null) {
             try {
@@ -103,14 +105,14 @@ public class TestZooKeeperStateServer {
 
     @Test
     public void testServerCreated() {
-        Assert.assertNotNull(zkServer);
+        assertNotNull(zkServer);
     }
 
     @Test
     public void testServerOk() throws IOException, SSLContextException {
         final String imok = FourLetterWordMain.send4LetterWord("localhost",
             clientPort, "ruok", false, 1000);
-        Assert.assertEquals(imok, "imok\n");
+        assertEquals(imok, "imok\n");
     }
 
     @Test
@@ -125,8 +127,7 @@ public class TestZooKeeperStateServer {
         final String createResult = client.create().forPath(testPath, new byte[0]);
         final Stat checkExistsResult = client.checkExists().forPath(testPath);
 
-        Assert.assertEquals(createResult, testPath);
-        Assert.assertNotNull(checkExistsResult);
+        assertEquals(createResult, testPath);
+        assertNotNull(checkExistsResult);
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/analytics/TestStatusAnalyticsModelMapFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/analytics/TestStatusAnalyticsModelMapFactory.java
@@ -16,8 +16,8 @@
  */
 package org.apache.nifi.controller.status.analytics;
 
-import static org.junit.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,15 +29,15 @@ import org.apache.nifi.nar.StandardExtensionDiscoveringManager;
 import org.apache.nifi.nar.SystemBundle;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.Tuple;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestStatusAnalyticsModelMapFactory {
 
     protected NiFiProperties nifiProperties;
     protected ExtensionManager extensionManager;
 
-    @Before
+    @BeforeEach
     public void setup() {
         final Map<String, String> otherProps = new HashMap<>();
         final String propsFile = "src/test/resources/conf/nifi.properties";

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/VolatileComponentStatusRepositoryForComponentsTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/VolatileComponentStatusRepositoryForComponentsTest.java
@@ -17,8 +17,8 @@
 package org.apache.nifi.controller.status.history;
 
 import org.apache.nifi.util.NiFiProperties;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
@@ -26,8 +26,9 @@ import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class verifies the VolatileComponentStatusRepository getConnectionStatusHistory method
@@ -41,7 +42,7 @@ public class VolatileComponentStatusRepositoryForComponentsTest {
   private static final int FIVE_MINUTES = 300000;
   private static int BUFSIZE3 = 10;
 
-  @BeforeClass
+  @BeforeAll
   public static void createBuffers() {
     // Fill the repo1 buffer completely with Date objects at five-minute intervals
     // This provides dates up to around Jul 1979
@@ -84,7 +85,7 @@ public class VolatileComponentStatusRepositoryForComponentsTest {
     List<Date> dates = repo.filterDates(null, null, Integer.MAX_VALUE);
     assert repo.timestamps != null;
     assertEquals(repo.timestamps.getSize(), dates.size());
-    assertTrue(dates.equals(repo.timestamps.asList()));
+    assertEquals(dates, repo.timestamps.asList());
     repo.timestamps.add(new Date());
   }
 
@@ -212,7 +213,7 @@ public class VolatileComponentStatusRepositoryForComponentsTest {
       emptyRepo.timestamps.add(new Date(i * FIVE_MINUTES));
       List<Date> dates = emptyRepo.filterDates(null, null, Integer.MAX_VALUE);
       if (i < BUFSIZE3 - 1) {
-        assertEquals(null, emptyRepo.timestamps.getOldestElement());
+        assertNull(emptyRepo.timestamps.getOldestElement());
       } else {
         assertEquals(emptyRepo.timestamps.getOldestElement(), dates.get(0));
       }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/cs/ControllerServiceReferenceIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/cs/ControllerServiceReferenceIT.java
@@ -24,7 +24,7 @@ import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.integration.DirectInjectionExtensionManager;
 import org.apache.nifi.integration.FrameworkIntegrationTest;
 import org.apache.nifi.processor.Processor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,8 +32,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ControllerServiceReferenceIT extends FrameworkIntegrationTest {
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/lifecycle/FlowFileRepositoryLifecycleIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/lifecycle/FlowFileRepositoryLifecycleIT.java
@@ -26,18 +26,18 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.integration.FrameworkIntegrationTest;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.reporting.Bulletin;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.testng.Assert.assertNull;
-import static org.testng.AssertJUnit.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class FlowFileRepositoryLifecycleIT extends FrameworkIntegrationTest {
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/provenance/ProvenanceEventsIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/provenance/ProvenanceEventsIT.java
@@ -22,7 +22,7 @@ import org.apache.nifi.integration.FrameworkIntegrationTest;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventRepository;
 import org.apache.nifi.provenance.ProvenanceEventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,9 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ProvenanceEventsIT extends FrameworkIntegrationTest {
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/swap/StandaloneSwapFileIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/swap/StandaloneSwapFileIT.java
@@ -24,18 +24,20 @@ import org.apache.nifi.controller.queue.QueueDiagnostics;
 import org.apache.nifi.controller.repository.FlowFileRecord;
 import org.apache.nifi.integration.FrameworkIntegrationTest;
 import org.apache.nifi.integration.processors.GenerateProcessor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class StandaloneSwapFileIT extends FrameworkIntegrationTest {
-    @Test(timeout=60_000)
+    @Timeout(60)
+    @Test
     public void testSwapOnRestart() throws ExecutionException, InterruptedException, IOException {
         final ProcessorNode generator = createProcessorNode(GenerateProcessor.class);
         generator.setProperties(Collections.singletonMap(GenerateProcessor.COUNT.getName(), "60000"));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/versioned/ImportFlowIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/integration/versioned/ImportFlowIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.integration.versioned;
 
-import org.apache.nifi.bundle.BundleCoordinate;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.validation.ValidationStatus;
 import org.apache.nifi.connectable.Connection;
@@ -26,7 +25,6 @@ import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.StandardSnippet;
 import org.apache.nifi.controller.service.ControllerServiceNode;
-import org.apache.nifi.flow.Bundle;
 import org.apache.nifi.flow.VersionedControllerService;
 import org.apache.nifi.flow.VersionedComponent;
 import org.apache.nifi.flow.VersionedExternalFlow;
@@ -47,8 +45,6 @@ import org.apache.nifi.parameter.ParameterReferenceManager;
 import org.apache.nifi.parameter.StandardParameterContext;
 import org.apache.nifi.parameter.StandardParameterReferenceManager;
 import org.apache.nifi.processor.Processor;
-import org.apache.nifi.registry.bucket.Bucket;
-import org.apache.nifi.registry.flow.VersionedFlow;
 import org.apache.nifi.registry.flow.diff.ComparableDataFlow;
 import org.apache.nifi.registry.flow.diff.ConciseEvolvingDifferenceDescriptor;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
@@ -74,11 +70,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.AssertJUnit.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ImportFlowIT extends FrameworkIntegrationTest {
     @Override
@@ -319,7 +315,7 @@ public class ImportFlowIT extends FrameworkIntegrationTest {
 
         final ProcessorNode initialImportedProcessor = innerGroup.getProcessors().iterator().next();
         assertEquals("user", initialImportedProcessor.getProperty(UsernamePasswordProcessor.USERNAME).getRawValue());
-        assertNull("pass", initialImportedProcessor.getProperty(UsernamePasswordProcessor.PASSWORD).getRawValue());
+        assertNull(initialImportedProcessor.getProperty(UsernamePasswordProcessor.PASSWORD).getRawValue());
 
         // Update the sensitive property to "pass"
         initialImportedProcessor.setProperties(initialProperties);
@@ -669,7 +665,7 @@ public class ImportFlowIT extends FrameworkIntegrationTest {
     }
 
     @Test
-    public void testExportImportFlowSwitchesVersionedIdToAndFromInstanceIdOfParameterReferencedControllerService() throws ExecutionException, InterruptedException {
+    public void testExportImportFlowSwitchesVersionedIdToAndFromInstanceIdOfParameterReferencedControllerService() {
         ControllerServiceNode controllerService = createControllerServiceNode(NopControllerService.class);
 
         ProcessorNode processor = createProcessorNode(NopServiceReferencingProcessor.class);
@@ -761,8 +757,6 @@ public class ImportFlowIT extends FrameworkIntegrationTest {
     }
 
     private VersionedExternalFlow createFlowSnapshot(final ProcessGroup group) {
-        createBundle();
-
         final NiFiRegistryFlowMapper flowMapper = new NiFiRegistryFlowMapper(getExtensionManager());
 
         InstantiatedVersionedProcessGroup instantiatedVersionedProcessGroup = flowMapper.mapNonVersionedProcessGroup(group, getFlowController().getControllerServiceProvider());
@@ -783,38 +777,4 @@ public class ImportFlowIT extends FrameworkIntegrationTest {
 
         return flow;
     }
-
-    private VersionedProcessGroup createFlowContents() {
-        final VersionedProcessGroup flowContents = new VersionedProcessGroup();
-        flowContents.setIdentifier("unit-test-flow-contents");
-        flowContents.setName("Unit Test");
-        return flowContents;
-    }
-
-    private void createBundle() {
-        final BundleCoordinate coordinate = getSystemBundle().getBundleDetails().getCoordinate();
-        final Bundle bundle = new Bundle();
-        bundle.setArtifact(coordinate.getId());
-        bundle.setGroup(coordinate.getGroup());
-        bundle.setVersion(coordinate.getVersion());
-    }
-
-    private VersionedFlow createVersionedFlow() {
-        final VersionedFlow flow = new VersionedFlow();
-        flow.setBucketIdentifier("unit-test-bucket");
-        flow.setBucketName("Unit Test Bucket");
-        flow.setCreatedTimestamp(System.currentTimeMillis());
-        flow.setIdentifier("unit-test-flow");
-        flow.setName("Unit Test Flow");
-        return flow;
-    }
-
-    private Bucket createBucket() {
-        final Bucket bucket = new Bucket();
-        bucket.setCreatedTimestamp(System.currentTimeMillis());
-        bucket.setIdentifier("unit-test-bucket");
-        bucket.setName("Unit Test Bucket");
-        return bucket;
-    }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/persistence/TestFlowConfigurationArchiveManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/persistence/TestFlowConfigurationArchiveManager.java
@@ -17,8 +17,8 @@
 package org.apache.nifi.persistence;
 
 import org.apache.nifi.util.NiFiProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,18 +35,20 @@ import java.nio.file.attribute.FileTime;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertNull;
 
 public class TestFlowConfigurationArchiveManager {
 
     private final File flowXmlFile = new File("./target/flow-archive/flow.xml.gz");
     private final File archiveDir = new File("./target/flow-archive");
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
 
         // Clean up old files.
@@ -141,8 +143,8 @@ public class TestFlowConfigurationArchiveManager {
         assertNull(getPrivateFieldValue(archiveManager, "maxStorageBytes"));
     }
 
-    @Test(expected = NoSuchFileException.class)
-    public void testArchiveWithoutOriginalFile() throws Exception {
+    @Test
+    public void testArchiveWithoutOriginalFile() {
         final NiFiProperties properties = mock(NiFiProperties.class);
         when(properties.getFlowConfigurationArchiveDir()).thenReturn(archiveDir.getPath());
         when(properties.getFlowConfigurationFile()).thenReturn(flowXmlFile);
@@ -151,7 +153,7 @@ public class TestFlowConfigurationArchiveManager {
         final File flowXmlFile = new File("does-not-exist");
         final FlowConfigurationArchiveManager archiveManager = new FlowConfigurationArchiveManager(properties);
 
-        archiveManager.archive(flowXmlFile);
+        assertThrows(NoSuchFileException.class, () -> archiveManager.archive(flowXmlFile));
     }
 
     private void createSimulatedOldArchives(final File[] oldArchives, final long intervalMillis) throws Exception {
@@ -202,14 +204,14 @@ public class TestFlowConfigurationArchiveManager {
 
         final File archive = archiveManager.archive(flowXmlFile);
 
-        assertTrue(!oldArchives[0].exists()); // -5 min
-        assertTrue(!oldArchives[1].exists()); // -4 min
+        assertFalse(oldArchives[0].exists()); // -5 min
+        assertFalse(oldArchives[1].exists()); // -4 min
         assertTrue(oldArchives[2].isFile()); // -3 min
         assertTrue(oldArchives[3].isFile()); // -2 min
         assertTrue(oldArchives[4].isFile()); // -1 min
         assertTrue(archive.exists()); // new archive
 
-        assertTrue("Original file should remain intact", flowXmlFile.isFile());
+        assertTrue(flowXmlFile.isFile(), "Original file should remain intact");
     }
 
     @Test
@@ -225,14 +227,14 @@ public class TestFlowConfigurationArchiveManager {
 
         final File archive = archiveManager.archive(flowXmlFile);
 
-        assertTrue(!oldArchives[0].exists()); // -5 min
-        assertTrue(!oldArchives[1].exists()); // -4 min
-        assertTrue(!oldArchives[2].exists()); // -3 min
-        assertTrue(!oldArchives[3].exists()); // -2 min
+        assertFalse(oldArchives[0].exists()); // -5 min
+        assertFalse(oldArchives[1].exists()); // -4 min
+        assertFalse(oldArchives[2].exists()); // -3 min
+        assertFalse(oldArchives[3].exists()); // -2 min
         assertTrue(oldArchives[4].exists()); // -1 min
         assertTrue(archive.exists()); // new archive
 
-        assertTrue("Original file should remain intact", flowXmlFile.isFile());
+        assertTrue(flowXmlFile.isFile(), "Original file should remain intact");
     }
 
     @Test
@@ -248,14 +250,14 @@ public class TestFlowConfigurationArchiveManager {
 
         final File archive = archiveManager.archive(flowXmlFile);
 
-        assertTrue(!oldArchives[0].exists()); // -5 min
-        assertTrue(!oldArchives[1].exists()); // -4 min
-        assertTrue(!oldArchives[2].exists()); // -3 min
-        assertTrue(!oldArchives[3].exists()); // -2 min
+        assertFalse(oldArchives[0].exists()); // -5 min
+        assertFalse(oldArchives[1].exists()); // -4 min
+        assertFalse(oldArchives[2].exists()); // -3 min
+        assertFalse(oldArchives[3].exists()); // -2 min
         assertTrue(oldArchives[4].exists()); // -1 min
         assertTrue(archive.exists()); // new archive
 
-        assertTrue("Original file should remain intact", flowXmlFile.isFile());
+        assertTrue(flowXmlFile.isFile(), "Original file should remain intact");
     }
 
     @Test
@@ -270,14 +272,14 @@ public class TestFlowConfigurationArchiveManager {
 
         final File archive = archiveManager.archive(flowXmlFile);
 
-        assertTrue(!oldArchives[0].exists()); // -5 min
-        assertTrue(!oldArchives[1].exists()); // -4 min
-        assertTrue(!oldArchives[2].exists()); // -3 min
-        assertTrue(!oldArchives[3].exists()); // -2 min
-        assertTrue(!oldArchives[4].exists()); // -1 min
-        assertTrue("Even if flow config file is larger than maxStorage file, it can be archived", archive.exists()); // new archive
+        assertFalse(oldArchives[0].exists()); // -5 min
+        assertFalse(oldArchives[1].exists()); // -4 min
+        assertFalse(oldArchives[2].exists()); // -3 min
+        assertFalse(oldArchives[3].exists()); // -2 min
+        assertFalse(oldArchives[4].exists()); // -1 min
+        assertTrue(archive.exists(), "Even if flow config file is larger than maxStorage file, it can be archived"); // new archive
 
-        assertTrue("Original file should remain intact", flowXmlFile.isFile());
+        assertTrue(flowXmlFile.isFile(), "Original file should remain intact");
     }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -458,12 +458,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>6.8.8</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>3.3.0</version>

--- a/nifi-toolkit/nifi-toolkit-assembly/NOTICE
+++ b/nifi-toolkit/nifi-toolkit-assembly/NOTICE
@@ -126,9 +126,6 @@ The following binary components are provided under the Apache Software License v
         groovy-sql
         groovy-swing
         groovy-templates
-        groovy-test
-        groovy-test-junit5
-        groovy-testng
         groovy-xml
     The following NOTICE information applies:
       Groovy Language

--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -50,6 +50,22 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-test</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-test-junit5</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-testng</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant-junit</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,24 @@
                 <version>${nifi.groovy.version}</version>
                 <type>pom</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-test</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-test-junit5</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-testng</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant-junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
@@ -948,6 +966,8 @@
                                 </requireReleaseDeps>
                                 <bannedDependencies>
                                     <excludes>
+                                        <!-- JUnit 5 is the preferred test framework -->
+                                        <exclude>org.testng:testng</exclude>
                                         <!-- Cat-X Deps -->
                                         <exclude>org.json:json:*:*:compile</exclude>
                                         <exclude>c3p0:c3p0:*:*:compile</exclude>


### PR DESCRIPTION
# Summary

[NIFI-10941](https://issues.apache.org/jira/browse/NIFI-10941) Removes all references to TestNG assertions and dependencies. Several test classes had inadvertent references to TestNG assertions, which should be using JUnit, and several Toolkit modules included TestNG dependencies through Groovy.

Changes include refactoring impacted tests to use JUnit 5 and adding TestNG to the list of banned dependencies.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
