### PR TITLE
NIFI-10637 Fixing Flaky Test In TestGenerateTableFetch

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -1467,9 +1467,7 @@ public class TestGenerateTableFetch {
 
 
         // Remove one element from columnTypeMap to simulate it's re-cache partial state
-        Map.Entry<String, Integer> entry = processor.columnTypeMap.entrySet().iterator().next();
-        String key = entry.getKey();
-        processor.columnTypeMap.remove(key);
+        processor.columnTypeMap.remove("TEST_QUERY_DB_TABLE");
 
         // Insert new records
         stmt.execute("insert into TEST_QUERY_DB_TABLE (id, bucket) VALUES (2, 0)");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10942](https://issues.apache.org/jira/browse/NIFI-10942)
Following the problem in the issue NIFI-10942. I set several printfs to see what exactly prints look like. According to the codes, the comment said "Remove one element from columnTypeMap to simulate it's re-cache partial state". And right after authors insert the new records. 
The original remove code looks like this:
```
Map.Entry<String, Integer> entry = processor.columnTypeMap.entrySet().iterator().next();
String key = entry.getKey();
processor.columnTypeMap.remove(key);

```
However, the set is non-deterministic. So everytime columnTypeMap remove a random key.
Instead, I put a deterministic key to remove which looks like this:
```
processor.columnTypeMap.remove("TEST_QUERY_DB_TABLE");
```
The reason I remove this key because author added back a same key after:
```
        // Insert new records
        stmt.execute("insert into TEST_QUERY_DB_TABLE (id, bucket) VALUES (2, 0)");

        // Re-launch FlowFile to se if re-cache column type works
        runner.enqueue("".getBytes(), new HashMap<String, String>() {{
            put("tableName", "TEST_QUERY_DB_TABLE");
            put("maxValueCol", "id");
        }});
```

By changing this, the bug has been fixed and it's not flaky anymore and can pass the NonDex's check.
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X ] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
