### PR TITLE
NIFI-10952 - Fix TestScriptedPartitionRecord.testWhenMultiplePartitions

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedPartitionRecord.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedPartitionRecord.java
@@ -91,8 +91,8 @@ public class TestScriptedPartitionRecord extends TestScriptedRouterProcessor {
 
         // then
         thenTheFollowingPartitionsExists(PARTITION_1, PARTITION_2);
-        thenPartitionContains(PARTITION_2, 0, 2, PARTITION_2_RECORD_1);
-        thenPartitionContains(PARTITION_1, 1, 2, PARTITION_1_RECORD_1, PARTITION_1_RECORD_2);
+        thenPartitionContains(PARTITION_2, 1, 2, PARTITION_2_RECORD_1);
+        thenPartitionContains(PARTITION_1, 0, 2, PARTITION_1_RECORD_1, PARTITION_1_RECORD_2);
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10952](https://issues.apache.org/jira/browse/NIFI-10952)
Following the problem in the issue NIFI-10952. The issue happens on "thenPartitionContains" function. And I dive in to "thenPartitionContains" function and MockFlowFile interface. And when partition = partition2, I print out the FlowFile attributes by following code:
```
System.out.println(flowFile.getAttributes());
``` 
And I get both flowFiles attributes, which looks like this:
```
FlowFile[1,39513435360922.mockFlowFile,33B]
{record.count=2, filename=39513435360922.mockFlowFile, fragment.index=0, uuid=4de4472c-fce3-4801-bb00-fd81a2c8e95d, path=target, mime.type=text/plain, partition=partition1, fragment.count=2}
FlowFile[2,39513435360922.mockFlowFile,21B]
{mime.type=text/plain, fragment.count=2, record.count=1, path=target, filename=39513435360922.mockFlowFile, partition=partition2, uuid=55e22965-9321-4963-8b39-a9c1160c4da6, fragment.index=1}
```
As we can see here, when the partition = partition2, the fragment.index is always 1. But what the author set the index parameter is 0. Which is never gonna happen. So I make changes on the place where the "thenPartitionContains" get called :

```
thenPartitionContains(PARTITION_2, 1, 2, PARTITION_2_RECORD_1);
thenPartitionContains(PARTITION_1, 0, 2, PARTITION_1_RECORD_1, PARTITION_1_RECORD_2);
```
By changing this, the if statement can correctly work and the bug has been fixed. It is not flaky anymore and can pass the NonDex's check.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
