### PR TITLE
NIFI-10967 Correct TestWriteJsonResult mixed arrays

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/choice-of-array-string-or-array-record.json
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/json/choice-of-array-string-or-array-record.json
@@ -1,9 +1,0 @@
-[ {
-  "items" : [ {
-    "itemData" : [ "test" ]
-  }, {
-    "itemData" : [ {
-      "quantity" : 10
-    } ]
-  } ]
-} ]


### PR DESCRIPTION
# Summary

[NIFI-10967](https://issues.apache.org/jira/browse/NIFI-10967) Corrects `TestWriteJsonResult.testChoiceArrayOfStringsOrArrayOfRecords` on Windows platforms. Changes replace the external JSON file with an inline string of JSON to avoid line-ending differences between operating systems.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
