### PR TITLE
NIFI-10958 Adjust Script Engine handling to avoid errors on Java 17

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
@@ -178,15 +178,21 @@ public class ScriptingComponentHelper {
             engineAllowableValues = engineList;
             AllowableValue[] engines = engineList.toArray(new AllowableValue[0]);
 
-            SCRIPT_ENGINE = new PropertyDescriptor.Builder()
+            final PropertyDescriptor.Builder enginePropertyBuilder = new PropertyDescriptor.Builder()
                     .name("Script Engine")
                     .required(true)
-                    .description("The engine to execute scripts")
-                    .allowableValues(engines)
-                    .defaultValue(engines[0].getValue())
+                    .description("Language Engine for executing scripts")
                     .required(true)
-                    .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-                    .build();
+                    .expressionLanguageSupported(ExpressionLanguageScope.NONE);
+
+            if (engineList.isEmpty()) {
+                enginePropertyBuilder.description("No Script Engines found");
+            } else {
+                enginePropertyBuilder.allowableValues(engines);
+                enginePropertyBuilder.defaultValue(engines[0].getValue());
+            }
+
+            SCRIPT_ENGINE = enginePropertyBuilder.build();
             descriptors.add(SCRIPT_ENGINE);
         }
 


### PR DESCRIPTION
# Summary

[NIFI-10958](https://issues.apache.org/jira/browse/NIFI-10958) Adjusts Script Engine property handling in `ScriptingComponentsHelper` to avoid exceptions on Java 17 during documentation generation. Additional work is necessary to support ECMAScript and the Nashorn engine on Java 17, but introduced an empty check during the Script Engine introspection process avoids complete documentation generation failures.

Current unit tests for `createResources()` work on Java 17 because the test environment has available classes.

Further work on ECMAScript support using the Nashorn engine dependency on Java 17 is described in [NIFI-9383](https://issues.apache.org/jira/browse/NIFI-9383).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
