### PR TITLE
NIFI-10968 - Test multipleKeysOneNotFound

### DIFF
--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -228,8 +229,17 @@ public class TestConvertAvroToParquet {
         assertEquals(firstRecord.getGroup("myarray",0).getGroup("list",1).getInteger("element", 0), 2);
 
         // Map
-        assertEquals(firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0), 1);
-        assertEquals(firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0), 2);
+        String key1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getValueToString(0,0);
+        String key2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getValueToString(0,0);
+        int v1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0);
+        int v2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0);
+        Map<String,Integer> mymap = new HashMap<String,Integer>();
+        mymap.put(key1,v1);
+        mymap.put(key2,v2);
+         Map<String,Integer> inputData = new HashMap<String,Integer>();
+        inputData.put("a",1);
+        inputData.put("b",2);
+        assertTrue(mymap.equals(inputData));
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -239,7 +239,7 @@ public class TestConvertAvroToParquet {
          Map<String,Integer> inputData = new HashMap<String,Integer>();
         inputData.put("a",1);
         inputData.put("b",2);
-        assertTrue(mymap.equals(inputData));
+        assertEquals(inputData, mymap);
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -230,17 +230,10 @@ public class TestConvertAvroToParquet {
         assertEquals(firstRecord.getGroup("myarray",0).getGroup("list",1).getInteger("element", 0), 2);
 
         // Map
-        String key1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getValueToString(0,0);
-        String key2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getValueToString(0,0);
         int v1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0);
         int v2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0);
-        Map<String,Integer> recordData = new LinkedHashMap<String,Integer>();
-        recordData.put(key1,v1);
-        recordData.put(key2,v2);
-        Map<String,Integer> inputData = new HashMap<String,Integer>();
-        inputData.put("a",1);
-        inputData.put("b",2);
-        assertEquals(inputData, recordData);
+        assertEquals(1, v1);
+        assertEquals(2, v2);
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -230,10 +230,17 @@ public class TestConvertAvroToParquet {
         assertEquals(firstRecord.getGroup("myarray",0).getGroup("list",1).getInteger("element", 0), 2);
 
         // Map
+        String key1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getValueToString(0,0);
+        String key2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getValueToString(0,0);
         int v1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0);
         int v2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0);
-        assertEquals(1, v1);
-        assertEquals(2, v2);
+        Map<String,Integer> recordData = new LinkedHashMap<String,Integer>();
+        recordData.put(key1,v1);
+        recordData.put(key2,v2);
+        Map<String,Integer> inputData = new HashMap<String,Integer>();
+        inputData.put("a",1);
+        inputData.put("b",2);
+        assertEquals(inputData, recordData);
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -236,7 +237,7 @@ public class TestConvertAvroToParquet {
         Map<String,Integer> recordData = new LinkedHashMap<String,Integer>();
         mymap.put(key1,v1);
         mymap.put(key2,v2);
-         Map<String,Integer> inputData = new HashMap<String,Integer>();
+        Map<String,Integer> inputData = new HashMap<String,Integer>();
         inputData.put("a",1);
         inputData.put("b",2);
         assertEquals(inputData, mymap);

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -233,7 +233,7 @@ public class TestConvertAvroToParquet {
         String key2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getValueToString(0,0);
         int v1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0);
         int v2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0);
-        Map<String,Integer> mymap = new HashMap<String,Integer>();
+        Map<String,Integer> recordData = new LinkedHashMap<String,Integer>();
         mymap.put(key1,v1);
         mymap.put(key2,v2);
          Map<String,Integer> inputData = new HashMap<String,Integer>();

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -240,7 +240,7 @@ public class TestConvertAvroToParquet {
         Map<String,Integer> inputData = new HashMap<String,Integer>();
         inputData.put("a",1);
         inputData.put("b",2);
-        assertEquals(inputData, mymap);
+        assertEquals(inputData, recordData);
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -235,8 +235,8 @@ public class TestConvertAvroToParquet {
         int v1 = firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0);
         int v2 = firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0);
         Map<String,Integer> recordData = new LinkedHashMap<String,Integer>();
-        mymap.put(key1,v1);
-        mymap.put(key2,v2);
+        recordData.put(key1,v1);
+        recordData.put(key2,v2);
         Map<String,Integer> inputData = new HashMap<String,Integer>();
         inputData.put("a",1);
         inputData.put("b",2);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchDistributedMapCache.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchDistributedMapCache.java
@@ -203,7 +203,7 @@ public class TestFetchDistributedMapCache {
         runner.assertTransferCount(FetchDistributedMapCache.REL_NOT_FOUND, 1);
 
         final MockFlowFile outputFlowFile = runner.getFlowFilesForRelationship(FetchDistributedMapCache.REL_NOT_FOUND).get(0);
-        outputFlowFile.assertAttributeEquals("test.key1","value1");
+        outputFlowFile.assertAttributeEquals("test.key2",null);
     }
 
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10968](https://issues.apache.org/jira/browse/NIFI-10968)
Following the problem in the issue NIFI-10968. I set several printfs to see what exactly prints look like. According to the codes, the test function called testMultipleKeysOneNotFound, so the test should test to get the key value which not exist. However, what assertion test is testing an exist value. 
```
 @Test
    public void testMultipleKeysOneNotFound() throws IOException {
        service.put("key1","value1", new FetchDistributedMapCache.StringSerializer(), new FetchDistributedMapCache.StringSerializer());
        runner.setProperty(FetchDistributedMapCache.PROP_CACHE_ENTRY_IDENTIFIER, "key1, key2");
        // Not valid to set multiple keys without Put Cache Value In Attribute set
        runner.assertNotValid();
        runner.setProperty(FetchDistributedMapCache.PROP_PUT_CACHE_VALUE_IN_ATTRIBUTE, "test");
        runner.assertValid();

        final Map<String, String> props = new HashMap<>();
        runner.enqueue(new byte[]{}, props);

        runner.run();

        runner.assertAllFlowFilesTransferred(FetchDistributedMapCache.REL_NOT_FOUND, 1);
        runner.assertTransferCount(FetchDistributedMapCache.REL_NOT_FOUND, 1);

        final MockFlowFile outputFlowFile = runner.getFlowFilesForRelationship(FetchDistributedMapCache.REL_NOT_FOUND).get(0);
        outputFlowFile.assertAttributeEquals("test.key1" "value1");
    }
```
I change the assertion to 
```
outputFlowFile.assertAttributeEquals("test.key2",null);
```
so the test not flaky anymore and pass the Nondex compile.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
