### PR TITLE
NIFI-10971: improved edge case handling while fetching objects using …

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-parameter-providers/src/main/java/org/apache/nifi/parameter/azure/AzureKeyVaultSecretsParameterProvider.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-parameter-providers/src/main/java/org/apache/nifi/parameter/azure/AzureKeyVaultSecretsParameterProvider.java
@@ -132,8 +132,10 @@ public class AzureKeyVaultSecretsParameterProvider extends AbstractParameterProv
         final List<KeyVaultSecret> secrets = new ArrayList<>();
 
         for (final SecretProperties secretProperties : secretClient.listPropertiesOfSecrets()) {
-            KeyVaultSecret secretWithValue = secretClient.getSecret(secretProperties.getName(), secretProperties.getVersion());
-            secrets.add(secretWithValue);
+            if (secretProperties.isEnabled()) {
+                KeyVaultSecret secretWithValue = secretClient.getSecret(secretProperties.getName(), secretProperties.getVersion());
+                secrets.add(secretWithValue);
+            }
         }
 
         return secrets;
@@ -145,7 +147,12 @@ public class AzureKeyVaultSecretsParameterProvider extends AbstractParameterProv
             final String parameterName = secret.getName();
             final String parameterValue = secret.getValue();
 
-            final String parameterGroupName = secret.getProperties().getTags().get(GROUP_NAME_TAG);
+            final Map<String, String> tags = secret.getProperties().getTags();
+            if (tags == null) {
+                getLogger().debug("Secret with parameter name [{}] not recognized as a valid parameter since it does not have tags");
+                continue;
+            }
+            final String parameterGroupName = tags.get(GROUP_NAME_TAG);
             if (parameterGroupName == null) {
                 getLogger().debug("Secret with parameter name [{}] not recognized as a valid parameter since it " +
                                 "does not have the [{}] tag", parameterName, GROUP_NAME_TAG);


### PR DESCRIPTION
…Azure Key Vault Client and added unit tests

Improved reliability of fetching objects from Azure Key Vault while using the Key Vault Client. Handles edge cases such as disregarding disabled secrets as well as handling possible null pointers

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10971](https://issues.apache.org/jira/browse/NIFI-10971)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
