### PR TITLE
NIFI-10456: Add client authentication strategy option to OAuth2 provider

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/ClientAuthenticationStrategy.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/ClientAuthenticationStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.oauth2;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum ClientAuthenticationStrategy implements DescribedValue {
+    REQUEST_BODY("Send client authentication in request body. RFC 6749 Section 2.3.1 recommends Basic Authentication instead of request body."),
+    BASIC_AUTHENTICATION("Send client authentication using HTTP Basic authentication.");
+
+    private final String description;
+
+    ClientAuthenticationStrategy(final String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return name();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/test/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/test/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProviderTest.java
@@ -22,6 +22,8 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okio.Buffer;
+
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ConfigurationContext;
@@ -46,7 +48,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,6 +96,8 @@ public class StandardOauth2AccessTokenProviderTest {
     private ArgumentCaptor<String> errorCaptor;
     @Captor
     private ArgumentCaptor<Throwable> throwableCaptor;
+    @Captor
+    private ArgumentCaptor<Request> requestCaptor;
 
     @BeforeEach
     public void setUp() {
@@ -113,6 +120,7 @@ public class StandardOauth2AccessTokenProviderTest {
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_ID).evaluateAttributeExpressions().getValue()).thenReturn(CLIENT_ID);
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_SECRET).getValue()).thenReturn(CLIENT_SECRET);
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.REFRESH_WINDOW).asTimePeriod(eq(TimeUnit.SECONDS))).thenReturn(FIVE_MINUTES);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_AUTHENTICATION_STRATEGY).getValue()).thenReturn(ClientAuthenticationStrategy.BASIC_AUTHENTICATION.getValue());
 
         testSubject.onEnabled(mockContext);
     }
@@ -125,7 +133,7 @@ public class StandardOauth2AccessTokenProviderTest {
 
         runner.addControllerService("testSubject", testSubject);
 
-        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL, "http://unimportant");
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL, AUTHORIZATION_SERVER_URL);
 
         // WHEN
         runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.GRANT_TYPE, StandardOauth2AccessTokenProvider.CLIENT_CREDENTIALS_GRANT_TYPE);
@@ -142,12 +150,50 @@ public class StandardOauth2AccessTokenProviderTest {
 
         runner.addControllerService("testSubject", testSubject);
 
-        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL, "http://unimportant");
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL, AUTHORIZATION_SERVER_URL);
 
         // WHEN
         runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.GRANT_TYPE, StandardOauth2AccessTokenProvider.CLIENT_CREDENTIALS_GRANT_TYPE);
-        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_ID, "clientId");
-        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_SECRET, "clientSecret");
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_ID, CLIENT_ID);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_SECRET, CLIENT_SECRET);
+
+        // THEN
+        runner.assertValid(testSubject);
+    }
+
+    @Test
+    public void testInvalidWhenClientAuthenticationStrategyIsInvalid() throws Exception {
+        // GIVEN
+        Processor processor = new NoOpProcessor();
+        TestRunner runner = TestRunners.newTestRunner(processor);
+
+        runner.addControllerService("testSubject", testSubject);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL, AUTHORIZATION_SERVER_URL);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.GRANT_TYPE, StandardOauth2AccessTokenProvider.CLIENT_CREDENTIALS_GRANT_TYPE);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_ID, CLIENT_ID);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_SECRET, CLIENT_SECRET);
+
+        // WHEN
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_AUTHENTICATION_STRATEGY, "UNKNOWN");
+
+        // THEN
+        runner.assertNotValid(testSubject);
+    }
+
+    @Test
+    public void testValidWhenClientAuthenticationStrategyIsValid() throws Exception {
+        // GIVEN
+        Processor processor = new NoOpProcessor();
+        TestRunner runner = TestRunners.newTestRunner(processor);
+
+        runner.addControllerService("testSubject", testSubject);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL, AUTHORIZATION_SERVER_URL);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.GRANT_TYPE, StandardOauth2AccessTokenProvider.CLIENT_CREDENTIALS_GRANT_TYPE);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_ID, CLIENT_ID);
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_SECRET, CLIENT_SECRET);
+
+        // WHEN
+        runner.setProperty(testSubject, StandardOauth2AccessTokenProvider.CLIENT_AUTHENTICATION_STRATEGY, ClientAuthenticationStrategy.REQUEST_BODY.getValue());
 
         // THEN
         runner.assertValid(testSubject);
@@ -248,6 +294,42 @@ public class StandardOauth2AccessTokenProviderTest {
 
         // THEN
         assertEquals(expectedToken, actualToken);
+    }
+
+    @Test
+    public void testBasicAuthentication() throws Exception {
+        // GIVEN
+        Response response = buildResponse(HTTP_OK, "{\"access_token\":\"foobar\"}");
+        when(mockHttpClient.newCall(any(Request.class)).execute()).thenReturn(response);
+        String expected = "Basic " + Base64.getEncoder().withoutPadding().encodeToString((CLIENT_ID + ":" + CLIENT_SECRET).getBytes());
+
+        // WHEN
+        testSubject.getAccessDetails();
+
+        // THEN
+        verify(mockHttpClient, atLeast(1)).newCall(requestCaptor.capture());
+        assertEquals(expected, requestCaptor.getValue().header("Authorization"));
+    }
+
+    @Test
+    public void testRequestBodyAuthentication() throws Exception {
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.GRANT_TYPE).getValue()).thenReturn(StandardOauth2AccessTokenProvider.CLIENT_CREDENTIALS_GRANT_TYPE.getValue());
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_AUTHENTICATION_STRATEGY).getValue()).thenReturn(ClientAuthenticationStrategy.REQUEST_BODY.getValue());
+        testSubject.onEnabled(mockContext);
+
+        // GIVEN
+        Response response = buildResponse(HTTP_OK, "{\"access_token\":\"foobar\"}");
+        when(mockHttpClient.newCall(any(Request.class)).execute()).thenReturn(response);
+        String expected = "grant_type=client_credentials&client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET;
+
+        // WHEN
+        testSubject.getAccessDetails();
+
+        // THEN
+        Buffer buffer = new Buffer();
+        verify(mockHttpClient, atLeast(1)).newCall(requestCaptor.capture());
+        requestCaptor.getValue().body().writeTo(buffer);
+        assertEquals(expected, buffer.readString(Charset.defaultCharset()));
     }
 
     @Test


### PR DESCRIPTION
StandardOauth2AccessTokenProvider has been updated with new property `Client Authentication Strategy` with allowable values `Basic Authentication` and `Request Body` (default). The `Request Body` authentication strategy retains the provider's old behavior while `Basic Authentication` sends the client credentials using HTTP Basic authentication such as

```
Authorization: Basic Zm9vOmJhcgo=
```

According to RFC 6749 (The OAuth2.0 Authorization Framework)...

> The authorization server MUST support the HTTP Basic
  authentication scheme for authenticating clients that were issued a
  client password.

And...

> [..] the authorization server MAY support including the
   client credentials in the request-body [..]

But...

> Including the client credentials in the request-body using the two
  parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
  to directly utilize the HTTP Basic authentication scheme [..]

# Summary

[NIFI-10456](https://issues.apache.org/jira/browse/NIFI-10456)

# Tracking

Please complete the following tracking steps prior to pull request creation.

## Issue Tracking

- [x] Apache NiFi Jira issue created

## Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as NIFI-00000
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such NIFI-00000

## Pull Request Formatting

- [x] Pull Request based on current revision of the main branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Added new unit tests for StandardOauth2AccessTokenProvider

## Build

- [x] Build completed using mvn clean install -P contrib-check
  - [ ] JDK 8
  - [ ] JDK 11
  - [x] JDK 17

## Licensing

No new dependencies

- [x] New dependencies are compatible with the Apache License 2.0 according to the License Policy
- [x] New dependencies are documented in applicable LICENSE and NOTICE files

## Documentation

No documentation changes, other than updates to javadoc for StandardOauth2AccessTokenProvider

- [x] Documentation formatting appears as expected in rendered files
