### PR TITLE
NIFI-10989 Remove SHA-1 and MD5 from TestHashContent

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHashContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestHashContent.java
@@ -30,21 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestHashContent {
 
     @Test
-    public void testMD5() throws IOException {
-        // Expected hash value obtained by running Linux md5sum against the file
-        test("MD5", "65a8e27d8879283831b664bd8b7f0ad4");
-    }
-
-    @Test
     public void testSHA256() throws IOException {
-        // Expected hash value obtained by running Linux sha256sum against the file
         test("SHA-256", "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f");
-    }
-
-    @Test
-    public void testSHA1() throws IOException {
-        // Expected hash value obtained by running Linux sha1sum against the file
-        test("SHA-1", "0a0a9f2a6772942557ab5355d76af442f8f65e01");
     }
 
     private void test(final String hashAlgorithm, final String expectedHash) throws IOException {


### PR DESCRIPTION
# Summary

[NIFI-10989](https://issues.apache.org/jira/browse/NIFI-10989) Removes test methods for `MD5` and `SHA-1` from `TestHashContent` to avoid intermittent failures due to lack of Bouncy Castle Security Provider registration.

The `SHA-1` method succeeds when Bouncy Castle is registered, but fails when not registered. The test methods should be removed because `HashContent` is deprecated in favor of `CryptographicHashContent` and is targeted for removal in subsequent major releases.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
