### PR TITLE
NIFI-10884 Conflict resolution in PutAzureDataLakeStorage should log the target filename

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -213,9 +213,9 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
     }
 
     /**
-     * This method serves as a "commit" for the upload process. To support various Conflict Resolution Strategies the processor uploads
-     * the content of the FlowFile to a temporary file with a unique name, then attempts to rename it. It is not an efficient approach,
-     * especially for large files, but it is needed because of the issue (azure-sdk-for-java/issues/31248) linked above.
+     * This method serves as a "commit" for the upload process. Upon upload, a 0-byte file is created, then the payload is appended to it.
+     * Because of that, a work-in-progress file is available for readers before the upload is complete. It is not an efficient approach in
+     * case of conflicts because FlowFiles are uploaded unnecessarily, but it is a calculated risk because consistency is more important.
      *
      * Visible for testing
      *

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -212,25 +212,38 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         fileClient.flush(length, true);
     }
 
-    //Visible for testing
+    /**
+     * This method serves as a "commit" for the upload process. To support various Conflict Resolution Strategies the processor uploads
+     * the content of the FlowFile to a temporary file with a unique name, then attempts to rename it. It is not an efficient approach,
+     * especially for large files, but it is needed because of the issue (azure-sdk-for-java/issues/31248) linked above.
+     *
+     * Visible for testing
+     *
+     * @param sourceFileClient client of the temporary file
+     * @param destinationDirectory final location of the uploaded file
+     * @param destinationFileName final name of the uploaded file
+     * @param conflictResolution conflict resolution strategy
+     * @return URL of the uploaded file
+     */
     String renameFile(final DataLakeFileClient sourceFileClient, final String destinationDirectory, final String destinationFileName, final String conflictResolution) {
+        final String destinationPath = createPath(destinationDirectory, destinationFileName);
+
         try {
             final DataLakeRequestConditions destinationCondition = new DataLakeRequestConditions();
             if (!conflictResolution.equals(REPLACE_RESOLUTION)) {
                 destinationCondition.setIfNoneMatch("*");
             }
-            final String destinationPath = createPath(destinationDirectory, destinationFileName);
             return sourceFileClient.renameWithResponse(null, destinationPath, null, destinationCondition, null, null).getValue().getFileUrl();
         } catch (DataLakeStorageException dataLakeStorageException) {
             removeTempFile(sourceFileClient);
             if (dataLakeStorageException.getStatusCode() == 409 && conflictResolution.equals(IGNORE_RESOLUTION)) {
-                getLogger().info("File with the same name [{}] already exists. Remote file not modified due to {} being set to '{}'.",
-                        sourceFileClient.getFileName(), CONFLICT_RESOLUTION.getDisplayName(), conflictResolution);
+                getLogger().info("File [{}] already exists. Remote file not modified due to {} being set to '{}'.",
+                        destinationPath, CONFLICT_RESOLUTION.getDisplayName(), conflictResolution);
                 return null;
             } else if (dataLakeStorageException.getStatusCode() == 409 && conflictResolution.equals(FAIL_RESOLUTION)) {
-                throw new ProcessException(String.format("File with the same name [%s] already exists.", sourceFileClient.getFileName()), dataLakeStorageException);
+                throw new ProcessException(String.format("File [%s] already exists.", destinationPath), dataLakeStorageException);
             } else {
-                throw new ProcessException(String.format("Renaming File [%s] failed", sourceFileClient.getFileName()), dataLakeStorageException);
+                throw new ProcessException(String.format("Renaming File [%s] failed", destinationPath), dataLakeStorageException);
             }
         }
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10884](https://issues.apache.org/jira/browse/NIFI-10884)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
