### PR TITLE
[NIFI-6498] Set error event listener on both the TransformerFactory a…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -611,6 +611,7 @@
                         <exclude>src/test/resources/TestTransformXml/math.html</exclude>
                         <exclude>src/test/resources/TestTransformXml/tokens.csv</exclude>
                         <exclude>src/test/resources/TestTransformXml/tokens.xml</exclude>
+                        <exclude>src/test/resources/TestTransformXml/employee.html</exclude>
                         <exclude>src/test/resources/TestUnpackContent/folder/cal.txt</exclude>
                         <exclude>src/test/resources/TestUnpackContent/folder/date.txt</exclude>
                         <exclude>src/test/resources/TestUnpackContent/data.flowfilev2</exclude>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
@@ -382,27 +382,28 @@ public class TransformXml extends AbstractProcessor {
             throw new TransformerConfigurationException("XSLT Source Stream Reader creation failed", e);
         }
     }
-}
 
-class ErrorListenerLogger implements ErrorListener {
-    private final ComponentLog logger;
+    private static class ErrorListenerLogger implements ErrorListener {
+        private final ComponentLog logger;
 
-    ErrorListenerLogger(ComponentLog logger) {
-        this.logger = logger;
-    }
+        ErrorListenerLogger(ComponentLog logger) {
+            this.logger = logger;
+        }
 
-    @Override
-    public void warning(TransformerException exception) throws TransformerException {
-        logger.warn(exception.getMessageAndLocation());
-    }
+        @Override
+        public void warning(TransformerException exception) {
+            logger.warn(exception.getMessageAndLocation(), exception);
+        }
 
-    @Override
-    public void error(TransformerException exception) throws TransformerException {
-        logger.error(exception.getMessageAndLocation());
-    }
+        @Override
+        public void error(TransformerException exception) {
+            logger.error(exception.getMessageAndLocation(), exception);
+        }
 
-    @Override
-    public void fatalError(TransformerException exception) throws TransformerException {
-        logger.log(LogLevel.FATAL, exception.getMessageAndLocation());
+        @Override
+        public void fatalError(TransformerException exception) throws TransformerException {
+            logger.log(LogLevel.FATAL, exception.getMessageAndLocation(), exception);
+            throw exception;
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
@@ -18,6 +18,9 @@ package org.apache.nifi.processors.standard;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import net.sf.saxon.event.Receiver;
+import net.sf.saxon.event.ReceiverOption;
+import net.sf.saxon.trans.XPathException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.EventDriven;
@@ -38,6 +41,7 @@ import org.apache.nifi.expression.AttributeExpression;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.logging.LogLevel;
 import org.apache.nifi.lookup.LookupFailureException;
 import org.apache.nifi.lookup.LookupService;
 import org.apache.nifi.lookup.StringLookupService;
@@ -55,12 +59,14 @@ import org.apache.nifi.xml.processing.stream.XMLStreamReaderProvider;
 
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.ErrorListener;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.stream.StreamResult;
@@ -70,6 +76,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -235,7 +242,7 @@ public class TransformXml extends AbstractProcessor {
                         .valid(false)
                         .subject(XSLT_CONTROLLER.getDisplayName())
                         .explanation("This processor requires a key-value lookup service supporting exactly one required key, was: " +
-                            (requiredKeys == null ? "null" : String.valueOf(requiredKeys.size())))
+                                (requiredKeys == null ? "null" : String.valueOf(requiredKeys.size())))
                         .build());
             }
         }
@@ -283,7 +290,7 @@ public class TransformXml extends AbstractProcessor {
         final StopWatch stopWatch = new StopWatch(true);
         final String path = context.getProperty(XSLT_FILE_NAME).isSet()
                 ? context.getProperty(XSLT_FILE_NAME).evaluateAttributeExpressions(original).getValue()
-                        : context.getProperty(XSLT_CONTROLLER_KEY).evaluateAttributeExpressions(original).getValue();
+                : context.getProperty(XSLT_CONTROLLER_KEY).evaluateAttributeExpressions(original).getValue();
 
         try {
             final FlowFile transformed = session.write(original, (inputStream, outputStream) -> {
@@ -298,6 +305,8 @@ public class TransformXml extends AbstractProcessor {
                     final Transformer transformer = templates.newTransformer();
                     final String indentProperty = context.getProperty(INDENT_OUTPUT).asBoolean() ? "yes" : "no";
                     transformer.setOutputProperty(OutputKeys.INDENT, indentProperty);
+                    transformer.setErrorListener(getErrorListenerLogger());
+                    setMessageReceiver(transformer);
 
                     // pass all dynamic properties to the transformer
                     for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
@@ -323,6 +332,52 @@ public class TransformXml extends AbstractProcessor {
         }
     }
 
+    private ErrorListenerLogger getErrorListenerLogger() {
+        return new ErrorListenerLogger(getLogger());
+    }
+
+    /**
+     * The Saxon transformer sends messages from <xsl:message/> to a message emitter
+     * which by default prints messages to the console. This method instantiates a custom message
+     * emitter to allow for using Nifi logging for these messages instead.
+     *
+     * @param transformer Instance of {@link Transformer}.
+     */
+    private void setMessageReceiver(final Transformer transformer) {
+        if (transformer instanceof net.sf.saxon.jaxp.TransformerImpl) {
+            net.sf.saxon.jaxp.TransformerImpl saxonTransformer = (net.sf.saxon.jaxp.TransformerImpl) transformer;
+            final ComponentLog logger = getLogger();
+            Receiver messageReceiver = new net.sf.saxon.serialize.XMLEmitter() {
+                boolean terminate = false;
+
+                @Override
+                public void startDocument(int properties) throws XPathException {
+                    setWriter(new StringWriter());
+                    terminate = (properties & ReceiverOption.TERMINATE) != 0;
+                    super.startDocument(properties);
+                }
+
+                @Override
+                public void endDocument() throws XPathException {
+                    String message = getWriter().toString();
+                    if (terminate) {
+                        //NOTE: trim is used as there may be a blank line before the actual message.
+                        logger.error(StringUtils.trim(message));
+                    } else {
+                        logger.warn(message);
+                    }
+                }
+
+                @Override
+                public void close() {
+                    /* This method is empty as the close methods in the two parent classes
+                     *  call things which are not necessary in this context. */
+                }
+            };
+            saxonTransformer.getUnderlyingController().setMessageEmitter(messageReceiver);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private Templates newTemplates(final ProcessContext context, final String path) throws TransformerConfigurationException, LookupFailureException {
         final boolean secureProcessing = context.getProperty(SECURE_PROCESSING).asBoolean();
@@ -341,6 +396,8 @@ public class TransformXml extends AbstractProcessor {
             factory.setFeature("http://saxon.sf.net/feature/parserFeature?uri=http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://saxon.sf.net/feature/parserFeature?uri=http://xml.org/sax/features/external-general-entities", false);
         }
+        factory.setErrorListener(getErrorListenerLogger());
+
         return factory;
     }
 
@@ -371,5 +428,28 @@ public class TransformXml extends AbstractProcessor {
         } catch (final ProcessingException e) {
             throw new TransformerConfigurationException("XSLT Source Stream Reader creation failed", e);
         }
+    }
+}
+
+class ErrorListenerLogger implements ErrorListener {
+    private final ComponentLog logger;
+
+    ErrorListenerLogger(ComponentLog logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void warning(TransformerException exception) throws TransformerException {
+        logger.warn(exception.getMessageAndLocation());
+    }
+
+    @Override
+    public void error(TransformerException exception) throws TransformerException {
+        logger.error(exception.getMessageAndLocation());
+    }
+
+    @Override
+    public void fatalError(TransformerException exception) throws TransformerException {
+        logger.log(LogLevel.FATAL, exception.getMessageAndLocation());
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -304,8 +304,7 @@ public class TestTransformXml {
         runner.setProperty("header", "Test for mod");
         runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/nonMatchingEndTag.xsl");
 
-        final Map<String, String> attributes = new HashMap<>();
-        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/math.xml"), attributes);
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/math.xml"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
@@ -317,8 +316,7 @@ public class TestTransformXml {
         runner.setProperty("header", "Test message terminate");
         runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/employeeMessageTerminate.xsl");
 
-        final Map<String, String> attributes = new HashMap<>();
-        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/employee.xml"), attributes);
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/employee.xml"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
@@ -330,8 +328,7 @@ public class TestTransformXml {
         runner.setProperty("header", "Test message non terminate");
         runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/employeeMessageNonTerminate.xsl");
 
-        final Map<String, String> attributes = new HashMap<>();
-        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/employee.xml"), attributes);
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/employee.xml"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -297,4 +297,47 @@ public class TestTransformXml {
 
         transformed.assertContentEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
     }
+
+    @Test
+    public void testNonMatchingTemplateTag() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
+        runner.setProperty("header", "Test for mod");
+        runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/nonMatchingEndTag.xsl");
+
+        final Map<String, String> attributes = new HashMap<>();
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/math.xml"), attributes);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
+    }
+
+    @Test
+    public void testMessageTerminate() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
+        runner.setProperty("header", "Test message terminate");
+        runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/employeeMessageTerminate.xsl");
+
+        final Map<String, String> attributes = new HashMap<>();
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/employee.xml"), attributes);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
+    }
+
+    @Test
+    public void testMessageNonTerminate() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new TransformXml());
+        runner.setProperty("header", "Test message non terminate");
+        runner.setProperty(TransformXml.XSLT_FILE_NAME, "src/test/resources/TestTransformXml/employeeMessageNonTerminate.xsl");
+
+        final Map<String, String> attributes = new HashMap<>();
+        runner.enqueue(Paths.get("src/test/resources/TestTransformXml/employee.xml"), attributes);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(TransformXml.REL_SUCCESS);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(TransformXml.REL_SUCCESS).get(0);
+        final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/employee.html")));
+
+        transformed.assertContentEquals(expectedContent);
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -317,8 +317,6 @@ public class TestTransformXml {
         assertTrue(logger.getErrorMessages().size() >= 1);
         String firstMessage = logger.getErrorMessages().get(0).getMsg();
         assertTrue(firstMessage.contains("xsl:template"));
-        assertTrue(firstMessage.contains("Line#"));
-        assertTrue(firstMessage.contains("Column#"));
     }
 
     @Test
@@ -336,8 +334,6 @@ public class TestTransformXml {
         assertTrue(logger.getErrorMessages().size() >= 1);
         String firstMessage = logger.getErrorMessages().get(0).getMsg();
         assertTrue(firstMessage.contains("xsl:message"));
-        assertTrue(firstMessage.contains("Line#"));
-        assertTrue(firstMessage.contains("Column#"));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -314,7 +314,6 @@ public class TestTransformXml {
         runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
         MockComponentLog logger = runner.getLogger();
         assertFalse(logger.getErrorMessages().isEmpty());
-        assertTrue(logger.getErrorMessages().size() >= 1);
         String firstMessage = logger.getErrorMessages().get(0).getMsg();
         assertTrue(firstMessage.contains("xsl:template"));
     }
@@ -331,7 +330,6 @@ public class TestTransformXml {
         runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
         MockComponentLog logger = runner.getLogger();
         assertFalse(logger.getErrorMessages().isEmpty());
-        assertTrue(logger.getErrorMessages().size() >= 1);
         String firstMessage = logger.getErrorMessages().get(0).getMsg();
         assertTrue(firstMessage.contains("xsl:message"));
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTransformXml.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.standard;
 
 import org.apache.nifi.lookup.SimpleKeyValueLookupService;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockComponentLog;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -31,6 +32,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTransformXml {
 
@@ -308,6 +312,13 @@ public class TestTransformXml {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
+        MockComponentLog logger = runner.getLogger();
+        assertFalse(logger.getErrorMessages().isEmpty());
+        assertTrue(logger.getErrorMessages().size() >= 1);
+        String firstMessage = logger.getErrorMessages().get(0).getMsg();
+        assertTrue(firstMessage.contains("xsl:template"));
+        assertTrue(firstMessage.contains("Line#"));
+        assertTrue(firstMessage.contains("Column#"));
     }
 
     @Test
@@ -320,6 +331,13 @@ public class TestTransformXml {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(TransformXml.REL_FAILURE);
+        MockComponentLog logger = runner.getLogger();
+        assertFalse(logger.getErrorMessages().isEmpty());
+        assertTrue(logger.getErrorMessages().size() >= 1);
+        String firstMessage = logger.getErrorMessages().get(0).getMsg();
+        assertTrue(firstMessage.contains("xsl:message"));
+        assertTrue(firstMessage.contains("Line#"));
+        assertTrue(firstMessage.contains("Column#"));
     }
 
     @Test
@@ -336,5 +354,8 @@ public class TestTransformXml {
         final String expectedContent = new String(Files.readAllBytes(Paths.get("src/test/resources/TestTransformXml/employee.html")));
 
         transformed.assertContentEquals(expectedContent);
+        MockComponentLog logger = runner.getLogger();
+        assertTrue(logger.getErrorMessages().isEmpty());
+        assertTrue(logger.getWarnMessages().isEmpty());
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employee.html
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employee.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML><html>
+   <body>
+      <h2>Employee</h2>
+      <table border="1">
+         <tr bgcolor="pink">
+            <th>ID</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Nick Name</th>
+            <th>Salary</th>
+         </tr>
+         <tr>
+            <td>001</td>
+            <td></td>
+            <td>Gupta</td>
+            <td>Raju</td>
+            <td>30000</td>
+         </tr>
+         <tr>
+            <td>024</td>
+            <td>Sara</td>
+            <td>Khan</td>
+            <td>Zoya</td>
+            <td>25000</td>
+         </tr>
+         <tr>
+            <td>056</td>
+            <td>Peter</td>
+            <td>Symon</td>
+            <td>John</td>
+            <td>10000</td>
+         </tr>
+      </table>
+   </body>
+</html>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employee.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employee.xml
@@ -1,0 +1,35 @@
+<?xml version = "1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<class>
+    <employee id = "001">
+        <firstname></firstname>
+        <lastname>Gupta</lastname>
+        <nickname>Raju</nickname>
+        <salary>30000</salary>
+    </employee>
+    <employee id = "024">
+        <firstname>Sara</firstname>
+        <lastname>Khan</lastname>
+        <nickname>Zoya</nickname>
+        <salary>25000</salary>
+    </employee>
+    <employee id = "056">
+        <firstname>Peter</firstname>
+        <lastname>Symon</lastname>
+        <nickname>John</nickname>
+        <salary>10000</salary>
+    </employee>
+</class>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employeeMessageNonTerminate.xsl
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employeeMessageNonTerminate.xsl
@@ -1,0 +1,50 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xsl:stylesheet version = "1.0"
+                xmlns:xsl = "http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match = "/">
+        <html>
+            <body>
+                <h2>Employee</h2>
+                <table border = "1">
+                    <tr bgcolor = "pink">
+                        <th>ID</th>
+                        <th>First Name</th>
+                        <th>Last Name</th>
+                        <th>Nick Name</th>
+                        <th>Salary</th>
+                    </tr>
+
+                    <xsl:for-each select = "class/employee">
+
+                        <xsl:if test = "firstname = ''">
+                            <xsl:message terminate = "no">A first name field is empty.
+                            </xsl:message>
+                        </xsl:if>
+
+                        <tr>
+                            <td><xsl:value-of select = "@id"/></td>
+                            <td><xsl:value-of select = "firstname"/></td>
+                            <td><xsl:value-of select = "lastname"/></td>
+                            <td><xsl:value-of select = "nickname"/></td>
+                            <td><xsl:value-of select = "salary"/></td>
+                        </tr>
+                    </xsl:for-each>
+                </table>
+            </body>
+        </html>
+    </xsl:template>
+</xsl:stylesheet>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employeeMessageTerminate.xsl
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/employeeMessageTerminate.xsl
@@ -1,0 +1,50 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xsl:stylesheet version = "1.0"
+                xmlns:xsl = "http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match = "/">
+        <html>
+            <body>
+                <h2>Employee</h2>
+                <table border = "1">
+                    <tr bgcolor = "pink">
+                        <th>ID</th>
+                        <th>First Name</th>
+                        <th>Last Name</th>
+                        <th>Nick Name</th>
+                        <th>Salary</th>
+                    </tr>
+
+                    <xsl:for-each select = "class/employee">
+
+                        <xsl:if test = "firstname = ''">
+                            <xsl:message terminate = "yes">A first name field is empty.
+                            </xsl:message>
+                        </xsl:if>
+
+                        <tr>
+                            <td><xsl:value-of select = "@id"/></td>
+                            <td><xsl:value-of select = "firstname"/></td>
+                            <td><xsl:value-of select = "lastname"/></td>
+                            <td><xsl:value-of select = "nickname"/></td>
+                            <td><xsl:value-of select = "salary"/></td>
+                        </tr>
+                    </xsl:for-each>
+                </table>
+            </body>
+        </html>
+    </xsl:template>
+</xsl:stylesheet>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/nonMatchingEndTag.xsl
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestTransformXml/nonMatchingEndTag.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xsl:param name="header" />
+
+    <xsl:template match="doc">
+        <HTML>
+            <H1>
+                <xsl:value-of select="$header"/>
+            </H1>
+            <HR/>
+            <P>Should say "1": <xsl:value-of select="5 mod 2"/></P>
+            <P>Should say "1": <xsl:value-of select="n1 mod n2"/></P>
+            <P>Should say "-1": <xsl:value-of select="div mod mod"/></P>
+            <P>
+                <xsl:value-of select="div or ((mod)) | or"/>
+            </P>
+        </HTML>
+</xsl:stylesheet>


### PR DESCRIPTION
…nd Transformer to enable logging errors when processing transformation instructions and when running the transformation itself. Also added ability to log errors from messages that are emitted with <xsl:message/>.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-6498](https://issues.apache.org/jira/browse/NIFI-6498)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
