### PR TITLE
NIFI-11000: CreateHadoopSequenceFile documentation enhancement with c…

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/resources/docs/org.apache.nifi.processors.hadoop.CreateHadoopSequenceFile/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/resources/docs/org.apache.nifi.processors.hadoop.CreateHadoopSequenceFile/additionalDetails.html
@@ -23,24 +23,70 @@
 
     <body>
         <!-- Processor Documentation ================================================== -->
-        <h2>Description:</h2>
-        <p>This processor is used to create a Hadoop Sequence File, which essentially is a file of key/value pairs. The key 
-            will be a file name and the value will be the flow file content. The processor will take either a merged (a.k.a. packaged) flow 
-            file or a singular flow file. Historically, this processor handled the merging by type and size or time prior to creating a 
+        <h2>Description</h2>
+        <p>
+            This processor is used to create a Hadoop Sequence File, which essentially is a file of key/value pairs. The key
+            will be a file name and the value will be the flow file content. The processor will take either a merged (a.k.a. packaged) flow
+            file or a singular flow file. Historically, this processor handled the merging by type and size or time prior to creating a
             SequenceFile output; it no longer does this. If creating a SequenceFile that contains multiple files of the same type is desired,
             precede this processor with a <code>RouteOnAttribute</code> processor to segregate files of the same type and follow that with a
-            <code>MergeContent</code> processor to bundle up files. If the type of files is not important, just use the 
-            <code>MergeContent</code> processor. When using the <code>MergeContent</code> processor, the following Merge Formats are 
+            <code>MergeContent</code> processor to bundle up files. If the type of files is not important, just use the
+            <code>MergeContent</code> processor. When using the <code>MergeContent</code> processor, the following Merge Formats are
             supported by this processor:
-        <ul>
-            <li>TAR</li>
-            <li>ZIP</li>
-            <li>FlowFileStream v3</li>
-        </ul>
-        The created SequenceFile is named the same as the incoming FlowFile with the suffix '.sf'. For incoming FlowFiles that are 
-        bundled, the keys in the SequenceFile are the individual file names, the values are the contents of each file.
-    </p>
-    NOTE: The value portion of a key/value pair is loaded into memory. While there is a max size limit of 2GB, this could cause memory
-    issues if there are too many concurrent tasks and the flow file sizes are large.
-</body>
+            <ul>
+                <li>TAR</li>
+                <li>ZIP</li>
+                <li>FlowFileStream v3</li>
+            </ul>
+            The created SequenceFile is named the same as the incoming FlowFile with the suffix '.sf'. For incoming FlowFiles that are
+            bundled, the keys in the SequenceFile are the individual file names, the values are the contents of each file.
+        </p>
+        <p>
+            NOTE: The value portion of a key/value pair is loaded into memory. While there is a max size limit of 2GB, this could cause memory
+            issues if there are too many concurrent tasks and the flow file sizes are large.
+        </p>
+
+        <h2>Using Comression</h2>
+        <p>
+            The value of the <code>Compression codec</code> property determines the compression library the processor uses to compress content.
+            Third party libraries are used for compression. These third party libraries can be Java libraries or native libraries.
+            In case of native libraries, the path of the parent folder needs to be in an environment variable called <code>LD_LIBRARY_PATH</code> so that NiFi can find the libraries.
+        </p>
+        <h3>Example: using Snappy compression with native library on CentOS</h3>
+        <p>
+            <ol>
+                <li>
+                    Snappy compression needs to be installed on the server running NiFi:
+                    <br/>
+                    <code>sudo yum install snappy</code>
+                    <br/>
+                </li>
+                <li>
+                    Let's suppose that the server running NiFi has the native compression libraries in <code>/opt/lib/hadoop/lib/native</code> .
+                    (Native libraries have file extensions like <code>.so</code>, <code>.dll</code>, <code>.lib</code>, etc. depending on the platform.)
+                    <br/>
+                    We need to make sure that the files can be executed by the NiFi process' user. For this purpose we can make a copy of these files
+                    to e.g. <code>/opt/nativelibs</code> and change their owner. If NiFi is executed by <code>nifi</code> user in the <code>nifi</code> group, then:
+                    <br/>
+                    <code>chown nifi:nifi /opt/nativelibs</code>
+                    <br/>
+                    <code>chown nifi:nifi /opt/nativelibs/*</code>
+                    <br/>
+                </li>
+                <li>
+                    The <code>LD_LIBRARY_PATH</code> needs to be set to contain the path to the folder <code>/opt/nativelibs</code>.
+                    <br/>
+                </li>
+                <li>
+                    NiFi needs to be restarted.
+                </li>
+                <li>
+                    <code>Compression codec</code> property can be set to <code>SNAPPY</code> and a <code>Compression type</code> can be selected.
+                </li>
+                <li>
+                    The processor can be started.
+                </li>
+            </ol>
+        </p>
+    </body>
 </html>


### PR DESCRIPTION
…ompression example

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11000](https://issues.apache.org/jira/browse/NIFI-11000)
An example has been added to CreateHadoopSequenceFile processor's additionalDetails.html documentation to provide guidance on how the processor can be configured to work with native compression libraries.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
