### PR TITLE
NIFI-11015 Correct Registry Trust Store Type handling

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactory.java
@@ -162,7 +162,7 @@ public class ApplicationServerConnectorFactory extends StandardServerConnectorFa
 
     private KeyStore buildTrustStore(final NiFiRegistryProperties properties) {
         final String trustStore = getRequiredProperty(properties, NiFiRegistryProperties.SECURITY_TRUSTSTORE);
-        final String trustStoreType = getRequiredProperty(properties, NiFiRegistryProperties.SECURITY_KEYSTORE_TYPE);
+        final String trustStoreType = getRequiredProperty(properties, NiFiRegistryProperties.SECURITY_TRUSTSTORE_TYPE);
         final String trustStorePassword = getRequiredProperty(properties, NiFiRegistryProperties.SECURITY_TRUSTSTORE_PASSWD);
         return buildStore(trustStore, trustStoreType, trustStorePassword);
     }

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/test/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactoryTest.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/test/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactoryTest.java
@@ -46,13 +46,15 @@ class ApplicationServerConnectorFactoryTest {
 
     private static final String LOCALHOST = "127.0.0.1";
 
+    private static final String PROPRIETARY_TRUST_STORE_TYPE = "JKS";
+
     static TlsConfiguration tlsConfiguration;
 
     Server server;
 
     @BeforeAll
     static void setTlsConfiguration() {
-        tlsConfiguration = new TemporaryKeyStoreBuilder().build();
+        tlsConfiguration = new TemporaryKeyStoreBuilder().trustStoreType(PROPRIETARY_TRUST_STORE_TYPE).build();
     }
 
     @BeforeEach


### PR DESCRIPTION
# Summary

[NIFI-11015](https://issues.apache.org/jira/browse/NIFI-11015) Corrects NiFi Registry configuration processing of the Trust Store Type property for the internal Jetty Server. Recent refactoring in NiFi 1.19.0 incorrectly used the Key Store Type property as the Trust Store Type, resulting in startup failures when the Trust Store Type was different from the Key Store Type. Changes include adjusting the associated unit test to build a TLS Configuration with JKS as the Trust Store Type, instead of the default PKCS12, which validates the expected behavior. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
