### PR TITLE
NIFI-2161 add option to skip attribute output for unmatched JSON path expressions in EvaluateJsonPath

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestEvaluateJsonPath.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestEvaluateJsonPath.java
@@ -16,34 +16,33 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.StringUtils;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class TestEvaluateJsonPath {
+class TestEvaluateJsonPath {
 
     private static final Path JSON_SNIPPET = Paths.get("src/test/resources/TestJson/json-sample.json");
     private static final Path XML_SNIPPET = Paths.get("src/test/resources/TestXml/xml-snippet.xml");
 
     @Test
-    public void testInvalidJsonPath() {
+    void testInvalidJsonPath() {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
         testRunner.setProperty("invalid.jsonPath", "$..");
@@ -52,7 +51,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testUpgradeToJsonPath24() throws Exception {
+    void testUpgradeToJsonPath24() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
         List<String> badInputs = Arrays.asList("LoremIpsum []", "LoremIpsum[]", "$..", "$.xyz.");
@@ -90,7 +89,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testInvalidJsonDocument() throws Exception {
+    void testInvalidJsonDocument() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
 
@@ -98,11 +97,10 @@ public class TestEvaluateJsonPath {
         testRunner.run();
 
         testRunner.assertAllFlowFilesTransferred(EvaluateJsonPath.REL_FAILURE, 1);
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(EvaluateJsonPath.REL_FAILURE).get(0);
     }
 
     @Test
-    public void testInvalidConfiguration_destinationContent_twoPaths() throws Exception {
+    void testInvalidConfiguration_destinationContent_twoPaths() {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_CONTENT);
         testRunner.setProperty("JsonPath1", "$[0]._id");
@@ -112,7 +110,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testInvalidConfiguration_invalidJsonPath_space() throws Exception {
+    void testInvalidConfiguration_invalidJsonPath_space() {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_CONTENT);
         testRunner.setProperty("JsonPath1", "$[0]. _id");
@@ -120,18 +118,22 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testConfiguration_destinationAttributes_twoPaths() throws Exception {
+    void testConfiguration_destinationAttributes_twoPaths() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
         testRunner.setProperty("JsonPath1", "$[0]._id");
-        testRunner.setProperty("JsonPath2", "$[0].name");
+        testRunner.setProperty("JsonPath2", "$[0].name"); // cannot be converted to scalar
 
         testRunner.enqueue(JSON_SNIPPET);
         testRunner.run();
+
+        Relationship expectedRel = EvaluateJsonPath.REL_FAILURE;
+
+        testRunner.assertAllFlowFilesTransferred(expectedRel, 1);
     }
 
     @Test
-    public void testExtractPath_destinationAttribute() throws Exception {
+    void testExtractPath_destinationAttribute() throws Exception {
         String jsonPathAttrKey = "JsonPath";
 
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
@@ -149,7 +151,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testExtractPath_destinationAttributes_twoPaths() throws Exception {
+    void testExtractPath_destinationAttributes_twoPaths() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
         testRunner.setProperty(EvaluateJsonPath.RETURN_TYPE, EvaluateJsonPath.RETURN_TYPE_JSON);
@@ -172,9 +174,10 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testExtractPath_destinationAttributes_twoPaths_notFound() throws Exception {
+    void testExtractPath_destinationAttributes_twoPaths_notFound() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
+        testRunner.setProperty(EvaluateJsonPath.PATH_NOT_FOUND, EvaluateJsonPath.PATH_NOT_FOUND_WARN);
 
         String jsonPathIdAttrKey = "evaluatejson.id";
         String jsonPathNameAttrKey = "evaluatejson.name";
@@ -189,14 +192,15 @@ public class TestEvaluateJsonPath {
 
         testRunner.assertAllFlowFilesTransferred(expectedRel, 1);
         final MockFlowFile out = testRunner.getFlowFilesForRelationship(expectedRel).get(0);
-        assertEquals("", out.getAttribute(jsonPathIdAttrKey), "Transferred flow file did not have the correct result for id attribute");
-        assertEquals("", out.getAttribute(jsonPathNameAttrKey), "Transferred flow file did not have the correct result for name attribute");
+        assertEquals(StringUtils.EMPTY, out.getAttribute(jsonPathIdAttrKey), "Transferred flow file did not have the correct result for id attribute");
+        assertEquals(StringUtils.EMPTY, out.getAttribute(jsonPathNameAttrKey), "Transferred flow file did not have the correct result for name attribute");
     }
 
     @Test
-    public void testExtractPath_destinationAttributes_twoPaths_oneFound() throws Exception {
+    void testExtractPath_destinationAttributes_twoPaths_oneFound() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
+        testRunner.setProperty(EvaluateJsonPath.PATH_NOT_FOUND, EvaluateJsonPath.PATH_NOT_FOUND_IGNORE);
 
         String jsonPathIdAttrKey = "evaluatejson.id";
         String jsonPathNameAttrKey = "evaluatejson.name";
@@ -216,7 +220,30 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testExtractPath_destinationContent() throws Exception {
+    void testExtractPath_destinationAttributes_twoPaths_oneFound_skipMissing() throws Exception {
+        final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
+        testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
+        testRunner.setProperty(EvaluateJsonPath.PATH_NOT_FOUND, EvaluateJsonPath.PATH_NOT_FOUND_SKIP);
+
+        String jsonPathIdAttrKey = "evaluatejson.id";
+        String jsonPathNameAttrKey = "evaluatejson.name";
+
+        testRunner.setProperty(jsonPathIdAttrKey, "$[0]._id");
+        testRunner.setProperty(jsonPathNameAttrKey, "$[0].name.nonexistent");
+
+        testRunner.enqueue(JSON_SNIPPET);
+        testRunner.run();
+
+        Relationship expectedRel = EvaluateJsonPath.REL_MATCH;
+
+        testRunner.assertAllFlowFilesTransferred(expectedRel, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(expectedRel).get(0);
+        assertEquals("54df94072d5dbf7dc6340cc5", out.getAttribute(jsonPathIdAttrKey), "Transferred flow file did not have the correct result for id attribute");
+        out.assertAttributeNotExists(jsonPathNameAttrKey);
+    }
+
+    @Test
+    void testExtractPath_destinationContent() throws Exception {
         String jsonPathAttrKey = "JsonPath";
 
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
@@ -233,7 +260,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testExtractPath_destinationContent_indefiniteResult() throws Exception {
+    void testExtractPath_destinationContent_indefiniteResult() throws Exception {
         String jsonPathAttrKey = "friends.indefinite.id.list";
 
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
@@ -250,7 +277,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testExtractPath_destinationContent_indefiniteResult_operators() throws Exception {
+    void testExtractPath_destinationContent_indefiniteResult_operators() throws Exception {
         String jsonPathAttrKey = "friends.indefinite.id.list";
 
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
@@ -267,7 +294,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testRouteUnmatched_destinationContent_noMatch() throws Exception {
+    void testRouteUnmatched_destinationContent_noMatch() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_CONTENT);
         testRunner.setProperty("jsonPath", "$[0].nonexistent.key");
@@ -282,7 +309,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testRouteFailure_returnTypeScalar_resultArray() throws Exception {
+    void testRouteFailure_returnTypeScalar_resultArray() throws Exception {
         String jsonPathAttrKey = "friends.indefinite.id.list";
 
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
@@ -300,7 +327,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testNullInput() throws Exception {
+    void testNullInput() {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.RETURN_TYPE, EvaluateJsonPath.RETURN_TYPE_JSON);
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
@@ -311,12 +338,9 @@ public class TestEvaluateJsonPath {
         ProcessSession session = testRunner.getProcessSessionFactory().createSession();
         FlowFile ff = session.create();
 
-        ff = session.write(ff, new OutputStreamCallback() {
-            @Override
-            public void process(OutputStream out) throws IOException {
-                try (OutputStream outputStream = new BufferedOutputStream(out)) {
-                    outputStream.write("{\"stringField\": \"String Value\", \"nullField\": null}".getBytes(StandardCharsets.UTF_8));
-                }
+        ff = session.write(ff, out -> {
+            try (OutputStream outputStream = new BufferedOutputStream(out)) {
+                outputStream.write("{\"stringField\": \"String Value\", \"nullField\": null}".getBytes(StandardCharsets.UTF_8));
             }
         });
 
@@ -338,7 +362,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testNullInput_nullStringRepresentation() throws Exception {
+    void testNullInput_nullStringRepresentation() {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.RETURN_TYPE, EvaluateJsonPath.RETURN_TYPE_JSON);
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
@@ -350,12 +374,9 @@ public class TestEvaluateJsonPath {
         ProcessSession session = testRunner.getProcessSessionFactory().createSession();
         FlowFile ff = session.create();
 
-        ff = session.write(ff, new OutputStreamCallback() {
-            @Override
-            public void process(OutputStream out) throws IOException {
-                try (OutputStream outputStream = new BufferedOutputStream(out)) {
-                    outputStream.write("{\"stringField\": \"String Value\", \"nullField\": null}".getBytes(StandardCharsets.UTF_8));
-                }
+        ff = session.write(ff, out -> {
+            try (OutputStream outputStream = new BufferedOutputStream(out)) {
+                outputStream.write("{\"stringField\": \"String Value\", \"nullField\": null}".getBytes(StandardCharsets.UTF_8));
             }
         });
 
@@ -377,7 +398,7 @@ public class TestEvaluateJsonPath {
     }
 
     @Test
-    public void testHandleAsciiControlCharacters() throws Exception {
+    void testHandleAsciiControlCharacters() throws Exception {
         final TestRunner testRunner = TestRunners.newTestRunner(new EvaluateJsonPath());
         testRunner.setProperty(EvaluateJsonPath.DESTINATION, EvaluateJsonPath.DESTINATION_ATTRIBUTE);
         testRunner.setProperty(EvaluateJsonPath.RETURN_TYPE, EvaluateJsonPath.RETURN_TYPE_JSON);


### PR DESCRIPTION
# Summary

[NIFI-2161](https://issues.apache.org/jira/browse/NIFI-2161) add option to skip attribute output for unmatched JSON path expressions in EvaluateJsonPath

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
