### PR TITLE
NIFI-11019 Convert JUnit4 to JUnit5 - scripting processors (Part 2)

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeJython.java
@@ -22,7 +22,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +30,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestInvokeJython extends BaseScriptTest {
 
@@ -56,8 +57,8 @@ public class TestInvokeJython extends BaseScriptTest {
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
 
         final Collection<ValidationResult> results = ((MockProcessContext) runner.getProcessContext()).validate();
-        Assert.assertEquals(1L, results.size());
-        Assert.assertEquals("Never valid.", results.iterator().next().getExplanation());
+        assertEquals(1L, results.size());
+        assertEquals("Never valid.", results.iterator().next().getExplanation());
     }
 
     /**
@@ -71,8 +72,8 @@ public class TestInvokeJython extends BaseScriptTest {
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_invalid.py");
 
         final Collection<ValidationResult> results = ((MockProcessContext) runner.getProcessContext()).validate();
-        Assert.assertEquals(1L, results.size());
-        Assert.assertEquals("Never valid.", results.iterator().next().getExplanation());
+        assertEquals(1L, results.size());
+        assertEquals("Never valid.", results.iterator().next().getExplanation());
 
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, "target/test/resources/jython/test_update_attribute.py");
         runner.setProperty("for-attributes", "value-1");
@@ -173,7 +174,7 @@ public class TestInvokeJython extends BaseScriptTest {
 
         two.assertAllFlowFilesTransferred("success", 1);
         final List<MockFlowFile> twoResult = two.getFlowFilesForRelationship("success");
-        Assert.assertEquals("test content", new String(twoResult.get(0).toByteArray(), StandardCharsets.UTF_8));
+        assertEquals("test content", new String(twoResult.get(0).toByteArray(), StandardCharsets.UTF_8));
     }
 
     /**

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedFilterRecord.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedFilterRecord.java
@@ -19,8 +19,9 @@ package org.apache.nifi.processors.script;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.MockFlowFile;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestScriptedFilterRecord extends TestScriptedRouterProcessor {
     private static final String SCRIPT = "return record.getValue(\"first\") == 1";
@@ -100,8 +101,8 @@ public class TestScriptedFilterRecord extends TestScriptedRouterProcessor {
     private void thenMatchingFlowFileContains(final Object[]... records) {
         testRunner.assertTransferCount(ScriptedFilterRecord.RELATIONSHIP_SUCCESS, 1);
         final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedFilterRecord.RELATIONSHIP_SUCCESS).get(0);
-        Assert.assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
-        Assert.assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
+        assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
+        assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
 
     }
 

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedPartitionRecord.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedPartitionRecord.java
@@ -19,13 +19,15 @@ package org.apache.nifi.processors.script;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.MockFlowFile;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestScriptedPartitionRecord extends TestScriptedRouterProcessor {
     private static final String PARTITION_ATTRIBUTE = "partition";
@@ -124,18 +126,18 @@ public class TestScriptedPartitionRecord extends TestScriptedRouterProcessor {
     }
 
     private void thenNoPartitionExists() {
-        Assert.assertEquals(0, testRunner.getFlowFilesForRelationship(ScriptedPartitionRecord.RELATIONSHIP_SUCCESS).size());
+        assertEquals(0, testRunner.getFlowFilesForRelationship(ScriptedPartitionRecord.RELATIONSHIP_SUCCESS).size());
     }
 
     private void thenTheFollowingPartitionsExists(final String... partitions) {
         final List<MockFlowFile> outgoingFlowFiles = testRunner.getFlowFilesForRelationship(ScriptedPartitionRecord.RELATIONSHIP_SUCCESS);
 
-        Assert.assertEquals(partitions.length, outgoingFlowFiles.size());
+        assertEquals(partitions.length, outgoingFlowFiles.size());
 
         final Set<String> outgoingPartitions = outgoingFlowFiles.stream().map(ff -> ff.getAttribute(PARTITION_ATTRIBUTE)).collect(Collectors.toSet());
 
         for (final String partition : partitions) {
-            Assert.assertTrue(outgoingPartitions.contains(partition));
+            assertTrue(outgoingPartitions.contains(partition));
         }
     }
 
@@ -153,12 +155,12 @@ public class TestScriptedPartitionRecord extends TestScriptedRouterProcessor {
             }
         }
 
-        Assert.assertEquals(1, outgoingFlowFiles.size());
+        assertEquals(1, outgoingFlowFiles.size());
         final MockFlowFile resultFlowFile = outgoingFlowFiles.iterator().next();
-        Assert.assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
-        Assert.assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
-        Assert.assertEquals(String.valueOf(index), resultFlowFile.getAttribute("fragment.index"));
-        Assert.assertEquals(String.valueOf(count), resultFlowFile.getAttribute("fragment.count"));
+        assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
+        assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
+        assertEquals(String.valueOf(index), resultFlowFile.getAttribute("fragment.index"));
+        assertEquals(String.valueOf(count), resultFlowFile.getAttribute("fragment.count"));
 
 
     }

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedRouterProcessor.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedRouterProcessor.java
@@ -24,10 +24,11 @@ import org.apache.nifi.serialization.record.MockRecordWriter;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 abstract class TestScriptedRouterProcessor {
     private static final String HEADER = "header§";
@@ -37,7 +38,7 @@ abstract class TestScriptedRouterProcessor {
     protected MockRecordWriter recordWriter;
     protected String incomingFlowFileContent;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         testRunner = TestRunners.newTestRunner(givenProcessorType());
 
@@ -77,13 +78,13 @@ abstract class TestScriptedRouterProcessor {
     protected void thenIncomingFlowFileIsRoutedToOriginal() {
         testRunner.assertTransferCount(getOriginalRelationship(), 1);
         testRunner.assertTransferCount(getFailedRelationship(), 0);
-        Assert.assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getOriginalRelationship()).get(0).getContent());
+        assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getOriginalRelationship()).get(0).getContent());
     }
 
     protected void thenIncomingFlowFileIsRoutedToFailed() {
         testRunner.assertTransferCount(getOriginalRelationship(), 0);
         testRunner.assertTransferCount(getFailedRelationship(), 1);
-        Assert.assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getFailedRelationship()).get(0).getContent());
+        assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getFailedRelationship()).get(0).getContent());
     }
 
     /**

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedValidateRecord.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedValidateRecord.java
@@ -19,8 +19,9 @@ package org.apache.nifi.processors.script;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.MockFlowFile;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestScriptedValidateRecord extends TestScriptedRouterProcessor {
     private static final String SCRIPT = "return record.getValue(\"first\") == 1";
@@ -105,15 +106,15 @@ public class TestScriptedValidateRecord extends TestScriptedRouterProcessor {
     private void thenValidFlowFileContains(final Object[]... records) {
         testRunner.assertTransferCount(ScriptedValidateRecord.RELATIONSHIP_VALID, 1);
         final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedValidateRecord.RELATIONSHIP_VALID).get(0);
-        Assert.assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
-        Assert.assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
+        assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
+        assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
     }
 
     private void thenInvalidFlowFileContains(final Object[]... records) {
         testRunner.assertTransferCount(ScriptedValidateRecord.RELATIONSHIP_INVALID, 1);
         final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedValidateRecord.RELATIONSHIP_INVALID).get(0);
-        Assert.assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
-        Assert.assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
+        assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
+        assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
     }
 
     private void thenNoValidFlowFile() {

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/rules/engine/script/ScriptedRulesEngineTest.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/rules/engine/script/ScriptedRulesEngineTest.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class ScriptedRulesEngineTest {

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/rules/handlers/script/ScriptedActionHandlerTest.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/rules/handlers/script/ScriptedActionHandlerTest.java
@@ -45,10 +45,10 @@ import java.util.List;
 import java.util.Map;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11019](https://issues.apache.org/jira/browse/NIFI-11019)
This has junit 4 to junit 5 conversions for some work that was not yet in main when the original effort for this was done.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
