### PR TITLE
NIFI-11027 Remove direct dependency on Joda Time

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -745,11 +745,6 @@ limitations under the License.
                 <version>1.1.3</version>
             </dependency>
             <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.8.2</version>
-            </dependency>
-            <dependency>
                 <groupId>com.yammer.metrics</groupId>
                 <artifactId>metrics-ganglia</artifactId>
                 <version>${yammer.metrics.version}</version>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
@@ -71,11 +71,6 @@
             <artifactId>avro</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/StandardContentViewerController.java
@@ -27,9 +27,6 @@ import org.apache.avro.io.DatumReader;
 import org.apache.nifi.web.ViewableContent.DisplayMode;
 import org.apache.nifi.xml.processing.ProcessingException;
 import org.apache.nifi.xml.processing.transform.StandardTransformProvider;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -43,7 +40,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Set;
 
 public class StandardContentViewerController extends HttpServlet {
@@ -115,17 +111,7 @@ public class StandardContentViewerController extends HttpServlet {
                     final StringBuilder sb = new StringBuilder();
                     sb.append("[");
                     // Use Avro conversions to display logical type values in human readable way.
-                    final GenericData genericData = new GenericData(){
-                        @Override
-                        protected void toString(Object datum, StringBuilder buffer, IdentityHashMap<Object, Object> seenObjects) {
-                            // Since these types are not quoted and produce a malformed JSON string, quote it here.
-                            if (datum instanceof LocalDate || datum instanceof LocalTime || datum instanceof DateTime) {
-                                buffer.append("\"").append(datum).append("\"");
-                                return;
-                            }
-                            super.toString(datum, buffer, seenObjects);
-                        }
-                    };
+                    final GenericData genericData = new GenericData();
                     genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
                     genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
                     genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -171,11 +171,6 @@
                 <version>10.6</version>
             </dependency>
             <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.8.2</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.jms</groupId>
                 <artifactId>javax.jms-api</artifactId>
                 <version>2.0.1</version>


### PR DESCRIPTION
# Summary

[NIFI-11027](https://issues.apache.org/jira/browse/NIFI-11027) Removes direct dependencies on Joda Time, which are no longer necessary following the upgrade of Avro to 1.11.1. Direct references to Joda Time in the Standard Content Viewer were specific to the Avro, and are no longer necessary in the current version of Avro.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
