### PR TITLE
NIFI-11029 Add Standard XML parsing to ExtractCCDAAttributes

### DIFF
--- a/nifi-nar-bundles/nifi-ccda-bundle/nifi-ccda-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-ccda-bundle/nifi-ccda-processors/pom.xml
@@ -36,6 +36,11 @@
             <version>1.20.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-xml-processing</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-ccda-bundle/nifi-ccda-processors/src/main/java/org/apache/nifi/processors/ccda/ExtractCCDAAttributes.java
+++ b/nifi-nar-bundles/nifi-ccda-bundle/nifi-ccda-processors/src/main/java/org/apache/nifi/processors/ccda/ExtractCCDAAttributes.java
@@ -41,6 +41,7 @@ import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -53,6 +54,7 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StopWatch;
+import org.apache.nifi.xml.processing.parsers.StandardDocumentProvider;
 import org.eclipse.emf.common.util.Diagnostic;
 import org.openhealthtools.mdht.uml.cda.CDAPackage;
 import org.openhealthtools.mdht.uml.cda.ClinicalDocument;
@@ -62,7 +64,9 @@ import org.openhealthtools.mdht.uml.cda.hitsp.HITSPPackage;
 import org.openhealthtools.mdht.uml.cda.ihe.IHEPackage;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil.ValidationHandler;
+import org.w3c.dom.Document;
 
+@DeprecationNotice(reason = "Parsing XML elements to FlowFile attributes is not recommend and should be replaced with record-oriented handling")
 @SideEffectFree
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -284,7 +288,11 @@ public class ExtractCCDAAttributes extends AbstractProcessor {
         ClinicalDocument cd = null;
 
         try {
-            cd = CDAUtil.load(inputStream); // load CDA document
+            final StandardDocumentProvider documentProvider = new StandardDocumentProvider();
+            documentProvider.setNamespaceAware(true);
+            final Document document = documentProvider.parse(inputStream);
+
+            cd = CDAUtil.load(document); // load CDA document
             if (!skipValidation && !CDAUtil.validate(cd, new CDAValidationHandler())) { //optional validation
                 getLogger().error("Failed to validate CDA document");
                 throw new ProcessException("Failed to validate CDA document");


### PR DESCRIPTION
# Summary

[NIFI-11029](https://issues.apache.org/jira/browse/NIFI-11029) Adds standard XML parsing to `ExtractCCDAAttributes` using the `nifi-xml-processing` library and includes an additional unit test for invalid documents.

Additional changes include adding the `DeprecationNotice` annotation to `ExtractCCDAAttributes`, recommending that usage of the Processor should be changed to record-oriented handling.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
