### PR TITLE
NIFI-11031: Fix logic error in GenerateRecord for nullPercentage

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
@@ -296,7 +296,7 @@ public class GenerateRecord extends AbstractProcessor {
     }
 
     private Object generateValueFromRecordField(RecordField recordField, Faker faker, int nullPercentage) {
-        if (recordField.isNullable() && faker.number().numberBetween(0, 100) <= nullPercentage) {
+        if (recordField.isNullable() && faker.number().numberBetween(0, 100) < nullPercentage) {
             return null;
         }
         switch (recordField.getDataType().getFieldType()) {


### PR DESCRIPTION
# Summary

[NIFI-11031](https://issues.apache.org/jira/browse/NIFI-11031) This PR changes `<=` to `<` for the calculation of `nullPercentage`, this fixes an error where `null` values can show up in a record where `nullPercentage` is zero.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11031`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11031`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
