### PR TITLE
NIFI-10965 PutGoogleDrive

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
@@ -67,6 +68,7 @@ import org.apache.nifi.proxy.ProxyConfiguration;
 @CapabilityDescription("Fetches files from a Google Drive Folder. Designed to be used in tandem with ListGoogleDrive. " +
     "Please see Additional Details to set up access to Google Drive.")
 @SeeAlso({ListGoogleDrive.class, PutGoogleDrive.class})
+@ReadsAttribute(attribute = ID, description = ID_DESC)
 @WritesAttributes({
         @WritesAttribute(attribute = ID, description = ID_DESC),
         @WritesAttribute(attribute = "filename", description = FILENAME_DESC),
@@ -81,7 +83,8 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
     public static final PropertyDescriptor FILE_ID = new PropertyDescriptor
             .Builder().name("drive-file-id")
             .displayName("File ID")
-            .description("The Drive ID of the File to fetch")
+            .description("The Drive ID of the File to fetch. "
+            + "Please see Additional Details to obtain Drive ID.")
             .required(true)
             .defaultValue("${drive.id}")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -16,9 +16,34 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP_DESC;
+
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
+import com.google.api.services.drive.model.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
@@ -39,26 +64,21 @@ import org.apache.nifi.processors.gcp.ProxyAwareTransportFactory;
 import org.apache.nifi.processors.gcp.util.GoogleUtils;
 import org.apache.nifi.proxy.ProxyConfiguration;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"google", "drive", "storage", "fetch"})
 @CapabilityDescription("Fetches files from a Google Drive Folder. Designed to be used in tandem with ListGoogleDrive. " +
     "For how to setup access to Google Drive please see additional details.")
-@SeeAlso({ListGoogleDrive.class})
+@SeeAlso({ListGoogleDrive.class, PutGoogleDrive.class})
 @WritesAttributes({
-        @WritesAttribute(attribute = FetchGoogleDrive.ERROR_CODE_ATTRIBUTE, description = "The error code returned by Google Drive when the fetch of a file fails"),
-        @WritesAttribute(attribute = FetchGoogleDrive.ERROR_MESSAGE_ATTRIBUTE, description = "The error message returned by Google Drive when the fetch of a file fails")
+        @WritesAttribute(attribute = ID, description = ID_DESC),
+        @WritesAttribute(attribute = FILENAME, description = FILENAME_DESC),
+        @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = MIME_TYPE, description = MIME_TYPE_DESC),
+        @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
+        @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })
 public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTrait {
-    public static final String ERROR_CODE_ATTRIBUTE = "error.code";
-    public static final String ERROR_MESSAGE_ATTRIBUTE = "error.message";
 
     public static final PropertyDescriptor FILE_ID = new PropertyDescriptor
             .Builder().name("drive-file-id")
@@ -73,12 +93,12 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
     public static final Relationship REL_SUCCESS =
             new Relationship.Builder()
                     .name("success")
-                    .description("A flowfile will be routed here for each successfully fetched File.")
+                    .description("A FlowFile will be routed here for each successfully fetched File.")
                     .build();
 
     public static final Relationship REL_FAILURE =
             new Relationship.Builder().name("failure")
-                    .description("A flowfile will be routed here for each File for which fetch was attempted but failed.")
+                    .description("A FlowFile will be routed here for each File for which fetch was attempted but failed.")
                     .build();
 
     private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
@@ -87,7 +107,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
             ProxyConfiguration.createProxyConfigPropertyDescriptor(false, ProxyAwareTransportFactory.PROXY_SPECS)
     ));
 
-    public static final Set<Relationship> relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             REL_SUCCESS,
             REL_FAILURE
     )));
@@ -101,7 +121,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @OnScheduled
@@ -125,9 +145,17 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         String fileId = context.getProperty(FILE_ID).evaluateAttributeExpressions(flowFile).getValue();
 
         FlowFile outFlowFile = flowFile;
+        final long startNanos = System.nanoTime();
         try {
             outFlowFile = fetchFile(fileId, session, outFlowFile);
 
+            File fileMetadata = fetchFileMetadata(fileId);
+            final Map<String, String> attributes = createAttributeMap(fileMetadata);
+            flowFile = session.putAllAttributes(flowFile, attributes);
+
+            final String url = DRIVE_URL + fileMetadata.getId();
+            final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            session.getProvenanceReporter().fetch(flowFile, url, transferMillis);
             session.transfer(outFlowFile, REL_SUCCESS);
         } catch (GoogleJsonResponseException e) {
             handleErrorResponse(session, fileId, flowFile, e);
@@ -136,8 +164,8 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         }
     }
 
-    FlowFile fetchFile(String fileId, ProcessSession session, FlowFile outFlowFile) throws IOException {
-        InputStream driveFileInputStream = driveService
+    private FlowFile fetchFile(String fileId, ProcessSession session, FlowFile outFlowFile) throws IOException {
+        final InputStream driveFileInputStream = driveService
                 .files()
                 .get(fileId)
                 .executeMediaAsInputStream();
@@ -147,20 +175,30 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         return outFlowFile;
     }
 
+    private File fetchFileMetadata(String fileId) throws IOException {
+        return driveService
+                .files()
+                .get(fileId)
+                .setFields("id, name, createdTime, mimeType, size")
+                .execute();
+    }
+
     private void handleErrorResponse(ProcessSession session, String fileId, FlowFile outFlowFile, GoogleJsonResponseException e) {
         getLogger().error("Couldn't fetch file with id '{}'", fileId, e);
 
-        outFlowFile = session.putAttribute(outFlowFile, ERROR_CODE_ATTRIBUTE, "" + e.getStatusCode());
-        outFlowFile = session.putAttribute(outFlowFile, ERROR_MESSAGE_ATTRIBUTE, e.getMessage());
+        outFlowFile = session.putAttribute(outFlowFile, ERROR_CODE, "" + e.getStatusCode());
+        outFlowFile = session.putAttribute(outFlowFile, ERROR_MESSAGE, e.getMessage());
 
+        outFlowFile = session.penalize(outFlowFile);
         session.transfer(outFlowFile, REL_FAILURE);
     }
 
     private void handleUnexpectedError(ProcessSession session, FlowFile flowFile, String fileId, Exception e) {
         getLogger().error("Unexpected error while fetching and processing file with id '{}'", fileId, e);
 
-        flowFile = session.putAttribute(flowFile, ERROR_MESSAGE_ATTRIBUTE, e.getMessage());
+        flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
 
+        flowFile = session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -20,11 +20,9 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_C
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
@@ -71,10 +69,10 @@ import org.apache.nifi.proxy.ProxyConfiguration;
 @SeeAlso({ListGoogleDrive.class, PutGoogleDrive.class})
 @WritesAttributes({
         @WritesAttribute(attribute = ID, description = ID_DESC),
-        @WritesAttribute(attribute = FILENAME, description = FILENAME_DESC),
+        @WritesAttribute(attribute = "filename", description = FILENAME_DESC),
+        @WritesAttribute(attribute = "mime.type", description = MIME_TYPE_DESC),
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
-        @WritesAttribute(attribute = MIME_TYPE, description = MIME_TYPE_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
@@ -16,12 +16,14 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+
 public class GoogleDriveAttributes {
 
     public static final String ID = "drive.id";
     public static final String ID_DESC = "The id of the file";
 
-    public static final String FILENAME = "filename";
+    public static final String FILENAME = CoreAttributes.FILENAME.key();
     public static final String FILENAME_DESC = "The name of the file";
 
     public static final String SIZE = "drive.size";
@@ -32,8 +34,8 @@ public class GoogleDriveAttributes {
             " The reason for this is that the original modified date of a file is preserved when uploaded to Google Drive." +
             " 'Created time' takes the time when the upload occurs. However uploaded files can still be modified later.";
 
-    public static final String MIME_TYPE = "mime.type";
-    public static final String MIME_TYPE_DESC =  "MimeType of the file";
+    public static final String MIME_TYPE = CoreAttributes.MIME_TYPE.key();
+    public static final String MIME_TYPE_DESC =  "The MIME type of the file";
 
     public static final String ERROR_MESSAGE = "error.message";
     public static final String ERROR_MESSAGE_DESC = "The error message returned by Google Drive";

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.drive;
+
+public class GoogleDriveAttributes {
+
+    public static final String ID = "drive.id";
+    public static final String ID_DESC = "The id of the file";
+
+    public static final String FILENAME = "filename";
+    public static final String FILENAME_DESC = "The name of the file";
+
+    public static final String SIZE = "drive.size";
+    public static final String SIZE_DESC = "The size of the file";
+
+    public static final String TIMESTAMP = "drive.timestamp";
+    public static final String TIMESTAMP_DESC =  "The last modified time or created time (whichever is greater) of the file." +
+            " The reason for this is that the original modified date of a file is preserved when uploaded to Google Drive." +
+            " 'Created time' takes the time when the upload occurs. However uploaded files can still be modified later.";
+
+    public static final String MIME_TYPE = "mime.type";
+    public static final String MIME_TYPE_DESC =  "MimeType of the file";
+
+    public static final String ERROR_MESSAGE = "error.message";
+    public static final String ERROR_MESSAGE_DESC = "The error message returned by Google Drive";
+
+    public static final String ERROR_CODE = "error.code";
+    public static final String ERROR_CODE_DESC = "The error code returned by Google Drive";
+
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
@@ -16,6 +16,12 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
+
 import org.apache.nifi.processor.util.list.ListableEntity;
 import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.record.MapRecord;
@@ -30,12 +36,6 @@ import java.util.List;
 import java.util.Map;
 
 public class GoogleDriveFileInfo implements ListableEntity {
-    public static final String ID = "drive.id";
-    public static final String FILENAME = "filename";
-    public static final String SIZE = "drive.size";
-    public static final String TIMESTAMP = "drive.timestamp";
-    public static final String MIME_TYPE = "mime.type";
-
     private  static final RecordSchema SCHEMA;
 
     static {

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFlowFileAttribute.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFlowFileAttribute.java
@@ -22,17 +22,17 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public enum GoogleDriveFlowFileAttribute {
-    ID(GoogleDriveFileInfo.ID, GoogleDriveFileInfo::getId),
-    FILE_NAME(GoogleDriveFileInfo.FILENAME, GoogleDriveFileInfo::getName),
-    SIZE(GoogleDriveFileInfo.SIZE, fileInfo -> Optional.ofNullable(fileInfo.getSize())
+    ID(GoogleDriveAttributes.ID, GoogleDriveFileInfo::getId),
+    FILENAME(GoogleDriveAttributes.FILENAME, GoogleDriveFileInfo::getName),
+    SIZE(GoogleDriveAttributes.SIZE, fileInfo -> Optional.ofNullable(fileInfo.getSize())
             .map(String::valueOf)
             .orElse(null)
     ),
-    TIME_STAMP(GoogleDriveFileInfo.TIMESTAMP, fileInfo -> Optional.ofNullable(fileInfo.getTimestamp())
+    TIMESTAMP(GoogleDriveAttributes.TIMESTAMP, fileInfo -> Optional.ofNullable(fileInfo.getTimestamp())
             .map(String::valueOf)
             .orElse(null)
     ),
-    MIME_TYPE(GoogleDriveFileInfo.MIME_TYPE, GoogleDriveFileInfo::getMimeType);
+    MIME_TYPE(GoogleDriveAttributes.MIME_TYPE, GoogleDriveFileInfo::getMimeType);
 
     private final String name;
     private final Function<GoogleDriveFileInfo, String> fromFileInfo;

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveTrait.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveTrait.java
@@ -20,8 +20,11 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.model.File;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.nifi.gcp.credentials.service.GCPCredentialsService;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.gcp.util.GoogleUtils;
@@ -30,6 +33,9 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public interface GoogleDriveTrait {
+
+    String DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+    String DRIVE_URL = "https://drive.google.com/open?id=" ;
     String APPLICATION_NAME = "NiFi";
 
     JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
@@ -65,5 +71,15 @@ public interface GoogleDriveTrait {
                 .asControllerService(GCPCredentialsService.class);
 
         return gcpCredentialsService.getGoogleCredentials();
+    }
+
+    default Map<String, String> createAttributeMap(File file) {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(GoogleDriveAttributes.ID, file.getId());
+        attributes.put(GoogleDriveAttributes.FILENAME, file.getName());
+        attributes.put(GoogleDriveAttributes.MIME_TYPE, file.getMimeType());
+        attributes.put(GoogleDriveAttributes.TIMESTAMP, String.valueOf(file.getCreatedTime()));
+        attributes.put(GoogleDriveAttributes.SIZE, String.valueOf(file.getSize()));
+        return attributes;
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -85,7 +85,7 @@ import java.util.concurrent.TimeUnit;
         "Or - in case the 'Record Writer' property is set - the entire result is written as records to a single flowfile. " +
         "This Processor is designed to run on Primary Node only in a cluster. If the primary node changes, the new Primary Node will pick up where the " +
         "previous node left off without duplicating all of the data. " +
-        "For how to setup access to Google Drive please see additional details.")
+        "Please see Additional Details to set up access to Google Drive.")
 @SeeAlso({FetchGoogleDrive.class, PutGoogleDrive.class})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @WritesAttributes({
@@ -104,7 +104,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             .name("folder-id")
             .displayName("Folder ID")
             .description("The ID of the folder from which to pull list of files." +
-                    " For how to setup access to Google Drive and obtain Folder ID please see additional details." +
+                    " Please see Additional Details to set up access to Google Drive and obtain Folder ID." +
                     " WARNING: Unauthorized access to the folder is treated as if the folder was empty." +
                     " This results in the processor not creating outgoing FlowFiles. No additional error message is provided.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -16,11 +16,9 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
@@ -33,6 +31,21 @@ import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.FileList;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.PrimaryNodeOnly;
@@ -61,22 +74,6 @@ import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.serialization.record.RecordSchema;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
 @PrimaryNodeOnly
 @TriggerSerially
 @Tags({"google", "drive", "storage"})
@@ -90,10 +87,10 @@ import java.util.concurrent.TimeUnit;
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @WritesAttributes({
         @WritesAttribute(attribute = ID, description = ID_DESC),
-        @WritesAttribute(attribute = FILENAME, description = FILENAME_DESC),
+        @WritesAttribute(attribute = "filename", description = FILENAME_DESC),
+        @WritesAttribute(attribute = "mime.type", description = MIME_TYPE_DESC),
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
-        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
-        @WritesAttribute(attribute = MIME_TYPE, description = MIME_TYPE_DESC)})
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already." +
         " What exactly needs to be stored depends on the 'Listing Strategy'." +
         " State is stored across the cluster so that this Processor can be run on Primary Node only and if a new Primary Node is selected, the new node can pick up" +

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -16,6 +16,17 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP_DESC;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
@@ -75,15 +86,14 @@ import java.util.concurrent.TimeUnit;
         "This Processor is designed to run on Primary Node only in a cluster. If the primary node changes, the new Primary Node will pick up where the " +
         "previous node left off without duplicating all of the data. " +
         "For how to setup access to Google Drive please see additional details.")
-@SeeAlso({FetchGoogleDrive.class})
+@SeeAlso({FetchGoogleDrive.class, PutGoogleDrive.class})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
-@WritesAttributes({@WritesAttribute(attribute = GoogleDriveFileInfo.ID, description = "The id of the file"),
-        @WritesAttribute(attribute = GoogleDriveFileInfo.FILENAME, description = "The name of the file"),
-        @WritesAttribute(attribute = GoogleDriveFileInfo.SIZE, description = "The size of the file"),
-        @WritesAttribute(attribute = GoogleDriveFileInfo.TIMESTAMP, description = "The last modified time or created time (whichever is greater) of the file." +
-                " The reason for this is that the original modified date of a file is preserved when uploaded to Google Drive." +
-                " 'Created time' takes the time when the upload occurs. However uploaded files can still be modified later."),
-        @WritesAttribute(attribute = GoogleDriveFileInfo.MIME_TYPE, description = "MimeType of the file")})
+@WritesAttributes({
+        @WritesAttribute(attribute = ID, description = ID_DESC),
+        @WritesAttribute(attribute = FILENAME, description = FILENAME_DESC),
+        @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = MIME_TYPE, description = MIME_TYPE_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already." +
         " What exactly needs to be stored depends on the 'Listing Strategy'." +
         " State is stored across the cluster so that this Processor can be run on Primary Node only and if a new Primary Node is selected, the new node can pick up" +

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.drive;
+
+/*
+ * This processor uploads objects to Google Drive.
+ */
+
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP_DESC;
+import static org.apache.nifi.processors.gcp.util.GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.DriveScopes;
+import com.google.api.services.drive.model.File;
+import com.google.api.services.drive.model.FileList;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.gcp.ProxyAwareTransportFactory;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.json.JSONObject;
+
+@SeeAlso({ListGoogleDrive.class, FetchGoogleDrive.class})
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@Tags({"google", "drive", "storage", "put"})
+@CapabilityDescription("Puts content to a Google Drive Folder.")
+@ReadsAttribute(attribute = "filename", description = "Uses the FlowFile's filename as the filename for the Google Drive object.")
+@WritesAttributes({
+        @WritesAttribute(attribute = ID, description = ID_DESC),
+        @WritesAttribute(attribute = FILENAME, description = FILENAME_DESC),
+        @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = MIME_TYPE, description = MIME_TYPE_DESC),
+        @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
+        @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)})
+public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrait {
+
+    public static final PropertyDescriptor FOLDER_ID = new PropertyDescriptor.Builder()
+            .name("folder-id")
+            .displayName("Folder ID")
+            .description("The ID of the folder to upload files to. In case neither 'Folder ID' nor 'Folder Name' is specified, file is uploaded to the folder " +
+                    " defined by 'Base Folder ID'." +
+                    " For how to setup access to Google Drive and obtain Folder ID please see additional details.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor FOLDER_NAME = new PropertyDescriptor.Builder()
+            .name("folder-name")
+            .displayName("Folder Name")
+            .description("The name (path) of the folder to upload files to. In case 'Folder ID' is also defined, the ID will be used to identify the folder.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor BASE_FOLDER_ID = new PropertyDescriptor.Builder()
+            .name("base-folder-id")
+            .displayName("Base Folder ID")
+            .description("The ID of the shared folder. In case neither 'Folder ID' nor 'Folder Name' is specified, file is uploaded to this folder." +
+                    " For how to setup access to Google Drive and obtain Folder ID please see additional details.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor FILE_NAME = new PropertyDescriptor
+            .Builder().name("file-name")
+            .displayName("Filename")
+            .description("The name of the file to upload to the specified Google Drive folder.")
+            .required(true)
+            .defaultValue("${filename}")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor CREATE_FOLDER = new PropertyDescriptor.Builder()
+            .name("create-folder")
+            .displayName("Create Folder")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .description("Specifies whether to check if the folder exists and to automatically create it if it does not. " +
+                    "Permission to list folders is required. ")
+            .build();
+
+    public static final PropertyDescriptor CHUNKED_UPLOAD_SIZE = new PropertyDescriptor.Builder()
+            .name("chunked-upload-size")
+            .displayName("Chunked Upload Size")
+            .description("Defines the size of a chunk. Used when a FlowFile's size exceeds 'Chunked Upload Threshold' and content is uploaded in smaller chunks. "
+                    + "It is recommended to specify chunked upload size smaller than 'Chunked Upload Threshold'.")
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .defaultValue("10 MB")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor CHUNKED_UPLOAD_THRESHOLD = new PropertyDescriptor.Builder()
+            .name("chunked-upload-threshold")
+            .displayName("Chunked Upload Threshold")
+            .description("The maximum size of the content which is uploaded at once. FlowFiles larger than this threshold are uploaded in chunks.")
+            .defaultValue("100 MB")
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .required(false)
+            .build();
+
+    public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(asList(
+            GCP_CREDENTIALS_PROVIDER_SERVICE,
+            BASE_FOLDER_ID,
+            FOLDER_ID,
+            FOLDER_NAME,
+            FILE_NAME,
+            CREATE_FOLDER,
+            CHUNKED_UPLOAD_THRESHOLD,
+            CHUNKED_UPLOAD_SIZE,
+            ProxyConfiguration.createProxyConfigPropertyDescriptor(false, ProxyAwareTransportFactory.PROXY_SPECS)
+    ));
+
+    public static final Relationship REL_SUCCESS =
+            new Relationship.Builder()
+                    .name("success")
+                    .description("Files that have been successfully written to Google Drive are transferred to this relationship.")
+                    .build();
+
+    public static final Relationship REL_FAILURE =
+            new Relationship.Builder()
+                    .name("failure")
+                    .description("Files that could not be written to Google Drive for some reason are transferred to this relationship.")
+                    .build();
+
+    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(asList(
+            REL_SUCCESS,
+            REL_FAILURE
+    )));
+
+    public static final String MULTIPART_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart";
+
+    private volatile Drive driveService;
+    private Future<File> uploadedFileFuture;
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return RELATIONSHIPS;
+    }
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        String folderId = null;
+        final String filename = context.getProperty(FILE_NAME).evaluateAttributeExpressions(flowFile).getValue();
+        final String mimeType = flowFile.getAttribute(CoreAttributes.MIME_TYPE.key());
+        final String folderName = context.getProperty(FOLDER_NAME).evaluateAttributeExpressions(flowFile).getValue();
+
+        try {
+            folderId = createFoldersAndGetParentId(context, flowFile);
+            final long startNanos = System.nanoTime();
+            final File uploadedFile;
+            final ExecutorService uploadExecutor = Executors.newSingleThreadExecutor();
+            final long size = flowFile.getSize();
+
+            try (final InputStream rawIn = session.read(flowFile)) {
+                final InputStreamContent mediaContent = new InputStreamContent(mimeType, new BufferedInputStream(rawIn));
+                mediaContent.setLength(size);
+
+                final long chunkUploadThreshold = context.getProperty(CHUNKED_UPLOAD_THRESHOLD)
+                        .asDataSize(DataUnit.B)
+                        .longValue();
+
+                final int uploadChunkSize = context.getProperty(CHUNKED_UPLOAD_SIZE)
+                        .asDataSize(DataUnit.B)
+                        .intValue();
+
+                final String parentFolderId = folderId;
+
+                uploadedFileFuture = uploadExecutor.submit(() -> {
+                    if (size > chunkUploadThreshold) {
+                        return uploadFileInChunks(parentFolderId, filename, uploadChunkSize, mediaContent);
+                    } else {
+                        final File fileMetadata = createMetadata(filename, parentFolderId);
+                        return driveService.files()
+                                .create(fileMetadata, mediaContent)
+                                .setFields("id, name, createdTime, mimeType, size")
+                                .execute();
+                    }
+                });
+                uploadedFile = uploadedFileFuture.get();
+
+            } finally {
+                uploadExecutor.shutdown();
+            }
+
+            final Map<String, String> attributes = createAttributeMap(uploadedFile);
+            final String url = DRIVE_URL + uploadedFile.getId();
+            flowFile = session.putAllAttributes(flowFile, attributes);
+            final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            session.getProvenanceReporter().send(flowFile, url, transferMillis);
+            session.transfer(flowFile, REL_SUCCESS);
+        } catch (GoogleJsonResponseException e) {
+            getLogger().error("Exception occurred while uploading file '{}' to Google Drive folder '{}'", filename,
+                    getFolder(folderId, folderName), e);
+            handleExpectedError(session, flowFile, e);
+        } catch (Exception e) {
+            getLogger().error("Exception occurred while uploading file '{}' to Google Drive folder '{}'", filename,
+                    getFolder(folderId, folderName), e);
+
+            if (e.getCause() != null && e.getCause() instanceof GoogleJsonResponseException) {
+                handleExpectedError(session, flowFile, (GoogleJsonResponseException) e.getCause());
+            } else {
+                handleUnexpectedError(session, flowFile, e);
+            }
+        }
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) throws IOException {
+        final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
+
+        final HttpTransport httpTransport = new ProxyAwareTransportFactory(proxyConfiguration).create();
+
+        driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE, DriveScopes.DRIVE_METADATA);
+    }
+
+    @OnUnscheduled
+    public void shutdown() {
+        if (uploadedFileFuture != null) {
+            uploadedFileFuture.cancel(true);
+        }
+    }
+
+    private String getFolder(String folderId, String folderName) {
+        return folderId == null ? folderName : folderId;
+    }
+
+    private File uploadFileInChunks(final String folderId, final String filename, final int chunkSize, final InputStreamContent mediaContent) throws IOException {
+        final File fileMetadata = createMetadata(filename, folderId);
+
+        final HttpResponse response = driveService.files()
+                .create(fileMetadata, mediaContent)
+                .setFields("id, name, createdTime, mimeType, size")
+                .getMediaHttpUploader()
+                .setChunkSize(chunkSize)
+                .setDirectUploadEnabled(false)
+                .upload(new GenericUrl(MULTIPART_UPLOAD_URL));
+
+        if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+            fileMetadata.setId(getUploadedFileId(response.getContent()));
+            fileMetadata.setMimeType(mediaContent.getType());
+            fileMetadata.setCreatedTime(new DateTime(System.currentTimeMillis()));
+            fileMetadata.setSize(mediaContent.getLength());
+            return fileMetadata;
+        } else {
+            throw new ProcessException(format("Upload of file '%s' to folder '%s' failed, HTTP error code: %d", filename, folderId, response.getStatusCode()));
+        }
+    }
+
+    private String getUploadedFileId(final InputStream content) {
+        final String contentAsString = new BufferedReader(new InputStreamReader(content, UTF_8))
+                .lines()
+                .collect(joining("\n"));
+        return new JSONObject(contentAsString).getString("id");
+    }
+
+    private File handleFolderNames(String folderName, String parentFolderId, boolean createFolder) throws IOException {
+        int index = folderName.indexOf("/");
+
+        if (index > 0 && index < folderName.length() - 1) {
+            String mainFolderName = folderName.substring(0, index);
+            String subFolders = folderName.substring(index + 1);
+            final File mainFolder = getOrCreateFolder(mainFolderName, parentFolderId, createFolder);
+            return handleFolderNames(subFolders, mainFolder.getId(), createFolder);
+        } else {
+            return getOrCreateFolder(folderName, parentFolderId, createFolder);
+        }
+    }
+
+    private File getOrCreateFolder(String folderName, String parentFolderId, boolean createFolder) throws IOException {
+        final Optional<File> existingFolder = checkFolderExistence(folderName, parentFolderId);
+
+        if (existingFolder.isPresent()) {
+            return existingFolder.get();
+        }
+
+        if (createFolder) {
+            getLogger().debug("Create folder " + folderName + " parent id: " + parentFolderId);
+            final File folderMetadata = createMetadata(folderName, parentFolderId);
+            folderMetadata.setMimeType(DRIVE_FOLDER_MIME_TYPE);
+
+            return driveService.files()
+                    .create(folderMetadata)
+                    .setFields("id, parents")
+                    .execute();
+        } else {
+            throw new ProcessException(format("The specified (sub)folder '%s' does not exists and '%s' is false.", folderName, CREATE_FOLDER.getDisplayName()));
+        }
+    }
+
+    private File createMetadata(final String name, final String parentId) {
+        final File metadata = new File();
+        metadata.setName(name);
+        metadata.setParents(singletonList(parentId));
+        return metadata;
+    }
+
+    private String createFoldersAndGetParentId(final ProcessContext context, FlowFile flowFile) throws IOException {
+        String folderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions(flowFile).getValue();
+        String folderName = context.getProperty(FOLDER_NAME).evaluateAttributeExpressions(flowFile).getValue();
+        final String baseFolderId = context.getProperty(BASE_FOLDER_ID).evaluateAttributeExpressions(flowFile).getValue();
+        final boolean createFolder = context.getProperty(CREATE_FOLDER).asBoolean();
+
+        if (folderId == null && folderName == null) {
+            getLogger().warn("Neither {} nor {} was defined, file will be uploaded to base folder", FOLDER_ID.getDisplayName(), FOLDER_NAME.getDisplayName());
+            return baseFolderId;
+        }
+
+        if (folderId == null) {
+            if ("/".equals(folderName)) {
+                return baseFolderId;
+            }
+
+            if (folderName.startsWith("/")) {
+                folderName = folderName.substring(1);
+            }
+
+            return handleFolderNames(folderName, baseFolderId, createFolder).getId();
+        }
+
+        return folderId;
+    }
+
+    private Optional<File> checkFolderExistence(String folderName, String parentId) throws IOException {
+        final FileList result = driveService.files()
+                .list()
+                .setQ(format("mimeType='%s' and ('%s' in parents)", DRIVE_FOLDER_MIME_TYPE, parentId))
+                .setFields("files(name, id)")
+                .execute();
+
+        return result.getFiles().stream()
+                .filter(file -> file.getName().equals(folderName))
+                .findFirst();
+    }
+
+    private void handleUnexpectedError(final ProcessSession session, FlowFile flowFile, final Exception e) {
+        flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_MESSAGE, e.getMessage());
+        flowFile = session.penalize(flowFile);
+        session.transfer(flowFile, REL_FAILURE);
+    }
+
+    private void handleExpectedError(final ProcessSession session, FlowFile flowFile, final GoogleJsonResponseException e) {
+        flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_MESSAGE, e.getMessage());
+        flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_CODE, valueOf(e.getStatusCode()));
+        flowFile = session.penalize(flowFile);
+        session.transfer(flowFile, REL_FAILURE);
+    }
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -16,16 +16,13 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
-/*
- * This processor uploads objects to Google Drive.
- */
-
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
+import static org.apache.nifi.processor.util.StandardValidators.DATA_SIZE_VALIDATOR;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
@@ -43,6 +40,7 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTA
 import static org.apache.nifi.processors.gcp.util.GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.googleapis.media.MediaHttpUploader;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
@@ -66,10 +64,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
@@ -79,8 +75,9 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -111,40 +108,32 @@ import org.json.JSONObject;
 public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrait {
 
     public static final String IGNORE_RESOLUTION = "ignore";
-    public static final String OVERWRITE_RESOLUTION = "overwrite";
+    public static final String REPLACE_RESOLUTION = "replace";
     public static final String FAIL_RESOLUTION = "fail";
+    public static final int MIN_ALLOWED_CHUNK_SIZE_IN_BYTES = MediaHttpUploader.MINIMUM_CHUNK_SIZE;
+    public static final int MAX_ALLOWED_CHUNK_SIZE_IN_BYTES = 1024 * 1024 * 1024;
 
     public static final PropertyDescriptor FOLDER_ID = new PropertyDescriptor.Builder()
             .name("folder-id")
             .displayName("Folder ID")
-            .description("The ID of the folder to upload files to. In case neither 'Folder ID' nor 'Folder Name' is specified, file is uploaded to the folder " +
-                    " defined by 'Base Folder ID'." +
-                    " For how to setup access to Google Drive and obtain Folder ID please see additional details.")
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .build();
-
-    public static final PropertyDescriptor FOLDER_NAME = new PropertyDescriptor.Builder()
-            .name("folder-name")
-            .displayName("Folder Name")
-            .description("The name (path) of the folder to upload files to. In case 'Folder ID' is also defined, the ID will be used to identify the folder.")
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .required(false)
-            .build();
-
-    public static final PropertyDescriptor BASE_FOLDER_ID = new PropertyDescriptor.Builder()
-            .name("base-folder-id")
-            .displayName("Base Folder ID")
-            .description("The ID of the shared folder. In case neither 'Folder ID' nor 'Folder Name' is specified, file is uploaded to this folder." +
-                    " For how to setup access to Google Drive and obtain Folder ID please see additional details.")
+            .description("The ID of the shared folder. " +
+                    " Please see Additional Details to set up access to Google Drive and obtain Folder ID.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(true)
             .build();
 
-    public static final PropertyDescriptor FILE_NAME = new PropertyDescriptor
-            .Builder()
+    public static final PropertyDescriptor SUBFOLDER_NAME = new PropertyDescriptor.Builder()
+            .name("subfolder-name")
+            .displayName("Subfolder Name")
+            .description("The name (path) of the subfolder where files are uploaded. The subfolder name is relative to the shared folder specified by 'Folder ID'."
+            + " Example: subFolder, subFolder1/subfolder2")
+            .addValidator(StandardValidators.createRegexMatchingValidator(Pattern.compile("^(?!/).+")))
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor FILE_NAME = new PropertyDescriptor.Builder()
             .name("file-name")
             .displayName("Filename")
             .description("The name of the file to upload to the specified Google Drive folder.")
@@ -154,15 +143,16 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    public static final PropertyDescriptor CREATE_FOLDER = new PropertyDescriptor.Builder()
-            .name("create-folder")
-            .displayName("Create Folder")
+    public static final PropertyDescriptor CREATE_SUBFOLDER = new PropertyDescriptor.Builder()
+            .name("create-subfolder")
+            .displayName("Create Subfolder")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(true)
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .allowableValues("true", "false")
             .defaultValue("false")
-            .description("Specifies whether to check if the folder exists and to automatically create it if it does not. " +
+            .dependsOn(SUBFOLDER_NAME)
+            .description("Specifies whether to automatically create the subfolder specified by 'Folder Name' if it does not exist. " +
                     "Permission to list folders is required. ")
             .build();
 
@@ -172,15 +162,16 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             .description("Indicates what should happen when a file with the same name already exists in the specified Google Drive folder.")
             .required(true)
             .defaultValue(FAIL_RESOLUTION)
-            .allowableValues(FAIL_RESOLUTION, IGNORE_RESOLUTION, OVERWRITE_RESOLUTION)
+            .allowableValues(FAIL_RESOLUTION, IGNORE_RESOLUTION, REPLACE_RESOLUTION)
             .build();
 
     public static final PropertyDescriptor CHUNKED_UPLOAD_SIZE = new PropertyDescriptor.Builder()
             .name("chunked-upload-size")
             .displayName("Chunked Upload Size")
             .description("Defines the size of a chunk. Used when a FlowFile's size exceeds 'Chunked Upload Threshold' and content is uploaded in smaller chunks. "
-                    + "It is recommended to specify chunked upload size smaller than 'Chunked Upload Threshold'.")
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+                    + "It is recommended to specify chunked upload size smaller than 'Chunked Upload Threshold'. "
+                    + "Minimum allowed chunk size is 256 KB, maximum allowed chunk size is 1 GB. ")
+            .addValidator(createChunkSizeValidator())
             .defaultValue("10 MB")
             .required(false)
             .build();
@@ -190,18 +181,17 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             .displayName("Chunked Upload Threshold")
             .description("The maximum size of the content which is uploaded at once. FlowFiles larger than this threshold are uploaded in chunks.")
             .defaultValue("100 MB")
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .addValidator(DATA_SIZE_VALIDATOR)
             .required(false)
             .build();
 
     public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(asList(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
-            BASE_FOLDER_ID,
             FOLDER_ID,
-            FOLDER_NAME,
+            SUBFOLDER_NAME,
+            CREATE_SUBFOLDER,
             FILE_NAME,
             CONFLICT_RESOLUTION,
-            CREATE_FOLDER,
             CHUNKED_UPLOAD_THRESHOLD,
             CHUNKED_UPLOAD_SIZE,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(false, ProxyAwareTransportFactory.PROXY_SPECS)
@@ -227,7 +217,6 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
     public static final String MULTIPART_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart";
 
     private volatile Drive driveService;
-    private Future<File> uploadedFileFuture;
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -246,15 +235,16 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             return;
         }
 
-        String folderId = null;
+        String folderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions(flowFile).getValue();
+        final String subfolderName = context.getProperty(SUBFOLDER_NAME).evaluateAttributeExpressions(flowFile).getValue();
+        final boolean createFolder = context.getProperty(CREATE_SUBFOLDER).asBoolean();
         final String filename = context.getProperty(FILE_NAME).evaluateAttributeExpressions(flowFile).getValue();
         final String mimeType = flowFile.getAttribute(CoreAttributes.MIME_TYPE.key());
-        final String folderName = context.getProperty(FOLDER_NAME).evaluateAttributeExpressions(flowFile).getValue();
 
         try {
-            folderId = createFoldersAndGetParentId(context, flowFile);
+            folderId = subfolderName != null ? getOrCreateParentSubfolder(subfolderName, folderId, createFolder).getId() : folderId;
+
             final long startNanos = System.nanoTime();
-            final ExecutorService uploadExecutor = Executors.newSingleThreadExecutor();
             final long size = flowFile.getSize();
 
             final long chunkUploadThreshold = context.getProperty(CHUNKED_UPLOAD_THRESHOLD)
@@ -267,18 +257,18 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
 
             final String conflictResolution = context.getProperty(CONFLICT_RESOLUTION).getValue();
 
-            Optional<File> alreadyExistingFile = checkFileExistence(filename, folderId);
+            final Optional<File> alreadyExistingFile = checkFileExistence(filename, folderId);
             final File fileMetadata = alreadyExistingFile.isPresent() ? alreadyExistingFile.get() : createMetadata(filename, folderId);
 
             if (alreadyExistingFile.isPresent() && FAIL_RESOLUTION.equals(conflictResolution)) {
-                getLogger().error("File '{}' already exists in folder '{}', conflict resolution is '{}' ", filename, folderId, FAIL_RESOLUTION);
+                getLogger().error("File '{}' already exists in {} folder, conflict resolution is '{}'", filename, getFolderName(subfolderName), FAIL_RESOLUTION);
                 flowFile = addAttributes(alreadyExistingFile.get(), flowFile, session);
                 session.transfer(flowFile, REL_FAILURE);
                 return;
             }
 
             if (alreadyExistingFile.isPresent() && IGNORE_RESOLUTION.equals(conflictResolution)) {
-                getLogger().info("File '{}' already exists in folder '{}', conflict resolution is '{}' ", filename, folderId, IGNORE_RESOLUTION);
+                getLogger().info("File '{}' already exists in {} folder, conflict resolution is '{}'", filename,  getFolderName(subfolderName), IGNORE_RESOLUTION);
                 flowFile = addAttributes(alreadyExistingFile.get(), flowFile, session);
                 session.transfer(flowFile, REL_SUCCESS);
                 return;
@@ -286,23 +276,17 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
 
             final File uploadedFile;
 
-            try (final InputStream rawIn = session.read(flowFile)) {
-                final InputStreamContent mediaContent = new InputStreamContent(mimeType, new BufferedInputStream(rawIn));
+            try (final InputStream rawIn = session.read(flowFile); final BufferedInputStream bufferedInputStream = new BufferedInputStream(rawIn)) {
+                final InputStreamContent mediaContent = new InputStreamContent(mimeType, bufferedInputStream);
                 mediaContent.setLength(size);
 
-                uploadedFileFuture = uploadExecutor.submit(() -> {
-                    final DriveRequest<File> driveRequest = createDriveRequest(fileMetadata, mediaContent);
+                final DriveRequest<File> driveRequest = createDriveRequest(fileMetadata, mediaContent);
 
-                    if (size > chunkUploadThreshold) {
-                        return uploadFileInChunks(driveRequest, fileMetadata, uploadChunkSize, mediaContent);
-                    } else {
-                        return driveRequest.execute();
-                    }
-                });
-                uploadedFile = uploadedFileFuture.get();
-
-            } finally {
-                uploadExecutor.shutdown();
+                if (size > chunkUploadThreshold) {
+                    uploadedFile = uploadFileInChunks(driveRequest, fileMetadata, uploadChunkSize, mediaContent);
+                } else {
+                    uploadedFile = driveRequest.execute();
+                }
             }
 
             if (uploadedFile != null) {
@@ -314,12 +298,12 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             }
             session.transfer(flowFile, REL_SUCCESS);
         } catch (GoogleJsonResponseException e) {
-            getLogger().error("Exception occurred while uploading file '{}' to Google Drive folder '{}'", filename,
-                    getFolder(folderId, folderName), e);
+            getLogger().error("Exception occurred while uploading file '{}' to {} Google Drive folder", filename,
+                    getFolderName(subfolderName), e);
             handleExpectedError(session, flowFile, e);
         } catch (Exception e) {
-            getLogger().error("Exception occurred while uploading file '{}' to Google Drive folder '{}'", filename,
-                    getFolder(folderId, folderName), e);
+            getLogger().error("Exception occurred while uploading file '{}' to {} Google Drive folder", filename,
+                    getFolderName(subfolderName), e);
 
             if (e.getCause() != null && e.getCause() instanceof GoogleJsonResponseException) {
                 handleExpectedError(session, flowFile, (GoogleJsonResponseException) e.getCause());
@@ -338,13 +322,6 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
         driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE, DriveScopes.DRIVE_METADATA);
     }
 
-    @OnUnscheduled
-    public void shutdown() {
-        if (uploadedFileFuture != null) {
-            uploadedFileFuture.cancel(true);
-        }
-    }
-
     private FlowFile addAttributes(File file, FlowFile flowFile, ProcessSession session) {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(ID, file.getId());
@@ -352,8 +329,8 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
         return session.putAllAttributes(flowFile, attributes);
     }
 
-    private String getFolder(String folderId, String folderName) {
-        return folderId == null ? folderName : folderId;
+    private String getFolderName(String subFolderName) {
+        return subFolderName == null ? "shared" : format("'%s'", subFolderName);
     }
 
     private DriveRequest<File> createDriveRequest(File fileMetadata, final InputStreamContent mediaContent) throws IOException {
@@ -393,17 +370,21 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
         return new JSONObject(contentAsString).getString("id");
     }
 
-    private File handleFolderNames(String folderName, String parentFolderId, boolean createFolder) throws IOException {
-        int index = folderName.indexOf("/");
+    private File getOrCreateParentSubfolder(String folderName, String parentFolderId, boolean createFolder) throws IOException {
+        final int indexOfPathSeparator = folderName.indexOf("/");
 
-        if (index > 0 && index < folderName.length() - 1) {
-            String mainFolderName = folderName.substring(0, index);
-            String subFolders = folderName.substring(index + 1);
+        if (isMultiLevelFolder(indexOfPathSeparator, folderName)) {
+            final String mainFolderName = folderName.substring(0, indexOfPathSeparator);
+            final String subFolders = folderName.substring(indexOfPathSeparator + 1);
             final File mainFolder = getOrCreateFolder(mainFolderName, parentFolderId, createFolder);
-            return handleFolderNames(subFolders, mainFolder.getId(), createFolder);
+            return getOrCreateParentSubfolder(subFolders, mainFolder.getId(), createFolder);
         } else {
             return getOrCreateFolder(folderName, parentFolderId, createFolder);
         }
+    }
+
+    private boolean isMultiLevelFolder(int indexOfPathSeparator, String folderName) {
+        return indexOfPathSeparator > 0 && indexOfPathSeparator < folderName.length() - 1;
     }
 
     private File getOrCreateFolder(String folderName, String parentFolderId, boolean createFolder) throws IOException {
@@ -423,7 +404,7 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
                     .setFields("id, parents")
                     .execute();
         } else {
-            throw new ProcessException(format("The specified (sub)folder '%s' does not exists and '%s' is false.", folderName, CREATE_FOLDER.getDisplayName()));
+            throw new ProcessException(format("The specified subfolder '%s' does not exist and '%s' is false.", folderName, CREATE_SUBFOLDER.getDisplayName()));
         }
     }
 
@@ -432,32 +413,6 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
         metadata.setName(name);
         metadata.setParents(singletonList(parentId));
         return metadata;
-    }
-
-    private String createFoldersAndGetParentId(final ProcessContext context, FlowFile flowFile) throws IOException {
-        String folderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions(flowFile).getValue();
-        String folderName = context.getProperty(FOLDER_NAME).evaluateAttributeExpressions(flowFile).getValue();
-        final String baseFolderId = context.getProperty(BASE_FOLDER_ID).evaluateAttributeExpressions(flowFile).getValue();
-        final boolean createFolder = context.getProperty(CREATE_FOLDER).asBoolean();
-
-        if (folderId == null && folderName == null) {
-            getLogger().warn("Neither {} nor {} was defined, file will be uploaded to base folder", FOLDER_ID.getDisplayName(), FOLDER_NAME.getDisplayName());
-            return baseFolderId;
-        }
-
-        if (folderId == null) {
-            if ("/".equals(folderName)) {
-                return baseFolderId;
-            }
-
-            if (folderName.startsWith("/")) {
-                folderName = folderName.substring(1);
-            }
-
-            return handleFolderNames(folderName, baseFolderId, createFolder).getId();
-        }
-
-        return folderId;
     }
 
     private Optional<File> checkFolderExistence(String folderName, String parentId) throws IOException {
@@ -491,5 +446,32 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
         flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_CODE, valueOf(e.getStatusCode()));
         flowFile = session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
+    }
+
+    private static Validator createChunkSizeValidator() {
+        return (subject, input, context) -> {
+            final ValidationResult vr = StandardValidators.createDataSizeBoundsValidator(MIN_ALLOWED_CHUNK_SIZE_IN_BYTES, MAX_ALLOWED_CHUNK_SIZE_IN_BYTES)
+                    .validate(subject, input, context);
+            if (!vr.isValid()) {
+                return vr;
+            }
+
+            final long dataSizeBytes = DataUnit.parseDataSize(input, DataUnit.B).longValue();
+
+            if (dataSizeBytes % MIN_ALLOWED_CHUNK_SIZE_IN_BYTES != 0 ) {
+                return new ValidationResult.Builder()
+                        .subject(subject)
+                        .input(input)
+                        .valid(false)
+                        .explanation("Must be a positive multiple of " + MIN_ALLOWED_CHUNK_SIZE_IN_BYTES + " bytes")
+                        .build();
+            }
+
+            return new ValidationResult.Builder()
+                    .subject(subject)
+                    .input(input)
+                    .valid(true)
+                    .build();
+        };
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -416,14 +416,14 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
     }
 
     private Optional<File> checkFolderExistence(String folderName, String parentId) throws IOException {
-        return checkObjectExistence(folderName, format("mimeType='%s' and ('%s' in parents)", DRIVE_FOLDER_MIME_TYPE, parentId));
+        return checkObjectExistence(format("mimeType='%s' and name='%s' and ('%s' in parents)", DRIVE_FOLDER_MIME_TYPE, folderName, parentId));
     }
 
     private Optional<File> checkFileExistence(String fileName, String parentId) throws IOException {
-        return checkObjectExistence(fileName, format("'%s' in parents", parentId));
+        return checkObjectExistence(format("name='%s' and ('%s' in parents)", fileName, parentId));
     }
 
-    private Optional<File> checkObjectExistence(String fileName, String query) throws IOException {
+    private Optional<File> checkObjectExistence(String query) throws IOException {
         final FileList result = driveService.files()
                 .list()
                 .setQ(query)
@@ -431,7 +431,6 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
                 .execute();
 
         return result.getFiles().stream()
-                .filter(file -> file.getName().equals(fileName))
                 .findFirst();
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -25,6 +25,7 @@ org.apache.nifi.processors.gcp.bigquery.PutBigQueryBatch
 org.apache.nifi.processors.gcp.bigquery.PutBigQueryStreaming
 org.apache.nifi.processors.gcp.drive.ListGoogleDrive
 org.apache.nifi.processors.gcp.drive.FetchGoogleDrive
+org.apache.nifi.processors.gcp.drive.PutGoogleDrive
 org.apache.nifi.processors.gcp.vision.StartGcpVisionAnnotateImagesOperation
 org.apache.nifi.processors.gcp.vision.StartGcpVisionAnnotateFilesOperation
 org.apache.nifi.processors.gcp.vision.GetGcpVisionAnnotateImagesOperationStatus

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/docs/org.apache.nifi.processors.gcp.drive.FetchGoogleDrive/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/docs/org.apache.nifi.processors.gcp.drive.FetchGoogleDrive/additionalDetails.html
@@ -45,6 +45,22 @@
             <li>Enter the service account email.</li>
         </ul>
     </li>
+    <li><b>Find File ID</b>
+        </br>
+        Usually FetchGoogleDrive is used with ListGoogleDrive and 'drive.id' is set.</br>
+        In case 'drive.id' is not available, you can find the Drive ID of the file in the following way:
+        </br>
+        <ul>
+            <li>Right-click on the file and select "Get Link".</li>
+            <li>In the pop-up window click on "Copy Link".</li>
+            <li>You can obtain the file ID from the URL copied to clipboard.
+                For example, if the URL were <code>https://drive.google.com/file/d/16ALV9KIU_KKeNG557zyctqy2Fmzyqtq/view?usp=share_link</code>,<br>
+                the File ID would be <code>16ALV9KIU_KKeNG557zyctqy2Fmzyqtq</code>
+            </li>
+        </ul>
+    </li>
+    <li><b>Set File ID in 'File ID' property</b>
+    </li>
 </ol>
 
 </body>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/docs/org.apache.nifi.processors.gcp.drive.PutGoogleDrive/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/resources/docs/org.apache.nifi.processors.gcp.drive.PutGoogleDrive/additionalDetails.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/html">
+<!--
+      Licensed to the Apache Software Foundation (ASF) under one or more
+      contributor license agreements.  See the NOTICE file distributed with
+      this work for additional information regarding copyright ownership.
+      The ASF licenses this file to You under the Apache License, Version 2.0
+      (the "License"); you may not use this file except in compliance with
+      the License.  You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    -->
+
+<head>
+    <meta charset="utf-8"/>
+    <title>PutGoogleDrive</title>
+    <link rel="stylesheet" href="../../../../../css/component-usage.css" type="text/css"/>
+</head>
+<body>
+
+<h1>Accessing Google Drive from NiFi</h1>
+
+<p>
+    This processor uses Google Cloud credentials for authentication to access Google Drive.
+    The following steps are required to prepare the Google Cloud and Google Drive accounts for the processors:
+</p>
+<ol>
+    <li><b>Enable Google Drive API in Google Cloud</b>
+        <ul>
+            <li>Follow instructions at <a href="https://developers.google.com/workspace/guides/enable-apis">
+                https://developers.google.com/workspace/guides/enable-apis</a> and search for 'Google Drive API'.
+            </li>
+        </ul>
+    </li>
+    <li><b>Grant access to Google Drive folder</b>
+        <ul>
+            <li>In Google Cloud Console navigate to IAM & Admin -> Service Accounts.</li>
+            <li>Take a note of the email of the service account you are going to use.</li>
+            <li>Navigate to the folder in Google Drive which will be used as the base folder.</li>
+            <li>Right-click on the Folder -> Share.</li>
+            <li>Enter the service account email.</li>
+        </ul>
+    </li>
+    <li><b>Find Folder ID</b>
+        <ul>
+            <li>Navigate to the folder to be listed in Google Drive and enter it. The URL in your browser will include the ID at the end of
+                the URL.
+                For example, if the URL were <code>https://drive.google.com/drive/folders/1trTraPVCnX5_TNwO8d9P_bz278xWOmGm</code>, the
+                Folder ID would be <code>1trTraPVCnX5_TNwO8d9P_bz278xWOmGm</code>
+            </li>
+        </ul>
+    </li>
+    <li><b>Set Folder ID in 'Folder ID' property</b>
+    </li>
+</ol>
+
+</body>
+</html>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveIT.java
@@ -49,11 +49,10 @@ import java.util.Arrays;
  * WARNING: The creation of a file is not a synchronized operation, may need to adjust tests accordingly!
  */
 public abstract class AbstractGoogleDriveIT<T extends GoogleDriveTrait & Processor> {
-    private static final String CREDENTIAL_JSON_FILE_PATH = "";
-    private static final String SHARED_FOLDER_ID = "";
-
+    protected static final String SHARED_FOLDER_ID = "";
     protected static final String DEFAULT_FILE_CONTENT = "test_content";
 
+    private static final String CREDENTIAL_JSON_FILE_PATH = "";
     private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
     protected T testSubject;
@@ -101,6 +100,7 @@ public abstract class AbstractGoogleDriveIT<T extends GoogleDriveTrait & Process
 
         GCPCredentialsControllerService gcpCredentialsControllerService = new GCPCredentialsControllerService();
         testRunner.addControllerService("gcp_credentials_provider_service", gcpCredentialsControllerService);
+
         testRunner.setProperty(gcpCredentialsControllerService, CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE, CREDENTIAL_JSON_FILE_PATH);
         testRunner.enableControllerService(gcpCredentialsControllerService);
         testRunner.setProperty(GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE, "gcp_credentials_provider_service");
@@ -140,7 +140,7 @@ public abstract class AbstractGoogleDriveIT<T extends GoogleDriveTrait & Process
 
         Drive.Files.Create create = driveService.files()
                 .create(fileMetadata, content)
-                .setFields("id, name, modifiedTime");
+                .setFields("id, name, modifiedTime, createdTime");
 
         File file = create.execute();
 
@@ -150,4 +150,6 @@ public abstract class AbstractGoogleDriveIT<T extends GoogleDriveTrait & Process
     public TestRunner getTestRunner() {
         return testRunner;
     }
+
+
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.gcp.drive;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.util.DateTime;
+import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.model.File;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processors.gcp.credentials.service.GCPCredentialsControllerService;
+import org.apache.nifi.processors.gcp.util.GoogleUtils;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class AbstractGoogleDriveTest {
+    public static final String CONTENT = "1234567890";
+    public static final String FILENAME = "testFile";
+    public static final String FILE_ID = "fileId";
+    public static final String FOLDER_NAME = "testFolder";
+    public static final String BASE_FOLDER_ID = "baseFolderId";
+    public static final String FOLDER_ID = "subFolderId";
+    public static final long CREATED_TIME = 1659707000;
+    public static final long SIZE = 42;
+    public static final String TEXT_TYPE = "text/plain";
+
+    protected TestRunner testRunner;
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    protected Drive mockDriverService;
+
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        String gcpCredentialsControllerServiceId = "gcp_credentials_provider_service";
+
+        final GCPCredentialsControllerService gcpCredentialsControllerService = mock(GCPCredentialsControllerService.class, Mockito.RETURNS_DEEP_STUBS);
+        when(gcpCredentialsControllerService.getIdentifier()).thenReturn(gcpCredentialsControllerServiceId);
+
+        testRunner.addControllerService(gcpCredentialsControllerServiceId, gcpCredentialsControllerService);
+        testRunner.enableControllerService(gcpCredentialsControllerService);
+        testRunner.setProperty(GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE, gcpCredentialsControllerServiceId);
+    }
+
+    protected void assertFlowFileAttributes(Relationship relationship) {
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(relationship).get(0);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.ID, FILE_ID);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.FILENAME, FILENAME);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.TIMESTAMP, String.valueOf(new DateTime(CREATED_TIME)));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.SIZE, Long.toString(SIZE));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.MIME_TYPE, TEXT_TYPE);
+    }
+
+    protected void assertProvenanceEvent(ProvenanceEventType eventType) {
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(eventType);
+        Set<ProvenanceEventType> actualEventTypes = testRunner.getProvenanceEvents().stream()
+                .map(ProvenanceEventRecord::getEventType)
+                .collect(toSet());
+        assertEquals(expectedEventTypes, actualEventTypes);
+    }
+
+    protected void assertNoProvenanceEvent() {
+        assertTrue(testRunner.getProvenanceEvents().isEmpty());
+    }
+
+    protected File createFile() {
+        return createFile(FILE_ID, FILENAME, FOLDER_ID, TEXT_TYPE);
+    }
+
+    protected File createFile(String id, String name, String parentId, String mimeType) {
+        File file = new File();
+        file.setId(id);
+        file.setName(name);
+        file.setParents(singletonList(parentId));
+        file.setCreatedTime(new DateTime(CREATED_TIME));
+        file.setSize(SIZE);
+        file.setMimeType(mimeType);
+        return file;
+    }
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
@@ -43,13 +43,13 @@ import org.mockito.Mockito;
 
 public class AbstractGoogleDriveTest {
     public static final String CONTENT = "1234567890";
-    public static final String FILENAME = "testFile";
-    public static final String FILE_ID = "fileId";
-    public static final String FOLDER_NAME = "testFolder";
-    public static final String BASE_FOLDER_ID = "baseFolderId";
-    public static final String FOLDER_ID = "subFolderId";
+    public static final String TEST_FILENAME = "testFile";
+    public static final String TEST_FILE_ID = "fileId";
+    public static final String SUBFOLDER_NAME = "subFolderName";
+    public static final String SHARED_FOLDER_ID = "sharedFolderId";
+    public static final String SUBFOLDER_ID = "subFolderId";
+    public static final long TEST_SIZE = 42;
     public static final long CREATED_TIME = 1659707000;
-    public static final long SIZE = 42;
     public static final String TEXT_TYPE = "text/plain";
 
     protected TestRunner testRunner;
@@ -72,10 +72,10 @@ public class AbstractGoogleDriveTest {
 
     protected void assertFlowFileAttributes(Relationship relationship) {
         final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(relationship).get(0);
-        flowFile.assertAttributeEquals(GoogleDriveAttributes.ID, FILE_ID);
-        flowFile.assertAttributeEquals(GoogleDriveAttributes.FILENAME, FILENAME);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.ID, TEST_FILE_ID);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.FILENAME, TEST_FILENAME);
         flowFile.assertAttributeEquals(GoogleDriveAttributes.TIMESTAMP, String.valueOf(new DateTime(CREATED_TIME)));
-        flowFile.assertAttributeEquals(GoogleDriveAttributes.SIZE, Long.toString(SIZE));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.SIZE, Long.toString(TEST_SIZE));
         flowFile.assertAttributeEquals(GoogleDriveAttributes.MIME_TYPE, TEXT_TYPE);
     }
 
@@ -92,7 +92,7 @@ public class AbstractGoogleDriveTest {
     }
 
     protected File createFile() {
-        return createFile(FILE_ID, FILENAME, FOLDER_ID, TEXT_TYPE);
+        return createFile(TEST_FILE_ID, TEST_FILENAME, SUBFOLDER_ID, TEXT_TYPE);
     }
 
     protected File createFile(String id, String name, String parentId, String mimeType) {
@@ -101,7 +101,7 @@ public class AbstractGoogleDriveTest {
         file.setName(name);
         file.setParents(singletonList(parentId));
         file.setCreatedTime(new DateTime(CREATED_TIME));
-        file.setSize(SIZE);
+        file.setSize(TEST_SIZE);
         file.setMimeType(mimeType);
         return file;
     }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
@@ -46,10 +46,10 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         File file = createFileWithDefaultContent("test_file.txt", mainFolderId);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put("drive.id", file.getId());
-        inputFlowFileAttributes.put("filename", file.getName());
-        inputFlowFileAttributes.put("drive.size", valueOf(DEFAULT_FILE_CONTENT.length()));
-        inputFlowFileAttributes.put("mime.type", "text/plain");
+        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, file.getId());
+        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, file.getName());
+        inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE, valueOf(DEFAULT_FILE_CONTENT.length()));
+        inputFlowFileAttributes.put(GoogleDriveAttributes.MIME_TYPE, "text/plain");
 
         HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
         List<String> expectedContent = singletonList(DEFAULT_FILE_CONTENT);
@@ -69,14 +69,14 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
     void testInputFlowFileReferencesMissingFile() {
         // GIVEN
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put("drive.id", "missing");
-        inputFlowFileAttributes.put("filename", "missing_filename");
+        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, "missing");
+        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, "missing_filename");
 
         Set<Map<String, String>> expectedFailureAttributes = new HashSet<>(singletonList(
                 new HashMap<String, String>() {{
-                    put("drive.id", "missing");
-                    put("filename", "missing_filename");
-                    put("error.code", "404");
+                    put(GoogleDriveAttributes.ID, "missing");
+                    put(GoogleDriveAttributes.FILENAME, "missing_filename");
+                    put(GoogleDriveAttributes.ERROR_CODE, "404");
                 }}
         ));
 
@@ -95,8 +95,8 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         File file = createFileWithDefaultContent("test_file.txt", mainFolderId);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put("drive.id", file.getId());
-        inputFlowFileAttributes.put("filename", file.getName());
+        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, file.getId());
+        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, file.getName());
 
         MockFlowFile input = new MockFlowFile(1) {
             final AtomicBoolean throwException = new AtomicBoolean(true);

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
@@ -16,17 +16,18 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
-import com.google.api.services.drive.model.File;
-import org.apache.nifi.util.MockFlowFile;
-import org.junit.jupiter.api.Test;
+import static java.lang.String.valueOf;
+import static java.util.Collections.singletonList;
 
-import java.util.Arrays;
+import com.google.api.services.drive.model.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.Test;
 
 /**
  * See Javadoc {@link AbstractGoogleDriveIT} for instructions how to run this test.
@@ -47,9 +48,11 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
         inputFlowFileAttributes.put("drive.id", file.getId());
         inputFlowFileAttributes.put("filename", file.getName());
+        inputFlowFileAttributes.put("drive.size", valueOf(DEFAULT_FILE_CONTENT.length()));
+        inputFlowFileAttributes.put("mime.type", "text/plain");
 
-        HashSet<Map<String, String>> expectedAttributes = new HashSet<>(Arrays.asList(inputFlowFileAttributes));
-        List<String> expectedContent = Arrays.asList(DEFAULT_FILE_CONTENT);
+        HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
+        List<String> expectedContent = singletonList(DEFAULT_FILE_CONTENT);
 
         // WHEN
         testRunner.enqueue("unimportant_data", inputFlowFileAttributes);
@@ -63,13 +66,13 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
     }
 
     @Test
-    void testInputFlowFileReferencesMissingFile() throws Exception {
+    void testInputFlowFileReferencesMissingFile() {
         // GIVEN
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
         inputFlowFileAttributes.put("drive.id", "missing");
         inputFlowFileAttributes.put("filename", "missing_filename");
 
-        Set<Map<String, String>> expectedFailureAttributes = new HashSet<>(Arrays.asList(
+        Set<Map<String, String>> expectedFailureAttributes = new HashSet<>(singletonList(
                 new HashMap<String, String>() {{
                     put("drive.id", "missing");
                     put("filename", "missing_filename");
@@ -83,7 +86,6 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
 
         // THEN
         testRunner.assertTransferCount(FetchGoogleDrive.REL_SUCCESS, 0);
-
         checkAttributes(FetchGoogleDrive.REL_FAILURE, expectedFailureAttributes);
     }
 
@@ -97,7 +99,7 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         inputFlowFileAttributes.put("filename", file.getName());
 
         MockFlowFile input = new MockFlowFile(1) {
-            AtomicBoolean throwException = new AtomicBoolean(true);
+            final AtomicBoolean throwException = new AtomicBoolean(true);
 
             @Override
             public boolean isPenalized() {
@@ -116,7 +118,7 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
             }
         };
 
-        Set<Map<String, String>> expectedFailureAttributes = new HashSet<>(Arrays.asList(
+        Set<Map<String, String>> expectedFailureAttributes = new HashSet<>(singletonList(
                 inputFlowFileAttributes
         ));
 
@@ -130,10 +132,12 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         checkAttributes(FetchGoogleDrive.REL_FAILURE, expectedFailureAttributes);
     }
 
+    @Override
     public Set<String> getCheckedAttributeNames() {
         Set<String> checkedAttributeNames = OutputChecker.super.getCheckedAttributeNames();
 
-        checkedAttributeNames.add(FetchGoogleDrive.ERROR_CODE_ATTRIBUTE);
+        checkedAttributeNames.add(GoogleDriveAttributes.ERROR_CODE);
+        checkedAttributeNames.remove(GoogleDriveAttributes.TIMESTAMP);
 
         return checkedAttributeNames;
     }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.drive;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.services.drive.Drive;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        final FetchGoogleDrive testSubject = new FetchGoogleDrive() {
+            @Override
+            public Drive createDriveService(ProcessContext context, HttpTransport httpTransport, String... scopes) {
+                return mockDriverService;
+            }
+        };
+
+        testRunner = TestRunners.newTestRunner(testSubject);
+        super.setUp();
+    }
+
+    @Test
+    void testFileFetchFileNameFromProperty() throws IOException {
+        testRunner.setProperty(FetchGoogleDrive.FILE_ID, FILE_ID);
+
+        mockFileDownload(FILE_ID);
+        runWithFlowFile();
+
+        testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_SUCCESS, 1);
+        assertFlowFileAttributes(FetchGoogleDrive.REL_SUCCESS);
+        assertProvenanceEvent(ProvenanceEventType.FETCH);
+    }
+
+    @Test
+    void testFetchFileNameFromFlowFileAttribute() throws Exception {
+        final MockFlowFile mockFlowFile = new MockFlowFile(0);
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("drive.id", FILE_ID);
+        mockFlowFile.putAttributes(attributes);
+
+        mockFileDownload(FILE_ID);
+
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_SUCCESS, 1);
+        assertFlowFileAttributes(FetchGoogleDrive.REL_SUCCESS);
+        assertProvenanceEvent(ProvenanceEventType.FETCH);
+    }
+
+    @Test
+    void testFileFetchError() throws Exception {
+        testRunner.setProperty(FetchGoogleDrive.FILE_ID, FILE_ID);
+
+        mockFileDownloadError(FILE_ID, new RuntimeException("Error during download"));
+
+        runWithFlowFile();
+
+        testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_FAILURE, 1);
+        final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_FAILURE);
+        final MockFlowFile ff0 = flowFiles.get(0);
+        ff0.assertAttributeEquals(GoogleDriveAttributes.ERROR_MESSAGE, "Error during download");
+        assertNoProvenanceEvent();
+    }
+
+    private void mockFileDownload(String fileId) throws IOException {
+        when(mockDriverService.files()
+                .get(fileId)
+                .executeMediaAsInputStream()).thenReturn(new ByteArrayInputStream(CONTENT.getBytes(UTF_8)));
+
+        when(mockDriverService.files()
+                .get(fileId)
+                .setFields("id, name, createdTime, mimeType, size")
+                .execute()).thenReturn(createFile());
+    }
+
+    private void mockFileDownloadError(String fileId, Exception exception) throws IOException {
+        when(mockDriverService.files()
+                .get(fileId)
+                .executeMediaAsInputStream())
+                .thenThrow(exception);
+    }
+
+    private void runWithFlowFile() {
+        testRunner.enqueue(new MockFlowFile(0));
+        testRunner.run();
+    }
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -53,9 +53,9 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
 
     @Test
     void testFileFetchFileNameFromProperty() throws IOException {
-        testRunner.setProperty(FetchGoogleDrive.FILE_ID, FILE_ID);
+        testRunner.setProperty(FetchGoogleDrive.FILE_ID, TEST_FILE_ID);
 
-        mockFileDownload(FILE_ID);
+        mockFileDownload(TEST_FILE_ID);
         runWithFlowFile();
 
         testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_SUCCESS, 1);
@@ -67,10 +67,10 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
     void testFetchFileNameFromFlowFileAttribute() throws Exception {
         final MockFlowFile mockFlowFile = new MockFlowFile(0);
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("drive.id", FILE_ID);
+        attributes.put(GoogleDriveAttributes.ID, TEST_FILE_ID);
         mockFlowFile.putAttributes(attributes);
 
-        mockFileDownload(FILE_ID);
+        mockFileDownload(TEST_FILE_ID);
 
         testRunner.enqueue(mockFlowFile);
         testRunner.run();
@@ -82,9 +82,9 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
 
     @Test
     void testFileFetchError() throws Exception {
-        testRunner.setProperty(FetchGoogleDrive.FILE_ID, FILE_ID);
+        testRunner.setProperty(FetchGoogleDrive.FILE_ID, TEST_FILE_ID);
 
-        mockFileDownloadError(FILE_ID, new RuntimeException("Error during download"));
+        mockFileDownloadError(TEST_FILE_ID, new RuntimeException("Error during download"));
 
         runWithFlowFile();
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ListGoogleDriverTestRunnerTest implements OutputChecker {
+public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     private ListGoogleDrive testSubject;
     private TestRunner testRunner;
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -16,10 +16,22 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
+import static java.lang.String.valueOf;
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.nifi.json.JsonRecordSetWriter;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.gcp.credentials.service.GCPCredentialsControllerService;
@@ -31,18 +43,6 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     private ListGoogleDrive testSubject;
@@ -126,7 +126,7 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
 
         mockFetchedGoogleDriveFileList(id, filename, size, createdTime, modifiedTime, mimeType);
 
-        List<String> expectedContents = Arrays.asList(
+        List<String> expectedContents = asList(
                 "[" +
                         "{" +
                         "\"drive.id\":\"" + id + "\"," +
@@ -159,7 +159,7 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                 .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType)")
                 .execute()
                 .getFiles()
-        ).thenReturn(Arrays.asList(
+        ).thenReturn(asList(
                 createFile(
                         id,
                         filename,
@@ -176,13 +176,13 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         mockFetchedGoogleDriveFileList(id, filename, size, createdTime, modifiedTime, mimeType);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put("drive.id", id);
-        inputFlowFileAttributes.put("filename", filename);
-        inputFlowFileAttributes.put("drive.size", "" + size);
-        inputFlowFileAttributes.put("drive.timestamp", "" + expectedTimestamp);
-        inputFlowFileAttributes.put("mime.type", mimeType);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, id);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, filename);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE, valueOf(size));
+        inputFlowFileAttributes.put(GoogleDriveAttributes.TIMESTAMP, valueOf(expectedTimestamp));
+        inputFlowFileAttributes.put(GoogleDriveAttributes.MIME_TYPE, mimeType);
 
-        HashSet<Map<String, String>> expectedAttributes = new HashSet<>(Arrays.asList(inputFlowFileAttributes));
+        HashSet<Map<String, String>> expectedAttributes = new HashSet<>(asList(inputFlowFileAttributes));
 
         // WHEN
         testRunner.run();

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveIT.java
@@ -16,6 +16,11 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
+import static org.apache.nifi.processors.gcp.drive.PutGoogleDrive.CREATE_SUBFOLDER;
+import static org.apache.nifi.processors.gcp.drive.PutGoogleDrive.FILE_NAME;
+import static org.apache.nifi.processors.gcp.drive.PutGoogleDrive.FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.PutGoogleDrive.SUBFOLDER_NAME;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +40,6 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @BeforeEach
     public void init() throws Exception {
         super.init();
-        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, SHARED_FOLDER_ID);
     }
 
     @Override
@@ -46,8 +50,8 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @Test
     void testUploadFileToFolderById() {
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, mainFolderId);
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(FOLDER_ID, mainFolderId);
+        testRunner.setProperty(FILE_NAME, TEST_FILENAME);
 
         // WHEN
         runWithFileContent();
@@ -60,10 +64,10 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @Test
     void testUploadFileFolderByName() {
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_NAME, "testFolderNew");
-        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, mainFolderId);
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
-        testRunner.setProperty(PutGoogleDrive.CREATE_FOLDER, "true");
+        testRunner.setProperty(SUBFOLDER_NAME, "testFolderNew");
+        testRunner.setProperty(FOLDER_ID, mainFolderId);
+        testRunner.setProperty(FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(CREATE_SUBFOLDER, "true");
 
         // WHEN
         runWithFileContent();
@@ -81,10 +85,10 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
         createFolder("existingFolder", mainFolderId);
 
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_NAME, "existingFolder/new1/new2");
-        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, mainFolderId);
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
-        testRunner.setProperty(PutGoogleDrive.CREATE_FOLDER, "true");
+        testRunner.setProperty(SUBFOLDER_NAME, "existingFolder/new1/new2");
+        testRunner.setProperty(FOLDER_ID, mainFolderId);
+        testRunner.setProperty(FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(CREATE_SUBFOLDER, "true");
 
         // WHEN
         runWithFileContent();
@@ -101,8 +105,8 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @Test
     void testSpecifiedFolderIdDoesNotExist() {
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, "nonExistentId");
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, "testFile4");
+        testRunner.setProperty(FOLDER_ID, "nonExistentId");
+        testRunner.setProperty(FILE_NAME, "testFile4");
 
         // WHEN
         runWithFileContent();
@@ -120,8 +124,8 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @Test
     void testUploadedFileAlreadyExistsFailResolution() {
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, mainFolderId);
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(FOLDER_ID, mainFolderId);
+        testRunner.setProperty(FILE_NAME, TEST_FILENAME);
 
         // WHEN
         runWithFileContent();
@@ -143,9 +147,9 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @Test
     void testUploadedFileAlreadyExistsOverwriteResolution() {
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, mainFolderId);
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
-        testRunner.setProperty(PutGoogleDrive.CONFLICT_RESOLUTION, PutGoogleDrive.OVERWRITE_RESOLUTION);
+        testRunner.setProperty(FOLDER_ID, mainFolderId);
+        testRunner.setProperty(FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(PutGoogleDrive.CONFLICT_RESOLUTION, PutGoogleDrive.REPLACE_RESOLUTION);
 
         // WHEN
         runWithFileContent();
@@ -170,8 +174,8 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
     @Test
     void testUploadedFileAlreadyExistsIgnoreResolution() {
         // GIVEN
-        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, mainFolderId);
-        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(FOLDER_ID, mainFolderId);
+        testRunner.setProperty(FILE_NAME, TEST_FILENAME);
         testRunner.setProperty(PutGoogleDrive.CONFLICT_RESOLUTION, PutGoogleDrive.IGNORE_RESOLUTION);
 
         // WHEN

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveIT.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.drive;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * See Javadoc {@link AbstractGoogleDriveIT} for instructions how to run this test.
+ */
+public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> implements OutputChecker {
+
+    public static final String TEST_FILENAME = "testFileName";
+
+    @BeforeEach
+    public void init() throws Exception {
+        super.init();
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, SHARED_FOLDER_ID);
+    }
+
+    @Override
+    public PutGoogleDrive createTestSubject() {
+        return new PutGoogleDrive();
+    }
+
+    @Test
+    void testUploadFileToFolderById() {
+        // GIVEN
+        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, mainFolderId);
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
+
+        // WHEN
+        runWithFileContent();
+
+        // THEN
+        testRunner.assertTransferCount(PutGoogleDrive.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutGoogleDrive.REL_FAILURE, 0);
+    }
+
+    @Test
+    void testUploadFileFolderByName() {
+        // GIVEN
+        testRunner.setProperty(PutGoogleDrive.FOLDER_NAME, "testFolderNew");
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, mainFolderId);
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(PutGoogleDrive.CREATE_FOLDER, "true");
+
+        // WHEN
+        runWithFileContent();
+
+        // THEN
+        testRunner.assertTransferCount(PutGoogleDrive.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutGoogleDrive.REL_FAILURE, 0);
+        final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_SUCCESS);
+        final MockFlowFile ff0 = flowFiles.get(0);
+        assertFlowFileAttributes(ff0);
+    }
+
+    @Test
+    void testUploadFileCreateMultiLevelFolder() throws IOException {
+        createFolder("existingFolder", mainFolderId);
+
+        // GIVEN
+        testRunner.setProperty(PutGoogleDrive.FOLDER_NAME, "existingFolder/new1/new2");
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, mainFolderId);
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, TEST_FILENAME);
+        testRunner.setProperty(PutGoogleDrive.CREATE_FOLDER, "true");
+
+        // WHEN
+        runWithFileContent();
+
+        // THEN
+        testRunner.assertTransferCount(PutGoogleDrive.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(PutGoogleDrive.REL_FAILURE, 0);
+
+        final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_SUCCESS);
+        final MockFlowFile ff0 = flowFiles.get(0);
+        assertFlowFileAttributes(ff0);
+    }
+
+    @Test
+    void testSpecifiedFolderIdDoesNotExist() {
+        // GIVEN
+        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, "nonExistentId");
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, "testFile4");
+
+        // WHEN
+        runWithFileContent();
+
+        // THEN
+        testRunner.assertTransferCount(PutGoogleDrive.REL_SUCCESS, 0);
+        testRunner.assertTransferCount(PutGoogleDrive.REL_FAILURE, 1);
+
+        final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_FAILURE);
+        final MockFlowFile ff0 = flowFiles.get(0);
+        ff0.assertAttributeEquals(GoogleDriveAttributes.ERROR_CODE, "404");
+        ff0.assertAttributeExists(GoogleDriveAttributes.ERROR_MESSAGE);
+    }
+
+    private void runWithFileContent() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.MIME_TYPE.key(), "text/plain");
+        testRunner.enqueue(DEFAULT_FILE_CONTENT, attributes);
+        testRunner.run();
+    }
+
+    private void assertFlowFileAttributes(MockFlowFile flowFile) {
+        flowFile.assertAttributeExists(GoogleDriveAttributes.ID);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.FILENAME, TEST_FILENAME);
+        flowFile.assertAttributeExists(GoogleDriveAttributes.TIMESTAMP);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.SIZE, String.valueOf(DEFAULT_FILE_CONTENT.length()));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.MIME_TYPE, "text/plain");
+    }
+}

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
@@ -84,11 +84,17 @@ public class PutGoogleDriveTest extends AbstractGoogleDriveTest{
 
     @Test
     void testSubfolderNameValidity() {
+        testRunner.setProperty(PutGoogleDrive.SUBFOLDER_NAME, "sub1");
+        testRunner.assertValid();
         testRunner.setProperty(PutGoogleDrive.SUBFOLDER_NAME, "sub1/sub2");
         testRunner.assertValid();
         testRunner.setProperty(PutGoogleDrive.SUBFOLDER_NAME, "/sub1");
         testRunner.assertNotValid();
         testRunner.setProperty(PutGoogleDrive.SUBFOLDER_NAME, "/");
+        testRunner.assertNotValid();
+        testRunner.setProperty(PutGoogleDrive.SUBFOLDER_NAME, "sub1/");
+        testRunner.assertNotValid();
+        testRunner.setProperty(PutGoogleDrive.SUBFOLDER_NAME, "/sub1/");
         testRunner.assertNotValid();
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
@@ -125,7 +125,7 @@ public class PutGoogleDriveTest extends AbstractGoogleDriveTest{
 
         when(mockDriverService.files()
                 .list()
-                .setQ(format("mimeType='%s' and ('%s' in parents)", DRIVE_FOLDER_MIME_TYPE, SHARED_FOLDER_ID))
+                .setQ(format("mimeType='%s' and name='%s' and ('%s' in parents)", DRIVE_FOLDER_MIME_TYPE, SUBFOLDER_NAME, SHARED_FOLDER_ID))
                 .setFields("files(name, id)")
                 .execute())
                 .thenReturn(new FileList().setFiles(singletonList(createFile(SUBFOLDER_ID, SUBFOLDER_NAME, SHARED_FOLDER_ID, DRIVE_FOLDER_MIME_TYPE))));
@@ -235,7 +235,7 @@ public class PutGoogleDriveTest extends AbstractGoogleDriveTest{
     private void mockFileExists() throws IOException {
         when(mockDriverService.files()
                 .list()
-                .setQ(format("'%s' in parents", SHARED_FOLDER_ID))
+                .setQ(format("name='%s' and ('%s' in parents)", TEST_FILENAME, SHARED_FOLDER_ID))
                 .setFields("files(name, id)")
                 .execute())
                 .thenReturn(new FileList().setFiles(singletonList(createFile())));

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
@@ -76,6 +76,10 @@ public class PutGoogleDriveTest extends AbstractGoogleDriveTest{
         testRunner.assertNotValid();
         testRunner.setProperty(PutGoogleDrive.CHUNKED_UPLOAD_SIZE, "2 GB");
         testRunner.assertNotValid();
+
+        testRunner.setProperty(PutGoogleDrive.CHUNKED_UPLOAD_THRESHOLD, "100 MB");
+        testRunner.setProperty(PutGoogleDrive.CHUNKED_UPLOAD_SIZE, "110 MB");
+        testRunner.assertNotValid();
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.gcp.drive;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveTrait.DRIVE_FOLDER_MIME_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.model.File;
+import com.google.api.services.drive.model.FileList;
+import com.google.gson.JsonParseException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PutGoogleDriveTest extends AbstractGoogleDriveTest{
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        final PutGoogleDrive testSubject = new PutGoogleDrive() {
+            @Override
+            public Drive createDriveService(ProcessContext context, HttpTransport httpTransport, String... scopes) {
+                return mockDriverService;
+            }
+        };
+
+        testRunner = TestRunners.newTestRunner(testSubject);
+        super.setUp();
+    }
+
+    @Test
+    void testFileUploadFileNameFromProperty() throws Exception {
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, FILENAME);
+        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, FOLDER_ID);
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, BASE_FOLDER_ID);
+
+        mockFileUpload(createFile());
+        runWithFlowFile();
+
+        testRunner.assertAllFlowFilesTransferred(PutGoogleDrive.REL_SUCCESS, 1);
+        assertFlowFileAttributes(PutGoogleDrive.REL_SUCCESS);
+        assertProvenanceEvent(ProvenanceEventType.SEND);
+    }
+
+    @Test
+    void testFileUploadFileNameFromFlowFileAttribute() throws Exception {
+        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, FOLDER_ID);
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, BASE_FOLDER_ID);
+
+        mockFileUpload(createFile());
+
+        final MockFlowFile mockFlowFile = getMockFlowFile();
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("filename", FILENAME);
+        mockFlowFile.putAttributes(attributes);
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(PutGoogleDrive.REL_SUCCESS, 1);
+        assertFlowFileAttributes(PutGoogleDrive.REL_SUCCESS);
+        assertProvenanceEvent(ProvenanceEventType.SEND);
+    }
+
+    @Test
+    void testFileUploadFileToFolderSpecifiedByNameFolderExists() throws Exception {
+        testRunner.setProperty(PutGoogleDrive.FOLDER_NAME, FOLDER_NAME);
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, BASE_FOLDER_ID);
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, FILENAME);
+
+        when(mockDriverService.files()
+                .list()
+                .setQ(format("mimeType='%s' and ('%s' in parents)", DRIVE_FOLDER_MIME_TYPE, BASE_FOLDER_ID))
+                .setFields("files(name, id)")
+                .execute())
+                .thenReturn(new FileList().setFiles(singletonList(createFile(FOLDER_ID, FOLDER_NAME, BASE_FOLDER_ID, DRIVE_FOLDER_MIME_TYPE))));
+
+        mockFileUpload(createFile());
+
+        runWithFlowFile();
+        testRunner.assertAllFlowFilesTransferred(PutGoogleDrive.REL_SUCCESS, 1);
+        assertFlowFileAttributes(PutGoogleDrive.REL_SUCCESS);
+        assertProvenanceEvent(ProvenanceEventType.SEND);
+    }
+
+    @Test
+    void testFileUploadError() throws Exception {
+        testRunner.setProperty(PutGoogleDrive.FOLDER_ID, FOLDER_ID);
+        testRunner.setProperty(PutGoogleDrive.BASE_FOLDER_ID, BASE_FOLDER_ID);
+        testRunner.setProperty(PutGoogleDrive.FILE_NAME, FILENAME);
+
+        final JsonParseException exception = new JsonParseException("Google Drive error", new FileNotFoundException());
+        mockFileUploadError(exception);
+
+        runWithFlowFile();
+
+        testRunner.assertAllFlowFilesTransferred(PutGoogleDrive.REL_FAILURE, 1);
+        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_FAILURE);
+        MockFlowFile ff0 = flowFiles.get(0);
+        ff0.assertAttributeExists(ERROR_MESSAGE);
+        assertNoProvenanceEvent();
+    }
+
+    private MockFlowFile getMockFlowFile() {
+        MockFlowFile inputFlowFile = new MockFlowFile(0);
+        inputFlowFile.setData(CONTENT.getBytes(UTF_8));
+        return inputFlowFile;
+    }
+
+    private void runWithFlowFile() {
+        MockFlowFile mockFlowFile = getMockFlowFile();
+        testRunner.enqueue(mockFlowFile);
+        testRunner.run();
+    }
+
+    private void mockFileUpload(File uploadedFile) throws IOException {
+        when(mockDriverService.files().create(any(File.class), any(InputStreamContent.class))
+                .setFields("id, name, createdTime, mimeType, size")
+                .execute())
+                .thenReturn(uploadedFile);
+    }
+
+    private void mockFileUploadError(Exception exception) throws IOException {
+        when(mockDriverService.files()
+                .create(any(File.class), any(InputStreamContent.class)))
+                .thenThrow(exception);
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10965](https://issues.apache.org/jira/browse/NIFI-10965)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-10965`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-10965`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
