### PR TITLE
NIFI-11036: Add Cluster Summary Metrics to Prometheus endpoint

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-prometheus-utils/src/main/java/org/apache/nifi/prometheus/util/ClusterMetricsRegistry.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-prometheus-utils/src/main/java/org/apache/nifi/prometheus/util/ClusterMetricsRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.prometheus.util;
+
+import io.prometheus.client.Gauge;
+
+/**
+ * This registry contains metrics related to a NiFi cluster, such as connected node count and total node count
+ */
+public class ClusterMetricsRegistry extends AbstractMetricsRegistry {
+
+    public ClusterMetricsRegistry() {
+
+        nameToGaugeMap.put("IS_CLUSTERED",  Gauge.build()
+                .name("cluster_is_clustered")
+                .help("Whether this NiFi instance is clustered. Values are 0 or 1")
+                .labelNames("instance")
+                .register(registry));
+
+        nameToGaugeMap.put("IS_CONNECTED_TO_CLUSTER",  Gauge.build()
+                .name("cluster_is_connected_to_cluster")
+                .help("Whether this NiFi instance is connected to a cluster. Values are 0 or 1")
+                .labelNames("instance")
+                .register(registry));
+
+        nameToGaugeMap.put("CONNECTED_NODE_COUNT", Gauge.build()
+                .name("cluster_connected_node_count")
+                .help("The number of connected nodes in this cluster")
+                .labelNames("instance", "connected_nodes")
+                .register(registry));
+
+        nameToGaugeMap.put("TOTAL_NODE_COUNT", Gauge.build()
+                .name("cluster_total_node_count")
+                .help("The total number of nodes in this cluster")
+                .labelNames("instance")
+                .register(registry));
+    }
+}

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-prometheus-utils/src/main/java/org/apache/nifi/prometheus/util/PrometheusMetricsUtil.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-prometheus-utils/src/main/java/org/apache/nifi/prometheus/util/PrometheusMetricsUtil.java
@@ -512,4 +512,15 @@ public class PrometheusMetricsUtil {
 
         return niFiMetricsRegistry.getRegistry();
     }
+
+    public static CollectorRegistry createClusterMetrics(final ClusterMetricsRegistry clusterMetricsRegistry, final String instId, final boolean isClustered, final boolean isConnectedToCluster,
+                                                         final String connectedNodes, final int connectedNodeCount, final int totalNodeCount) {
+        final String instanceId = StringUtils.isEmpty(instId) ? DEFAULT_LABEL_STRING : instId;
+        clusterMetricsRegistry.setDataPoint(isClustered ? 1 : 0, "IS_CLUSTERED", instanceId);
+        clusterMetricsRegistry.setDataPoint(isConnectedToCluster ? 1 : 0, "IS_CONNECTED_TO_CLUSTER", instanceId);
+        clusterMetricsRegistry.setDataPoint(connectedNodeCount, "CONNECTED_NODE_COUNT", instanceId, connectedNodes);
+        clusterMetricsRegistry.setDataPoint(totalNodeCount, "TOTAL_NODE_COUNT", instanceId);
+
+        return clusterMetricsRegistry.getRegistry();
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/request/FlowMetricsRegistry.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/request/FlowMetricsRegistry.java
@@ -18,6 +18,7 @@ package org.apache.nifi.web.api.request;
 
 import org.apache.nifi.prometheus.util.AbstractMetricsRegistry;
 import org.apache.nifi.prometheus.util.BulletinMetricsRegistry;
+import org.apache.nifi.prometheus.util.ClusterMetricsRegistry;
 import org.apache.nifi.prometheus.util.ConnectionAnalyticsMetricsRegistry;
 import org.apache.nifi.prometheus.util.JvmMetricsRegistry;
 import org.apache.nifi.prometheus.util.NiFiMetricsRegistry;
@@ -32,7 +33,9 @@ public enum FlowMetricsRegistry {
 
     BULLETIN("BULLETIN", BulletinMetricsRegistry.class),
 
-    CONNECTION("CONNECTION", ConnectionAnalyticsMetricsRegistry.class);
+    CONNECTION("CONNECTION", ConnectionAnalyticsMetricsRegistry.class),
+
+    CLUSTER("CLUSTER", ClusterMetricsRegistry.class);
 
     private final String registry;
 


### PR DESCRIPTION
# Summary

[NIFI-11036](https://issues.apache.org/jira/browse/NIFI-11036)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11036`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11036`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
