### PR TITLE
NIFI-11046 Upgrade Dependency Check from 7.3.2 to 7.4.4

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -25,16 +25,6 @@
         <cpe regex="true">^cpe:.*$</cpe>
     </suppress>
     <suppress>
-        <notes>MySQL Binary Log Connector is incorrectly identified as MySQL server</notes>
-        <packageUrl regex="true">^pkg:maven/com\.zendesk/mysql\-binlog\-connector\-java@.*$</packageUrl>
-        <cpe>cpe:/a:mysql:mysql</cpe>
-    </suppress>
-    <suppress>
-        <notes>Twill ZooKeeper is incorrectly identified with ZooKeeper server</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill\-zookeeper@.*$</packageUrl>
-        <cpe>cpe:/a:apache:zookeeper</cpe>
-    </suppress>
-    <suppress>
         <notes>H2 1.4.200 is shaded and repackaged without vulnerable components in nifi-h2-database for migration</notes>
         <packageUrl>pkg:maven/com.h2database/h2@1.4.200</packageUrl>
         <vulnerabilityName regex="true">^CVE.*$</vulnerabilityName>
@@ -53,11 +43,6 @@
         <notes>CVE-2020-5408 does not apply to Spring Security Crypto 5.7.1 and later</notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes>Servlet API 2.5 does not include Jetty Server vulnerabilities</notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jetty/servlet\-api@.*$</packageUrl>
-        <cpe regex="true">^cpe:.*$</cpe>
     </suppress>
     <suppress>
         <notes>Spark 2.13 used in nifi-spark-receiver is not impacted by Spark Server vulnerabilities</notes>
@@ -145,19 +130,9 @@
         <vulnerabilityName>CVE-2014-3643</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes>Fan Platform vulnerabilities do not apply to JUnit Platform libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.junit\.platform/junit\-platform\-engine@.*$</packageUrl>
-        <cpe>cpe:/a:fan_platform_project:fan_platform</cpe>
-    </suppress>
-    <suppress>
         <notes>CVE-2007-6465 applies to Ganglia Server not Ganglia client libraries</notes>
         <packageUrl regex="true">^pkg:maven/com\.yammer\.metrics/metrics\-ganglia@.*$</packageUrl>
         <cve>CVE-2007-6465</cve>
-    </suppress>
-    <suppress>
-        <notes>Pro Search vulnerabilities do not apply to Spatial4j</notes>
-        <packageUrl regex="true">^pkg:maven/org\.locationtech\.spatial4j/spatial4j@.*$</packageUrl>
-        <cpe>cpe:/a:pro_search:pro_search</cpe>
     </suppress>
     <suppress>
         <notes>CVE-2021-43045 applies to the Apache Avro .NET SDK and not to the Java SDK</notes>
@@ -168,11 +143,6 @@
         <notes>CVE-2022-31159 applies to AWS S3 library not the SWF libraries</notes>
         <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-swf\-libraries@.*$</packageUrl>
         <cve>CVE-2022-31159</cve>
-    </suppress>
-    <suppress>
-        <notes>Hive vulnerabilities do not apply to Iceberg Hive Metadata</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg\-hive\-metastore@.*$</packageUrl>
-        <cpe>cpe:/a:apache:hive</cpe>
     </suppress>
     <suppress>
         <notes>Elasticsearch Server vulnerabilities do not apply to Elasticsearch Plugin</notes>

--- a/pom.xml
+++ b/pom.xml
@@ -1184,7 +1184,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.3.2</version>
+                        <version>7.4.4</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-11046](https://issues.apache.org/jira/browse/NIFI-11046) Upgrades the OWASP Dependency Check Plugin from 7.3.2 to 7.4.4 and removes several false positive suppression entries no longer necessary in the current version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
