### PR TITLE
NIFI-11051 Corrected handling of empty Registry host property

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactory.java
@@ -49,6 +49,8 @@ public class ApplicationServerConnectorFactory extends StandardServerConnectorFa
 
     private static final String CIPHER_SUITE_SEPARATOR_PATTERN = ",\\s*";
 
+    private static final String DEFAULT_HOST = null;
+
     private final String includeCipherSuites;
 
     private final String excludeCipherSuites;
@@ -213,7 +215,7 @@ public class ApplicationServerConnectorFactory extends StandardServerConnectorFa
             host = properties.getHttpHost();
         }
 
-        return host;
+        return StringUtils.defaultIfEmpty(host, DEFAULT_HOST);
     }
 
     private static int getPort(final NiFiRegistryProperties properties) {

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/test/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactoryTest.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/test/java/org/apache/nifi/registry/jetty/connector/ApplicationServerConnectorFactoryTest.java
@@ -20,6 +20,7 @@ import org.apache.nifi.registry.properties.NiFiRegistryProperties;
 import org.apache.nifi.remote.io.socket.NetworkUtils;
 import org.apache.nifi.security.util.TemporaryKeyStoreBuilder;
 import org.apache.nifi.security.util.TlsConfiguration;
+import org.apache.nifi.util.StringUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.jupiter.api.BeforeAll;
@@ -91,6 +92,22 @@ class ApplicationServerConnectorFactoryTest {
 
         assertNotNull(serverConnector);
         assertEquals(LOCALHOST, serverConnector.getHost());
+    }
+
+    @Test
+    void testGetServerConnectorHostPropertyEmpty() {
+        final int port = NetworkUtils.getAvailableTcpPort();
+        final Properties configuredProperties = new Properties();
+        configuredProperties.put(NiFiRegistryProperties.WEB_HTTP_PORT, Integer.toString(port));
+        configuredProperties.put(NiFiRegistryProperties.WEB_HTTP_HOST, StringUtils.EMPTY);
+
+        final NiFiRegistryProperties properties = getProperties(configuredProperties);
+        final ApplicationServerConnectorFactory factory = new ApplicationServerConnectorFactory(server, properties);
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        assertNotNull(serverConnector);
+        assertNull(serverConnector.getHost());
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-11051](https://issues.apache.org/jira/browse/NIFI-11051) Corrects handling of empty values for `nifi.registry.web.http.host` and `nifi.registry.web.https.host` properties.

Changes introduced in NiFi 1.19.0 passed the default empty value to the Jetty Server Connector, resulting in listening on 127.0.0.1. The correction substitutes `null` for an empty property value, restoring the default behavior of listening on all interfaces when the property value is empty.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
