### PR TITLE
NIFI-10991 Add AWS MSK IAM support to Kafka processors

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -199,6 +199,18 @@ The following binary components are provided under the Apache Software License v
       This project contains annotations derived from JCIP-ANNOTATIONS
       Copyright (c) 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
 
+      Apache HttpComponents Client
+      Copyright 1999-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+      Apache HttpComponents Core
+      Copyright 2005-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
   (ASLv2) Apache Jakarta HttpClient
     The following NOTICE information applies:
       Apache Jakarta HttpClient
@@ -1134,6 +1146,23 @@ The following binary components are provided under the Apache Software License v
       Since product implements StAX API, it has dependencies to StAX API
       classes.
 
+  (ASLv2) AWS SDK for Java
+    The following NOTICE information applies:
+      AWS SDK for Java
+      Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+      This product includes software developed by
+      Amazon Technologies, Inc (http://www.amazon.com/).
+
+      **********************
+      THIRD PARTY COMPONENTS
+      **********************
+      This software includes third party software subject to the following copyrights:
+      - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+      - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+
+      The licenses for these third party components are included in LICENSE.txt
+
   (ASLv2) AWS SDK for Java 2.0
       The following NOTICE information applies:
         Copyright 2010-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -1154,6 +1183,16 @@ The following binary components are provided under the Apache Software License v
       This software includes third party software subject to the following copyrights:
       - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
       - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+
+  (ASLv2) AWS EventStream for Java
+    The following NOTICE information applies:
+      AWS EventStream for Java
+      Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  (ASLv2) Amazon Ion Java
+    The following NOTICE information applies:
+      Amazon Ion Java
+      Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    (ASLv2) Apache Commons DBCP
       The following NOTICE information applies:

--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -2392,6 +2392,11 @@ The following binary components are provided under the Apache Software License v
       The Box SDK for Java
       Copyright 2019 Box, Inc. All rights reserved.
 
+  (ASLv2) aws-msk-iam-auth
+    The following NOTICE information applies:
+      aws-msk-iam-auth
+      Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 ************************
 Common Development and Distribution License 1.1
 ************************

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-nar/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
-nifi-kafka-1-0-nar
-Copyright 2014-2022 The Apache Software Foundation
+nifi-kafka-2-0-nar
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -80,4 +80,9 @@ The following binary components are provided under the Apache Software License v
       A list of contributors may be found from CREDITS file, which is included
       in some artifacts (usually source distributions); but is always available
       from the source code management (SCM) system project uses.
+
+  (ASLv2) aws-msk-iam-auth
+    The following NOTICE information applies:
+      aws-msk-iam-auth
+      Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-nar/src/main/resources/META-INF/NOTICE
@@ -86,3 +86,322 @@ The following binary components are provided under the Apache Software License v
       aws-msk-iam-auth
       Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+  (ASLv2) AWS SDK for Java
+    The following NOTICE information applies:
+      AWS SDK for Java
+      Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+      This product includes software developed by
+      Amazon Technologies, Inc (http://www.amazon.com/).
+
+      **********************
+      THIRD PARTY COMPONENTS
+      **********************
+      This software includes third party software subject to the following copyrights:
+      - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+      - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+
+      The licenses for these third party components are included in LICENSE.txt
+
+  (ASLv2) AWS EventStream for Java
+    The following NOTICE information applies:
+      AWS EventStream for Java
+      Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  (ASLv2) Apache HttpComponents
+    The following NOTICE information applies:
+      Apache HttpComponents Client
+      Copyright 1999-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+      Apache HttpComponents Core
+      Copyright 2005-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+  (ASLv2) Amazon Ion Java
+    The following NOTICE information applies:
+      Amazon Ion Java
+      Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  (ASLv2) Joda-Time
+    The following NOTICE information applies:
+      This product includes software developed by
+      Joda.org (http://www.joda.org/).
+
+  (ASLv2) The Netty Project
+    The following NOTICE information applies:
+                                  The Netty Project
+                                  =================
+
+      Please visit the Netty web site for more information:
+
+        * https://netty.io/
+
+      Copyright 2014 The Netty Project
+
+      The Netty Project licenses this file to you under the Apache License,
+      version 2.0 (the "License"); you may not use this file except in compliance
+      with the License. You may obtain a copy of the License at:
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and limitations
+      under the License.
+
+      Also, please refer to each LICENSE.<component>.txt file, which is located in
+      the 'license' directory of the distribution file, for the license terms of the
+      components that this product depends on.
+
+      -------------------------------------------------------------------------------
+      This product contains the extensions to Java Collections Framework which has
+      been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+
+        * LICENSE:
+          * license/LICENSE.jsr166y.txt (Public Domain)
+        * HOMEPAGE:
+          * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+          * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+
+      This product contains a modified version of Robert Harder's Public Domain
+      Base64 Encoder and Decoder, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.base64.txt (Public Domain)
+        * HOMEPAGE:
+          * http://iharder.sourceforge.net/current/java/base64/
+
+      This product contains a modified portion of 'Webbit', an event based
+      WebSocket and HTTP server, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.webbit.txt (BSD License)
+        * HOMEPAGE:
+          * https://github.com/joewalnes/webbit
+
+      This product contains a modified portion of 'SLF4J', a simple logging
+      facade for Java, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.slf4j.txt (MIT License)
+        * HOMEPAGE:
+          * https://www.slf4j.org/
+
+      This product contains a modified portion of 'Apache Harmony', an open source
+      Java SE, which can be obtained at:
+
+        * NOTICE:
+          * license/NOTICE.harmony.txt
+        * LICENSE:
+          * license/LICENSE.harmony.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://archive.apache.org/dist/harmony/
+
+      This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+      and decompression library written by Matthew J. Francis. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jbzip2.txt (MIT License)
+        * HOMEPAGE:
+          * https://code.google.com/p/jbzip2/
+
+      This product contains a modified portion of 'libdivsufsort', a C API library to construct
+      the suffix array and the Burrows-Wheeler transformed string for any input string of
+      a constant-size alphabet written by Yuta Mori. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.libdivsufsort.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/y-256/libdivsufsort
+
+      This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+       which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jctools.txt (ASL2 License)
+        * HOMEPAGE:
+          * https://github.com/JCTools/JCTools
+
+      This product optionally depends on 'JZlib', a re-implementation of zlib in
+      pure Java, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jzlib.txt (BSD style License)
+        * HOMEPAGE:
+          * http://www.jcraft.com/jzlib/
+
+      This product optionally depends on 'Compress-LZF', a Java library for encoding and
+      decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/ning/compress
+
+      This product optionally depends on 'lz4', a LZ4 Java compression
+      and decompression library written by Adrien Grand. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.lz4.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jpountz/lz4-java
+
+      This product optionally depends on 'lzma-java', a LZMA Java compression
+      and decompression library, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.lzma-java.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jponge/lzma-java
+
+      This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+      and decompression library, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.zstd-jni.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/luben/zstd-jni
+
+      This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+      and decompression library written by William Kinney. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jfastlz.txt (MIT License)
+        * HOMEPAGE:
+          * https://code.google.com/p/jfastlz/
+
+      This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+      interchange format, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.protobuf.txt (New BSD License)
+        * HOMEPAGE:
+          * https://github.com/google/protobuf
+
+      This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+      a temporary self-signed X.509 certificate when the JVM does not provide the
+      equivalent functionality.  It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.bouncycastle.txt (MIT License)
+        * HOMEPAGE:
+          * https://www.bouncycastle.org/
+
+      This product optionally depends on 'Snappy', a compression library produced
+      by Google Inc, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.snappy.txt (New BSD License)
+        * HOMEPAGE:
+          * https://github.com/google/snappy
+
+      This product optionally depends on 'JBoss Marshalling', an alternative Java
+      serialization API, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jboss-remoting/jboss-marshalling
+
+      This product optionally depends on 'Caliper', Google's micro-
+      benchmarking framework, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.caliper.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/google/caliper
+
+      This product optionally depends on 'Apache Commons Logging', a logging
+      framework, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.commons-logging.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://commons.apache.org/logging/
+
+      This product optionally depends on 'Apache Log4J', a logging framework, which
+      can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.log4j.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://logging.apache.org/log4j/
+
+      This product optionally depends on 'Aalto XML', an ultra-high performance
+      non-blocking XML processor, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://wiki.fasterxml.com/AaltoHome
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.hpack.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/twitter/hpack
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.hyper-hpack.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/python-hyper/hpack/
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.nghttp2-hpack.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/nghttp2/nghttp2/
+
+      This product contains a modified portion of 'Apache Commons Lang', a Java library
+      provides utilities for the java.lang API, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.commons-lang.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://commons.apache.org/proper/commons-lang/
+
+
+      This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+        * LICENSE:
+          * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/takari/maven-wrapper
+
+      This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+      This private header is also used by Apple's open source
+       mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+
+       * LICENSE:
+          * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+        * HOMEPAGE:
+          * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+
+      This product optionally depends on 'Brotli4j', Brotli compression and
+      decompression for Java., which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.brotli4j.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/hyperxpro/Brotli4j
+
+************************
+Creative Commons Zero license version 1.0
+************************
+
+The following binary components are provided under the Creative Commons Zero license version 1.0.  See project link for details.
+
+    (CC0v1.0) Reactive Streams (org.reactivestreams:reactive-streams:jar:1.0.3 - http://www.reactive-streams.org/)

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/pom.xml
@@ -135,5 +135,18 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>include-kafka-aws</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.msk</groupId>
+                    <artifactId>aws-msk-iam-auth</artifactId>
+                    <version>${aws-msk-iam-auth.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_0.java
@@ -267,7 +267,6 @@ public class ConsumeKafkaRecord_2_0 extends AbstractProcessor implements KafkaCl
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
         descriptors.add(AWS_PROFILE_NAME);
-        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(GROUP_ID);
         descriptors.add(SEPARATE_BY_KEY);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_0.java
@@ -266,6 +266,8 @@ public class ConsumeKafkaRecord_2_0 extends AbstractProcessor implements KafkaCl
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
+        descriptors.add(AWS_PROFILE_NAME);
+        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(GROUP_ID);
         descriptors.add(SEPARATE_BY_KEY);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_0.java
@@ -250,7 +250,6 @@ public class ConsumeKafka_2_0 extends AbstractProcessor implements KafkaClientCo
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
         descriptors.add(AWS_PROFILE_NAME);
-        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(TOPICS);
         descriptors.add(TOPIC_TYPE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_0.java
@@ -249,6 +249,8 @@ public class ConsumeKafka_2_0 extends AbstractProcessor implements KafkaClientCo
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
+        descriptors.add(AWS_PROFILE_NAME);
+        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(TOPICS);
         descriptors.add(TOPIC_TYPE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_0.java
@@ -307,6 +307,8 @@ public class PublishKafkaRecord_2_0 extends AbstractProcessor implements KafkaPu
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);
+        properties.add(AWS_PROFILE_NAME);
+        properties.add(AWS_DEBUG_CREDS);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(MESSAGE_KEY_FIELD);
         properties.add(MAX_REQUEST_SIZE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_0.java
@@ -308,7 +308,6 @@ public class PublishKafkaRecord_2_0 extends AbstractProcessor implements KafkaPu
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);
         properties.add(AWS_PROFILE_NAME);
-        properties.add(AWS_DEBUG_CREDS);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(MESSAGE_KEY_FIELD);
         properties.add(MAX_REQUEST_SIZE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_0.java
@@ -292,7 +292,6 @@ public class PublishKafka_2_0 extends AbstractProcessor implements KafkaPublishC
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);
         properties.add(AWS_PROFILE_NAME);
-        properties.add(AWS_DEBUG_CREDS);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(TOPIC);
         properties.add(DELIVERY_GUARANTEE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_0.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-0-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_0.java
@@ -291,6 +291,8 @@ public class PublishKafka_2_0 extends AbstractProcessor implements KafkaPublishC
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);
+        properties.add(AWS_PROFILE_NAME);
+        properties.add(AWS_DEBUG_CREDS);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(TOPIC);
         properties.add(DELIVERY_GUARANTEE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-nar/src/main/resources/META-INF/NOTICE
@@ -86,3 +86,322 @@ The following binary components are provided under the Apache Software License v
       aws-msk-iam-auth
       Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+  (ASLv2) AWS SDK for Java
+    The following NOTICE information applies:
+      AWS SDK for Java
+      Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+      This product includes software developed by
+      Amazon Technologies, Inc (http://www.amazon.com/).
+
+      **********************
+      THIRD PARTY COMPONENTS
+      **********************
+      This software includes third party software subject to the following copyrights:
+      - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+      - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+
+      The licenses for these third party components are included in LICENSE.txt
+
+  (ASLv2) AWS EventStream for Java
+    The following NOTICE information applies:
+      AWS EventStream for Java
+      Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  (ASLv2) Apache HttpComponents
+    The following NOTICE information applies:
+      Apache HttpComponents Client
+      Copyright 1999-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+      Apache HttpComponents Core
+      Copyright 2005-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+  (ASLv2) Amazon Ion Java
+    The following NOTICE information applies:
+      Amazon Ion Java
+      Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  (ASLv2) Joda-Time
+    The following NOTICE information applies:
+      This product includes software developed by
+      Joda.org (http://www.joda.org/).
+
+  (ASLv2) The Netty Project
+    The following NOTICE information applies:
+                                  The Netty Project
+                                  =================
+
+      Please visit the Netty web site for more information:
+
+        * https://netty.io/
+
+      Copyright 2014 The Netty Project
+
+      The Netty Project licenses this file to you under the Apache License,
+      version 2.0 (the "License"); you may not use this file except in compliance
+      with the License. You may obtain a copy of the License at:
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and limitations
+      under the License.
+
+      Also, please refer to each LICENSE.<component>.txt file, which is located in
+      the 'license' directory of the distribution file, for the license terms of the
+      components that this product depends on.
+
+      -------------------------------------------------------------------------------
+      This product contains the extensions to Java Collections Framework which has
+      been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+
+        * LICENSE:
+          * license/LICENSE.jsr166y.txt (Public Domain)
+        * HOMEPAGE:
+          * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+          * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+
+      This product contains a modified version of Robert Harder's Public Domain
+      Base64 Encoder and Decoder, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.base64.txt (Public Domain)
+        * HOMEPAGE:
+          * http://iharder.sourceforge.net/current/java/base64/
+
+      This product contains a modified portion of 'Webbit', an event based
+      WebSocket and HTTP server, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.webbit.txt (BSD License)
+        * HOMEPAGE:
+          * https://github.com/joewalnes/webbit
+
+      This product contains a modified portion of 'SLF4J', a simple logging
+      facade for Java, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.slf4j.txt (MIT License)
+        * HOMEPAGE:
+          * https://www.slf4j.org/
+
+      This product contains a modified portion of 'Apache Harmony', an open source
+      Java SE, which can be obtained at:
+
+        * NOTICE:
+          * license/NOTICE.harmony.txt
+        * LICENSE:
+          * license/LICENSE.harmony.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://archive.apache.org/dist/harmony/
+
+      This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+      and decompression library written by Matthew J. Francis. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jbzip2.txt (MIT License)
+        * HOMEPAGE:
+          * https://code.google.com/p/jbzip2/
+
+      This product contains a modified portion of 'libdivsufsort', a C API library to construct
+      the suffix array and the Burrows-Wheeler transformed string for any input string of
+      a constant-size alphabet written by Yuta Mori. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.libdivsufsort.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/y-256/libdivsufsort
+
+      This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+       which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jctools.txt (ASL2 License)
+        * HOMEPAGE:
+          * https://github.com/JCTools/JCTools
+
+      This product optionally depends on 'JZlib', a re-implementation of zlib in
+      pure Java, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jzlib.txt (BSD style License)
+        * HOMEPAGE:
+          * http://www.jcraft.com/jzlib/
+
+      This product optionally depends on 'Compress-LZF', a Java library for encoding and
+      decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/ning/compress
+
+      This product optionally depends on 'lz4', a LZ4 Java compression
+      and decompression library written by Adrien Grand. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.lz4.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jpountz/lz4-java
+
+      This product optionally depends on 'lzma-java', a LZMA Java compression
+      and decompression library, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.lzma-java.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jponge/lzma-java
+
+      This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+      and decompression library, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.zstd-jni.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/luben/zstd-jni
+
+      This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+      and decompression library written by William Kinney. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jfastlz.txt (MIT License)
+        * HOMEPAGE:
+          * https://code.google.com/p/jfastlz/
+
+      This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+      interchange format, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.protobuf.txt (New BSD License)
+        * HOMEPAGE:
+          * https://github.com/google/protobuf
+
+      This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+      a temporary self-signed X.509 certificate when the JVM does not provide the
+      equivalent functionality.  It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.bouncycastle.txt (MIT License)
+        * HOMEPAGE:
+          * https://www.bouncycastle.org/
+
+      This product optionally depends on 'Snappy', a compression library produced
+      by Google Inc, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.snappy.txt (New BSD License)
+        * HOMEPAGE:
+          * https://github.com/google/snappy
+
+      This product optionally depends on 'JBoss Marshalling', an alternative Java
+      serialization API, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jboss-remoting/jboss-marshalling
+
+      This product optionally depends on 'Caliper', Google's micro-
+      benchmarking framework, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.caliper.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/google/caliper
+
+      This product optionally depends on 'Apache Commons Logging', a logging
+      framework, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.commons-logging.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://commons.apache.org/logging/
+
+      This product optionally depends on 'Apache Log4J', a logging framework, which
+      can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.log4j.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://logging.apache.org/log4j/
+
+      This product optionally depends on 'Aalto XML', an ultra-high performance
+      non-blocking XML processor, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://wiki.fasterxml.com/AaltoHome
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.hpack.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/twitter/hpack
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.hyper-hpack.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/python-hyper/hpack/
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.nghttp2-hpack.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/nghttp2/nghttp2/
+
+      This product contains a modified portion of 'Apache Commons Lang', a Java library
+      provides utilities for the java.lang API, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.commons-lang.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://commons.apache.org/proper/commons-lang/
+
+
+      This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+        * LICENSE:
+          * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/takari/maven-wrapper
+
+      This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+      This private header is also used by Apple's open source
+       mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+
+       * LICENSE:
+          * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+        * HOMEPAGE:
+          * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+
+      This product optionally depends on 'Brotli4j', Brotli compression and
+      decompression for Java., which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.brotli4j.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/hyperxpro/Brotli4j
+
+************************
+Creative Commons Zero license version 1.0
+************************
+
+The following binary components are provided under the Creative Commons Zero license version 1.0.  See project link for details.
+
+    (CC0v1.0) Reactive Streams (org.reactivestreams:reactive-streams:jar:1.0.3 - http://www.reactive-streams.org/)

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-nar/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
-nifi-kafka-2-5-nar
-Copyright 2014-2022 The Apache Software Foundation
+nifi-kafka-2-6-nar
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -80,4 +80,9 @@ The following binary components are provided under the Apache Software License v
       A list of contributors may be found from CREDITS file, which is included
       in some artifacts (usually source distributions); but is always available
       from the source code management (SCM) system project uses.
+
+  (ASLv2) aws-msk-iam-auth
+    The following NOTICE information applies:
+      aws-msk-iam-auth
+      Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/pom.xml
@@ -147,5 +147,18 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>include-kafka-aws</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.msk</groupId>
+                    <artifactId>aws-msk-iam-auth</artifactId>
+                    <version>${aws-msk-iam-auth.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
@@ -321,7 +321,6 @@ public class ConsumeKafkaRecord_2_6 extends AbstractProcessor implements KafkaCl
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
         descriptors.add(AWS_PROFILE_NAME);
-        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(SEPARATE_BY_KEY);
         descriptors.add(AUTO_OFFSET_RESET);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
@@ -320,6 +320,8 @@ public class ConsumeKafkaRecord_2_6 extends AbstractProcessor implements KafkaCl
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
+        descriptors.add(AWS_PROFILE_NAME);
+        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(SEPARATE_BY_KEY);
         descriptors.add(AUTO_OFFSET_RESET);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -275,7 +275,6 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
         descriptors.add(AWS_PROFILE_NAME);
-        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(KEY_ATTRIBUTE_ENCODING);
         descriptors.add(AUTO_OFFSET_RESET);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -274,6 +274,8 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);
+        descriptors.add(AWS_PROFILE_NAME);
+        descriptors.add(AWS_DEBUG_CREDS);
         descriptors.add(SSL_CONTEXT_SERVICE);
         descriptors.add(KEY_ATTRIBUTE_ENCODING);
         descriptors.add(AUTO_OFFSET_RESET);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -350,6 +350,8 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);
+        properties.add(AWS_PROFILE_NAME);
+        properties.add(AWS_DEBUG_CREDS);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(MESSAGE_KEY_FIELD);
         properties.add(MAX_REQUEST_SIZE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -351,7 +351,6 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);
         properties.add(AWS_PROFILE_NAME);
-        properties.add(AWS_DEBUG_CREDS);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(MESSAGE_KEY_FIELD);
         properties.add(MAX_REQUEST_SIZE);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -305,6 +305,8 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         properties.add(KERBEROS_KEYTAB);
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
+        properties.add(AWS_PROFILE_NAME);
+        properties.add(AWS_DEBUG_CREDS);
         properties.add(TOKEN_AUTHENTICATION);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(KEY);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -306,7 +306,6 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(AWS_PROFILE_NAME);
-        properties.add(AWS_DEBUG_CREDS);
         properties.add(TOKEN_AUTHENTICATION);
         properties.add(SSL_CONTEXT_SERVICE);
         properties.add(KEY);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -58,7 +58,7 @@ public interface KafkaClientComponent {
             .description("SASL mechanism used for authentication. Corresponds to Kafka Client sasl.mechanism property")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .allowableValues(SaslMechanism.class)
+            .allowableValues(SaslMechanism.getAvailableSaslMechanisms())
             .defaultValue(SaslMechanism.GSSAPI.getValue())
             .build();
 
@@ -105,6 +105,35 @@ public interface KafkaClientComponent {
                     SaslMechanism.SCRAM_SHA_256.getValue(),
                     SaslMechanism.SCRAM_SHA_512.getValue()
             )
+            .build();
+
+    PropertyDescriptor AWS_PROFILE_NAME = new PropertyDescriptor.Builder()
+            .name("aws.profile.name")
+            .displayName("AWS Profile Name")
+            .description("The AWS Profile to consider when there are multiple profiles available.")
+            .dependsOn(
+                    SASL_MECHANISM,
+                    SaslMechanism.AWS_MSK_IAM
+            )
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .build();
+
+    PropertyDescriptor AWS_DEBUG_CREDS = new PropertyDescriptor.Builder()
+            .name("aws.debug.creds")
+            .displayName("Debug AWS Credentials")
+            .description("This property helps to debug which AWS credential is being exactly used. If this property is set to true "
+                    + "and `software.amazon.msk.auth.iam.internals.MSKCredentialProvider` logger is set to DEBUG, a log will be printed "
+                    + "including IAM Account, IAM user id and the ARN of the IAM Principal corresponding to the credential being used. "
+                    + "It is recommended to use this property only during debug since it makes an additional remote call.")
+            .dependsOn(
+                    SASL_MECHANISM,
+                    SaslMechanism.AWS_MSK_IAM
+            )
+            .required(false)
+            .allowableValues("true", "false")
+            .defaultValue("false")
             .build();
 
     PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -110,30 +110,14 @@ public interface KafkaClientComponent {
     PropertyDescriptor AWS_PROFILE_NAME = new PropertyDescriptor.Builder()
             .name("aws.profile.name")
             .displayName("AWS Profile Name")
-            .description("The AWS Profile to consider when there are multiple profiles available.")
+            .description("The Amazon Web Services Profile to select when multiple profiles are available.")
             .dependsOn(
                     SASL_MECHANISM,
                     SaslMechanism.AWS_MSK_IAM
             )
             .required(false)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-            .build();
-
-    PropertyDescriptor AWS_DEBUG_CREDS = new PropertyDescriptor.Builder()
-            .name("aws.debug.creds")
-            .displayName("Debug AWS Credentials")
-            .description("This property helps to debug which AWS credential is being exactly used. If this property is set to true "
-                    + "and `software.amazon.msk.auth.iam.internals.MSKCredentialProvider` logger is set to DEBUG, a log will be printed "
-                    + "including IAM Account, IAM user id and the ARN of the IAM Principal corresponding to the credential being used. "
-                    + "It is recommended to use this property only during debug since it makes an additional remote call.")
-            .dependsOn(
-                    SASL_MECHANISM,
-                    SaslMechanism.AWS_MSK_IAM
-            )
-            .required(false)
-            .allowableValues("true", "false")
-            .defaultValue("false")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
     PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
@@ -21,29 +21,22 @@ import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 import org.apache.nifi.util.StringUtils;
 
 /**
- * SASL AWS IAM Login Module implementation of configuration provider
+ * SASL AWS MSK IAM Login Module implementation of configuration provider
  */
-public class IAMLoginConfigProvider implements LoginConfigProvider {
+public class AwsMskIamLoginConfigProvider implements LoginConfigProvider {
 
     private static final String MODULE_CLASS = "software.amazon.msk.auth.iam.IAMLoginModule";
 
     private static final String AWS_PROFILE_NAME_FORMAT = "awsProfileName=\"%s\"";
 
-    private static final String AWS_ENABLE_DEBUG_CREDS = "awsDebugCreds=true";
-
     @Override
     public String getConfiguration(PropertyContext context) {
         final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
-        final boolean awsDebugCreds = context.getProperty(KafkaClientComponent.AWS_DEBUG_CREDS).asBoolean();
 
         final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS);
 
-        if (!StringUtils.isBlank(awsProfileName)) {
+        if (StringUtils.isNotBlank(awsProfileName)) {
             builder.append(String.format(AWS_PROFILE_NAME_FORMAT, awsProfileName));
-        }
-
-        if (awsDebugCreds) {
-            builder.append(AWS_ENABLE_DEBUG_CREDS);
         }
 
         return builder.build();

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
@@ -20,6 +20,8 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 import org.apache.nifi.util.StringUtils;
 
+import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+
 /**
  * SASL AWS MSK IAM Login Module implementation of configuration provider
  */
@@ -27,16 +29,16 @@ public class AwsMskIamLoginConfigProvider implements LoginConfigProvider {
 
     private static final String MODULE_CLASS = "software.amazon.msk.auth.iam.IAMLoginModule";
 
-    private static final String AWS_PROFILE_NAME_FORMAT = "awsProfileName=\"%s\"";
+    private static final String AWS_PROFILE_NAME_KEY = "awsProfileName";
 
     @Override
     public String getConfiguration(PropertyContext context) {
         final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
 
-        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS);
+        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS, REQUIRED);
 
         if (StringUtils.isNotBlank(awsProfileName)) {
-            builder.append(String.format(AWS_PROFILE_NAME_FORMAT, awsProfileName));
+            builder.append(AWS_PROFILE_NAME_KEY, awsProfileName);
         }
 
         return builder.build();

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
@@ -36,7 +36,7 @@ public class DelegatingLoginConfigProvider implements LoginConfigProvider {
         PROVIDERS.put(SaslMechanism.PLAIN, new PlainLoginConfigProvider());
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_256, SCRAM_PROVIDER);
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_512, SCRAM_PROVIDER);
-        PROVIDERS.put(SaslMechanism.AWS_MSK_IAM, new IAMLoginConfigProvider());
+        PROVIDERS.put(SaslMechanism.AWS_MSK_IAM, new AwsMskIamLoginConfigProvider());
     }
 
     /**

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
@@ -36,6 +36,7 @@ public class DelegatingLoginConfigProvider implements LoginConfigProvider {
         PROVIDERS.put(SaslMechanism.PLAIN, new PlainLoginConfigProvider());
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_256, SCRAM_PROVIDER);
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_512, SCRAM_PROVIDER);
+        PROVIDERS.put(SaslMechanism.AWS_MSK_IAM, new IAMLoginConfigProvider());
     }
 
     /**

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/IAMLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/IAMLoginConfigProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.shared.login;
+
+import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
+import org.apache.nifi.util.StringUtils;
+
+/**
+ * SASL AWS IAM Login Module implementation of configuration provider
+ */
+public class IAMLoginConfigProvider implements LoginConfigProvider {
+
+    private static final String MODULE_CLASS = "software.amazon.msk.auth.iam.IAMLoginModule";
+
+    private static final String AWS_PROFILE_NAME_FORMAT = "awsProfileName=\"%s\"";
+
+    private static final String AWS_ENABLE_DEBUG_CREDS = "awsDebugCreds=true";
+
+    @Override
+    public String getConfiguration(PropertyContext context) {
+        final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
+        final boolean awsDebugCreds = context.getProperty(KafkaClientComponent.AWS_DEBUG_CREDS).asBoolean();
+
+        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS);
+
+        if (!StringUtils.isBlank(awsProfileName)) {
+            builder.append(String.format(AWS_PROFILE_NAME_FORMAT, awsProfileName));
+        }
+
+        if (awsDebugCreds) {
+            builder.append(AWS_ENABLE_DEBUG_CREDS);
+        }
+
+        return builder.build();
+    }
+}

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/KerberosUserServiceLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/KerberosUserServiceLoginConfigProvider.java
@@ -16,31 +16,20 @@
  */
 package org.apache.nifi.kafka.shared.login;
 
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SELF_CONTAINED_KERBEROS_USER_SERVICE;
-
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.kerberos.KerberosUserService;
 import org.apache.nifi.kerberos.SelfContainedKerberosUserService;
 import org.apache.nifi.security.krb.KerberosUser;
 
 import javax.security.auth.login.AppConfigurationEntry;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
+
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SELF_CONTAINED_KERBEROS_USER_SERVICE;
 
 /**
  * Kerberos User Service Login Module implementation of configuration provider
  */
 public class KerberosUserServiceLoginConfigProvider implements LoginConfigProvider {
-
-    private static final Map<AppConfigurationEntry.LoginModuleControlFlag, String> CONTROL_FLAGS = new LinkedHashMap<>();
-
-    static {
-        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.OPTIONAL, "optional");
-        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, "required");
-        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.REQUISITE, "requisite");
-        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT, "sufficient");
-    }
 
     /**
      * Get JAAS configuration using configured Kerberos credentials
@@ -54,11 +43,7 @@ public class KerberosUserServiceLoginConfigProvider implements LoginConfigProvid
         final KerberosUser kerberosUser = kerberosUserService.createKerberosUser();
         final AppConfigurationEntry configurationEntry = kerberosUser.getConfigurationEntry();
 
-        final LoginConfigBuilder builder = new LoginConfigBuilder(configurationEntry.getLoginModuleName());
-
-        final AppConfigurationEntry.LoginModuleControlFlag controlFlag = configurationEntry.getControlFlag();
-        final String moduleControlFlag = Objects.requireNonNull(CONTROL_FLAGS.get(controlFlag), "Control Flag not found");
-        builder.append(moduleControlFlag);
+        final LoginConfigBuilder builder = new LoginConfigBuilder(configurationEntry.getLoginModuleName(), configurationEntry.getControlFlag());
 
         final Map<String, ?> options = configurationEntry.getOptions();
         options.forEach(builder::append);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/KerberosUserServiceLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/KerberosUserServiceLoginConfigProvider.java
@@ -32,13 +32,6 @@ import java.util.Objects;
  * Kerberos User Service Login Module implementation of configuration provider
  */
 public class KerberosUserServiceLoginConfigProvider implements LoginConfigProvider {
-    private static final String SPACE = " ";
-
-    private static final String EQUALS = "=";
-
-    private static final String DOUBLE_QUOTE = "\"";
-
-    private static final String SEMI_COLON = ";";
 
     private static final Map<AppConfigurationEntry.LoginModuleControlFlag, String> CONTROL_FLAGS = new LinkedHashMap<>();
 
@@ -61,32 +54,15 @@ public class KerberosUserServiceLoginConfigProvider implements LoginConfigProvid
         final KerberosUser kerberosUser = kerberosUserService.createKerberosUser();
         final AppConfigurationEntry configurationEntry = kerberosUser.getConfigurationEntry();
 
-        final StringBuilder builder = new StringBuilder();
-
-        final String loginModuleName = configurationEntry.getLoginModuleName();
-        builder.append(loginModuleName);
+        final LoginConfigBuilder builder = new LoginConfigBuilder(configurationEntry.getLoginModuleName());
 
         final AppConfigurationEntry.LoginModuleControlFlag controlFlag = configurationEntry.getControlFlag();
         final String moduleControlFlag = Objects.requireNonNull(CONTROL_FLAGS.get(controlFlag), "Control Flag not found");
-        builder.append(SPACE);
         builder.append(moduleControlFlag);
 
         final Map<String, ?> options = configurationEntry.getOptions();
-        options.forEach((key, value) -> {
-            builder.append(SPACE);
+        options.forEach(builder::append);
 
-            builder.append(key);
-            builder.append(EQUALS);
-            if (value instanceof String) {
-                builder.append(DOUBLE_QUOTE);
-                builder.append(value);
-                builder.append(DOUBLE_QUOTE);
-            } else {
-                builder.append(value);
-            }
-        });
-
-        builder.append(SEMI_COLON);
-        return builder.toString();
+        return builder.build();
     }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/LoginConfigBuilder.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/LoginConfigBuilder.java
@@ -16,10 +16,24 @@
  */
 package org.apache.nifi.kafka.shared.login;
 
+import javax.security.auth.login.AppConfigurationEntry;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
 /**
  * Helper class to build JAAS configuration
  */
 public class LoginConfigBuilder {
+
+    private static final Map<AppConfigurationEntry.LoginModuleControlFlag, String> CONTROL_FLAGS = new LinkedHashMap<>();
+
+    static {
+        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.OPTIONAL, "optional");
+        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, "required");
+        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.REQUISITE, "requisite");
+        CONTROL_FLAGS.put(AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT, "sufficient");
+    }
 
     private static final String SPACE = " ";
 
@@ -29,17 +43,11 @@ public class LoginConfigBuilder {
 
     private static final String SEMI_COLON = ";";
 
-    private static final String REQUIRE_MODULE_CLASS_FORMAT = "%s required";
-
     private final StringBuilder builder;
 
-    public LoginConfigBuilder(String moduleClassName) {
-        this.builder = new StringBuilder(String.format(REQUIRE_MODULE_CLASS_FORMAT, moduleClassName));
-    }
-
-    public LoginConfigBuilder append(String configEntry) {
-        builder.append(SPACE).append(configEntry);
-        return this;
+    public LoginConfigBuilder(final String moduleClassName, final AppConfigurationEntry.LoginModuleControlFlag controlFlag) {
+        final String moduleControlFlag = Objects.requireNonNull(CONTROL_FLAGS.get(controlFlag), "Control Flag not found");
+        this.builder = new StringBuilder(moduleClassName).append(SPACE).append(moduleControlFlag);
     }
 
     public LoginConfigBuilder append(String key, Object value) {
@@ -63,8 +71,4 @@ public class LoginConfigBuilder {
         return builder.toString();
     }
 
-    @Override
-    public String toString() {
-        return build();
-    }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/LoginConfigBuilder.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/LoginConfigBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.shared.login;
+
+/**
+ * Helper class to build JAAS configuration
+ */
+public class LoginConfigBuilder {
+
+    private static final String SPACE = " ";
+
+    private static final String EQUALS = "=";
+
+    private static final String DOUBLE_QUOTE = "\"";
+
+    private static final String SEMI_COLON = ";";
+
+    private static final String REQUIRE_MODULE_CLASS_FORMAT = "%s required";
+
+    private final StringBuilder builder;
+
+    public LoginConfigBuilder(String moduleClassName) {
+        this.builder = new StringBuilder(String.format(REQUIRE_MODULE_CLASS_FORMAT, moduleClassName));
+    }
+
+    public LoginConfigBuilder append(String configEntry) {
+        builder.append(SPACE).append(configEntry);
+        return this;
+    }
+
+    public LoginConfigBuilder append(String key, Object value) {
+        builder.append(SPACE);
+
+        builder.append(key);
+        builder.append(EQUALS);
+        if (value instanceof String) {
+            builder.append(DOUBLE_QUOTE);
+            builder.append(value);
+            builder.append(DOUBLE_QUOTE);
+        } else {
+            builder.append(value);
+        }
+
+        return this;
+    }
+
+    public String build() {
+        builder.append(SEMI_COLON);
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        return build();
+    }
+}

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/ScramLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/ScramLoginConfigProvider.java
@@ -19,15 +19,18 @@ package org.apache.nifi.kafka.shared.login;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 
+import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+
 /**
  * SASL SCRAM Login Module implementation of configuration provider
  */
 public class ScramLoginConfigProvider implements LoginConfigProvider {
     private static final String MODULE_CLASS_NAME = "org.apache.kafka.common.security.scram.ScramLoginModule";
 
-    private static final String USERNAME_AND_PASSWORD_FORMAT = "username=\"%s\" password=\"%s\"";
+    private static final String USERNAME_KEY = "username";
+    private static final String PASSWORD_KEY = "password";
 
-    private static final String TOKEN_AUTH_ENABLED = "tokenauth=true";
+    private static final String TOKEN_AUTH_KEY = "tokenauth";
 
     /**
      * Get JAAS configuration using configured username and password with optional token authentication
@@ -37,17 +40,17 @@ public class ScramLoginConfigProvider implements LoginConfigProvider {
      */
     @Override
     public String getConfiguration(final PropertyContext context) {
-        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS_NAME);
+        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS_NAME, REQUIRED);
 
         final String username = context.getProperty(KafkaClientComponent.SASL_USERNAME).evaluateAttributeExpressions().getValue();
         final String password = context.getProperty(KafkaClientComponent.SASL_PASSWORD).evaluateAttributeExpressions().getValue();
 
-        final String usernamePassword = String.format(USERNAME_AND_PASSWORD_FORMAT, username, password);
-        builder.append(usernamePassword);
+        builder.append(USERNAME_KEY, username);
+        builder.append(PASSWORD_KEY, password);
 
         final Boolean tokenAuthenticationEnabled = context.getProperty(KafkaClientComponent.TOKEN_AUTHENTICATION).asBoolean();
         if (Boolean.TRUE == tokenAuthenticationEnabled) {
-            builder.append(TOKEN_AUTH_ENABLED);
+            builder.append(TOKEN_AUTH_KEY, Boolean.TRUE);
         }
 
         return builder.build();

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/ScramLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/ScramLoginConfigProvider.java
@@ -25,11 +25,9 @@ import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 public class ScramLoginConfigProvider implements LoginConfigProvider {
     private static final String MODULE_CLASS_NAME = "org.apache.kafka.common.security.scram.ScramLoginModule";
 
-    private static final String FORMAT = "%s required username=\"%s\" password=\"%s\"";
+    private static final String USERNAME_AND_PASSWORD_FORMAT = "username=\"%s\" password=\"%s\"";
 
     private static final String TOKEN_AUTH_ENABLED = "tokenauth=true";
-
-    private static final String SEMI_COLON = ";";
 
     /**
      * Get JAAS configuration using configured username and password with optional token authentication
@@ -39,20 +37,19 @@ public class ScramLoginConfigProvider implements LoginConfigProvider {
      */
     @Override
     public String getConfiguration(final PropertyContext context) {
-        final StringBuilder builder = new StringBuilder();
+        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS_NAME);
 
         final String username = context.getProperty(KafkaClientComponent.SASL_USERNAME).evaluateAttributeExpressions().getValue();
         final String password = context.getProperty(KafkaClientComponent.SASL_PASSWORD).evaluateAttributeExpressions().getValue();
 
-        final String moduleUsernamePassword = String.format(FORMAT, MODULE_CLASS_NAME, username, password);
-        builder.append(moduleUsernamePassword);
+        final String usernamePassword = String.format(USERNAME_AND_PASSWORD_FORMAT, username, password);
+        builder.append(usernamePassword);
 
         final Boolean tokenAuthenticationEnabled = context.getProperty(KafkaClientComponent.TOKEN_AUTHENTICATION).asBoolean();
         if (Boolean.TRUE == tokenAuthenticationEnabled) {
             builder.append(TOKEN_AUTH_ENABLED);
         }
 
-        builder.append(SEMI_COLON);
-        return builder.toString();
+        return builder.build();
     }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KafkaClientProperty.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KafkaClientProperty.java
@@ -24,6 +24,8 @@ public enum KafkaClientProperty {
 
     SASL_LOGIN_CLASS("sasl.login.class"),
 
+    SASL_CLIENT_CALLBACK_HANDLER_CLASS("sasl.client.callback.handler.class"),
+
     SSL_KEYSTORE_LOCATION("ssl.keystore.location"),
 
     SSL_KEYSTORE_PASSWORD("ssl.keystore.password"),

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
@@ -17,8 +17,10 @@
 package org.apache.nifi.kafka.shared.property;
 
 import org.apache.nifi.components.DescribedValue;
+import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyProvider;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -31,7 +33,10 @@ public enum SaslMechanism implements DescribedValue {
 
     SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA-256", "Salted Challenge Response Authentication Mechanism using SHA-512 with username and password"),
 
-    SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA-512", "Salted Challenge Response Authentication Mechanism using SHA-256 with username and password");
+    SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA-512", "Salted Challenge Response Authentication Mechanism using SHA-256 with username and password"),
+
+    AWS_MSK_IAM("AWS_MSK_IAM", "AWS IAM", "Allows to use AWS IAM for authentication and authorization against Amazon MSK clusters that have AWS IAM enabled " +
+            "as an authentication mechanism. The IAM credentials will be found using the AWS Default Credentials Provider Chain.");
 
     private final String value;
 
@@ -50,6 +55,14 @@ public enum SaslMechanism implements DescribedValue {
                 .filter(saslMechanism -> saslMechanism.getValue().equals(value))
                 .findFirst();
         return foundSaslMechanism.orElseThrow(() -> new IllegalArgumentException(String.format("SaslMechanism value [%s] not found", value)));
+    }
+
+    public static EnumSet<SaslMechanism> getAvailableSaslMechanisms() {
+        if (StandardKafkaPropertyProvider.isIAMCallbackHandlerFound()) {
+            return EnumSet.allOf(SaslMechanism.class);
+        } else {
+            return EnumSet.complementOf(EnumSet.of(SaslMechanism.AWS_MSK_IAM));
+        }
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
@@ -35,7 +35,7 @@ public enum SaslMechanism implements DescribedValue {
 
     SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA-512", "Salted Challenge Response Authentication Mechanism using SHA-256 with username and password"),
 
-    AWS_MSK_IAM("AWS_MSK_IAM", "AWS IAM", "Allows to use AWS IAM for authentication and authorization against Amazon MSK clusters that have AWS IAM enabled " +
+    AWS_MSK_IAM("AWS_MSK_IAM", "AWS_MSK_IAM", "Allows to use AWS IAM for authentication and authorization against Amazon MSK clusters that have AWS IAM enabled " +
             "as an authentication mechanism. The IAM credentials will be found using the AWS Default Credentials Provider Chain.");
 
     private final String value;
@@ -58,7 +58,7 @@ public enum SaslMechanism implements DescribedValue {
     }
 
     public static EnumSet<SaslMechanism> getAvailableSaslMechanisms() {
-        if (StandardKafkaPropertyProvider.isIAMCallbackHandlerFound()) {
+        if (StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
             return EnumSet.allOf(SaslMechanism.class);
         } else {
             return EnumSet.complementOf(EnumSet.of(SaslMechanism.AWS_MSK_IAM));

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
@@ -89,7 +89,7 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
             final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(context.getProperty(SASL_MECHANISM).getValue());
             if (SaslMechanism.GSSAPI == saslMechanism && isCustomKerberosLoginFound()) {
                 properties.put(SASL_LOGIN_CLASS.getProperty(), SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
-            } else if (SaslMechanism.AWS_MSK_IAM == saslMechanism && isIAMCallbackHandlerFound()) {
+            } else if (SaslMechanism.AWS_MSK_IAM == saslMechanism && isAwsMskIamCallbackHandlerFound()) {
                 properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS.getProperty(), SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
             }
         }
@@ -169,13 +169,13 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
         return isClassFound(SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
     }
 
-    public static boolean isIAMCallbackHandlerFound() {
+    public static boolean isAwsMskIamCallbackHandlerFound() {
         return isClassFound(SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
     }
 
-    private static boolean isClassFound(String clazz) {
+    private static boolean isClassFound(final String className) {
         try {
-            Class.forName(clazz);
+            Class.forName(className);
             return true;
         } catch (final ClassNotFoundException e) {
             return false;

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
@@ -19,6 +19,7 @@ package org.apache.nifi.kafka.shared.property.provider;
 import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
 import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
 import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SSL_CONTEXT_SERVICE;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
 import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_JAAS_CONFIG;
 import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_LOGIN_CLASS;
 import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_LOCATION;
@@ -56,6 +57,8 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
 
     private static final String SASL_GSSAPI_CUSTOM_LOGIN_CLASS = "org.apache.nifi.processors.kafka.pubsub.CustomKerberosLogin";
 
+    public static final String SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS = "software.amazon.msk.auth.iam.IAMClientCallbackHandler";
+
     private static final LoginConfigProvider LOGIN_CONFIG_PROVIDER = new DelegatingLoginConfigProvider();
 
     private final Set<String> clientPropertyNames;
@@ -86,6 +89,8 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
             final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(context.getProperty(SASL_MECHANISM).getValue());
             if (SaslMechanism.GSSAPI == saslMechanism && isCustomKerberosLoginFound()) {
                 properties.put(SASL_LOGIN_CLASS.getProperty(), SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
+            } else if (SaslMechanism.AWS_MSK_IAM == saslMechanism && isIAMCallbackHandlerFound()) {
+                properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS.getProperty(), SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
             }
         }
     }
@@ -160,9 +165,17 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
         }
     }
 
-    private boolean isCustomKerberosLoginFound() {
+    private static boolean isCustomKerberosLoginFound() {
+        return isClassFound(SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
+    }
+
+    public static boolean isIAMCallbackHandlerFound() {
+        return isClassFound(SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
+    }
+
+    private static boolean isClassFound(String clazz) {
         try {
-            Class.forName(SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
+            Class.forName(clazz);
             return true;
         } catch (final ClassNotFoundException e) {
             return false;

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
@@ -238,8 +238,10 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
     private void validateAWSIAMMechanism(final ValidationContext validationContext, final Collection<ValidationResult> results) {
         final String saslMechanism = validationContext.getProperty(SASL_MECHANISM).getValue();
 
-        if (SaslMechanism.AWS_MSK_IAM.getValue().equals(saslMechanism) && !StandardKafkaPropertyProvider.isIAMCallbackHandlerFound()) {
-            final String explanation = String.format("[%s] should be on classpath", StandardKafkaPropertyProvider.SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
+        if (SaslMechanism.AWS_MSK_IAM.getValue().equals(saslMechanism) && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
+            final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AWS MSK enabled",
+                    StandardKafkaPropertyProvider.SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
+
             results.add(new ValidationResult.Builder()
                     .subject(SASL_MECHANISM.getDisplayName())
                     .valid(false)

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
@@ -75,7 +75,7 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
         validateKerberosServices(validationContext, results);
         validateKerberosCredentials(validationContext, results);
         validateUsernamePassword(validationContext, results);
-        validateAWSIAMMechanism(validationContext, results);
+        validateAwsMskIamMechanism(validationContext, results);
         return results;
     }
 
@@ -235,10 +235,10 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
         }
     }
 
-    private void validateAWSIAMMechanism(final ValidationContext validationContext, final Collection<ValidationResult> results) {
-        final String saslMechanism = validationContext.getProperty(SASL_MECHANISM).getValue();
+    private void validateAwsMskIamMechanism(final ValidationContext validationContext, final Collection<ValidationResult> results) {
+        final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(validationContext.getProperty(SASL_MECHANISM).getValue());
 
-        if (SaslMechanism.AWS_MSK_IAM.getValue().equals(saslMechanism) && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
+        if (SaslMechanism.AWS_MSK_IAM == saslMechanism && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
             final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AWS MSK enabled",
                     StandardKafkaPropertyProvider.SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
@@ -236,17 +236,20 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
     }
 
     private void validateAwsMskIamMechanism(final ValidationContext validationContext, final Collection<ValidationResult> results) {
-        final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(validationContext.getProperty(SASL_MECHANISM).getValue());
+        final PropertyValue saslMechanismProperty = validationContext.getProperty(SASL_MECHANISM);
+        if (saslMechanismProperty.isSet()) {
+            final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(saslMechanismProperty.getValue());
 
-        if (SaslMechanism.AWS_MSK_IAM == saslMechanism && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
-            final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AWS MSK enabled",
-                    StandardKafkaPropertyProvider.SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
+            if (SaslMechanism.AWS_MSK_IAM == saslMechanism && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
+                final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AWS MSK enabled",
+                        StandardKafkaPropertyProvider.SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
 
-            results.add(new ValidationResult.Builder()
-                    .subject(SASL_MECHANISM.getDisplayName())
-                    .valid(false)
-                    .explanation(explanation)
-                    .build());
+                results.add(new ValidationResult.Builder()
+                        .subject(SASL_MECHANISM.getDisplayName())
+                        .valid(false)
+                        .explanation(explanation)
+                        .build());
+            }
         }
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/LoginConfigBuilderTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/LoginConfigBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.shared.login;
+
+import org.junit.jupiter.api.Test;
+
+import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LoginConfigBuilderTest {
+
+    @Test
+    void createExampleJaasConfigTest() {
+        String expectedConfig = "test.class.name required booleanFlag=true numberFlag=1 stringFlag=\"string-flag\";";
+
+        LoginConfigBuilder builder = new LoginConfigBuilder("test.class.name", REQUIRED);
+        builder.append("booleanFlag", Boolean.TRUE);
+        builder.append("numberFlag", 1);
+        builder.append("stringFlag", "string-flag");
+
+        assertEquals(expectedConfig, builder.build());
+    }
+}

--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -23,9 +23,10 @@
     <packaging>pom</packaging>
 
     <properties>
-      <kafka1.0.version>1.0.2</kafka1.0.version>
-      <kafka2.0.version>2.0.0</kafka2.0.version>
-      <kafka2.6.version>2.6.3</kafka2.6.version>
+        <kafka1.0.version>1.0.2</kafka1.0.version>
+        <kafka2.0.version>2.0.0</kafka2.0.version>
+        <kafka2.6.version>2.6.3</kafka2.6.version>
+        <aws-msk-iam-auth.version>1.1.5</aws-msk-iam-auth.version>
     </properties>
 
     <modules>
@@ -44,7 +45,7 @@
                 <artifactId>nifi-kafka-1-0-processors</artifactId>
                 <version>1.20.0-SNAPSHOT</version>
             </dependency>
-           <dependency>
+            <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-kafka-2-0-processors</artifactId>
                 <version>1.20.0-SNAPSHOT</version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10991](https://issues.apache.org/jira/browse/NIFI-10991)

This PR adds AWS IAM for authentication and authorization functionality against Amazon MSK clusters that have AWS IAM enabled as an authentication mechanism. You need to enable `include-kafka-aws` profile to include the required module. A previous PR (https://github.com/apache/nifi/pull/5291) tried to tackle this problem. In this PR, though, we decided not to include `awsRoleArn, awsRoleSessionName, awsStsRegion` as properties because they just add extra complexity with minimal value. When NiFi runs in EC2, and no profile is specified, the processor will use the role assigned to the EC2 instance. When NiFi runs locally, we can define a profile name that will reference a profile in` ~/.aws/credentials` (depends on os) file. In this file, you can specify the above properties along with the access key id and secret.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
