### PR TITLE
NIFI-5642 QueryCassandra processor : output FlowFiles as soon fetch_size is reached

### DIFF
--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
@@ -56,6 +56,10 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+import java.text.SimpleDateFormat;
+
 /**
  * AbstractCassandraProcessor is a base class for Cassandra processors and contains logic and variables common to most
  * processors integrating with Apache Cassandra.
@@ -390,8 +394,10 @@ public abstract class AbstractCassandraProcessor extends AbstractProcessor {
             return row.getDouble(i);
 
         } else if (dataType.equals(DataType.timestamp())) {
-            return row.getTimestamp(i);
-
+            // Timestamp type returned with ISO 8601 format
+            SimpleDateFormat formatter =
+                    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault());
+            return formatter.format(row.getTimestamp(i));
         } else if (dataType.equals(DataType.date())) {
             return row.getDate(i);
 

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
@@ -157,7 +157,7 @@ public abstract class AbstractCassandraProcessor extends AbstractProcessor {
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
-            .description("Successfully created FlowFile from CQL query result set.")
+            .description("A FlowFile is transferred to this relationship if the operation completed successfully.")
             .build();
 
     static final Relationship REL_ORIGINAL = new Relationship.Builder()

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
@@ -166,17 +166,17 @@ public abstract class AbstractCassandraProcessor extends AbstractProcessor {
 
     static final Relationship REL_ORIGINAL = new Relationship.Builder()
             .name("original")
-            .description("All input FlowFiles that are part of a successful query execution go here.")
+            .description("All input FlowFiles that are part of a successful CQL operation execution go here.")
             .build();
 
     public static final Relationship REL_FAILURE = new Relationship.Builder()
             .name("failure")
-            .description("CQL query execution failed.")
+            .description("CQL operation execution failed.")
             .build();
 
-    static final Relationship REL_RETRY = new Relationship.Builder().name("retry")
+    public static final Relationship REL_RETRY = new Relationship.Builder().name("retry")
             .description("A FlowFile is transferred to this relationship if the operation cannot be completed but attempting "
-                    + "it again may succeed.")
+                    + "the operation again may succeed.")
             .build();
 
     protected static List<PropertyDescriptor> descriptors = new ArrayList<>();

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/AbstractCassandraProcessor.java
@@ -155,14 +155,19 @@ public abstract class AbstractCassandraProcessor extends AbstractProcessor {
             .addValidator(StandardValidators.CHARACTER_SET_VALIDATOR)
             .build();
 
-    static final Relationship REL_SUCCESS = new Relationship.Builder()
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
-            .description("A FlowFile is transferred to this relationship if the operation completed successfully.")
+            .description("Successfully created FlowFile from CQL query result set.")
             .build();
 
-    static final Relationship REL_FAILURE = new Relationship.Builder()
+    static final Relationship REL_ORIGINAL = new Relationship.Builder()
+            .name("original")
+            .description("All input FlowFiles that are part of a successful query execution go here.")
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
             .name("failure")
-            .description("A FlowFile is transferred to this relationship if the operation failed.")
+            .description("CQL query execution failed.")
             .build();
 
     static final Relationship REL_RETRY = new Relationship.Builder().name("retry")

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -69,9 +69,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.TimeZone;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -288,13 +289,11 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                                             out, charset, 0, null));
                                 }
                             }
-
                         } catch (final TimeoutException | InterruptedException | ExecutionException e) {
                             throw new ProcessException(e);
                         }
                     }
                 });
-
 
                 // set attribute how many rows were selected
                 fileToProcess = session.putAttribute(fileToProcess, RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
@@ -330,8 +329,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             }
             fileToProcess = session.penalize(fileToProcess);
             session.transfer(fileToProcess, REL_RETRY);
-
         } catch (final QueryExecutionException qee) {
+            //session.rollback();
             logger.error("Cannot execute the query with the requested consistency level successfully", qee);
             if (fileToProcess == null) {
                 fileToProcess = session.create();
@@ -412,19 +411,20 @@ public class QueryCassandra extends AbstractCassandraProcessor {
 
         final Schema schema = createSchema(rs);
         final GenericRecord rec = new GenericData.Record(schema);
-
         final DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+
         try (final DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter)) {
             dataFileWriter.create(schema, outStream);
 
-            final ColumnDefinitions columnDefinitions = rs.getColumnDefinitions();
+            ColumnDefinitions columnDefinitions = rs.getColumnDefinitions();
             long nrOfRows = 0;
             long rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
 
             if (columnDefinitions != null) {
 
                 // Grab the ones we have
-                if (rowsAvailableWithoutFetching == 0) {
+                if (rowsAvailableWithoutFetching == 0
+                        || rowsAvailableWithoutFetching < maxRowsPerFlowFile) {
                     // Get more
                     if (timeout <= 0 || timeUnit == null) {
                         rs.fetchMoreResults().get();
@@ -439,11 +439,18 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                 }
 
                 Row row;
+                //Iterator<Row> it = rs.iterator();
                 while(nrOfRows < maxRowsPerFlowFile){
                     try {
                         row = rs.iterator().next();
                     }catch (NoSuchElementException nsee){
                         nrOfRows -= 1;
+                        break;
+                    }
+
+                    // iterator().next() is like iterator().one() => return null on end
+                    // https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/ResultSet.html#one--
+                    if(row == null){
                         break;
                     }
 
@@ -456,9 +463,9 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                             rec.put(i, getCassandraObject(row, i, dataType));
                         }
                     }
+
                     dataFileWriter.append(rec);
                     nrOfRows += 1;
-
                 }
             }
             return nrOfRows;
@@ -493,7 +500,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         try {
             // Write the initial object brace
             outStream.write("{\"results\":[".getBytes(charset));
-            final ColumnDefinitions columnDefinitions = rs.getColumnDefinitions();
+            ColumnDefinitions columnDefinitions = rs.getColumnDefinitions();
             long nrOfRows = 0;
             long rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
 
@@ -513,6 +520,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                 if(maxRowsPerFlowFile == 0){
                     maxRowsPerFlowFile = rowsAvailableWithoutFetching;
                 }
+
                 Row row;
                 while(nrOfRows < maxRowsPerFlowFile){
                     try {
@@ -521,9 +529,17 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                         nrOfRows -= 1;
                         break;
                     }
+
+                    // iterator().next() is like iterator().one() => return null on end
+                    // https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/ResultSet.html#one--
+                    if(row == null){
+                        break;
+                    }
+
                     if (nrOfRows != 0) {
                         outStream.write(",".getBytes(charset));
                     }
+
                     outStream.write("{".getBytes(charset));
                     for (int i = 0; i < columnDefinitions.size(); i++) {
                         final DataType dataType = columnDefinitions.getType(i);

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -32,7 +32,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -518,7 +518,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                     try {
                         row = rs.iterator().next();
                     }catch (NoSuchElementException nsee){
-                        //nrOfRows -= 1;
+                        nrOfRows -= 1;
                         break;
                     }
                     if (nrOfRows != 0) {

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -318,15 +318,10 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                     if (flowFileCount == outputBatchSize) {
                         session.commitAsync();
                         flowFileCount = 0;
-                        fileToProcess = session.create();
+//                        fileToProcess = session.create();
                     }
                 }
-//                try {
-                    resultSet.fetchMoreResults().get();
-//                } catch (Exception e) {
-//                    logger.error("ExecutionException : query {} for {} due to {}; routing to failure",
-//                            new Object[]{selectQuery, fileToProcess, e});
-//                }
+                resultSet.fetchMoreResults().get();
                 if (resultSet.isExhausted()) {
                     break;
                 }

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -19,7 +19,6 @@ package org.apache.nifi.processors.cassandra;
 import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
@@ -33,7 +32,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
-import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -63,16 +62,17 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Collections;
 import java.util.TimeZone;
+import java.util.Date;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -123,6 +123,16 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .addValidator(StandardValidators.INTEGER_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor MAX_ROWS_PER_FLOW_FILE = new PropertyDescriptor.Builder()
+            .name("Max Rows Per Flow File")
+            .description("The maximum number of result rows that will be included in a single FlowFile. This will allow you to break up very large "
+                    + "result sets into multiple FlowFiles. If the value specified is zero, then all rows are returned in a single FlowFile.")
+            .defaultValue("0")
+            .required(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .addValidator(StandardValidators.INTEGER_VALIDATOR)
+            .build();
+
     public static final PropertyDescriptor OUTPUT_FORMAT = new PropertyDescriptor.Builder()
             .name("Output Format")
             .description("The format to which the result rows will be converted. If JSON is selected, the output will "
@@ -165,12 +175,14 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         _propertyDescriptors.add(CQL_SELECT_QUERY);
         _propertyDescriptors.add(QUERY_TIMEOUT);
         _propertyDescriptors.add(FETCH_SIZE);
+        _propertyDescriptors.add(MAX_ROWS_PER_FLOW_FILE);
         _propertyDescriptors.add(OUTPUT_FORMAT);
         _propertyDescriptors.add(TIMESTAMP_FORMAT_PATTERN);
         propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
 
         Set<Relationship> _relationships = new HashSet<>();
         _relationships.add(REL_SUCCESS);
+        _relationships.add(REL_ORIGINAL);
         _relationships.add(REL_FAILURE);
         _relationships.add(REL_RETRY);
         relationships = Collections.unmodifiableSet(_relationships);
@@ -201,76 +213,110 @@ public class QueryCassandra extends AbstractCassandraProcessor {
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile inputFlowFile = null;
         FlowFile fileToProcess = null;
+
+        Map<String, String> attributes = null;
+
         if (context.hasIncomingConnection()) {
-            fileToProcess = session.get();
+            inputFlowFile = session.get();
 
             // If we have no FlowFile, and all incoming connections are self-loops then we can continue on.
             // However, if we have no FlowFile and we have connections coming from other Processors, then
             // we know that we should run only if we have a FlowFile.
-            if (fileToProcess == null && context.hasNonLoopConnection()) {
+            if (inputFlowFile == null && context.hasNonLoopConnection()) {
                 return;
             }
+
+            attributes = inputFlowFile.getAttributes();
         }
 
         final ComponentLog logger = getLogger();
-        final String selectQuery = context.getProperty(CQL_SELECT_QUERY).evaluateAttributeExpressions(fileToProcess).getValue();
-        final long queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions(fileToProcess).asTimePeriod(TimeUnit.MILLISECONDS);
+        final String selectQuery = context.getProperty(CQL_SELECT_QUERY).evaluateAttributeExpressions(inputFlowFile).getValue();
+        final long queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions(inputFlowFile).asTimePeriod(TimeUnit.MILLISECONDS);
         final String outputFormat = context.getProperty(OUTPUT_FORMAT).getValue();
-        final Charset charset = Charset.forName(context.getProperty(CHARSET).evaluateAttributeExpressions(fileToProcess).getValue());
+        final long maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions().asInteger();
+        final Charset charset = Charset.forName(context.getProperty(CHARSET).evaluateAttributeExpressions(inputFlowFile).getValue());
         final StopWatch stopWatch = new StopWatch(true);
 
-        if (fileToProcess == null) {
-            fileToProcess = session.create();
+        if(inputFlowFile != null){
+            session.transfer(inputFlowFile, REL_ORIGINAL);
         }
 
         try {
             // The documentation for the driver recommends the session remain open the entire time the processor is running
             // and states that it is thread-safe. This is why connectionSession is not in a try-with-resources.
             final Session connectionSession = cassandraSession.get();
-            final ResultSetFuture queryFuture = connectionSession.executeAsync(selectQuery);
+            final ResultSet resultSet;
+
+            if (queryTimeout > 0) {
+                resultSet = connectionSession.execute(selectQuery, queryTimeout, TimeUnit.MILLISECONDS);
+            }else{
+                resultSet = connectionSession.execute(selectQuery);
+            }
+
             final AtomicLong nrOfRows = new AtomicLong(0L);
 
-            fileToProcess = session.write(fileToProcess, new OutputStreamCallback() {
-                @Override
-                public void process(final OutputStream rawOut) throws IOException {
-                    try (final OutputStream out = new BufferedOutputStream(rawOut)) {
-                        logger.debug("Executing CQL query {}", new Object[]{selectQuery});
-                        final ResultSet resultSet;
-                        if (queryTimeout > 0) {
-                            resultSet = queryFuture.getUninterruptibly(queryTimeout, TimeUnit.MILLISECONDS);
-                            if (AVRO_FORMAT.equals(outputFormat)) {
-                                nrOfRows.set(convertToAvroStream(resultSet, out, queryTimeout, TimeUnit.MILLISECONDS));
-                            } else if (JSON_FORMAT.equals(outputFormat)) {
-                                nrOfRows.set(convertToJsonStream(Optional.of(context), resultSet, out, charset, queryTimeout, TimeUnit.MILLISECONDS));
-                            }
-                        } else {
-                            resultSet = queryFuture.getUninterruptibly();
-                            if (AVRO_FORMAT.equals(outputFormat)) {
-                                nrOfRows.set(convertToAvroStream(resultSet, out, 0, null));
-                            } else if (JSON_FORMAT.equals(outputFormat)) {
-                                nrOfRows.set(convertToJsonStream(Optional.of(context), resultSet, out, charset, 0, null));
-                            }
-                        }
+            do {
+                fileToProcess = session.create();
 
-                    } catch (final TimeoutException | InterruptedException | ExecutionException e) {
-                        throw new ProcessException(e);
-                    }
+                // Assuring that if we have an input FlowFile
+                // the generated output inherit the attributes
+                if(attributes != null){
+                    fileToProcess = session.putAllAttributes(fileToProcess, attributes);
                 }
-            });
 
-            // set attribute how many rows were selected
-            fileToProcess = session.putAttribute(fileToProcess, RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
+                fileToProcess = session.write(fileToProcess, new OutputStreamCallback() {
+                    @Override
+                    public void process(final OutputStream out) throws IOException {
+                        try {
+                            logger.debug("Executing CQL query {}", new Object[]{selectQuery});
+                            if (queryTimeout > 0) {
+                                if (AVRO_FORMAT.equals(outputFormat)) {
+                                    nrOfRows.set(convertToAvroStream(resultSet, maxRowsPerFlowFile,
+                                            out, queryTimeout, TimeUnit.MILLISECONDS));
+                                } else if (JSON_FORMAT.equals(outputFormat)) {
+                                    nrOfRows.set(convertToJsonStream(resultSet, maxRowsPerFlowFile,
+                                            out, charset, queryTimeout, TimeUnit.MILLISECONDS));
+                                }
+                            } else {
+                                if (AVRO_FORMAT.equals(outputFormat)) {
+                                    nrOfRows.set(convertToAvroStream(resultSet, maxRowsPerFlowFile,
+                                            out, 0, null));
+                                } else if (JSON_FORMAT.equals(outputFormat)) {
+                                    nrOfRows.set(convertToJsonStream(resultSet, maxRowsPerFlowFile,
+                                            out, charset, 0, null));
+                                }
+                            }
 
-            // set mime.type based on output format
-            fileToProcess = session.putAttribute(fileToProcess, CoreAttributes.MIME_TYPE.key(),
-                    JSON_FORMAT.equals(outputFormat) ? "application/json" : "application/avro-binary");
+                        } catch (final TimeoutException | InterruptedException | ExecutionException e) {
+                            throw new ProcessException(e);
+                        }
+                    }
+                });
 
-            logger.info("{} contains {} Avro records; transferring to 'success'",
-                    new Object[]{fileToProcess, nrOfRows.get()});
-            session.getProvenanceReporter().modifyContent(fileToProcess, "Retrieved " + nrOfRows.get() + " rows",
-                    stopWatch.getElapsed(TimeUnit.MILLISECONDS));
-            session.transfer(fileToProcess, REL_SUCCESS);
+
+                // set attribute how many rows were selected
+                fileToProcess = session.putAttribute(fileToProcess, RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
+
+                // set mime.type based on output format
+                fileToProcess = session.putAttribute(fileToProcess, CoreAttributes.MIME_TYPE.key(),
+                        JSON_FORMAT.equals(outputFormat) ? "application/json" : "application/avro-binary");
+
+                logger.info("{} contains {} records; transferring to 'success'",
+                        new Object[]{fileToProcess, nrOfRows.get()});
+                session.getProvenanceReporter().modifyContent(fileToProcess, "Retrieved " + nrOfRows.get() + " rows",
+                        stopWatch.getElapsed(TimeUnit.MILLISECONDS));
+                session.transfer(fileToProcess, REL_SUCCESS);
+                session.commit();
+
+                try {
+                    resultSet.fetchMoreResults().get();
+                } catch (Exception e) {
+                    logger.error("ExecutionException : query {} for {} due to {}; routing to failure",
+                            new Object[]{selectQuery, fileToProcess, e});
+                }
+            } while (!resultSet.isExhausted());
 
         } catch (final NoHostAvailableException nhae) {
             getLogger().error("No host in the Cassandra cluster can be contacted successfully to execute this query", nhae);
@@ -279,11 +325,17 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             // cap the error limit at 10, format the messages, and don't include the stack trace (it is displayed by the
             // logger message above).
             getLogger().error(nhae.getCustomMessage(10, true, false));
+            if (fileToProcess == null) {
+                fileToProcess = session.create();
+            }
             fileToProcess = session.penalize(fileToProcess);
             session.transfer(fileToProcess, REL_RETRY);
 
         } catch (final QueryExecutionException qee) {
             logger.error("Cannot execute the query with the requested consistency level successfully", qee);
+            if (fileToProcess == null) {
+                fileToProcess = session.create();
+            }
             fileToProcess = session.penalize(fileToProcess);
             session.transfer(fileToProcess, REL_RETRY);
 
@@ -292,28 +344,41 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                 logger.error("The CQL query {} is invalid due to syntax error, authorization issue, or another "
                                 + "validation problem; routing {} to failure",
                         new Object[]{selectQuery, fileToProcess}, qve);
+
+                if (fileToProcess == null) {
+                    fileToProcess = session.create();
+                }
                 fileToProcess = session.penalize(fileToProcess);
                 session.transfer(fileToProcess, REL_FAILURE);
             } else {
                 // This can happen if any exceptions occur while setting up the connection, statement, etc.
                 logger.error("The CQL query {} is invalid due to syntax error, authorization issue, or another "
                         + "validation problem", new Object[]{selectQuery}, qve);
-                session.remove(fileToProcess);
+                if (fileToProcess != null) {
+                    session.remove(fileToProcess);
+                }
                 context.yield();
             }
         } catch (final ProcessException e) {
             if (context.hasIncomingConnection()) {
                 logger.error("Unable to execute CQL select query {} for {} due to {}; routing to failure",
                         new Object[]{selectQuery, fileToProcess, e});
+                if (fileToProcess == null) {
+                    fileToProcess = session.create();
+                }
                 fileToProcess = session.penalize(fileToProcess);
                 session.transfer(fileToProcess, REL_FAILURE);
+
             } else {
                 logger.error("Unable to execute CQL select query {} due to {}",
                         new Object[]{selectQuery, e});
-                session.remove(fileToProcess);
+                if (fileToProcess != null) {
+                    session.remove(fileToProcess);
+                }
                 context.yield();
             }
         }
+        session.commit();
     }
 
 
@@ -340,7 +405,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
      * @throws TimeoutException     If a result set fetch has taken longer than the specified timeout
      * @throws ExecutionException   If any error occurs during the result set fetch
      */
-    public static long convertToAvroStream(final ResultSet rs, final OutputStream outStream,
+    public static long convertToAvroStream(final ResultSet rs, long maxRowsPerFlowFile,
+                                           final OutputStream outStream,
                                            long timeout, TimeUnit timeUnit)
             throws IOException, InterruptedException, TimeoutException, ExecutionException {
 
@@ -353,36 +419,47 @@ public class QueryCassandra extends AbstractCassandraProcessor {
 
             final ColumnDefinitions columnDefinitions = rs.getColumnDefinitions();
             long nrOfRows = 0;
+            long rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
+
             if (columnDefinitions != null) {
-                do {
 
-                    // Grab the ones we have
-                    int rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
-                    if (rowsAvailableWithoutFetching == 0) {
-                        // Get more
-                        if (timeout <= 0 || timeUnit == null) {
-                            rs.fetchMoreResults().get();
+                // Grab the ones we have
+                if (rowsAvailableWithoutFetching == 0) {
+                    // Get more
+                    if (timeout <= 0 || timeUnit == null) {
+                        rs.fetchMoreResults().get();
+                    } else {
+                        rs.fetchMoreResults().get(timeout, timeUnit);
+                    }
+                    rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
+                }
+
+                if(maxRowsPerFlowFile == 0){
+                    maxRowsPerFlowFile = rowsAvailableWithoutFetching;
+                }
+
+                Row row;
+                while(nrOfRows < maxRowsPerFlowFile){
+                    try {
+                        row = rs.iterator().next();
+                    }catch (NoSuchElementException nsee){
+                        nrOfRows -= 1;
+                        break;
+                    }
+
+                    for (int i = 0; i < columnDefinitions.size(); i++) {
+                        final DataType dataType = columnDefinitions.getType(i);
+
+                        if (row.isNull(i)) {
+                            rec.put(i, null);
                         } else {
-                            rs.fetchMoreResults().get(timeout, timeUnit);
+                            rec.put(i, getCassandraObject(row, i, dataType));
                         }
                     }
+                    dataFileWriter.append(rec);
+                    nrOfRows += 1;
 
-                    for (Row row : rs) {
-
-                        for (int i = 0; i < columnDefinitions.size(); i++) {
-                            final DataType dataType = columnDefinitions.getType(i);
-
-                            if (row.isNull(i)) {
-                                rec.put(i, null);
-                            } else {
-                                rec.put(i, getCassandraObject(row, i, dataType));
-                            }
-                        }
-                        dataFileWriter.append(rec);
-                        nrOfRows += 1;
-
-                    }
-                } while (!rs.isFullyFetched());
+                }
             }
             return nrOfRows;
         }
@@ -401,7 +478,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
      * @throws TimeoutException     If a result set fetch has taken longer than the specified timeout
      * @throws ExecutionException   If any error occurs during the result set fetch
      */
-    public static long convertToJsonStream(final ResultSet rs, final OutputStream outStream,
+    public static long convertToJsonStream(final ResultSet rs, long maxRowsPerFlowFile,
+                                           final OutputStream outStream,
                                            Charset charset, long timeout, TimeUnit timeUnit)
         throws IOException, InterruptedException, TimeoutException, ExecutionException {
         return convertToJsonStream(Optional.empty(), rs, outStream, charset, timeout, timeUnit);
@@ -417,77 +495,87 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             outStream.write("{\"results\":[".getBytes(charset));
             final ColumnDefinitions columnDefinitions = rs.getColumnDefinitions();
             long nrOfRows = 0;
+            long rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
+
             if (columnDefinitions != null) {
-                do {
 
-                    // Grab the ones we have
-                    int rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
-                    if (rowsAvailableWithoutFetching == 0) {
-                        // Get more
-                        if (timeout <= 0 || timeUnit == null) {
-                            rs.fetchMoreResults().get();
-                        } else {
-                            rs.fetchMoreResults().get(timeout, timeUnit);
-                        }
+                // Grab the ones we have
+                if (rowsAvailableWithoutFetching == 0) {
+                    // Get more
+                    if (timeout <= 0 || timeUnit == null) {
+                        rs.fetchMoreResults().get();
+                    } else {
+                        rs.fetchMoreResults().get(timeout, timeUnit);
                     }
+                    rowsAvailableWithoutFetching = rs.getAvailableWithoutFetching();
+                }
 
-                    for (Row row : rs) {
-                        if (nrOfRows != 0) {
+                if(maxRowsPerFlowFile == 0){
+                    maxRowsPerFlowFile = rowsAvailableWithoutFetching;
+                }
+                Row row;
+                while(nrOfRows < maxRowsPerFlowFile){
+                    try {
+                        row = rs.iterator().next();
+                    }catch (NoSuchElementException nsee){
+                        //nrOfRows -= 1;
+                        break;
+                    }
+                    if (nrOfRows != 0) {
+                        outStream.write(",".getBytes(charset));
+                    }
+                    outStream.write("{".getBytes(charset));
+                    for (int i = 0; i < columnDefinitions.size(); i++) {
+                        final DataType dataType = columnDefinitions.getType(i);
+                        final String colName = columnDefinitions.getName(i);
+                        if (i != 0) {
                             outStream.write(",".getBytes(charset));
                         }
-                        outStream.write("{".getBytes(charset));
-                        for (int i = 0; i < columnDefinitions.size(); i++) {
-                            final DataType dataType = columnDefinitions.getType(i);
-                            final String colName = columnDefinitions.getName(i);
-                            if (i != 0) {
-                                outStream.write(",".getBytes(charset));
-                            }
-                            if (row.isNull(i)) {
-                                outStream.write(("\"" + colName + "\"" + ":null").getBytes(charset));
-                            } else {
-                                Object value = getCassandraObject(row, i, dataType);
-                                String valueString;
-                                if (value instanceof List || value instanceof Set) {
-                                    boolean first = true;
-                                    StringBuilder sb = new StringBuilder("[");
-                                    for (Object element : ((Collection) value)) {
-                                        if (!first) {
-                                            sb.append(",");
-                                        }
-                                        sb.append(getJsonElement(context, element));
-                                        first = false;
+                        if (row.isNull(i)) {
+                            outStream.write(("\"" + colName + "\"" + ":null").getBytes(charset));
+                        } else {
+                            Object value = getCassandraObject(row, i, dataType);
+                            String valueString;
+                            if (value instanceof List || value instanceof Set) {
+                                boolean first = true;
+                                StringBuilder sb = new StringBuilder("[");
+                                for (Object element : ((Collection) value)) {
+                                    if (!first) {
+                                        sb.append(",");
                                     }
-                                    sb.append("]");
-                                    valueString = sb.toString();
-                                } else if (value instanceof Map) {
-                                    boolean first = true;
-                                    StringBuilder sb = new StringBuilder("{");
-                                    for (Object element : ((Map) value).entrySet()) {
-                                        Map.Entry entry = (Map.Entry) element;
-                                        Object mapKey = entry.getKey();
-                                        Object mapValue = entry.getValue();
-
-                                        if (!first) {
-                                            sb.append(",");
-                                        }
-                                        sb.append(getJsonElement(context, mapKey));
-                                        sb.append(":");
-                                        sb.append(getJsonElement(context, mapValue));
-                                        first = false;
-                                    }
-                                    sb.append("}");
-                                    valueString = sb.toString();
-                                } else {
-                                    valueString = getJsonElement(context, value);
+                                    sb.append(getJsonElement(element));
+                                    first = false;
                                 }
-                                outStream.write(("\"" + colName + "\":"
-                                        + valueString + "").getBytes(charset));
+                                sb.append("]");
+                                valueString = sb.toString();
+                            } else if (value instanceof Map) {
+                                boolean first = true;
+                                StringBuilder sb = new StringBuilder("{");
+                                for (Object element : ((Map) value).entrySet()) {
+                                    Map.Entry entry = (Map.Entry) element;
+                                    Object mapKey = entry.getKey();
+                                    Object mapValue = entry.getValue();
+
+                                    if (!first) {
+                                        sb.append(",");
+                                    }
+                                    sb.append(getJsonElement(mapKey));
+                                    sb.append(":");
+                                    sb.append(getJsonElement(mapValue));
+                                    first = false;
+                                }
+                                sb.append("}");
+                                valueString = sb.toString();
+                            } else {
+                                valueString = getJsonElement(value);
                             }
+                            outStream.write(("\"" + colName + "\":"
+                                    + valueString + "").getBytes(charset));
                         }
-                        nrOfRows += 1;
-                        outStream.write("}".getBytes(charset));
                     }
-                } while (!rs.isFullyFetched());
+                    nrOfRows += 1;
+                    outStream.write("}".getBytes(charset));
+                }
             }
             return nrOfRows;
         } finally {
@@ -578,3 +666,4 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         return builder.endRecord();
     }
 }
+

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -134,6 +134,20 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             .addValidator(StandardValidators.INTEGER_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor OUTPUT_BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("qdbt-output-batch-size")
+            .displayName("Output Batch Size")
+            .description("The number of output FlowFiles to queue before committing the process session. When set to zero, the session will be committed when all result set rows "
+                    + "have been processed and the output FlowFiles are ready for transfer to the downstream relationship. For large result sets, this can cause a large burst of FlowFiles "
+                    + "to be transferred at the end of processor execution. If this property is set, then when the specified number of FlowFiles are ready for transfer, then the session will "
+                    + "be committed, thus releasing the FlowFiles to the downstream relationship. NOTE: The maxvalue.* and fragment.count attributes will not be set on FlowFiles when this "
+                    + "property is set.")
+            .defaultValue("0")
+            .required(true)
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .build();
+
     public static final PropertyDescriptor OUTPUT_FORMAT = new PropertyDescriptor.Builder()
             .name("Output Format")
             .description("The format to which the result rows will be converted. If JSON is selected, the output will "
@@ -177,6 +191,7 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         _propertyDescriptors.add(QUERY_TIMEOUT);
         _propertyDescriptors.add(FETCH_SIZE);
         _propertyDescriptors.add(MAX_ROWS_PER_FLOW_FILE);
+        _propertyDescriptors.add(OUTPUT_BATCH_SIZE);
         _propertyDescriptors.add(OUTPUT_FORMAT);
         _propertyDescriptors.add(TIMESTAMP_FORMAT_PATTERN);
         propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
@@ -237,12 +252,13 @@ public class QueryCassandra extends AbstractCassandraProcessor {
         final long queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions(inputFlowFile).asTimePeriod(TimeUnit.MILLISECONDS);
         final String outputFormat = context.getProperty(OUTPUT_FORMAT).getValue();
         final long maxRowsPerFlowFile = context.getProperty(MAX_ROWS_PER_FLOW_FILE).evaluateAttributeExpressions().asInteger();
+        final long outputBatchSize = context.getProperty(OUTPUT_BATCH_SIZE).evaluateAttributeExpressions().asInteger();
         final Charset charset = Charset.forName(context.getProperty(CHARSET).evaluateAttributeExpressions(inputFlowFile).getValue());
         final StopWatch stopWatch = new StopWatch(true);
 
-        if(inputFlowFile != null){
+        /*if(inputFlowFile != null){
             session.transfer(inputFlowFile, REL_ORIGINAL);
-        }
+        }*/
 
         try {
             // The documentation for the driver recommends the session remain open the entire time the processor is running
@@ -258,13 +274,21 @@ public class QueryCassandra extends AbstractCassandraProcessor {
 
             final AtomicLong nrOfRows = new AtomicLong(0L);
 
+            long flowFileCount = 0;
+
             do {
-                fileToProcess = session.create();
+                //fileToProcess = session.create();
 
                 // Assuring that if we have an input FlowFile
                 // the generated output inherit the attributes
-                if(attributes != null){
-                    fileToProcess = session.putAllAttributes(fileToProcess, attributes);
+                //if(attributes != null){
+                //    fileToProcess = session.putAllAttributes(fileToProcess, attributes);
+                //}
+
+                if(inputFlowFile != null){
+                    fileToProcess = session.create(inputFlowFile);
+                }else{
+                    fileToProcess = session.create();
                 }
 
                 fileToProcess = session.write(fileToProcess, new OutputStreamCallback() {
@@ -307,7 +331,16 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                 session.getProvenanceReporter().modifyContent(fileToProcess, "Retrieved " + nrOfRows.get() + " rows",
                         stopWatch.getElapsed(TimeUnit.MILLISECONDS));
                 session.transfer(fileToProcess, REL_SUCCESS);
-                session.commit();
+
+                if (outputBatchSize > 0) {
+                    flowFileCount++;
+
+                    if (flowFileCount== outputBatchSize) {
+                        session.commit();
+                        flowFileCount = 0;
+                    }
+                }
+
 
                 try {
                     resultSet.fetchMoreResults().get();
@@ -330,7 +363,6 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             fileToProcess = session.penalize(fileToProcess);
             session.transfer(fileToProcess, REL_RETRY);
         } catch (final QueryExecutionException qee) {
-            //session.rollback();
             logger.error("Cannot execute the query with the requested consistency level successfully", qee);
             if (fileToProcess == null) {
                 fileToProcess = session.create();
@@ -377,6 +409,11 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                 context.yield();
             }
         }
+
+        if(inputFlowFile != null){
+            session.transfer(inputFlowFile, REL_ORIGINAL);
+        }
+
         session.commit();
     }
 

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -277,14 +277,6 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             long flowFileCount = 0;
 
             do {
-                //fileToProcess = session.create();
-
-                // Assuring that if we have an input FlowFile
-                // the generated output inherit the attributes
-                //if(attributes != null){
-                //    fileToProcess = session.putAllAttributes(fileToProcess, attributes);
-                //}
-
                 if(inputFlowFile != null){
                     fileToProcess = session.create(inputFlowFile);
                 }else{

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/CassandraQueryTestUtil.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/CassandraQueryTestUtil.java
@@ -22,19 +22,20 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.text.SimpleDateFormat;
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -56,7 +57,7 @@ public class CassandraQueryTestUtil {
         TEST_DATE = c.getTime();
     }
 
-    public static ResultSet createMockResultSet() throws Exception {
+    public static ResultSet createMockResultSet(boolean falseThenTrue) throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
         ColumnDefinitions columnDefinitions = mock(ColumnDefinitions.class);
         when(columnDefinitions.size()).thenReturn(9);
@@ -106,12 +107,26 @@ public class CassandraQueryTestUtil {
                         }}, true, 3.0f, 4.0)
         );
 
+        ListenableFuture future = mock(ListenableFuture.class);
+        when(future.get()).thenReturn(rows);
+        when(resultSet.fetchMoreResults()).thenReturn(future);
+
         when(resultSet.iterator()).thenReturn(rows.iterator());
         when(resultSet.all()).thenReturn(rows);
         when(resultSet.getAvailableWithoutFetching()).thenReturn(rows.size());
         when(resultSet.isFullyFetched()).thenReturn(false).thenReturn(true);
+        if(falseThenTrue) {
+            when(resultSet.isExhausted()).thenReturn(false, true);
+        }else{
+            when(resultSet.isExhausted()).thenReturn(true);
+        }
         when(resultSet.getColumnDefinitions()).thenReturn(columnDefinitions);
+
         return resultSet;
+    }
+
+    public static ResultSet createMockResultSet() throws Exception {
+        return createMockResultSet(true);
     }
 
     public static ResultSet createMockResultSetOneColumn() throws Exception {
@@ -143,10 +158,15 @@ public class CassandraQueryTestUtil {
                 createRow("user2")
         );
 
+        ListenableFuture future = mock(ListenableFuture.class);
+        when(future.get()).thenReturn(rows);
+        when(resultSet.fetchMoreResults()).thenReturn(future);
+
         when(resultSet.iterator()).thenReturn(rows.iterator());
         when(resultSet.all()).thenReturn(rows);
         when(resultSet.getAvailableWithoutFetching()).thenReturn(rows.size());
         when(resultSet.isFullyFetched()).thenReturn(false).thenReturn(true);
+        when(resultSet.isExhausted()).thenReturn(false).thenReturn(true);
         when(resultSet.getColumnDefinitions()).thenReturn(columnDefinitions);
         return resultSet;
     }
@@ -195,3 +215,4 @@ public class CassandraQueryTestUtil {
         return row;
     }
 }
+

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraIT.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraIT.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.querybuilder.Select;
+import com.datastax.driver.core.querybuilder.Truncate;
+import groovy.util.logging.Log4j2;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.MockRecordParser;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+@Log4j2
+public class QueryCassandraIT {
+    @Container
+    private static final CassandraContainer CASSANDRA_CONTAINER = new CassandraContainer(DockerImageName.parse("cassandra:4.1"));
+
+    private static TestRunner putCassandraTestRunner;
+    private static TestRunner queryCassandraTestRunner;
+    private static MockRecordParser recordReader;
+
+    private static Cluster cluster;
+    private static Session session;
+
+    private static final int LOAD_FLOW_FILE_SIZE = 100;
+    private static final int LOAD_FLOW_FILE_BATCH_SIZE = 10;
+
+    private static final String KEYSPACE = "sample_keyspace";
+    private static final String TABLE = "sample_table";
+
+    @BeforeAll
+    public static void setup() throws InitializationException {
+        recordReader = new MockRecordParser();
+        putCassandraTestRunner = TestRunners.newTestRunner(PutCassandraRecord.class);
+        queryCassandraTestRunner = TestRunners.newTestRunner(QueryCassandra.class);
+
+        InetSocketAddress contactPoint = CASSANDRA_CONTAINER.getContactPoint();
+        putCassandraTestRunner.setProperty(PutCassandraRecord.RECORD_READER_FACTORY, "reader");
+        putCassandraTestRunner.setProperty(PutCassandraRecord.CONTACT_POINTS, contactPoint.getHostString() + ":" + contactPoint.getPort());
+        putCassandraTestRunner.setProperty(PutCassandraRecord.KEYSPACE, KEYSPACE);
+        putCassandraTestRunner.setProperty(PutCassandraRecord.TABLE, TABLE);
+        putCassandraTestRunner.setProperty(PutCassandraRecord.CONSISTENCY_LEVEL, "SERIAL");
+        putCassandraTestRunner.setProperty(PutCassandraRecord.BATCH_STATEMENT_TYPE, "LOGGED");
+        putCassandraTestRunner.addControllerService("reader", recordReader);
+        putCassandraTestRunner.enableControllerService(recordReader);
+
+        queryCassandraTestRunner.setProperty(QueryCassandra.CONTACT_POINTS, contactPoint.getHostName() + ":" + contactPoint.getPort());
+        queryCassandraTestRunner.setProperty(QueryCassandra.FETCH_SIZE, "10");
+        queryCassandraTestRunner.setProperty(QueryCassandra.OUTPUT_BATCH_SIZE, "10");
+        queryCassandraTestRunner.setProperty(QueryCassandra.KEYSPACE, KEYSPACE);
+        queryCassandraTestRunner.setProperty(QueryCassandra.CQL_SELECT_QUERY, "select * from " + TABLE + ";");
+
+        cluster = Cluster.builder().addContactPoint(contactPoint.getHostName())
+                .withPort(contactPoint.getPort()).build();
+        session = cluster.connect();
+
+        String createKeyspace = "CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class':'SimpleStrategy','replication_factor':1};";
+        String createTable = "CREATE TABLE IF NOT EXISTS " + KEYSPACE + "." + TABLE + "(id int PRIMARY KEY, uuid text, age int);";
+
+        session.execute(createKeyspace);
+        session.execute(createTable);
+        loadData();
+    }
+
+    private static void loadData() {
+        recordReader.addSchemaField("id", RecordFieldType.INT);
+        recordReader.addSchemaField("uuid", RecordFieldType.STRING);
+        recordReader.addSchemaField("age", RecordFieldType.INT);
+        int recordCount = 0;
+
+        for (int i = 0; i<LOAD_FLOW_FILE_SIZE; i++) {
+            for (int j = 0; j<LOAD_FLOW_FILE_BATCH_SIZE; j++) {
+                recordCount++;
+                recordReader.addRecord(recordCount, UUID.randomUUID().toString(),
+                        ThreadLocalRandom.current().nextInt(0, 101));
+            }
+            putCassandraTestRunner.enqueue("");
+            putCassandraTestRunner.run();
+        }
+        putCassandraTestRunner.assertAllFlowFilesTransferred(PutCassandraRecord.REL_SUCCESS, LOAD_FLOW_FILE_SIZE);
+        assertEquals(LOAD_FLOW_FILE_SIZE*LOAD_FLOW_FILE_BATCH_SIZE, getRecordsCount());
+    }
+
+    @Test
+    public void testSimpleQuery() {
+        queryCassandraTestRunner.enqueue("");
+        queryCassandraTestRunner.run();
+        Assertions.assertEquals(LOAD_FLOW_FILE_SIZE, queryCassandraTestRunner.getFlowFilesForRelationship(QueryCassandra.REL_SUCCESS).size());
+        queryCassandraTestRunner.clearTransferState();
+    }
+
+    @Test
+    public void testWithoutBatchSize() {
+        queryCassandraTestRunner.removeProperty(QueryCassandra.OUTPUT_BATCH_SIZE);
+        queryCassandraTestRunner.enqueue("");
+        queryCassandraTestRunner.run();
+        Assertions.assertEquals(LOAD_FLOW_FILE_SIZE, queryCassandraTestRunner.getFlowFilesForRelationship(QueryCassandra.REL_SUCCESS).size());
+        queryCassandraTestRunner.clearTransferState();
+    }
+
+    private static int getRecordsCount() {
+        Select selectQuery = QueryBuilder.select().all().from(KEYSPACE, TABLE);
+        ResultSet result = session.execute(selectQuery);
+
+        List<Integer> resultsList = result.all()
+                .stream()
+                .map(r -> r.getInt(0))
+                .collect(Collectors.toList());
+
+        return resultsList.size();
+    }
+
+    private void dropRecords() {
+        Truncate query = QueryBuilder.truncate(KEYSPACE, TABLE);
+        session.execute(query);
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        String dropKeyspace = "DROP KEYSPACE " + KEYSPACE;
+        String dropTable = "DROP TABLE IF EXISTS " + KEYSPACE + "." + TABLE;
+
+        session.execute(dropTable);
+        session.execute(dropKeyspace);
+
+        session.close();
+        cluster.close();
+    }
+}

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraIT.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraIT.java
@@ -22,7 +22,6 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.core.querybuilder.Truncate;
-import groovy.util.logging.Log4j2;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.record.MockRecordParser;
 import org.apache.nifi.serialization.record.RecordFieldType;
@@ -46,7 +45,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Testcontainers
-@Log4j2
 public class QueryCassandraIT {
     @Container
     private static final CassandraContainer CASSANDRA_CONTAINER = new CassandraContainer(DockerImageName.parse("cassandra:4.1"));

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
@@ -165,6 +165,7 @@ public class QueryCassandraTest {
 
     @Test
     public void testProcessorELConfigJsonOutput() {
+        setUpStandardProcessorConfig();
         testRunner.setProperty(AbstractCassandraProcessor.CONTACT_POINTS, "${hosts}");
         testRunner.setProperty(QueryCassandra.CQL_SELECT_QUERY, "${query}");
         testRunner.setProperty(AbstractCassandraProcessor.PASSWORD, "${pass}");
@@ -172,6 +173,7 @@ public class QueryCassandraTest {
         testRunner.setProperty(AbstractCassandraProcessor.CHARSET, "${charset}");
         testRunner.setProperty(QueryCassandra.QUERY_TIMEOUT, "${timeout}");
         testRunner.setProperty(QueryCassandra.FETCH_SIZE, "${fetch}");
+        testRunner.setProperty(QueryCassandra.MAX_ROWS_PER_FLOW_FILE, "${max-rows-per-flow}");
         testRunner.setIncomingConnection(false);
         testRunner.assertValid();
 
@@ -181,6 +183,7 @@ public class QueryCassandraTest {
         testRunner.setVariable("charset", "UTF-8");
         testRunner.setVariable("timeout", "30 sec");
         testRunner.setVariable("fetch", "0");
+        testRunner.setVariable("max-rows-per-flow", "0");
 
         // Test JSON output
         testRunner.setProperty(QueryCassandra.OUTPUT_FORMAT, QueryCassandra.JSON_FORMAT);
@@ -216,7 +219,7 @@ public class QueryCassandraTest {
     }
 
     @Test
-    public void testProcessorEmptyFlowFileAndExceptions() {
+    public void testProcessorEmptyFlowFile() {
         setUpStandardProcessorConfig();
 
         // Run with empty flowfile
@@ -224,35 +227,81 @@ public class QueryCassandraTest {
         processor.setExceptionToThrow(null);
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
-        testRunner.assertAllFlowFilesTransferred(QueryCassandra.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testProcessorEmptyFlowFileMaxRowsPerFlowFileEqOne() {
+
+        processor = new MockQueryCassandraTwoRounds();
+        testRunner = TestRunners.newTestRunner(processor);
+
+        setUpStandardProcessorConfig();
+
+        testRunner.setIncomingConnection(true);
+        testRunner.setProperty(QueryCassandra.MAX_ROWS_PER_FLOW_FILE, "1");
+        processor.setExceptionToThrow(null);
+        testRunner.enqueue("".getBytes());
+        testRunner.run(1, true, true);
+        testRunner.assertTransferCount(QueryCassandra.REL_SUCCESS, 2);
+        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
+        testRunner.clearTransferState();
+    }
+
+
+    @Test
+    public void testProcessorEmptyFlowFileAndNoHostAvailableException() {
+        setUpStandardProcessorConfig();
 
         // Test exceptions
         processor.setExceptionToThrow(new NoHostAvailableException(new HashMap<EndPoint, Throwable>()));
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
-        testRunner.assertAllFlowFilesTransferred(QueryCassandra.REL_RETRY, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_RETRY, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testProcessorEmptyFlowFileAndInetSocketAddressConsistencyLevelANY() {
+        setUpStandardProcessorConfig();
 
         processor.setExceptionToThrow(
                 new ReadTimeoutException(new SniEndPoint(new InetSocketAddress("localhost", 9042), ""), ConsistencyLevel.ANY, 0, 1, false));
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
-        testRunner.assertAllFlowFilesTransferred(QueryCassandra.REL_RETRY, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_RETRY, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testProcessorEmptyFlowFileAndInetSocketAddressDefault() {
+        setUpStandardProcessorConfig();
 
         processor.setExceptionToThrow(
                 new InvalidQueryException(new SniEndPoint(new InetSocketAddress("localhost", 9042), ""), "invalid query"));
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
-        testRunner.assertAllFlowFilesTransferred(QueryCassandra.REL_FAILURE, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_FAILURE, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testProcessorEmptyFlowFileAndExceptionsProcessException() {
+        setUpStandardProcessorConfig();
 
         processor.setExceptionToThrow(new ProcessException());
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
-        testRunner.assertAllFlowFilesTransferred(QueryCassandra.REL_FAILURE, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_FAILURE, 1);
+        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
     }
+
+    // --
 
     @Test
     public void testCreateSchemaOneColumn() throws Exception {
@@ -264,7 +313,7 @@ public class QueryCassandraTest {
 
     @Test
     public void testCreateSchema() throws Exception {
-        ResultSet rs = CassandraQueryTestUtil.createMockResultSet();
+        ResultSet rs = CassandraQueryTestUtil.createMockResultSet(true);
         Schema schema = QueryCassandra.createSchema(rs);
         assertNotNull(schema);
         assertEquals(Schema.Type.RECORD, schema.getType());
@@ -369,17 +418,20 @@ public class QueryCassandraTest {
 
     @Test
     public void testConvertToAvroStream() throws Exception {
+        setUpStandardProcessorConfig();
         ResultSet rs = CassandraQueryTestUtil.createMockResultSet();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        long numberOfRows = QueryCassandra.convertToAvroStream(rs, baos, 0, null);
+        long numberOfRows = QueryCassandra.convertToAvroStream(rs, 0, baos, 0, null);
         assertEquals(2, numberOfRows);
     }
 
     @Test
     public void testConvertToJSONStream() throws Exception {
+        setUpStandardProcessorConfig();
         ResultSet rs = CassandraQueryTestUtil.createMockResultSet();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        long numberOfRows = QueryCassandra.convertToJsonStream(rs, baos, StandardCharsets.UTF_8, 0, null);
+        long numberOfRows = QueryCassandra.convertToJsonStream(rs, 0, baos, StandardCharsets.UTF_8,
+                0, null);
         assertEquals(2, numberOfRows);
     }
 
@@ -425,6 +477,7 @@ public class QueryCassandraTest {
         testRunner.setProperty(QueryCassandra.CQL_SELECT_QUERY, "select * from test");
         testRunner.setProperty(AbstractCassandraProcessor.PASSWORD, "password");
         testRunner.setProperty(AbstractCassandraProcessor.USERNAME, "username");
+        testRunner.setProperty(QueryCassandra.MAX_ROWS_PER_FLOW_FILE, "0");
     }
 
     /**
@@ -448,17 +501,21 @@ public class QueryCassandraTest {
                 Configuration config = Configuration.builder().build();
                 when(mockCluster.getConfiguration()).thenReturn(config);
                 ResultSetFuture future = mock(ResultSetFuture.class);
-                ResultSet rs = CassandraQueryTestUtil.createMockResultSet();
+                ResultSet rs = CassandraQueryTestUtil.createMockResultSet(false);
                 when(future.getUninterruptibly()).thenReturn(rs);
+
                 try {
                     doReturn(rs).when(future).getUninterruptibly(anyLong(), any(TimeUnit.class));
                 } catch (TimeoutException te) {
                     throw new IllegalArgumentException("Mocked cluster doesn't time out");
                 }
+
                 if (exceptionToThrow != null) {
-                    when(mockSession.executeAsync(anyString())).thenThrow(exceptionToThrow);
+                    when(mockSession.execute(anyString(), any(), any())).thenThrow(exceptionToThrow);
+                    when(mockSession.execute(anyString())).thenThrow(exceptionToThrow);
                 } else {
-                    when(mockSession.executeAsync(anyString())).thenReturn(future);
+                    when(mockSession.execute(anyString(),any(), any())).thenReturn(rs);
+                    when(mockSession.execute(anyString())).thenReturn(rs);
                 }
             } catch (Exception e) {
                 fail(e.getMessage());
@@ -469,7 +526,52 @@ public class QueryCassandraTest {
         public void setExceptionToThrow(Exception e) {
             this.exceptionToThrow = e;
         }
+    }
 
+    private static class MockQueryCassandraTwoRounds extends MockQueryCassandra {
+
+        private Exception exceptionToThrow = null;
+
+        @Override
+        protected Cluster createCluster(List<InetSocketAddress> contactPoints, SSLContext sslContext,
+                                        String username, String password) {
+            Cluster mockCluster = mock(Cluster.class);
+            try {
+                Metadata mockMetadata = mock(Metadata.class);
+                when(mockMetadata.getClusterName()).thenReturn("cluster1");
+                when(mockCluster.getMetadata()).thenReturn(mockMetadata);
+                Session mockSession = mock(Session.class);
+                when(mockCluster.connect()).thenReturn(mockSession);
+                when(mockCluster.connect(anyString())).thenReturn(mockSession);
+                Configuration config = Configuration.builder().build();
+                when(mockCluster.getConfiguration()).thenReturn(config);
+                ResultSetFuture future = mock(ResultSetFuture.class);
+                ResultSet rs = CassandraQueryTestUtil.createMockResultSet(true);
+                when(future.getUninterruptibly()).thenReturn(rs);
+
+                try {
+                    doReturn(rs).when(future).getUninterruptibly(anyLong(), any(TimeUnit.class));
+                } catch (TimeoutException te) {
+                    throw new IllegalArgumentException("Mocked cluster doesn't time out");
+                }
+
+                if (exceptionToThrow != null) {
+                    when(mockSession.execute(anyString(), any(), any())).thenThrow(exceptionToThrow);
+                    when(mockSession.execute(anyString())).thenThrow(exceptionToThrow);
+                } else {
+                    when(mockSession.execute(anyString(),any(), any())).thenReturn(rs);
+                    when(mockSession.execute(anyString())).thenReturn(rs);
+                }
+            } catch (Exception e) {
+                fail(e.getMessage());
+            }
+            return mockCluster;
+        }
+
+        public void setExceptionToThrow(Exception e) {
+            this.exceptionToThrow = e;
+        }
     }
 
 }
+

--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/test/java/org/apache/nifi/processors/cassandra/QueryCassandraTest.java
@@ -228,7 +228,6 @@ public class QueryCassandraTest {
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
         testRunner.assertTransferCount(QueryCassandra.REL_SUCCESS, 1);
-        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
     }
 
@@ -246,7 +245,6 @@ public class QueryCassandraTest {
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
         testRunner.assertTransferCount(QueryCassandra.REL_SUCCESS, 2);
-        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
     }
 
@@ -260,7 +258,6 @@ public class QueryCassandraTest {
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
         testRunner.assertTransferCount(QueryCassandra.REL_RETRY, 1);
-        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
     }
 
@@ -273,7 +270,6 @@ public class QueryCassandraTest {
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
         testRunner.assertTransferCount(QueryCassandra.REL_RETRY, 1);
-        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
     }
 
@@ -286,7 +282,6 @@ public class QueryCassandraTest {
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
         testRunner.assertTransferCount(QueryCassandra.REL_FAILURE, 1);
-        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
         testRunner.clearTransferState();
     }
 
@@ -298,7 +293,6 @@ public class QueryCassandraTest {
         testRunner.enqueue("".getBytes());
         testRunner.run(1, true, true);
         testRunner.assertTransferCount(QueryCassandra.REL_FAILURE, 1);
-        testRunner.assertTransferCount(QueryCassandra.REL_ORIGINAL, 1);
     }
 
     // --
@@ -443,7 +437,7 @@ public class QueryCassandraTest {
         DateFormat df = new SimpleDateFormat(QueryCassandra.TIMESTAMP_FORMAT_PATTERN.getDefaultValue());
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(testRunner.getProcessContext()), rs, baos,
+        long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(testRunner.getProcessContext()), rs, 0, baos,
             StandardCharsets.UTF_8, 0, null);
         assertEquals(1, numberOfRows);
 
@@ -463,7 +457,7 @@ public class QueryCassandraTest {
         DateFormat df = new SimpleDateFormat(customDateFormat);
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(context), rs, baos, StandardCharsets.UTF_8, 0, null);
+        long numberOfRows = QueryCassandra.convertToJsonStream(Optional.of(context), rs, 0, baos, StandardCharsets.UTF_8, 0, null);
         assertEquals(1, numberOfRows);
 
         Map<String, List<Map<String, String>>> map = new ObjectMapper().readValue(baos.toByteArray(), HashMap.class);
@@ -534,7 +528,7 @@ public class QueryCassandraTest {
 
         @Override
         protected Cluster createCluster(List<InetSocketAddress> contactPoints, SSLContext sslContext,
-                                        String username, String password) {
+                                        String username, String password, String compressionType) {
             Cluster mockCluster = mock(Cluster.class);
             try {
                 Metadata mockMetadata = mock(Metadata.class);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

This brings back https://github.com/apache/nifi/pull/3051 and updates it to be in alignment with the newest nifi version. This is needed functionality as in the current iteration of the Cassandra processor, a "select * from" query returns a single very large flow file. This will allow for smaller flowfiles to be outputted, increasing the performance associated with this processor. Tracked in this jira issue: [NIFI-5642](https://issues.apache.org/jira/browse/NIFI-5642)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
