### PR TITLE
NIFI-11049 Fixed flaky PutDropboxTest, attribute description corrected

### DIFF
--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxAttributes.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/DropboxAttributes.java
@@ -30,11 +30,11 @@ public class DropboxAttributes {
     public static final String SIZE_DESC = "The size of the file";
 
     public static final String TIMESTAMP = "dropbox.timestamp";
-    public static final String TIMESTAMP_DESC = "The server modified time, when the file was uploaded to Dropbox";
+    public static final String TIMESTAMP_DESC = "The server modified time of the file";
 
     public static final String REVISION = "dropbox.revision";
     public static final String REVISION_DESC = "Revision of the file";
 
     public static final String ERROR_MESSAGE = "error.message";
-    public static final String ERROR_MESSAGE_DESC = "The error message returned by Dropbox when the fetch of a file fails";
+    public static final String ERROR_MESSAGE_DESC = "The error message returned by Dropbox";
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
@@ -258,14 +258,8 @@ public class PutDropboxTest extends AbstractDropboxTest {
                 .thenReturn(mockUploadSessionAppendV2Uploader);
 
         //finish session: 30 - 8 - 2 * 8 = 6 bytes uploaded
-        CommitInfo commitInfo = CommitInfo.newBuilder(getPath(TEST_FOLDER, FILENAME_1))
-                .withMode(WriteMode.ADD)
-                .withStrictConflict(true)
-                .withClientModified(new Date(mockFlowFile.getEntryDate()))
-                .build();
-
         when(mockDbxUserFilesRequest
-                .uploadSessionFinish(any(UploadSessionCursor.class), argThat(new CommitInfoArgMatcher(commitInfo))))
+                .uploadSessionFinish(any(UploadSessionCursor.class), any(CommitInfo.class)))
                 .thenReturn(mockUploadSessionFinishUploader);
 
         when(mockUploadSessionFinishUploader
@@ -332,28 +326,5 @@ public class PutDropboxTest extends AbstractDropboxTest {
         MockFlowFile mockFlowFile = getMockFlowFile(CONTENT);
         testRunner.enqueue(mockFlowFile);
         testRunner.run();
-    }
-
-    /**
-     * Custom args matcher for CommitInfo, clientModified field is not checked.
-     */
-    private static class CommitInfoArgMatcher implements ArgumentMatcher<CommitInfo> {
-
-        private final CommitInfo expected;
-
-        public CommitInfoArgMatcher(CommitInfo expected) {
-            this.expected = expected;
-        }
-
-        @Override
-        public boolean matches(final CommitInfo actual) {
-            if (actual == null) {
-                return false;
-            }
-
-            return expected.getPath().equals(actual.getPath())
-                    && expected.getStrictConflict() == actual.getStrictConflict()
-                    && expected.getMode().equals(actual.getMode());
-        }
     }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
@@ -24,7 +24,6 @@ import static org.apache.nifi.processors.dropbox.DropboxAttributes.ERROR_MESSAGE
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,7 +45,6 @@ import com.dropbox.core.v2.files.UploadWriteFailed;
 import com.dropbox.core.v2.files.WriteError;
 import com.dropbox.core.v2.files.WriteMode;
 import java.io.InputStream;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +55,6 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11049](https://issues.apache.org/jira/browse/NIFI-11049)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11049`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11049`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
