### PR TITLE
NIFI-11069 PutDropbox: remove upload cancellation, unify conflict res…

### DIFF
--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -158,7 +158,7 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
             ProxyConfiguration.createProxyConfigPropertyDescriptor(false, ProxySpec.HTTP_AUTH)
     ));
 
-    private DbxClientV2 dropboxApiClient;
+    private volatile DbxClientV2 dropboxApiClient;
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) {

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
@@ -184,7 +184,7 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
         RELATIONSHIPS = Collections.unmodifiableSet(rels);
     }
 
-    private DbxClientV2 dropboxApiClient;
+    private volatile DbxClientV2 dropboxApiClient;
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
@@ -33,8 +33,8 @@ import static org.apache.nifi.processors.dropbox.DropboxAttributes.SIZE_DESC;
 import static org.apache.nifi.processors.dropbox.DropboxAttributes.TIMESTAMP;
 import static org.apache.nifi.processors.dropbox.DropboxAttributes.TIMESTAMP_DESC;
 
+import com.dropbox.core.DbxApiException;
 import com.dropbox.core.DbxException;
-import com.dropbox.core.DbxUploader;
 import com.dropbox.core.RateLimitException;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.CommitInfo;
@@ -42,6 +42,7 @@ import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.UploadErrorException;
 import com.dropbox.core.v2.files.UploadSessionAppendV2Uploader;
 import com.dropbox.core.v2.files.UploadSessionCursor;
+import com.dropbox.core.v2.files.UploadSessionFinishErrorException;
 import com.dropbox.core.v2.files.UploadSessionFinishUploader;
 import com.dropbox.core.v2.files.UploadSessionStartUploader;
 import com.dropbox.core.v2.files.UploadUploader;
@@ -66,7 +67,6 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
@@ -101,7 +101,7 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
     public static final int SINGLE_UPLOAD_LIMIT_IN_BYTES = 150 * 1024 * 1024;
 
     public static final String IGNORE_RESOLUTION = "ignore";
-    public static final String OVERWRITE_RESOLUTION = "overwrite";
+    public static final String REPLACE_RESOLUTION = "replace";
     public static final String FAIL_RESOLUTION = "fail";
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -141,7 +141,7 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
             .description("Indicates what should happen when a file with the same name already exists in the specified Dropbox folder.")
             .required(true)
             .defaultValue(FAIL_RESOLUTION)
-            .allowableValues(FAIL_RESOLUTION, IGNORE_RESOLUTION, OVERWRITE_RESOLUTION)
+            .allowableValues(FAIL_RESOLUTION, IGNORE_RESOLUTION, REPLACE_RESOLUTION)
             .build();
 
     public static final PropertyDescriptor CHUNKED_UPLOAD_SIZE = new PropertyDescriptor.Builder()
@@ -185,8 +185,6 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
     }
 
     private DbxClientV2 dropboxApiClient;
-
-    private DbxUploader<?, ?, ?> dbxUploader;
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -239,6 +237,8 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
                 }
             } catch (UploadErrorException e) {
                 handleUploadError(conflictResolution, uploadPath, e);
+            } catch (UploadSessionFinishErrorException e) {
+                handleUploadError(conflictResolution, uploadPath, e);
             } catch (RateLimitException e) {
                 context.yield();
                 throw new ProcessException("Dropbox API rate limit exceeded while uploading file", e);
@@ -261,25 +261,29 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
         }
     }
 
-    @OnUnscheduled
-    public void shutdown() {
-        if (dbxUploader != null) {
-            dbxUploader.close();
+    private void handleUploadError(final String conflictResolution, final String uploadPath, final UploadErrorException e)  {
+        if (e.errorValue.isPath() && e.errorValue.getPathValue().getReason().isConflict()) {
+            handleConflict(conflictResolution, uploadPath, e);
+        } else {
+            throw new ProcessException(e);
         }
     }
 
-    private void handleUploadError(final String conflictResolution, final String uploadPath, final UploadErrorException e) throws UploadErrorException {
-        if (e.errorValue.isPath() && e.errorValue.getPathValue().getReason().isConflict()) {
-
-            if (IGNORE_RESOLUTION.equals(conflictResolution)) {
-                getLogger().info("File with the same name [{}] already exists. Remote file is not modified due to {} being set to '{}'.",
-                        uploadPath, CONFLICT_RESOLUTION.getDisplayName(), conflictResolution);
-                return;
-            } else if (conflictResolution.equals(FAIL_RESOLUTION)) {
-                throw new ProcessException(format("File with the same name [%s] already exists.", uploadPath), e);
-            }
+    private void handleUploadError(final String conflictResolution, final String uploadPath, final UploadSessionFinishErrorException e) {
+        if (e.errorValue.isPath() && e.errorValue.getPathValue().isConflict()) {
+            handleConflict(conflictResolution, uploadPath, e);
+        } else {
+            throw new ProcessException(e);
         }
-        throw new ProcessException(e);
+    }
+
+    private void handleConflict(final String conflictResolution, final String uploadPath, final DbxApiException e) {
+        if (IGNORE_RESOLUTION.equals(conflictResolution)) {
+            getLogger().info("File with the same name [{}] already exists. Remote file is not modified due to {} being set to '{}'.",
+                    uploadPath, CONFLICT_RESOLUTION.getDisplayName(), conflictResolution);
+        } else if (conflictResolution.equals(FAIL_RESOLUTION)) {
+            throw new ProcessException(format("File with the same name [%s] already exists.", uploadPath), e);
+        }
     }
 
     private FileMetadata uploadLargeFileInChunks(String path, InputStream rawIn, long size, long uploadChunkSize, String conflictResolution) throws DbxException, IOException {
@@ -314,7 +318,7 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
     }
 
     private WriteMode getWriteMode(String conflictResolution) {
-        if (OVERWRITE_RESOLUTION.equals(conflictResolution)) {
+        if (REPLACE_RESOLUTION.equals(conflictResolution)) {
             return WriteMode.OVERWRITE;
         } else {
             return WriteMode.ADD;
@@ -322,37 +326,29 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
     }
 
     private UploadUploader createUploadUploader(String path, String conflictResolution) throws DbxException {
-        final UploadUploader uploadUploader = dropboxApiClient
+        return dropboxApiClient
                 .files()
                 .uploadBuilder(path)
                 .withMode(getWriteMode(conflictResolution))
                 .withStrictConflict(true)
                 .start();
-        dbxUploader = uploadUploader;
-        return uploadUploader;
     }
 
     private UploadSessionStartUploader createUploadSessionStartUploader() throws DbxException {
-        final UploadSessionStartUploader sessionStartUploader = dropboxApiClient
+        return dropboxApiClient
                 .files()
                 .uploadSessionStart();
-        dbxUploader = sessionStartUploader;
-        return sessionStartUploader;
     }
 
     private UploadSessionAppendV2Uploader createUploadSessionAppendV2Uploader(UploadSessionCursor cursor) throws DbxException {
-        final UploadSessionAppendV2Uploader sessionAppendV2Uploader = dropboxApiClient
+        return dropboxApiClient
                 .files()
                 .uploadSessionAppendV2(cursor);
-        dbxUploader = sessionAppendV2Uploader;
-        return sessionAppendV2Uploader;
     }
 
     private UploadSessionFinishUploader createUploadSessionFinishUploader(UploadSessionCursor cursor, CommitInfo commitInfo) throws DbxException {
-        final UploadSessionFinishUploader sessionFinishUploader = dropboxApiClient
+        return dropboxApiClient
                 .files()
                 .uploadSessionFinish(cursor, commitInfo);
-        dbxUploader = sessionFinishUploader;
-        return sessionFinishUploader;
     }
 }

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxIT.java
@@ -115,9 +115,9 @@ public class PutDropboxIT extends AbstractDropboxIT<PutDropbox> {
     }
 
     @Test
-    void testUploadExistingFileOverwriteStrategy()  {
+    void testUploadExistingFileReplaceStrategy()  {
         testRunner.setProperty(PutDropbox.FOLDER, MAIN_FOLDER);
-        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.OVERWRITE_RESOLUTION);
+        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.REPLACE_RESOLUTION);
 
         testRunner.enqueue(CONTENT);
         testRunner.run();

--- a/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
+++ b/nifi-nar-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/PutDropboxTest.java
@@ -164,9 +164,9 @@ public class PutDropboxTest extends AbstractDropboxTest {
     }
 
     @Test
-    void testFileUploadWithOverwriteConflictResolutionStrategy() throws Exception {
+    void testFileUploadWithReplaceConflictResolutionStrategy() throws Exception {
         testRunner.setProperty(PutDropbox.FILE_NAME, FILENAME_1);
-        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.OVERWRITE_RESOLUTION);
+        testRunner.setProperty(PutDropbox.CONFLICT_RESOLUTION, PutDropbox.REPLACE_RESOLUTION);
 
         mockFileUpload(TEST_FOLDER, FILENAME_1, WriteMode.OVERWRITE);
 


### PR DESCRIPTION
…olution naming

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11069](https://issues.apache.org/jira/browse/NIFI-11069)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11069`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11069`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
