### PR TITLE
NIFI-11048 Add FileNameCompleter to avoid style parsing failures

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>3.21.0</jline.version>
+        <jline.version>3.22.0</jline.version>
     </properties>
 
     <build>

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/CLICompleter.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/CLICompleter.java
@@ -21,7 +21,7 @@ import org.apache.nifi.toolkit.cli.api.CommandGroup;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 import org.apache.nifi.toolkit.cli.impl.command.session.SessionCommandGroup;
 import org.apache.nifi.toolkit.cli.impl.session.SessionVariable;
-import org.jline.builtins.Completers;
+import org.apache.nifi.toolkit.cli.impl.util.StandardFileNameCompleter;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
@@ -76,6 +76,8 @@ public class CLICompleter implements Completer {
      * Second-level commands would be the values in topLevelCommandMap above, and options would arguments likes "-ks" or "-ts".
      */
     private final Map<String, List<String>> commandOptionsMap;
+
+    private final Completer fileNameCompleter = new StandardFileNameCompleter();
 
     /**
      * Initializes the completer based on the top-level commands and command groups.
@@ -185,7 +187,6 @@ public class CLICompleter implements Completer {
                     final String currWord = line.word();
                     final String prevWord = line.words().get(line.wordIndex() - 1);
                     if (FILE_COMPLETION_VARS.contains(prevWord)) {
-                        final Completers.FileNameCompleter fileNameCompleter = new Completers.FileNameCompleter();
                         fileNameCompleter.complete(reader, new ArgumentCompleter.ArgumentLine(currWord, currWord.length()), candidates);
                     }
                 }
@@ -196,7 +197,6 @@ public class CLICompleter implements Completer {
 
                 // determine if the word before the current is an arg that needs file completion, otherwise return all args
                 if (FILE_COMPLETION_ARGS.contains(prevWord)) {
-                    final Completers.FileNameCompleter fileNameCompleter = new Completers.FileNameCompleter();
                     fileNameCompleter.complete(reader, new ArgumentCompleter.ArgumentLine(currWord, currWord.length()), candidates);
                 } else {
                     final List<String> options = commandOptionsMap.get(secondLevel);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/StandardFileNameCompleter.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/StandardFileNameCompleter.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.util;
+
+import org.jline.builtins.Completers;
+import org.jline.builtins.Styles;
+import org.jline.reader.Candidate;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+import org.jline.utils.StyleResolver;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Standard File Name Completer overriding references to Styles.lsStyle() to avoid parsing issues with LS_COLORS
+ */
+public class StandardFileNameCompleter extends Completers.FileNameCompleter {
+    private static final String STANDARD_LS_COLORS = "di=1;91:ex=1;92:ln=1;96:fi=";
+
+    private static final String HOME_DIRECTORY_ALIAS = "~";
+
+    private static final String EMPTY = "";
+
+    private static final StyleResolver STYLE_RESOLVER = Styles.style(STANDARD_LS_COLORS);
+
+    /**
+     * Complete file names based on JLine 3.22.0 without calling Styles.lsStyle()
+     *
+     * @param reader        Line Reader
+     * @param commandLine   Parsed Command
+     * @param candidates    Candidates to be populated
+     */
+    @Override
+    public void complete(final LineReader reader, final ParsedLine commandLine, final List<Candidate> candidates) {
+        assert commandLine != null;
+        assert candidates != null;
+
+        final String buffer = commandLine.word().substring(0, commandLine.wordCursor());
+
+        final Path current;
+        final String curBuf;
+        final String sep = getSeparator(reader.isSet(LineReader.Option.USE_FORWARD_SLASH));
+        final int lastSep = buffer.lastIndexOf(sep);
+        try {
+            if (lastSep >= 0) {
+                curBuf = buffer.substring(0, lastSep + 1);
+                if (curBuf.startsWith(HOME_DIRECTORY_ALIAS)) {
+                    if (curBuf.startsWith(HOME_DIRECTORY_ALIAS + sep)) {
+                        current = getUserHome().resolve(curBuf.substring(2));
+                    } else {
+                        current = getUserHome().getParent().resolve(curBuf.substring(1));
+                    }
+                } else {
+                    current = getUserDir().resolve(curBuf);
+                }
+            } else {
+                curBuf = EMPTY;
+                current = getUserDir();
+            }
+
+            try (final DirectoryStream<Path> directory = Files.newDirectoryStream(current, this::accept)) {
+                directory.forEach(path -> {
+                    final String value = curBuf + path.getFileName().toString();
+                    if (Files.isDirectory(path)) {
+                        candidates.add(
+                                new Candidate(
+                                        value + (reader.isSet(LineReader.Option.AUTO_PARAM_SLASH) ? sep : EMPTY),
+                                        getDisplay(reader.getTerminal(), path, STYLE_RESOLVER, sep),
+                                        null,
+                                        null,
+                                        reader.isSet(LineReader.Option.AUTO_REMOVE_SLASH) ? sep : null,
+                                        null,
+                                        false
+                                )
+                        );
+                    } else {
+                        candidates.add(
+                                new Candidate(
+                                        value,
+                                        getDisplay(reader.getTerminal(), path, STYLE_RESOLVER, sep),
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        true
+                                )
+                        );
+                    }
+                });
+            } catch (final IOException e) {
+                // Ignore
+            }
+        } catch (final Exception e) {
+            // Ignore
+        }
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-11048](https://issues.apache.org/jira/browse/NIFI-11048) Adds a custom `StandardFileNameCompleter` in `nifi-toolkit-cli` to avoid hanging on regular expression parsing of the `LS_COLORS` environment variable on some platforms, such as Fedora 37 with Java 8.

The JLine 3 `Completers.FileNameCompleter` in version 3.19.0 and following calls `Styles.lsStyle()`, which resolves the `LS_COLORS` environment variable and attempts to parse the style information. The `StandardFileNameCompleter` provides a workaround using a hard-coded style for `LS_COLORS` based on the default value in JLine 3.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
