### PR TITLE
NIFI-11064 Change TestPutSFTP run iterations based on files queued

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
@@ -222,9 +222,10 @@ class TestPutSFTP {
         secondAttributes.put(TRANSFER_HOST_ATTRIBUTE, LOCALHOST_ADDRESS);
         runner.enqueue(FLOW_FILE_CONTENTS, secondAttributes);
 
-        runner.run();
+        final int flowFilesQueued = runner.getQueueSize().getObjectCount();
+        runner.run(flowFilesQueued);
 
-        runner.assertTransferCount(PutSFTP.REL_SUCCESS, 2);
+        runner.assertTransferCount(PutSFTP.REL_SUCCESS, flowFilesQueued);
 
         final List<ProvenanceEventRecord> records = runner.getProvenanceEvents();
 


### PR DESCRIPTION
# Summary

[NIFI-11064](https://issues.apache.org/jira/browse/NIFI-11064) Changes `TestPutSFTP.testRunTransitUriDifferentHosts()` to run multiple times for improved test stability. The current implementation adds two files to the queue, but fails intermittently when only one file is processed. There is a separate `testRunBatching` method to handle testing support for batched file processing, so changes in `testRunTransitUriDifferentHosts` make this particular method more reliable for the scenario being evaluated.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
