### PR TITLE
NIFI-11041 Convert nifi-registry to use JUnit5 - Part 1

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-bundle-utils/src/test/java/org/apache/nifi/registry/bundle/extract/nar/TestNarBundleExtractor.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-bundle-utils/src/test/java/org/apache/nifi/registry/bundle/extract/nar/TestNarBundleExtractor.java
@@ -21,24 +21,24 @@ import org.apache.nifi.registry.bundle.extract.BundleExtractor;
 import org.apache.nifi.registry.bundle.model.BundleIdentifier;
 import org.apache.nifi.registry.bundle.model.BundleDetails;
 import org.apache.nifi.registry.extension.bundle.BuildInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestNarBundleExtractor {
 
     private BundleExtractor extractor;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.extractor = new NarBundleExtractor();
     }
@@ -88,19 +88,17 @@ public class TestNarBundleExtractor {
         }
     }
 
-    @Test(expected = BundleException.class)
+    @Test
     public void testExtractFromNarMissingRequiredManifestEntries() throws IOException {
         try (final InputStream in = new FileInputStream("src/test/resources/nars/nifi-missing-manifest-entries.nar")) {
-            extractor.extract(in);
-            fail("Should have thrown exception");
+            assertThrows(BundleException.class, () -> extractor.extract(in));
         }
     }
 
-    @Test(expected = BundleException.class)
+    @Test
     public void testExtractFromNarMissingManifest() throws IOException {
         try (final InputStream in = new FileInputStream("src/test/resources/nars/nifi-missing-manifest.nar")) {
-            extractor.extract(in);
-            fail("Should have thrown exception");
+            assertThrows(BundleException.class, () -> extractor.extract(in));
         }
     }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/request/TestBasicAuthRequestConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/request/TestBasicAuthRequestConfig.java
@@ -17,14 +17,14 @@
 package org.apache.nifi.registry.client.impl.request;
 
 import org.apache.nifi.registry.client.RequestConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestBasicAuthRequestConfig {
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/request/TestBearerTokenRequestConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/request/TestBearerTokenRequestConfig.java
@@ -17,12 +17,12 @@
 package org.apache.nifi.registry.client.impl.request;
 
 import org.apache.nifi.registry.client.RequestConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestBearerTokenRequestConfig {
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/request/TestProxiedEntityRequestConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/request/TestProxiedEntityRequestConfig.java
@@ -18,12 +18,12 @@ package org.apache.nifi.registry.client.impl.request;
 
 import org.apache.nifi.registry.client.RequestConfig;
 import org.apache.nifi.registry.security.util.ProxiedEntitiesUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestProxiedEntityRequestConfig {
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-data-model/src/test/java/org/apache/nifi/registry/flow/TestVersionedRemoteProcessGroup.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-data-model/src/test/java/org/apache/nifi/registry/flow/TestVersionedRemoteProcessGroup.java
@@ -17,9 +17,9 @@
 package org.apache.nifi.registry.flow;
 
 import org.apache.nifi.flow.VersionedRemoteProcessGroup;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestVersionedRemoteProcessGroup {
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-revision/nifi-registry-revision-entity-service/src/test/java/org/apache/nifi/registry/revision/entity/TestStandardRevisableEntityService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-revision/nifi-registry-revision-entity-service/src/test/java/org/apache/nifi/registry/revision/entity/TestStandardRevisableEntityService.java
@@ -19,22 +19,23 @@ package org.apache.nifi.registry.revision.entity;
 import org.apache.nifi.registry.revision.api.InvalidRevisionException;
 import org.apache.nifi.registry.revision.api.RevisionManager;
 import org.apache.nifi.registry.revision.naive.NaiveRevisionManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestStandardRevisableEntityService {
 
     private RevisionManager revisionManager;
     private RevisableEntityService entityService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         revisionManager = new NaiveRevisionManager();
         entityService = new StandardRevisableEntityService(revisionManager);
@@ -62,26 +63,26 @@ public class TestStandardRevisableEntityService {
         assertEquals(userIdentity, createdRevision.getLastModifier());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWhenMissingRevision() {
         final RevisableEntity requestEntity = new TestEntity("1", null);
-        entityService.create(requestEntity, "user1", () -> requestEntity);
+        assertThrows(IllegalArgumentException.class, () ->  entityService.create(requestEntity, "user1", () -> requestEntity));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWhenNonZeroRevision() {
         final RevisionInfo requestRevision = new RevisionInfo(null, 99L);
         final RevisableEntity requestEntity = new TestEntity("1", requestRevision);
-        entityService.create(requestEntity, "user1", () -> requestEntity);
+        assertThrows(IllegalArgumentException.class, () ->  entityService.create(requestEntity, "user1", () -> requestEntity));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWhenTaskThrowsException() {
         final RevisionInfo requestRevision = new RevisionInfo("client1", 0L);
         final RevisableEntity requestEntity = new TestEntity("1", requestRevision);
-        entityService.create(requestEntity, "user1", () -> {
+        assertThrows(IllegalArgumentException.class, () -> entityService.create(requestEntity, "user1", () -> {
             throw new IllegalArgumentException("");
-        });
+        }));
     }
 
     @Test
@@ -161,7 +162,7 @@ public class TestStandardRevisableEntityService {
         assertEquals("user3", updatedEntity2.getRevision().getLastModifier());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUpdateWhenMissingRevision() {
         final RevisionInfo revisionInfo = new RevisionInfo(null, 0L);
         final TestEntity requestEntity = new TestEntity("1", revisionInfo);
@@ -174,7 +175,7 @@ public class TestStandardRevisableEntityService {
         assertEquals(1, createdEntity.getRevision().getVersion().longValue());
 
         createdEntity.setRevision(null);
-        entityService.update(createdEntity, "user2", () -> createdEntity);
+        assertThrows(IllegalArgumentException.class, () -> entityService.update(createdEntity, "user2", () -> createdEntity));
     }
 
     @Test
@@ -191,7 +192,7 @@ public class TestStandardRevisableEntityService {
         assertNotNull(deletedEntity);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDeleteWhenMissingRevision() {
         final RevisionInfo revisionInfo = new RevisionInfo(null, 0L);
         final TestEntity requestEntity = new TestEntity("1", revisionInfo);
@@ -202,14 +203,13 @@ public class TestStandardRevisableEntityService {
         assertNotNull(createdEntity.getRevision());
 
         createdEntity.setRevision(null);
-        entityService.delete(createdEntity.getIdentifier(), createdEntity.getRevision(), () -> createdEntity);
+        assertThrows(IllegalArgumentException.class, () -> entityService.delete(createdEntity.getIdentifier(), createdEntity.getRevision(), () -> createdEntity));
     }
 
-    @Test(expected = InvalidRevisionException.class)
+    @Test
     public void testDeleteWhenDoesNotExist() {
         final RevisionInfo revisionInfo = new RevisionInfo(null, 1L);
-        final RevisableEntity deletedEntity = entityService.delete("1", revisionInfo, () -> null);
-        assertNull(deletedEntity);
+        assertThrows(InvalidRevisionException.class, () -> entityService.delete("1", revisionInfo, () -> null));
     }
 
     /**

--- a/nifi-registry/nifi-registry-core/nifi-registry-revision/nifi-registry-revision-spring-jdbc/src/test/java/org/apache/nifi/registry/revision/jdbc/TestJdbcRevisionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-revision/nifi-registry-revision-spring-jdbc/src/test/java/org/apache/nifi/registry/revision/jdbc/TestJdbcRevisionManager.java
@@ -30,17 +30,14 @@ import org.apache.nifi.registry.revision.standard.StandardUpdateResult;
 import org.flywaydb.core.internal.database.DatabaseType;
 import org.flywaydb.core.internal.database.DatabaseTypeRegister;
 import org.flywaydb.database.mysql.MySQLDatabaseType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,13 +52,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Transactional
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestApplication.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestExecutionListeners({DependencyInjectionTestExecutionListener.class, TransactionalTestExecutionListener.class})
 public class TestJdbcRevisionManager {
@@ -89,7 +86,7 @@ public class TestJdbcRevisionManager {
 
     private RevisionManager revisionManager;
 
-    @Before
+    @BeforeEach
     public void setup() throws SQLException {
         revisionManager = new JdbcRevisionManager(jdbcTemplate);
 
@@ -157,7 +154,7 @@ public class TestJdbcRevisionManager {
         verifyRevisionUpdate(entityId, revisionUpdate, new Long(100), null);
     }
 
-    @Test(expected = InvalidRevisionException.class)
+    @Test
     public void testUpdateRevisionWithStaleVersionNoClientId() {
         // create the revision being sent in by the client
         final String entityId = "entity-1";
@@ -168,7 +165,7 @@ public class TestJdbcRevisionManager {
         createRevision(revision.getEntityId(), revision.getVersion() + 1, null);
 
         // perform an update task which should throw InvalidRevisionException
-        revisionManager.updateRevision(revisionClaim, createUpdateTask(entityId));
+        assertThrows(InvalidRevisionException.class, () -> revisionManager.updateRevision(revisionClaim, createUpdateTask(entityId)));
     }
 
     @Test
@@ -246,7 +243,7 @@ public class TestJdbcRevisionManager {
         assertEquals(entityId, deletedEntity.getId());
     }
 
-    @Test(expected = InvalidRevisionException.class)
+    @Test
     public void testDeleteRevisionWithStaleVersionAndNoClientId() {
         // create the revision being sent in by the client
         final String entityId = "entity-1";
@@ -257,7 +254,7 @@ public class TestJdbcRevisionManager {
         createRevision(revision.getEntityId(), revision.getVersion() + 1, null);
 
         // perform an update task which should throw InvalidRevisionException
-        revisionManager.deleteRevision(revisionClaim, createDeleteTask(entityId));
+        assertThrows(InvalidRevisionException.class, () -> revisionManager.deleteRevision(revisionClaim, createDeleteTask(entityId)));
     }
 
     @Test
@@ -366,7 +363,7 @@ public class TestJdbcRevisionManager {
         // verify the entity modification is correctly populated
         final EntityModification entityModification = revisionUpdate.getLastModification();
         assertNotNull(entityModification);
-        Assert.assertEquals("user1", entityModification.getLastModifier());
+        assertEquals("user1", entityModification.getLastModifier());
 
         // verify the revision in the entity modification is set and is the updated revision (i.e. version of 100, not 99)
         final Revision updatedRevision = entityModification.getRevision();

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-utils/src/test/java/org/apache/nifi/registry/security/util/KeyStoreUtilsTest.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-utils/src/test/java/org/apache/nifi/registry/security/util/KeyStoreUtilsTest.java
@@ -17,11 +17,14 @@
 package org.apache.nifi.registry.security.util;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class KeyStoreUtilsTest {
 
@@ -29,20 +32,20 @@ public class KeyStoreUtilsTest {
     public void testGetKeyStore() throws KeyStoreException {
         for (final KeystoreType keystoreType : KeystoreType.values()) {
             final KeyStore keyStore = KeyStoreUtils.getKeyStore(keystoreType.toString());
-            Assert.assertNotNull(String.format("KeyStore not found for Keystore Type [%s]", keystoreType), keyStore);
-            Assert.assertEquals(keystoreType.name(), keyStore.getType());
+            assertNotNull(keyStore, String.format("KeyStore not found for Keystore Type [%s]", keystoreType));
+            assertEquals(keystoreType.name(), keyStore.getType());
         }
     }
 
     @Test
     public void testGetKeyStoreProviderNullType() {
         final String keyStoreProvider = KeyStoreUtils.getKeyStoreProvider(null);
-        Assert.assertNull(keyStoreProvider);
+        assertNull(keyStoreProvider);
     }
 
     @Test
     public void testGetKeyStoreProviderBouncyCastleProvider() {
         final String keyStoreProvider = KeyStoreUtils.getKeyStoreProvider(KeystoreType.PKCS12.name());
-        Assert.assertEquals(BouncyCastleProvider.PROVIDER_NAME, keyStoreProvider);
+        assertEquals(BouncyCastleProvider.PROVIDER_NAME, keyStoreProvider);
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-utils/src/test/java/org/apache/nifi/registry/util/TestFileUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-utils/src/test/java/org/apache/nifi/registry/util/TestFileUtils.java
@@ -17,9 +17,9 @@
 
 package org.apache.nifi.registry.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestFileUtils {
     @Test

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-aws/nifi-registry-aws-extensions/src/test/java/org/apache/nifi/registry/aws/S3BundlePersistenceProviderIT.java
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-aws/nifi-registry-aws-extensions/src/test/java/org/apache/nifi/registry/aws/S3BundlePersistenceProviderIT.java
@@ -22,10 +22,10 @@ import org.apache.nifi.registry.extension.BundlePersistenceProvider;
 import org.apache.nifi.registry.extension.BundleVersionCoordinate;
 import org.apache.nifi.registry.extension.BundleVersionType;
 import org.apache.nifi.registry.provider.ProviderConfigurationContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
@@ -39,8 +39,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +51,7 @@ public class S3BundlePersistenceProviderIT {
     private BundlePersistenceProvider provider;
     private ProviderConfigurationContext configurationContext;
 
-    @Before
+    @BeforeEach
     public void setup() {
         final Region region = Region.US_EAST_1;
         final String bucketName = "integration-test-" + System.currentTimeMillis();
@@ -84,7 +84,7 @@ public class S3BundlePersistenceProviderIT {
 
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         try {
             provider.preDestruction();
@@ -100,7 +100,7 @@ public class S3BundlePersistenceProviderIT {
     }
 
     @Test
-    @Ignore // Remove to run this against S3, assumes you have setup external credentials
+    @Disabled // Remove to run this against S3, assumes you have setup external credentials
     public void testS3PersistenceProvider() throws IOException {
         final File narFile = new File("src/test/resources/nars/nifi-foo-nar-1.0.0.nar");
 

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/src/test/java/org/apache/nifi/registry/ranger/TestRangerBasePluginWithPolicies.java
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/src/test/java/org/apache/nifi/registry/ranger/TestRangerBasePluginWithPolicies.java
@@ -29,7 +29,7 @@ import org.apache.nifi.registry.security.exception.SecurityProviderCreationExcep
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.util.ServicePolicies;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,11 +40,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRangerBasePluginWithPolicies {
 

--- a/nifi-registry/nifi-registry-toolkit/nifi-registry-toolkit-persistence/src/test/java/org/apache/nifi/registry/toolkit/persistence/FlowPersistenceProviderMigratorTest.java
+++ b/nifi-registry/nifi-registry-toolkit/nifi-registry-toolkit-persistence/src/test/java/org/apache/nifi/registry/toolkit/persistence/FlowPersistenceProviderMigratorTest.java
@@ -24,8 +24,8 @@ import org.apache.nifi.registry.provider.flow.StandardFlowSnapshotContext;
 import org.apache.nifi.registry.service.MetadataService;
 import org.apache.nifi.registry.service.mapper.BucketMappings;
 import org.apache.nifi.registry.service.mapper.FlowMappings;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.AdditionalMatchers;
 
 import java.nio.charset.StandardCharsets;
@@ -37,8 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,6 +44,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class FlowPersistenceProviderMigratorTest {
     private MetadataService metadataService;
@@ -57,7 +58,7 @@ public class FlowPersistenceProviderMigratorTest {
     private Map<String, BucketEntity> flowBuckets;
     private Map<String, List<FlowSnapshotEntity>> flowSnapshots;
 
-    @Before
+    @BeforeEach
     public void setup() {
         metadataService = mock(MetadataService.class);
         fromProvider = mock(FlowPersistenceProvider.class);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11041](https://issues.apache.org/jira/browse/NIFI-11041)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
