### PR TITLE
NIFI-10932 Change PKCS12 KeyStore Type Provider to SunJSSE

### DIFF
--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java
@@ -83,7 +83,7 @@ public class KeyStoreUtils {
         Security.addProvider(new BouncyCastleProvider());
 
         KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.BCFKS.getType(), BouncyCastleProvider.PROVIDER_NAME);
-        KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.PKCS12.getType(), BouncyCastleProvider.PROVIDER_NAME);
+        KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.PKCS12.getType(), SUN_JSSE_PROVIDER_NAME);
         KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.JKS.getType(), SUN_PROVIDER_NAME);
 
         SECRET_KEY_STORE_PROVIDERS.put(KeystoreType.BCFKS, BouncyCastleProvider.PROVIDER_NAME);

--- a/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/manager/BaseTlsManager.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/main/java/org/apache/nifi/toolkit/tls/manager/BaseTlsManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.toolkit.tls.manager;
 
-import org.apache.nifi.security.util.KeystoreType;
 import org.apache.nifi.security.util.KeyStoreUtils;
 import org.apache.nifi.toolkit.tls.configuration.TlsConfig;
 import org.apache.nifi.toolkit.tls.manager.writer.ConfigurationWriter;
@@ -108,21 +107,16 @@ public class BaseTlsManager {
     }
 
     private String getKeyPassword() {
-        if (keyStore.getType().equalsIgnoreCase(KeystoreType.PKCS12.toString())) {
-            tlsConfig.setKeyPassword(null);
-            return null;
-        } else {
-            String result = tlsConfig.getKeyPassword();
-            if (StringUtils.isEmpty(result)) {
-                if (differentKeyAndKeyStorePassword) {
-                    result = passwordUtil.generatePassword();
-                } else {
-                    result = getKeyStorePassword();
-                }
-                tlsConfig.setKeyPassword(result);
+        String result = tlsConfig.getKeyPassword();
+        if (StringUtils.isEmpty(result)) {
+            if (differentKeyAndKeyStorePassword) {
+                result = passwordUtil.generatePassword();
+            } else {
+                result = getKeyStorePassword();
             }
-            return result;
+            tlsConfig.setKeyPassword(result);
         }
+        return result;
     }
 
     private String getKeyStorePassword() {

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/standalone/TlsToolkitStandaloneTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/standalone/TlsToolkitStandaloneTest.java
@@ -200,8 +200,9 @@ public class TlsToolkitStandaloneTest {
 
     @Test
     public void testKeyStoreTypeArg() throws Exception {
+        final String certificateAuthorityHostname = "certificate-authority";
         runAndAssertExitCode(ExitCode.SUCCESS, "-o", tempDir.getAbsolutePath(), "-n", TlsConfig.DEFAULT_HOSTNAME, "-T", KeystoreType.PKCS12.toString().toLowerCase(),
-                "-K", "change", "-S", "change", "-P", "change");
+                "-K", "change", "-S", "change", "-P", "change", "-c", certificateAuthorityHostname);
         X509Certificate x509Certificate = checkLoadCertPrivateKey(TlsConfig.DEFAULT_KEY_PAIR_ALGORITHM);
         checkHostDirAndReturnNifiProperties(TlsConfig.DEFAULT_HOSTNAME, x509Certificate);
     }


### PR DESCRIPTION
# Summary

[NIFI-10932](https://issues.apache.org/jira/browse/NIFI-10932) Changes the internal Security Provider from Bouncy Castle to the standard Sun JSSE when reading and writing PKCS12 Key Store files.

The TLS Toolkit included custom handling for PKCS12 that specified `null` for the Key Password, which causes problems when using the Java `keytool` command to read a PKCS12 Trust Store. Removing this `null` setting and using the standard Security Provider for PKCS12 allow `keytool` and other services to read and write PKCS12 Trust Stores as expected.

Changes for [NIFI-2943](https://issues.apache.org/jira/browse/NIFI-2943) in PR #1165 switched to using the Bouncy Castle Security Provider for PKCS12 in NiFi 1.1.0. These changes were implemented to address issues with PKCS12 handling in earlier Java versions. More recent versions of Java have improved PKCS12 support to the point where [JEP 229](https://openjdk.org/jeps/229) changed the default Key Store Type from JKS to PKCS12 in Java 9 and later. With these changes, the standard Java implementation of PKCS12 should be preferred.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
