### PR TITLE
NIFI-11091 Upgrade Google libraries-bom from 25.4.0 to 26.4.0

### DIFF
--- a/nifi-commons/nifi-property-protection-gcp/pom.xml
+++ b/nifi-commons/nifi-property-protection-gcp/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <artifactId>nifi-property-protection-gcp</artifactId>
     <properties>
-        <gcp.sdk.version>25.4.0</gcp.sdk.version>
+        <gcp.sdk.version>26.4.0</gcp.sdk.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -92,6 +92,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -155,7 +159,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20220709-1.32.1</version>
+            <version>v3-rev20221219-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/FetchGCSObjectTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/FetchGCSObjectTest.java
@@ -91,7 +91,7 @@ public class FetchGCSObjectTest extends AbstractGCSTest {
     private static final String CONTENT_TYPE = "test-content-type";
     private static final String CRC32C = "test-crc32c";
     private static final String ENCRYPTION = "test-encryption";
-    private static final String ENCRYPTION_SHA256 = "test-encryption-256";
+    private static final String ENCRYPTION_SHA256 = "12345678";
     private static final String ETAG = "test-etag";
     private static final String GENERATED_ID = "test-generated-id";
     private static final String MD5 = "test-md5";

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
@@ -78,7 +78,7 @@ public class PutGCSObjectTest extends AbstractGCSTest {
     private static final String MD5 = "test-md5";
     private static final String CRC32C = "test-crc32c";
     private static final Storage.PredefinedAcl ACL = BUCKET_OWNER_READ;
-    private static final String ENCRYPTION_KEY = "test-encryption-key";
+    private static final String ENCRYPTION_KEY = "12345678";
     private static final Boolean OVERWRITE = false;
     private static final String CONTENT_DISPOSITION_TYPE = "inline";
 
@@ -89,7 +89,7 @@ public class PutGCSObjectTest extends AbstractGCSTest {
     private static final String CONTENT_ENCODING = "test-content-encoding";
     private static final String CONTENT_LANGUAGE = "test-content-language";
     private static final String ENCRYPTION = "test-encryption";
-    private static final String ENCRYPTION_SHA256 = "test-encryption-256";
+    private static final String ENCRYPTION_SHA256 = "12345678";
     private static final String ETAG = "test-etag";
     private static final String GENERATED_ID = "test-generated-id";
     private static final String MEDIA_LINK = "test-media-link";

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>25.2.0</google.libraries.version>
+        <google.libraries.version>26.4.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11091](https://issues.apache.org/jira/browse/NIFI-11091) Upgrades Google Libraries Bill of Materials dependency from 25.4.0 to [26.4.0](https://github.com/googleapis/java-cloud-bom/releases/tag/libraries-bom-v26.4.0). These changes apply to the `nifi-property-protection-gcp` library for access to Google KMS, and `nifi-gcp-bundle` for access to multiple Google services.

Additional changes include upgrading the Google Drive client library, excluding a reference to the banned `org.json:json` library, and correcting test encryption key values to match expected encoding checks during key property validation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
