### PR TITLE
NIFI-11064 Remove unstable TestPutSFTP.testRunTransitUriDifferentHosts

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
@@ -33,10 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,13 +43,9 @@ class TestPutSFTP {
 
     private static final String LOCALHOST = "localhost";
 
-    private static final String LOCALHOST_ADDRESS = "127.0.0.1";
-
     private static final String REMOTE_DIRECTORY = "nifi_test/";
 
     private static final String FIRST_FILENAME = "1.txt";
-
-    private static final String TRANSFER_HOST_ATTRIBUTE = "transfer-host";
 
     private static final int BATCH_SIZE = 2;
 
@@ -205,41 +198,6 @@ class TestPutSFTP {
         final ProvenanceEventRecord record = records.iterator().next();
         final String firstTransitUri = String.format(TRANSIT_URI_FORMAT, LOCALHOST);
         assertTrue(record.getTransitUri().startsWith(firstTransitUri), "Transit URI not found");
-    }
-
-    @Test
-    void testRunTransitUriDifferentHosts() {
-        runner.setProperty(SFTPTransfer.REJECT_ZERO_BYTE, Boolean.FALSE.toString());
-        runner.setProperty(SFTPTransfer.HOSTNAME, "${transfer-host}");
-
-        final Map<String, String> firstAttributes = new LinkedHashMap<>();
-        firstAttributes.put(CoreAttributes.FILENAME.key(), FIRST_FILENAME);
-        firstAttributes.put(TRANSFER_HOST_ATTRIBUTE, LOCALHOST);
-        runner.enqueue(FLOW_FILE_CONTENTS, firstAttributes);
-
-        final Map<String, String> secondAttributes = new LinkedHashMap<>();
-        secondAttributes.put(CoreAttributes.FILENAME.key(), FIRST_FILENAME);
-        secondAttributes.put(TRANSFER_HOST_ATTRIBUTE, LOCALHOST_ADDRESS);
-        runner.enqueue(FLOW_FILE_CONTENTS, secondAttributes);
-
-        final int flowFilesQueued = runner.getQueueSize().getObjectCount();
-        runner.run(flowFilesQueued);
-
-        runner.assertTransferCount(PutSFTP.REL_SUCCESS, flowFilesQueued);
-
-        final List<ProvenanceEventRecord> records = runner.getProvenanceEvents();
-
-        final String firstTransitUri = String.format(TRANSIT_URI_FORMAT, LOCALHOST);
-        final Optional<ProvenanceEventRecord> firstRecord = records.stream()
-                .filter(record -> record.getTransitUri().startsWith(firstTransitUri))
-                .findFirst();
-        assertTrue(firstRecord.isPresent(), "First Transit URI not found");
-
-        final String secondTransitUri = String.format(TRANSIT_URI_FORMAT, LOCALHOST_ADDRESS);
-        final Optional<ProvenanceEventRecord> secondRecord = records.stream()
-                .filter(record -> record.getTransitUri().startsWith(secondTransitUri))
-                .findFirst();
-        assertTrue(secondRecord.isPresent(), "Second Transit URI not found");
     }
 
     private void createRemoteFile() throws IOException {


### PR DESCRIPTION
# Summary

[NIFI-11064](https://issues.apache.org/jira/browse/NIFI-11064) Removes the unstable `testRunTransitUriDifferentHosts` method from `TestPutSFTP`. Other test methods handle testing batched FlowFiles, and a different method tests transit URI formatting. This test method has failed intermittently on parallel builds.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
