### PR TITLE
NIFI-11096 Add EncodeContent to Processor services definition

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Base64EncodeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Base64EncodeContent.java
@@ -34,6 +34,7 @@ import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
@@ -54,6 +55,10 @@ import org.apache.nifi.util.StopWatch;
 @Tags({"encode", "base64"})
 @CapabilityDescription("Encodes or decodes content to and from base64")
 @InputRequirement(Requirement.INPUT_REQUIRED)
+@DeprecationNotice(
+        alternatives = EncodeContent.class,
+        reason = "EncodeContent supports Base64 and additional encoding schemes"
+)
 public class Base64EncodeContent extends AbstractProcessor {
 
     public static final String ENCODE_MODE = "Encode";

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -29,6 +29,7 @@ org.apache.nifi.processors.standard.DetectDuplicate
 org.apache.nifi.processors.standard.DeduplicateRecord
 org.apache.nifi.processors.standard.DistributeLoad
 org.apache.nifi.processors.standard.DuplicateFlowFile
+org.apache.nifi.processors.standard.EncodeContent
 org.apache.nifi.processors.standard.EncryptContent
 org.apache.nifi.processors.standard.EnforceOrder
 org.apache.nifi.processors.standard.EvaluateJsonPath

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestEncodeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestEncodeContent.java
@@ -16,8 +16,8 @@
  */
 package org.apache.nifi.processors.standard;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.nifi.util.MockFlowFile;
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 public class TestEncodeContent {
 
+    private static final Path FILE_PATH = Paths.get("src/test/resources/hello.txt");
+
     @Test
     public void testBase64RoundTrip() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(new EncodeContent());
@@ -34,7 +36,7 @@ public class TestEncodeContent {
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.ENCODE_MODE);
         testRunner.setProperty(EncodeContent.ENCODING, EncodeContent.BASE64_ENCODING);
 
-        testRunner.enqueue(Paths.get("src/test/resources/hello.txt"));
+        testRunner.enqueue(FILE_PATH);
         testRunner.clearTransferState();
         testRunner.run();
 
@@ -50,7 +52,7 @@ public class TestEncodeContent {
         testRunner.assertAllFlowFilesTransferred(EncodeContent.REL_SUCCESS, 1);
 
         flowFile = testRunner.getFlowFilesForRelationship(EncodeContent.REL_SUCCESS).get(0);
-        flowFile.assertContentEquals(new File("src/test/resources/hello.txt"));
+        flowFile.assertContentEquals(FILE_PATH);
     }
 
     @Test
@@ -60,7 +62,7 @@ public class TestEncodeContent {
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.DECODE_MODE);
         testRunner.setProperty(EncodeContent.ENCODING, EncodeContent.BASE64_ENCODING);
 
-        testRunner.enqueue(Paths.get("src/test/resources/hello.txt"));
+        testRunner.enqueue(FILE_PATH);
         testRunner.clearTransferState();
         testRunner.run();
 
@@ -68,7 +70,7 @@ public class TestEncodeContent {
     }
 
     @Test
-    public void testFailDecodeNotBase64ButIsAMultipleOfFourBytes() throws IOException {
+    public void testFailDecodeNotBase64ButIsAMultipleOfFourBytes() {
         final TestRunner testRunner = TestRunners.newTestRunner(new EncodeContent());
 
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.DECODE_MODE);
@@ -88,7 +90,7 @@ public class TestEncodeContent {
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.ENCODE_MODE);
         testRunner.setProperty(EncodeContent.ENCODING, EncodeContent.BASE32_ENCODING);
 
-        testRunner.enqueue(Paths.get("src/test/resources/hello.txt"));
+        testRunner.enqueue(FILE_PATH);
         testRunner.clearTransferState();
         testRunner.run();
 
@@ -104,7 +106,7 @@ public class TestEncodeContent {
         testRunner.assertAllFlowFilesTransferred(EncodeContent.REL_SUCCESS, 1);
 
         flowFile = testRunner.getFlowFilesForRelationship(EncodeContent.REL_SUCCESS).get(0);
-        flowFile.assertContentEquals(new File("src/test/resources/hello.txt"));
+        flowFile.assertContentEquals(FILE_PATH);
     }
 
     @Test
@@ -114,7 +116,7 @@ public class TestEncodeContent {
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.DECODE_MODE);
         testRunner.setProperty(EncodeContent.ENCODING, EncodeContent.BASE32_ENCODING);
 
-        testRunner.enqueue(Paths.get("src/test/resources/hello.txt"));
+        testRunner.enqueue(FILE_PATH);
         testRunner.clearTransferState();
         testRunner.run();
 
@@ -128,7 +130,7 @@ public class TestEncodeContent {
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.ENCODE_MODE);
         testRunner.setProperty(EncodeContent.ENCODING, EncodeContent.HEX_ENCODING);
 
-        testRunner.enqueue(Paths.get("src/test/resources/hello.txt"));
+        testRunner.enqueue(FILE_PATH);
         testRunner.clearTransferState();
         testRunner.run();
 
@@ -144,7 +146,7 @@ public class TestEncodeContent {
         testRunner.assertAllFlowFilesTransferred(EncodeContent.REL_SUCCESS, 1);
 
         flowFile = testRunner.getFlowFilesForRelationship(EncodeContent.REL_SUCCESS).get(0);
-        flowFile.assertContentEquals(new File("src/test/resources/hello.txt"));
+        flowFile.assertContentEquals(FILE_PATH);
     }
 
     @Test
@@ -154,7 +156,7 @@ public class TestEncodeContent {
         testRunner.setProperty(EncodeContent.MODE, EncodeContent.DECODE_MODE);
         testRunner.setProperty(EncodeContent.ENCODING, EncodeContent.HEX_ENCODING);
 
-        testRunner.enqueue(Paths.get("src/test/resources/hello.txt"));
+        testRunner.enqueue(FILE_PATH);
         testRunner.clearTransferState();
         testRunner.run();
 


### PR DESCRIPTION
# Summary

[NIFI-11096](https://issues.apache.org/jira/browse/NIFI-11096) Adds the standard `EncodeContent` Processor to `org.apache.nifi.processor.Processor` under `META-INF/services`, making it available for standard configuration.

Additional changes include deprecating `Base64EncodeContent` in favor of `EncodeContent`, as well as optimizing property and relationship declarations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
