### PR TITLE
NIFI-11097 Adjust RegistryClientIT with unique name for Clients

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -67,7 +68,8 @@ public class RegistryClientIT extends NiFiSystemIT {
     }
 
     private FlowRegistryClientEntity registerClient() throws NiFiClientException, IOException {
-        final FlowRegistryClientEntity clientEntity = getClientUtil().createFlowRegistryClient("FileRegistry");
+        final String clientName = String.format("FileRegistry-%s", UUID.randomUUID());
+        final FlowRegistryClientEntity clientEntity = getClientUtil().createFlowRegistryClient(clientName);
         final File storageDir = new File("target/flowRegistryStorage/" + getTestName().replace("\\(.*?\\)", ""));
         Files.createDirectories(storageDir.toPath());
         getClientUtil().updateRegistryClientProperties(clientEntity, Collections.singletonMap("Directory", storageDir.getAbsolutePath()));


### PR DESCRIPTION
# Summary

[NIFI-11097](https://issues.apache.org/jira/browse/NIFI-11097) Adjusts the `RegistryClientIT` system test to use a UUID as part of the name for the Flow Registry Client instance to meet requirements added in PR #6750 for NIFI-10934

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
