### PR TITLE
NIFI-11098 Deprecate ProcessContext encrypt and decrypt methods

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessContext.java
@@ -99,18 +99,22 @@ public interface ProcessContext extends PropertyContext, ClusterContext {
      * Encrypts the given value using the password provided in the NiFi
      * Properties
      *
+     * @deprecated Processors should not depend on framework encryption operations
      * @param unencrypted plaintext value
      * @return encrypted value
      */
+    @Deprecated
     String encrypt(String unencrypted);
 
     /**
      * Decrypts the given value using the password provided in the NiFi
      * Properties
      *
+     * @deprecated Processors should not depend on framework encryption operations
      * @param encrypted the encrypted value
      * @return the plaintext value
      */
+    @Deprecated
     String decrypt(String encrypted);
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/scheduling/ConnectableProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/scheduling/ConnectableProcessContext.java
@@ -25,6 +25,8 @@ import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.encrypt.PropertyEncryptor;
 import org.apache.nifi.expression.AttributeValueDecorator;
 import org.apache.nifi.flowfile.FlowFile;
@@ -52,10 +54,13 @@ public class ConnectableProcessContext implements ProcessContext {
     private final PropertyEncryptor propertyEncryptor;
     private final StateManager stateManager;
 
+    private final DeprecationLogger deprecationLogger;
+
     public ConnectableProcessContext(final Connectable connectable, final PropertyEncryptor propertyEncryptor, final StateManager stateManager) {
         this.connectable = connectable;
         this.propertyEncryptor = propertyEncryptor;
         this.stateManager = stateManager;
+        this.deprecationLogger = DeprecationLoggerFactory.getLogger(connectable.getClass());
     }
 
     @Override
@@ -224,11 +229,13 @@ public class ConnectableProcessContext implements ProcessContext {
 
     @Override
     public String decrypt(String encrypted) {
+        deprecationLogger.warn("ProcessContext.decrypt() should be replaced an alternative implementation");
         return propertyEncryptor.decrypt(encrypted);
     }
 
     @Override
     public String encrypt(String unencrypted) {
+        deprecationLogger.warn("ProcessContext.encrypt() should be replaced an alternative implementation");
         return propertyEncryptor.encrypt(unencrypted);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
@@ -36,6 +36,8 @@ import org.apache.nifi.controller.PropertyConfiguration;
 import org.apache.nifi.controller.PropertyConfigurationMapper;
 import org.apache.nifi.controller.lifecycle.TaskTermination;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.encrypt.PropertyEncryptor;
 import org.apache.nifi.parameter.ParameterLookup;
 import org.apache.nifi.processor.exception.TerminatedTaskException;
@@ -62,6 +64,7 @@ public class StandardProcessContext implements ProcessContext, ControllerService
     private final NodeTypeProvider nodeTypeProvider;
     private final Map<PropertyDescriptor, String> properties;
     private final String annotationData;
+    private final DeprecationLogger deprecationLogger;
 
 
     public StandardProcessContext(final ProcessorNode processorNode, final ControllerServiceProvider controllerServiceProvider, final PropertyEncryptor propertyEncryptor,
@@ -89,6 +92,9 @@ public class StandardProcessContext implements ProcessContext, ControllerService
         this.taskTermination = taskTermination;
         this.nodeTypeProvider = nodeTypeProvider;
         this.annotationData = annotationData;
+        final Class<?> componentClass = processorNode.getComponentClass();
+        final Class<?> loggerClass = componentClass == null ? getClass() : componentClass;
+        this.deprecationLogger = DeprecationLoggerFactory.getLogger(loggerClass);
 
         properties = Collections.unmodifiableMap(propertyValues);
 
@@ -227,12 +233,14 @@ public class StandardProcessContext implements ProcessContext, ControllerService
     @Override
     public String encrypt(final String unencrypted) {
         verifyTaskActive();
+        deprecationLogger.warn("ProcessContext.encrypt() should be replaced an alternative implementation");
         return propertyEncryptor.encrypt(unencrypted);
     }
 
     @Override
     public String decrypt(final String encrypted) {
         verifyTaskActive();
+        deprecationLogger.warn("ProcessContext.decrypt() should be replaced an alternative implementation");
         return propertyEncryptor.decrypt(encrypted);
     }
 


### PR DESCRIPTION
# Summary

[NIFI-11098](https://issues.apache.org/jira/browse/NIFI-11098) Deprecates `ProcessContext.encrypt()` and `ProcessContext.decrypt()` methods. The deprecated `GetJMSTopic` Processor is the only component using these methods, and they should be removed in a subsequent major release due to the tight coupling between framework configuration settings and potential Processor use of these methods.

Changes include adding deprecation logging in `ProcessContext` implementations to provide runtime warnings for referencing components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
