### PR TITLE
NIFI-11111 add option to output Elasticsearch error responses as FlowFile to PutElasticsearchJson and PutElasticsearchRecord

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
@@ -223,10 +223,9 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
                     errorResponsesFF = session.create(parent);
                     try (final OutputStream errorsOutputStream = session.write(errorResponsesFF)) {
                         errorMapper.writeValue(errorsOutputStream, errorResponses);
-
-                        errorResponsesFF = session.putAttribute(errorResponsesFF, "elasticsearch.put.error.count", String.valueOf(errorResponses.size()));
-                        session.transfer(errorResponsesFF, REL_ERROR_RESPONSES);
                     }
+                    errorResponsesFF = session.putAttribute(errorResponsesFF, "elasticsearch.put.error.count", String.valueOf(errorResponses.size()));
+                    session.transfer(errorResponsesFF, REL_ERROR_RESPONSES);
                 } catch (final IOException ex) {
                     getLogger().error("Unable to write error responses", ex);
                     session.remove(errorResponsesFF);

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.processors.elasticsearch;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -37,6 +36,8 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public abstract class AbstractPutElasticsearch extends AbstractProcessor implements ElasticsearchRestProcessor {
     static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
@@ -67,11 +69,26 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
         .required(true)
         .build();
 
+    static final PropertyDescriptor OUTPUT_ERROR_RESPONSES = new PropertyDescriptor.Builder()
+            .name("put-es-output-error-responses")
+            .displayName("Output Error Responses")
+            .description("If this is enabled, errors will be output to the \"error_responses\" relationship.")
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+
     static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("All flowfiles that succeed in being transferred into Elasticsearch go here. " +
                     "Documents received by the Elasticsearch _bulk API may still result in errors on the Elasticsearch side. " +
                     "The Elasticsearch response will need to be examined to determine whether any Document(s)/Record(s) resulted in errors.")
+            .build();
+
+    static final Relationship REL_ERROR_RESPONSES = new Relationship.Builder()
+            .name("error_responses")
+            .description("Elasticsearch _bulk API responses marked as \"error\" (and optionally \"not_found\") go here.")
+            .autoTerminateDefault(true)
             .build();
 
     static final List<String> ALLOWED_INDEX_OPERATIONS = Collections.unmodifiableList(Arrays.asList(
@@ -83,6 +100,7 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
     ));
 
     boolean logErrors;
+    boolean outputErrorResponses;
     boolean notFoundIsSuccessful;
     ObjectMapper errorMapper;
 
@@ -110,8 +128,9 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
         clientService.set(context.getProperty(CLIENT_SERVICE).asControllerService(ElasticSearchClientService.class));
 
         this.logErrors = context.getProperty(LOG_ERROR_RESPONSES).asBoolean();
+        this.outputErrorResponses = context.getProperty(OUTPUT_ERROR_RESPONSES).asBoolean();
 
-        if (errorMapper == null && (logErrors || getLogger().isDebugEnabled())) {
+        if (errorMapper == null && (outputErrorResponses || logErrors || getLogger().isDebugEnabled())) {
             errorMapper = new ObjectMapper();
             errorMapper.enable(SerializationFeature.INDENT_OUTPUT);
         }
@@ -158,15 +177,38 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
         }
     }
 
-    void logElasticsearchDocumentErrors(final IndexOperationResponse response) throws JsonProcessingException {
-        if (logErrors || getLogger().isDebugEnabled()) {
-            final List<Map<String, Object>> errors = response.getItems();
-            final String output = String.format("An error was encountered while processing bulk operations. Server response below:%n%n%s", errorMapper.writeValueAsString(errors));
+    void handleElasticsearchDocumentErrors(final IndexOperationResponse response, final List<Integer> errorIndices, final ProcessSession session, final FlowFile parent) throws IOException {
+        if (!errorIndices.isEmpty() && (outputErrorResponses || logErrors || getLogger().isDebugEnabled())) {
+            final List<Map<String, Object>> errorResponses = errorIndices.stream().map(index -> response.getItems().get(index)).collect(Collectors.toList());
 
-            if (logErrors) {
-                getLogger().error(output);
-            } else {
-                getLogger().debug(output);
+            if (logErrors || getLogger().isDebugEnabled()) {
+                final String output = String.format(
+                        "An error was encountered while processing bulk operations. Server response below:%n%n%s",
+                        errorMapper.writeValueAsString(errorResponses)
+                );
+
+                if (logErrors) {
+                    getLogger().error(output);
+                } else {
+                    getLogger().debug(output);
+                }
+            }
+
+            if (outputErrorResponses) {
+                FlowFile errorResponsesFF = null;
+                try {
+                    errorResponsesFF = session.create(parent);
+                    try (final OutputStream errorsOutputStream = session.write(errorResponsesFF)) {
+                        errorMapper.writeValue(errorsOutputStream, errorResponses);
+
+                        errorResponsesFF = session.putAttribute(errorResponsesFF, "elasticsearch.put.error.count", String.valueOf(errorResponses.size()));
+                        session.transfer(errorResponsesFF, REL_ERROR_RESPONSES);
+                    }
+                } catch (final IOException ex) {
+                    getLogger().error("Unable to write error responses", ex);
+                    session.remove(errorResponsesFF);
+                    throw ex;
+                }
             }
         }
     }
@@ -179,16 +221,24 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
         return inner -> inner.containsKey("result") && "not_found".equals(inner.get("result"));
     }
 
-    @SafeVarargs
-    final List<Integer> findElasticsearchResponseIndices(final IndexOperationResponse response, final Predicate<Map<String, Object>>... responseItemFilter) {
+    final List<Integer> findElasticsearchResponseErrorIndices(final IndexOperationResponse response) {
         final List<Integer> indices = new ArrayList<>(response.getItems() == null ? 0 : response.getItems().size());
-        if (response.getItems() != null) {
+
+        final List<Predicate<Map<String, Object>>> errorItemFilters = new ArrayList<>(2);
+        if (response.hasErrors()) {
+            errorItemFilters.add(isElasticsearchError());
+        }
+        if (!notFoundIsSuccessful) {
+            errorItemFilters.add(isElasticsearchNotFound());
+        }
+
+        if (response.getItems() != null && !errorItemFilters.isEmpty()) {
             for (int index = 0; index < response.getItems().size(); index++) {
                 final Map<String, Object> current = response.getItems().get(index);
                 if (!current.isEmpty()) {
                     final String key = current.keySet().stream().findFirst().orElse(null);
                     @SuppressWarnings("unchecked") final Map<String, Object> inner = (Map<String, Object>) current.get(key);
-                    if (inner != null && Arrays.stream(responseItemFilter).anyMatch(p -> p.test(inner))) {
+                    if (inner != null && errorItemFilters.stream().anyMatch(p -> p.test(inner))) {
                         indices.add(index);
                     }
                 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJson.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJson.java
@@ -109,9 +109,11 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
 
     static final PropertyDescriptor NOT_FOUND_IS_SUCCESSFUL = new PropertyDescriptor.Builder()
         .name("put-es-json-not_found-is-error")
-        .displayName("Treat \"Not Found\" as Error")
+        .displayName("Treat \"Not Found\" as Success")
         .description("If true, \"not_found\" Elasticsearch Document associated FlowFiles will be routed to the \"" + REL_SUCCESS.getName() +
-                "\" relationship, otherwise to the \"" + REL_FAILED_DOCUMENTS.getName() + "\" relationship.")
+                "\" relationship, otherwise to the \"" + REL_FAILED_DOCUMENTS.getName() + "\" relationship. " +
+                "If " + OUTPUT_ERROR_RESPONSES.getDisplayName() + " is \"true\" then \"not_found\" responses from Elasticsearch " +
+                "will be sent to the " + REL_ERROR_RESPONSES.getName() + " relationship")
         .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
         .allowableValues("true", "false")
         .defaultValue("true")
@@ -123,16 +125,16 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         ID_ATTRIBUTE, INDEX_OP, INDEX, TYPE, BATCH_SIZE, CHARSET, CLIENT_SERVICE,
         LOG_ERROR_RESPONSES, OUTPUT_ERROR_RESPONSES, OUTPUT_ERROR_DOCUMENTS, NOT_FOUND_IS_SUCCESSFUL
     ));
-    static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-        REL_SUCCESS, REL_FAILURE, REL_RETRY, REL_FAILED_DOCUMENTS, REL_ERROR_RESPONSES
+    static final Set<Relationship> BASE_RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            REL_SUCCESS, REL_FAILURE, REL_RETRY, REL_FAILED_DOCUMENTS
     )));
 
     private boolean outputErrors;
     private final ObjectMapper inputMapper = new ObjectMapper();
 
     @Override
-    public Set<Relationship> getRelationships() {
-        return RELATIONSHIPS;
+    Set<Relationship> getBaseRelationships() {
+        return BASE_RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -215,9 +215,11 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
 
     static final PropertyDescriptor NOT_FOUND_IS_SUCCESSFUL = new PropertyDescriptor.Builder()
         .name("put-es-record-not_found-is-error")
-        .displayName("Treat \"Not Found\" as Error")
+        .displayName("Treat \"Not Found\" as Success")
         .description("If true, \"not_found\" Elasticsearch Document associated Records will be routed to the \"" +
-                REL_SUCCESSFUL_RECORDS.getName() + "\" relationship, otherwise to the \"" + REL_FAILED_RECORDS.getName() + "\" relationship.")
+                REL_SUCCESSFUL_RECORDS.getName() + "\" relationship, otherwise to the \"" + REL_FAILED_RECORDS.getName() + "\" relationship. " +
+                "If " + OUTPUT_ERROR_RESPONSES.getDisplayName() + " is \"true\" then \"not_found\" responses from Elasticsearch " +
+                "will be sent to the " + REL_ERROR_RESPONSES.getName() + " relationship")
         .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
         .allowableValues("true", "false")
         .defaultValue("true")
@@ -268,8 +270,8 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         DATE_FORMAT, TIME_FORMAT, TIMESTAMP_FORMAT, LOG_ERROR_RESPONSES, OUTPUT_ERROR_RESPONSES, RESULT_RECORD_WRITER,
         NOT_FOUND_IS_SUCCESSFUL
     ));
-    static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-        REL_SUCCESS, REL_FAILURE, REL_RETRY, REL_FAILED_RECORDS, REL_SUCCESSFUL_RECORDS, REL_ERROR_RESPONSES
+    static final Set<Relationship> BASE_RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            REL_SUCCESS, REL_FAILURE, REL_RETRY, REL_FAILED_RECORDS, REL_SUCCESSFUL_RECORDS
     )));
 
     private RecordPathCache recordPathCache;
@@ -281,8 +283,8 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
     private volatile String timestampFormat;
 
     @Override
-    public Set<Relationship> getRelationships() {
-        return RELATIONSHIPS;
+    Set<Relationship> getBaseRelationships() {
+        return BASE_RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearchTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearchTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License") you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.elasticsearch
+
+import org.apache.nifi.util.TestRunner
+import org.apache.nifi.util.TestRunners
+import org.junit.jupiter.api.Test
+
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.MatcherAssert.assertThat
+
+abstract class AbstractPutElasticsearchTest<P extends AbstractPutElasticsearch> {
+    abstract P getProcessor()
+
+    @Test
+    void testOutputErrorResponsesRelationship() {
+        final TestRunner runner = createRunner()
+
+        assertThat(runner.getProcessor().getRelationships(), not(hasItem(AbstractPutElasticsearch.REL_ERROR_RESPONSES)))
+
+        runner.setProperty(AbstractPutElasticsearch.OUTPUT_ERROR_RESPONSES, "true")
+        assertThat(runner.getProcessor().getRelationships(), hasItem(AbstractPutElasticsearch.REL_ERROR_RESPONSES))
+
+        runner.setProperty(AbstractPutElasticsearch.OUTPUT_ERROR_RESPONSES, "false")
+        assertThat(runner.getProcessor().getRelationships(), not(hasItem(AbstractPutElasticsearch.REL_ERROR_RESPONSES)))
+    }
+
+    TestRunner createRunner() {
+        final P processor = getProcessor()
+        final TestRunner runner = TestRunners.newTestRunner(processor)
+
+        return runner
+    }
+}

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.groovy
@@ -22,20 +22,18 @@ import org.apache.nifi.elasticsearch.IndexOperationResponse
 import org.apache.nifi.processors.elasticsearch.mock.MockBulkLoadClientService
 import org.apache.nifi.provenance.ProvenanceEventType
 import org.apache.nifi.util.TestRunner
-import org.apache.nifi.util.TestRunners
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 import static groovy.json.JsonOutput.prettyPrint
 import static groovy.json.JsonOutput.toJson
-
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
-class PutElasticsearchJsonTest {
+class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutElasticsearchJson> {
     MockBulkLoadClientService clientService
     TestRunner runner
 
@@ -43,10 +41,15 @@ class PutElasticsearchJsonTest {
             [ msg: "Hello, world", from: "john.smith" ]
     ))
 
+    @Override
+    PutElasticsearchJson getProcessor() {
+        return new PutElasticsearchJson()
+    }
+
     @BeforeEach
     void setup() {
         clientService = new MockBulkLoadClientService()
-        runner   = TestRunners.newTestRunner(PutElasticsearchJson.class)
+        runner = createRunner()
 
         clientService.response = new IndexOperationResponse(1500)
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
@@ -32,7 +32,6 @@ import org.apache.nifi.serialization.record.MockSchemaRegistry
 import org.apache.nifi.serialization.record.RecordFieldType
 import org.apache.nifi.util.StringUtils
 import org.apache.nifi.util.TestRunner
-import org.apache.nifi.util.TestRunners
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -53,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
-class PutElasticsearchRecordTest {
+class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<PutElasticsearchRecord> {
     private static final int DATE_YEAR = 2020
     private static final int DATE_MONTH = 11
     private static final int DATE_DAY = 27
@@ -86,12 +85,17 @@ class PutElasticsearchRecordTest {
 
     static final String flowFileContents = prettyPrint(toJson(flowFileContentMaps))
 
+    @Override
+    PutElasticsearchRecord getProcessor() {
+        return new PutElasticsearchRecord()
+    }
+
     @BeforeEach
     void setup() {
         clientService = new MockBulkLoadClientService()
         registry = new MockSchemaRegistry()
         reader   = new JsonTreeReader()
-        runner   = TestRunners.newTestRunner(PutElasticsearchRecord.class)
+        runner   = createRunner()
 
         registry.addSchema("simple", AvroTypeUtil.createSchema(new Schema.Parser().parse(SCHEMA)))
 

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
@@ -46,7 +46,12 @@ import java.time.format.DateTimeFormatter
 
 import static groovy.json.JsonOutput.prettyPrint
 import static groovy.json.JsonOutput.toJson
-import static org.junit.jupiter.api.Assertions.*
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class PutElasticsearchRecordTest {
     private static final int DATE_YEAR = 2020
@@ -141,6 +146,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, success)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         if (success > 0) {
             runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_SUCCESS).forEach({ ff ->
@@ -319,6 +325,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -374,6 +381,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -416,6 +424,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -455,6 +464,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -477,6 +487,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -502,6 +513,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -528,6 +540,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
     }
 
     @Test
@@ -604,6 +617,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.clearTransferState()
 
@@ -658,6 +672,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
     }
 
     @Test
@@ -681,6 +696,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
     }
 
     @Test
@@ -691,6 +707,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
     }
 
     @Test
@@ -734,6 +751,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 1)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 1)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS)[0]
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "1")
@@ -760,6 +778,7 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 1)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 1)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0)
 
         runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS)[0]
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "2")
@@ -776,7 +795,9 @@ class PutElasticsearchRecordTest {
         runner.clearTransferState()
         runner.clearProvenanceEvents()
 
+        // errors still counted/logged even if not outputting to the error relationship
         runner.removeProperty(PutElasticsearchRecord.RESULT_RECORD_WRITER)
+        runner.setProperty(PutElasticsearchRecord.OUTPUT_ERROR_RESPONSES, "true")
         runner.enqueue(prettyPrint(toJson(values)), [ 'schema.name': 'errorTest' ])
         runner.assertValid()
         runner.run()
@@ -786,10 +807,15 @@ class PutElasticsearchRecordTest {
         runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0)
         runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0)
+        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 1)
+
+        final String errorResponses = runner.getFlowFilesForRelationship(PutElasticsearchJson.REL_ERROR_RESPONSES)[0].getContent()
+        assertThat(errorResponses, containsString("not_found"))
+        assertThat(errorResponses, containsString("For input string: 20abc"))
 
         assertEquals(1,
                 runner.getProvenanceEvents().stream().filter({
-                    e -> ProvenanceEventType.SEND == e.getEventType() && e.getDetails() == "1 Elasticsearch _bulk operation batch(es) [1 error(s), 4 success(es)]"
+                    e -> ProvenanceEventType.SEND == e.getEventType() && e.getDetails() == "1 Elasticsearch _bulk operation batch(es) [2 error(s), 3 success(es)]"
                 }).count()
         )
     }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -51,7 +51,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.6.1"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.7.0"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -101,7 +101,7 @@ language governing permissions and limitations under the License. -->
             </activation>
             <properties>
                 <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
-                <elasticsearch_docker_image>8.6.2</elasticsearch_docker_image>
+                <elasticsearch_docker_image>8.7.0</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>
             <build>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -101,7 +101,7 @@ language governing permissions and limitations under the License. -->
             </activation>
             <properties>
                 <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
-                <elasticsearch_docker_image>8.6.1</elasticsearch_docker_image>
+                <elasticsearch_docker_image>8.6.2</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>
             <build>


### PR DESCRIPTION
# Summary

[NIFI-11111](https://issues.apache.org/jira/browse/NIFI-11111) add option to output Elasticsearch error responses as FlowFile to PutElasticsearchJson and PutElasticsearchRecord

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
