### PR TITLE
NIFI-11114 Upgrade OWASP Dependency Check from 7.4.4 to 8.0.2

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -180,8 +180,23 @@
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
-        <notes>HTTP server vulnerabilities do not apply to Apache FTP Server</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/.*$</packageUrl>
-        <cpe>cpe:/a:apache:apache_http_server</cpe>
+        <notes>CVE-2022-45046 description notes that the initial issue was not a security vulnerability</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.camel/camel\-salesforce@.*$</packageUrl>
+        <cve>CVE-2022-45046</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-36632 applies to JavaScript module named hughsk/flat not flatbuffers</notes>
+        <packageUrl regex="true">^pkg:maven/com\.vlkan/flatbuffers@.*$</packageUrl>
+        <cve>CVE-2020-36632</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-8015 applies to Apache ORC not to Apache Iceberg</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg\-orc@.*$</packageUrl>
+        <cve>CVE-2018-8015</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-39135 applies to Calcite not Calcite Avatica</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/.*?@.*$</packageUrl>
+        <cve>CVE-2022-39135</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,11 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jmx</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty.http2</groupId>
                 <artifactId>http2-client</artifactId>
                 <version>${jetty.version}</version>
@@ -1190,7 +1195,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.4.4</version>
+                        <version>8.0.2</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-11114](https://issues.apache.org/jira/browse/NIFI-11114) Upgrades the OWASP Dependency Check Maven Plugin from 7.4.4 to 8.0.2 and also updates the suppressions configuration to eliminate several false positives.

Additional changes include adding `jetty-jmx` to the list of managed dependencies so that child modules use the same version of `jetty-jmx` as other Jetty dependencies.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
