### PR TITLE
NIFI-11094: Allow CaptureChangeMySQL to send multiple events per FlowFile

### DIFF
--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/AbstractEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/AbstractEventWriter.java
@@ -33,7 +33,9 @@ public abstract class AbstractEventWriter<T extends EventInfo> implements EventW
 
     // Common method to create a JSON generator and start the root object. Should be called by sub-classes unless they need their own generator and such.
     protected void startJson(OutputStream outputStream, T event) throws IOException {
-        jsonGenerator = createJsonGenerator(outputStream);
+        if (jsonGenerator == null) {
+            jsonGenerator = createJsonGenerator(outputStream);
+        }
         jsonGenerator.writeStartObject();
         String eventType = event.getEventType();
         if (eventType == null) {
@@ -54,11 +56,15 @@ public abstract class AbstractEventWriter<T extends EventInfo> implements EventW
             throw new IOException("endJson called without a JsonGenerator");
         }
         jsonGenerator.writeEndObject();
-        jsonGenerator.flush();
-        jsonGenerator.close();
     }
 
-    private JsonGenerator createJsonGenerator(OutputStream out) throws IOException {
+    protected void endFile() throws IOException {
+        jsonGenerator.flush();
+        jsonGenerator.close();
+        jsonGenerator = null;
+    }
+
+    protected JsonGenerator createJsonGenerator(OutputStream out) throws IOException {
         return JSON_FACTORY.createGenerator(out);
     }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/EventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/EventWriter.java
@@ -32,12 +32,14 @@ public interface EventWriter<T extends EventInfo> {
     /**
      * Writes the given event to the process session, possibly via transferring it to the specified relationship (usually used for success)
      *
-     * @param session           The session to write the event to
-     * @param transitUri        The URI indicating the source MySQL system from which the specified event is associated
-     * @param eventInfo         The event data
-     * @param currentSequenceId the current sequence ID
-     * @param relationship      A relationship to transfer any flowfile(s) to
-     * @return a sequence ID, usually incremented from the specified current sequence id by the number of flow files transferred and/or committed
+     * @param session                   The session to write the event to
+     * @param transitUri                The URI indicating the source MySQL system from which the specified event is associated
+     * @param eventInfo                 The event data
+     * @param currentSequenceId         The current sequence ID
+     * @param relationship              A relationship to transfer any flowfile(s) to
+     * @param eventWriterConfiguration  A configuration object used for FlowFile management (how many events to write to each FlowFile, e.g.)
+     * @return a sequence ID, usually incremented from the specified current sequence ID by the number of FlowFiles transferred and/or committed
      */
-    long writeEvent(final ProcessSession session, String transitUri, final T eventInfo, final long currentSequenceId, Relationship relationship);
+    long writeEvent(final ProcessSession session, String transitUri, final T eventInfo, final long currentSequenceId, Relationship relationship,
+                    final EventWriterConfiguration eventWriterConfiguration);
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/EventWriterConfiguration.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/EventWriterConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cdc.event.io;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessSession;
+
+import java.io.OutputStream;
+
+public class EventWriterConfiguration {
+
+    private FlowFileEventWriteStrategy flowFileEventWriteStrategy;
+    private int numberOfEventsWritten = 0;
+    private int numberOfEventsPerFlowFile = 1000;
+    private FlowFile currentFlowFile;
+    private OutputStream flowFileOutputStream;
+    private ProcessSession workingSession;
+    private JsonGenerator jsonGenerator;
+
+    public EventWriterConfiguration(FlowFileEventWriteStrategy flowFileEventWriteStrategy, int numberOfEventsWritten, int numberOfEventsPerFlowFile, FlowFile currentFlowFile) {
+        this.flowFileEventWriteStrategy = flowFileEventWriteStrategy;
+        this.numberOfEventsWritten = numberOfEventsWritten;
+        this.numberOfEventsPerFlowFile = numberOfEventsPerFlowFile;
+        this.currentFlowFile = currentFlowFile;
+    }
+
+    public FlowFileEventWriteStrategy getFlowFileEventWriteStrategy() {
+        return flowFileEventWriteStrategy;
+    }
+
+    public void setFlowFileEventWriteStrategy(FlowFileEventWriteStrategy flowFileEventWriteStrategy) {
+        this.flowFileEventWriteStrategy = flowFileEventWriteStrategy;
+    }
+
+    public int getNumberOfEventsWritten() {
+        return numberOfEventsWritten;
+    }
+
+    public void setNumberOfEventsWritten(int numberOfEventsWritten) {
+        this.numberOfEventsWritten = numberOfEventsWritten;
+    }
+
+    public void incrementNumberOfEventsWritten() {
+        this.numberOfEventsWritten++;
+    }
+
+    public int getNumberOfEventsPerFlowFile() {
+        return numberOfEventsPerFlowFile;
+    }
+
+    public void setNumberOfEventsPerFlowFile(int numberOfEventsPerFlowFile) {
+        this.numberOfEventsPerFlowFile = numberOfEventsPerFlowFile;
+    }
+
+    public FlowFile getCurrentFlowFile() {
+        return currentFlowFile;
+    }
+
+    public void setCurrentFlowFile(FlowFile currentFlowFile) {
+        this.currentFlowFile = currentFlowFile;
+    }
+
+    public OutputStream getFlowFileOutputStream() {
+        return flowFileOutputStream;
+    }
+
+    public void setFlowFileOutputStream(OutputStream flowFileOutputStream) {
+        this.flowFileOutputStream = flowFileOutputStream;
+    }
+
+
+    public ProcessSession getWorkingSession() {
+        return workingSession;
+    }
+
+    public void setWorkingSession(ProcessSession workingSession) {
+        this.workingSession = workingSession;
+    }
+
+    public JsonGenerator getJsonGenerator() {
+        return jsonGenerator;
+    }
+
+    public void setJsonGenerator(JsonGenerator jsonGenerator) {
+        this.jsonGenerator = jsonGenerator;
+    }
+}

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/EventWriterConfiguration.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/EventWriterConfiguration.java
@@ -18,85 +18,65 @@ package org.apache.nifi.cdc.event.io;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.processor.ProcessSession;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
 public class EventWriterConfiguration {
 
-    private FlowFileEventWriteStrategy flowFileEventWriteStrategy;
-    private int numberOfEventsWritten = 0;
-    private int numberOfEventsPerFlowFile = 1000;
+    private final FlowFileEventWriteStrategy flowFileEventWriteStrategy;
+    private final int numberOfEventsPerFlowFile;
+
+    private int numberOfEventsWritten;
+
     private FlowFile currentFlowFile;
     private OutputStream flowFileOutputStream;
-    private ProcessSession workingSession;
     private JsonGenerator jsonGenerator;
 
-    public EventWriterConfiguration(FlowFileEventWriteStrategy flowFileEventWriteStrategy, int numberOfEventsWritten, int numberOfEventsPerFlowFile, FlowFile currentFlowFile) {
+    public EventWriterConfiguration(FlowFileEventWriteStrategy flowFileEventWriteStrategy, int numberOfEventsPerFlowFile) {
         this.flowFileEventWriteStrategy = flowFileEventWriteStrategy;
-        this.numberOfEventsWritten = numberOfEventsWritten;
         this.numberOfEventsPerFlowFile = numberOfEventsPerFlowFile;
-        this.currentFlowFile = currentFlowFile;
     }
 
     public FlowFileEventWriteStrategy getFlowFileEventWriteStrategy() {
         return flowFileEventWriteStrategy;
     }
 
-    public void setFlowFileEventWriteStrategy(FlowFileEventWriteStrategy flowFileEventWriteStrategy) {
-        this.flowFileEventWriteStrategy = flowFileEventWriteStrategy;
-    }
-
     public int getNumberOfEventsWritten() {
         return numberOfEventsWritten;
-    }
-
-    public void setNumberOfEventsWritten(int numberOfEventsWritten) {
-        this.numberOfEventsWritten = numberOfEventsWritten;
     }
 
     public void incrementNumberOfEventsWritten() {
         this.numberOfEventsWritten++;
     }
 
-    public int getNumberOfEventsPerFlowFile() {
-        return numberOfEventsPerFlowFile;
+    public void startNewFlowFile(FlowFile flowFile, OutputStream flowFileOutputStream, JsonGenerator jsonGenerator) {
+        this.currentFlowFile = flowFile;
+        this.flowFileOutputStream = flowFileOutputStream;
+        this.jsonGenerator = jsonGenerator;
     }
 
-    public void setNumberOfEventsPerFlowFile(int numberOfEventsPerFlowFile) {
-        this.numberOfEventsPerFlowFile = numberOfEventsPerFlowFile;
+    public void cleanUp() throws IOException {
+        this.currentFlowFile = null;
+        this.flowFileOutputStream.close();
+        this.flowFileOutputStream = null;
+        this.jsonGenerator = null;
+        this.numberOfEventsWritten = 0;
+    }
+
+    public int getNumberOfEventsPerFlowFile() {
+        return numberOfEventsPerFlowFile;
     }
 
     public FlowFile getCurrentFlowFile() {
         return currentFlowFile;
     }
 
-    public void setCurrentFlowFile(FlowFile currentFlowFile) {
-        this.currentFlowFile = currentFlowFile;
-    }
-
     public OutputStream getFlowFileOutputStream() {
         return flowFileOutputStream;
     }
 
-    public void setFlowFileOutputStream(OutputStream flowFileOutputStream) {
-        this.flowFileOutputStream = flowFileOutputStream;
-    }
-
-
-    public ProcessSession getWorkingSession() {
-        return workingSession;
-    }
-
-    public void setWorkingSession(ProcessSession workingSession) {
-        this.workingSession = workingSession;
-    }
-
     public JsonGenerator getJsonGenerator() {
         return jsonGenerator;
-    }
-
-    public void setJsonGenerator(JsonGenerator jsonGenerator) {
-        this.jsonGenerator = jsonGenerator;
     }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/FlowFileEventWriteStrategy.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/FlowFileEventWriteStrategy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cdc.event.io;
+
+public enum FlowFileEventWriteStrategy {
+    N_EVENTS_PER_FLOWFILE,
+    ONE_TRANSACTION_PER_FLOWFILE,
+}

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/FlowFileEventWriteStrategy.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/io/FlowFileEventWriteStrategy.java
@@ -16,7 +16,39 @@
  */
 package org.apache.nifi.cdc.event.io;
 
-public enum FlowFileEventWriteStrategy {
-    N_EVENTS_PER_FLOWFILE,
-    ONE_TRANSACTION_PER_FLOWFILE,
+import org.apache.nifi.components.DescribedValue;
+
+public enum FlowFileEventWriteStrategy implements DescribedValue {
+    MAX_EVENTS_PER_FLOWFILE(
+            "Max Events Per FlowFile",
+            "This strategy causes at most the number of events specified in the 'Number of Events Per FlowFile' property to be written per FlowFile. If the processor is stopped before the "
+                    + "specified number of events has been written (or the event queue becomes empty), the fewer number of events will still be written as a FlowFile before stopping."
+    ),
+    ONE_TRANSACTION_PER_FLOWFILE(
+            "One Transaction Per FlowFile",
+            "This strategy causes each event from a transaction (from BEGIN to COMMIT) to be written to a FlowFile"
+    );
+
+    private String displayName;
+    private String description;
+
+    FlowFileEventWriteStrategy(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/AbstractBinlogEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/AbstractBinlogEventWriter.java
@@ -86,7 +86,7 @@ public abstract class AbstractBinlogEventWriter<T extends BinlogEventInfo> exten
         eventWriterConfiguration.incrementNumberOfEventsWritten();
 
         // Check if it is time to finish the FlowFile
-        if (nEventsPerFlowFile(eventWriterConfiguration)
+        if (maxEventsPerFlowFile(eventWriterConfiguration)
                 && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
             finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, currentSequenceId, eventInfo, relationship);
         }
@@ -144,7 +144,7 @@ public abstract class AbstractBinlogEventWriter<T extends BinlogEventInfo> exten
     }
 
     private boolean multipleEventsPerFlowFile(EventWriterConfiguration eventWriterConfiguration) {
-        return (nEventsPerFlowFile(eventWriterConfiguration)
+        return (maxEventsPerFlowFile(eventWriterConfiguration)
                 && eventWriterConfiguration.getNumberOfEventsPerFlowFile() > 1)
                 || oneTransactionPerFlowFile(eventWriterConfiguration);
     }
@@ -154,7 +154,7 @@ public abstract class AbstractBinlogEventWriter<T extends BinlogEventInfo> exten
                 || oneTransactionPerFlowFile(eventWriterConfiguration);
     }
 
-    protected boolean nEventsPerFlowFile(EventWriterConfiguration eventWriterConfiguration) {
+    protected boolean maxEventsPerFlowFile(EventWriterConfiguration eventWriterConfiguration) {
         return FlowFileEventWriteStrategy.MAX_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy());
     }
 

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/AbstractBinlogTableEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/AbstractBinlogTableEventWriter.java
@@ -16,9 +16,6 @@
  */
 package org.apache.nifi.cdc.mysql.event.io;
 
-import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.cdc.mysql.event.BinlogTableEventInfo;
 
 import java.io.IOException;
@@ -45,21 +42,5 @@ public abstract class AbstractBinlogTableEventWriter<T extends BinlogTableEventI
         } else {
             jsonGenerator.writeNullField("table_id");
         }
-    }
-
-    // Default implementation for table-related binlog events
-    @Override
-    public long writeEvent(ProcessSession session, String transitUri, T eventInfo, long currentSequenceId, Relationship relationship) {
-        FlowFile flowFile = session.create();
-        flowFile = session.write(flowFile, (outputStream) -> {
-            super.startJson(outputStream, eventInfo);
-            writeJson(eventInfo);
-            // Nothing in the body
-            super.endJson();
-        });
-        flowFile = session.putAllAttributes(flowFile, getCommonAttributes(currentSequenceId, eventInfo));
-        session.transfer(flowFile, relationship);
-        session.getProvenanceReporter().receive(flowFile, transitUri);
-        return currentSequenceId + 1;
     }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/CommitTransactionEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/CommitTransactionEventWriter.java
@@ -18,7 +18,6 @@ package org.apache.nifi.cdc.mysql.event.io;
 
 
 import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
-import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
 import org.apache.nifi.cdc.mysql.event.CommitTransactionEventInfo;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
@@ -35,8 +34,8 @@ public class CommitTransactionEventWriter extends AbstractBinlogEventWriter<Comm
                            Relationship relationship, EventWriterConfiguration eventWriterConfiguration) {
         long sequenceId = super.writeEvent(session, transitUri, eventInfo, currentSequenceId, relationship, eventWriterConfiguration);
         // If writing one transaction per flowfile, finish the flowfile here before committing the session
-        if (FlowFileEventWriteStrategy.ONE_TRANSACTION_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())) {
-            super.finishAndTransferFlowFile(eventWriterConfiguration, transitUri, sequenceId, eventInfo, relationship);
+        if (oneTransactionPerFlowFile(eventWriterConfiguration)) {
+            super.finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, sequenceId, eventInfo, relationship);
         }
         return sequenceId;
     }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DDLEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DDLEventWriter.java
@@ -16,10 +16,17 @@
  */
 package org.apache.nifi.cdc.mysql.event.io;
 
+import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
+import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.cdc.mysql.event.DDLEventInfo;
+import org.apache.nifi.processor.exception.FlowFileAccessException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
 
 /**
  * A writer class to output MySQL binlog Data Definition Language (DDL) events to flow file(s).
@@ -27,17 +34,28 @@ import org.apache.nifi.cdc.mysql.event.DDLEventInfo;
 public class DDLEventWriter extends AbstractBinlogTableEventWriter<DDLEventInfo> {
 
     @Override
-    public long writeEvent(ProcessSession session, String transitUri, DDLEventInfo eventInfo, long currentSequenceId, Relationship relationship) {
-        FlowFile flowFile = session.create();
-        flowFile = session.write(flowFile, (outputStream) -> {
+    public long writeEvent(ProcessSession session, String transitUri, DDLEventInfo eventInfo, long currentSequenceId, Relationship relationship,
+                           final EventWriterConfiguration eventWriterConfiguration) {
+        FlowFile flowFile = configureEventWriter(eventWriterConfiguration, session, eventInfo);
+        OutputStream outputStream = eventWriterConfiguration.getFlowFileOutputStream();
+
+        try {
             super.startJson(outputStream, eventInfo);
             super.writeJson(eventInfo);
             jsonGenerator.writeStringField("query", eventInfo.getQuery());
             super.endJson();
-        });
-        flowFile = session.putAllAttributes(flowFile, getCommonAttributes(currentSequenceId, eventInfo));
-        session.transfer(flowFile, relationship);
-        session.getProvenanceReporter().receive(flowFile, transitUri);
+        } catch (IOException ioe) {
+            throw new FlowFileAccessException("Couldn't write start of event array", ioe);
+        }
+
+        eventWriterConfiguration.incrementNumberOfEventsWritten();
+
+        // Check if it is time to finish the FlowFile
+        if (FlowFileEventWriteStrategy.N_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())
+                && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
+            flowFile = finishAndTransferFlowFile(eventWriterConfiguration, transitUri, currentSequenceId, eventInfo, relationship);
+        }
+        eventWriterConfiguration.setCurrentFlowFile(flowFile);
         return currentSequenceId + 1;
     }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DDLEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DDLEventWriter.java
@@ -17,15 +17,13 @@
 package org.apache.nifi.cdc.mysql.event.io;
 
 import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
-import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
-import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.cdc.mysql.event.DDLEventInfo;
-import org.apache.nifi.processor.exception.FlowFileAccessException;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 
 
 /**
@@ -36,7 +34,7 @@ public class DDLEventWriter extends AbstractBinlogTableEventWriter<DDLEventInfo>
     @Override
     public long writeEvent(ProcessSession session, String transitUri, DDLEventInfo eventInfo, long currentSequenceId, Relationship relationship,
                            final EventWriterConfiguration eventWriterConfiguration) {
-        FlowFile flowFile = configureEventWriter(eventWriterConfiguration, session, eventInfo);
+        configureEventWriter(eventWriterConfiguration, session, eventInfo);
         OutputStream outputStream = eventWriterConfiguration.getFlowFileOutputStream();
 
         try {
@@ -45,17 +43,16 @@ public class DDLEventWriter extends AbstractBinlogTableEventWriter<DDLEventInfo>
             jsonGenerator.writeStringField("query", eventInfo.getQuery());
             super.endJson();
         } catch (IOException ioe) {
-            throw new FlowFileAccessException("Couldn't write start of event array", ioe);
+            throw new UncheckedIOException("Write JSON start array failed", ioe);
         }
 
         eventWriterConfiguration.incrementNumberOfEventsWritten();
 
         // Check if it is time to finish the FlowFile
-        if (FlowFileEventWriteStrategy.N_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())
+        if (nEventsPerFlowFile(eventWriterConfiguration)
                 && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
-            flowFile = finishAndTransferFlowFile(eventWriterConfiguration, transitUri, currentSequenceId, eventInfo, relationship);
+            finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, currentSequenceId, eventInfo, relationship);
         }
-        eventWriterConfiguration.setCurrentFlowFile(flowFile);
         return currentSequenceId + 1;
     }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DDLEventWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DDLEventWriter.java
@@ -49,7 +49,7 @@ public class DDLEventWriter extends AbstractBinlogTableEventWriter<DDLEventInfo>
         eventWriterConfiguration.incrementNumberOfEventsWritten();
 
         // Check if it is time to finish the FlowFile
-        if (nEventsPerFlowFile(eventWriterConfiguration)
+        if (maxEventsPerFlowFile(eventWriterConfiguration)
                 && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
             finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, currentSequenceId, eventInfo, relationship);
         }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
@@ -16,18 +16,20 @@
  */
 package org.apache.nifi.cdc.mysql.event.io;
 
+import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
+import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
 import org.apache.nifi.cdc.mysql.event.MySQLCDCUtils;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.cdc.event.ColumnDefinition;
 import org.apache.nifi.cdc.mysql.event.DeleteRowsEventInfo;
 import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.FlowFileAccessException;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.BitSet;
-import java.util.concurrent.atomic.AtomicLong;
-
 
 /**
  * A writer class to output MySQL binlog "delete rows" events to flow file(s).
@@ -42,12 +44,13 @@ public class DeleteRowsWriter extends AbstractBinlogTableEventWriter<DeleteRowsE
      * @return The next available CDC sequence ID for use by the CDC processor
      */
     @Override
-    public long writeEvent(final ProcessSession session, String transitUri, final DeleteRowsEventInfo eventInfo, final long currentSequenceId, Relationship relationship) {
-        final AtomicLong seqId = new AtomicLong(currentSequenceId);
+    public long writeEvent(final ProcessSession session, String transitUri, final DeleteRowsEventInfo eventInfo, final long currentSequenceId, Relationship relationship,
+                           final EventWriterConfiguration eventWriterConfiguration) {
+        long seqId = currentSequenceId;
         for (Serializable[] row : eventInfo.getRows()) {
-
-            FlowFile flowFile = session.create();
-            flowFile = session.write(flowFile, outputStream -> {
+            FlowFile flowFile = configureEventWriter(eventWriterConfiguration, session, eventInfo);
+            OutputStream outputStream = eventWriterConfiguration.getFlowFileOutputStream();
+            try {
 
                 super.startJson(outputStream, eventInfo);
                 super.writeJson(eventInfo);
@@ -56,14 +59,21 @@ public class DeleteRowsWriter extends AbstractBinlogTableEventWriter<DeleteRowsE
                 writeRow(eventInfo, row, bitSet);
 
                 super.endJson();
-            });
+            } catch (IOException ioe) {
+                throw new FlowFileAccessException("Couldn't write start of event array", ioe);
+            }
 
-            flowFile = session.putAllAttributes(flowFile, getCommonAttributes(seqId.get(), eventInfo));
-            session.transfer(flowFile, relationship);
-            session.getProvenanceReporter().receive(flowFile, transitUri);
-            seqId.getAndIncrement();
+            eventWriterConfiguration.incrementNumberOfEventsWritten();
+
+            // Check if it is time to finish the FlowFile
+            if (FlowFileEventWriteStrategy.N_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())
+                    && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
+                flowFile = finishAndTransferFlowFile(eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
+            }
+            eventWriterConfiguration.setCurrentFlowFile(flowFile);
+            seqId++;
         }
-        return seqId.get();
+        return seqId;
     }
 
     protected void writeRow(DeleteRowsEventInfo event, Serializable[] row, BitSet includedColumns) throws IOException {

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
@@ -17,18 +17,16 @@
 package org.apache.nifi.cdc.mysql.event.io;
 
 import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
-import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
 import org.apache.nifi.cdc.mysql.event.MySQLCDCUtils;
-import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.cdc.event.ColumnDefinition;
 import org.apache.nifi.cdc.mysql.event.DeleteRowsEventInfo;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.exception.FlowFileAccessException;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.util.BitSet;
 
 /**
@@ -48,7 +46,7 @@ public class DeleteRowsWriter extends AbstractBinlogTableEventWriter<DeleteRowsE
                            final EventWriterConfiguration eventWriterConfiguration) {
         long seqId = currentSequenceId;
         for (Serializable[] row : eventInfo.getRows()) {
-            FlowFile flowFile = configureEventWriter(eventWriterConfiguration, session, eventInfo);
+            configureEventWriter(eventWriterConfiguration, session, eventInfo);
             OutputStream outputStream = eventWriterConfiguration.getFlowFileOutputStream();
             try {
 
@@ -60,17 +58,16 @@ public class DeleteRowsWriter extends AbstractBinlogTableEventWriter<DeleteRowsE
 
                 super.endJson();
             } catch (IOException ioe) {
-                throw new FlowFileAccessException("Couldn't write start of event array", ioe);
+                throw new UncheckedIOException("Write JSON start array failed", ioe);
             }
 
             eventWriterConfiguration.incrementNumberOfEventsWritten();
 
             // Check if it is time to finish the FlowFile
-            if (FlowFileEventWriteStrategy.N_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())
+            if (nEventsPerFlowFile(eventWriterConfiguration)
                     && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
-                flowFile = finishAndTransferFlowFile(eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
+                finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
             }
-            eventWriterConfiguration.setCurrentFlowFile(flowFile);
             seqId++;
         }
         return seqId;

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
@@ -64,7 +64,7 @@ public class DeleteRowsWriter extends AbstractBinlogTableEventWriter<DeleteRowsE
             eventWriterConfiguration.incrementNumberOfEventsWritten();
 
             // Check if it is time to finish the FlowFile
-            if (nEventsPerFlowFile(eventWriterConfiguration)
+            if (maxEventsPerFlowFile(eventWriterConfiguration)
                     && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
                 finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
             }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/InsertRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/InsertRowsWriter.java
@@ -65,7 +65,7 @@ public class InsertRowsWriter extends AbstractBinlogTableEventWriter<InsertRowsE
             eventWriterConfiguration.incrementNumberOfEventsWritten();
 
             // Check if it is time to finish the FlowFile
-            if (nEventsPerFlowFile(eventWriterConfiguration)
+            if (maxEventsPerFlowFile(eventWriterConfiguration)
                     && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
                 finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
             }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/InsertRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/InsertRowsWriter.java
@@ -16,17 +16,20 @@
  */
 package org.apache.nifi.cdc.mysql.event.io;
 
+import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
+import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
 import org.apache.nifi.cdc.mysql.event.MySQLCDCUtils;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.cdc.event.ColumnDefinition;
 import org.apache.nifi.cdc.mysql.event.InsertRowsEventInfo;
 import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.FlowFileAccessException;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.BitSet;
-import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -42,12 +45,13 @@ public class InsertRowsWriter extends AbstractBinlogTableEventWriter<InsertRowsE
      * @return The next available CDC sequence ID for use by the CDC processor
      */
     @Override
-    public long writeEvent(final ProcessSession session, String transitUri, final InsertRowsEventInfo eventInfo, final long currentSequenceId, Relationship relationship) {
-        final AtomicLong seqId = new AtomicLong(currentSequenceId);
+    public long writeEvent(final ProcessSession session, String transitUri, final InsertRowsEventInfo eventInfo, final long currentSequenceId, Relationship relationship,
+                           final EventWriterConfiguration eventWriterConfiguration) {
+        long seqId = currentSequenceId;
         for (Serializable[] row : eventInfo.getRows()) {
-
-            FlowFile flowFile = session.create();
-            flowFile = session.write(flowFile, outputStream -> {
+            FlowFile flowFile = configureEventWriter(eventWriterConfiguration, session, eventInfo);
+            OutputStream outputStream = eventWriterConfiguration.getFlowFileOutputStream();
+            try {
 
                 super.startJson(outputStream, eventInfo);
                 super.writeJson(eventInfo);
@@ -56,14 +60,21 @@ public class InsertRowsWriter extends AbstractBinlogTableEventWriter<InsertRowsE
                 writeRow(eventInfo, row, bitSet);
 
                 super.endJson();
-            });
+            } catch (IOException ioe) {
+                throw new FlowFileAccessException("Couldn't write start of event array", ioe);
+            }
 
-            flowFile = session.putAllAttributes(flowFile, getCommonAttributes(seqId.get(), eventInfo));
-            session.transfer(flowFile, relationship);
-            session.getProvenanceReporter().receive(flowFile, transitUri);
-            seqId.getAndIncrement();
+            eventWriterConfiguration.incrementNumberOfEventsWritten();
+
+            // Check if it is time to finish the FlowFile
+            if (FlowFileEventWriteStrategy.N_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())
+                    && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
+                flowFile = finishAndTransferFlowFile(eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
+            }
+            eventWriterConfiguration.setCurrentFlowFile(flowFile);
+            seqId++;
         }
-        return seqId.get();
+        return seqId;
     }
 
     protected void writeRow(InsertRowsEventInfo event, Serializable[] row, BitSet includedColumns) throws IOException {

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/UpdateRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/UpdateRowsWriter.java
@@ -66,7 +66,7 @@ public class UpdateRowsWriter extends AbstractBinlogTableEventWriter<UpdateRowsE
             eventWriterConfiguration.incrementNumberOfEventsWritten();
 
             // Check if it is time to finish the FlowFile
-            if (nEventsPerFlowFile(eventWriterConfiguration)
+            if (maxEventsPerFlowFile(eventWriterConfiguration)
                     && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
                 finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
             }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/UpdateRowsWriter.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/UpdateRowsWriter.java
@@ -17,18 +17,16 @@
 package org.apache.nifi.cdc.mysql.event.io;
 
 import org.apache.nifi.cdc.event.io.EventWriterConfiguration;
-import org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy;
 import org.apache.nifi.cdc.mysql.event.MySQLCDCUtils;
-import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.cdc.event.ColumnDefinition;
 import org.apache.nifi.cdc.mysql.event.UpdateRowsEventInfo;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.exception.FlowFileAccessException;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.util.BitSet;
 import java.util.Map;
 
@@ -50,7 +48,7 @@ public class UpdateRowsWriter extends AbstractBinlogTableEventWriter<UpdateRowsE
                            final EventWriterConfiguration eventWriterConfiguration) {
         long seqId = currentSequenceId;
         for (Map.Entry<Serializable[], Serializable[]> row : eventInfo.getRows()) {
-            FlowFile flowFile = configureEventWriter(eventWriterConfiguration, session, eventInfo);
+            configureEventWriter(eventWriterConfiguration, session, eventInfo);
             OutputStream outputStream = eventWriterConfiguration.getFlowFileOutputStream();
 
             try {
@@ -62,17 +60,16 @@ public class UpdateRowsWriter extends AbstractBinlogTableEventWriter<UpdateRowsE
 
                 super.endJson();
             } catch (IOException ioe) {
-                throw new FlowFileAccessException("Couldn't write start of event array", ioe);
+                throw new UncheckedIOException("Write JSON start array failed", ioe);
             }
 
             eventWriterConfiguration.incrementNumberOfEventsWritten();
 
             // Check if it is time to finish the FlowFile
-            if (FlowFileEventWriteStrategy.N_EVENTS_PER_FLOWFILE.equals(eventWriterConfiguration.getFlowFileEventWriteStrategy())
+            if (nEventsPerFlowFile(eventWriterConfiguration)
                     && eventWriterConfiguration.getNumberOfEventsWritten() == eventWriterConfiguration.getNumberOfEventsPerFlowFile()) {
-                flowFile = finishAndTransferFlowFile(eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
+                finishAndTransferFlowFile(session, eventWriterConfiguration, transitUri, seqId, eventInfo, relationship);
             }
-            eventWriterConfiguration.setCurrentFlowFile(flowFile);
             seqId++;
         }
         return seqId;


### PR DESCRIPTION

# Summary

[NIFI-11094](https://issues.apache.org/jira/browse/NIFI-11094) This PR refactors CaptureChangeMySQL to support two modes of operation, N events per FlowFile and one transaction per FlowFile. The default is N events per FlowFile with N set to 1 to retain existing behavior (1 event per FlowFile). However now this number is configurable, or the user can choose to output a FlowFile with all events between BEGIN and COMMIT events. The latter can help with downstream processing, as PutDatabaseRecord treats a FlowFile as a transaction so failure handling can be more consistent.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
