### PR TITLE
NIFI-11117 Remove folder creation from PutGoogleDrive

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-conflict-resolution</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <scope>test</scope>
         </dependency>

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -183,7 +183,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
     }
 
     private void handleErrorResponse(ProcessSession session, String fileId, FlowFile flowFile, GoogleJsonResponseException e) {
-        getLogger().error("Couldn't fetch file with id '{}'", fileId, e);
+        getLogger().error("Fetching File [{}] failed", fileId, e);
 
         flowFile = session.putAttribute(flowFile, ERROR_CODE, "" + e.getStatusCode());
         flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
@@ -193,7 +193,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
     }
 
     private void handleUnexpectedError(ProcessSession session, FlowFile flowFile, String fileId, Exception e) {
-        getLogger().error("Unexpected error while fetching and processing file with id '{}'", fileId, e);
+        getLogger().error("Fetching File [{}] failed", fileId, e);
 
         flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
@@ -42,7 +42,6 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
 
     @Test
     void testFetch() throws Exception {
-        // GIVEN
         File file = createFileWithDefaultContent("test_file.txt", mainFolderId);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
@@ -54,11 +53,9 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
         List<String> expectedContent = singletonList(DEFAULT_FILE_CONTENT);
 
-        // WHEN
         testRunner.enqueue("unimportant_data", inputFlowFileAttributes);
         testRunner.run();
 
-        // THEN
         testRunner.assertTransferCount(FetchGoogleDrive.REL_FAILURE, 0);
 
         checkAttributes(FetchGoogleDrive.REL_SUCCESS, expectedAttributes);
@@ -67,7 +64,6 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
 
     @Test
     void testInputFlowFileReferencesMissingFile() {
-        // GIVEN
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
         inputFlowFileAttributes.put(GoogleDriveAttributes.ID, "missing");
         inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, "missing_filename");
@@ -80,24 +76,20 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
                 }}
         ));
 
-        // WHEN
         testRunner.enqueue("unimportant_data", inputFlowFileAttributes);
         testRunner.run();
 
-        // THEN
         testRunner.assertTransferCount(FetchGoogleDrive.REL_SUCCESS, 0);
         checkAttributes(FetchGoogleDrive.REL_FAILURE, expectedFailureAttributes);
     }
 
     @Test
     void testInputFlowFileThrowsExceptionBeforeFetching() throws Exception {
-        // GIVEN
         File file = createFileWithDefaultContent("test_file.txt", mainFolderId);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
         inputFlowFileAttributes.put(GoogleDriveAttributes.ID, file.getId());
         inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, file.getName());
-
         MockFlowFile input = new MockFlowFile(1) {
             final AtomicBoolean throwException = new AtomicBoolean(true);
 
@@ -111,7 +103,6 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
                     return super.isPenalized();
                 }
             }
-
             @Override
             public Map<String, String> getAttributes() {
                 return inputFlowFileAttributes;
@@ -122,11 +113,9 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
                 inputFlowFileAttributes
         ));
 
-        // WHEN
         testRunner.enqueue(input);
         testRunner.run();
 
-        // THEN
         testRunner.assertTransferCount(FetchGoogleDrive.REL_SUCCESS, 0);
 
         checkAttributes(FetchGoogleDrive.REL_FAILURE, expectedFailureAttributes);

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveIT.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveIT.java
@@ -49,7 +49,6 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
 
     @Test
     void listFilesFrom3LayerDeepDirectoryTree() throws Exception {
-        // GIVEN
         File main_sub1 = createFolder("main_sub1", mainFolderId);
         File main_sub2 = createFolder("main_sub2", mainFolderId);
 
@@ -78,10 +77,8 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
         // The creation of the files are not (completely) synchronized.
         Thread.sleep(2000);
 
-        // WHEN
         testRunner.run();
 
-        // THEN
         List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
 
         Set<String> actualFileNames = successFlowFiles.stream()
@@ -93,19 +90,17 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
         // Next, list a sub folder, non-recursively this time. (Changing these properties will clear the Processor state as well
         //  so all files are eligible for listing again.)
 
-        // GIVEN
+
         testRunner.clearTransferState();
 
         expectedFileNames = new HashSet<>(Arrays.asList(
                 "main_sub1_file1"
         ));
 
-        // WHEN
         testRunner.setProperty(ListGoogleDrive.FOLDER_ID, main_sub1.getId());
         testRunner.setProperty(ListGoogleDrive.RECURSIVE_SEARCH, "false");
         testRunner.run();
 
-        // THEN
         successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
 
         actualFileNames = successFlowFiles.stream()
@@ -117,7 +112,6 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
 
     @Test
     void doNotListTooYoungFilesWhenMinAgeIsSet() throws Exception {
-        // GIVEN
         testRunner.setProperty(ListGoogleDrive.MIN_AGE, "15 s");
 
         createFileWithDefaultContent("main_file", mainFolderId);
@@ -125,10 +119,8 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
         // Make sure the file 'arrives' and could be listed
         Thread.sleep(5000);
 
-        // WHEN
         testRunner.run();
 
-        // THEN
         List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
 
         Set<String> actualFileNames = successFlowFiles.stream()
@@ -139,17 +131,15 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
 
         // Next, wait for another 10+ seconds for MIN_AGE to expire then list again
 
-        // GIVEN
+
         Thread.sleep(10000);
 
         Set<String> expectedFileNames = new HashSet<>(Arrays.asList(
                 "main_file"
         ));
 
-        // WHEN
         testRunner.run();
 
-        // THEN
         successFlowFiles = testRunner.getFlowFilesForRelationship(ListGoogleDrive.REL_SUCCESS);
 
         actualFileNames = successFlowFiles.stream()
@@ -158,5 +148,4 @@ public class ListGoogleDriveIT extends AbstractGoogleDriveIT<ListGoogleDrive> {
 
         assertEquals(expectedFileNames, actualFileNames);
     }
-
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.when;
 
 public class ListGoogleDriveSimpleTest {
     private ListGoogleDrive testSubject;
-
     private ProcessContext mockProcessContext;
     private Drive mockDriverService;
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -84,7 +84,6 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
 
     @Test
     void testOutputAsAttributesWhereTimestampIsCreatedTime() throws Exception {
-        // GIVEN
         String id = "id_1";
         String filename = "file_name_1";
         Long size = 125L;
@@ -92,14 +91,10 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         Long modifiedTime = null;
         String mimeType = "mime_type_1";
 
-        // WHEN
-        // THEN
         testOutputAsAttributes(id, filename, size, createdTime, modifiedTime, mimeType, createdTime);
     }
-
     @Test
     void testOutputAsAttributesWhereTimestampIsModifiedTime() throws Exception {
-        // GIVEN
         String id = "id_1";
         String filename = "file_name_1";
         Long size = 125L;
@@ -107,14 +102,11 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         Long modifiedTime = 123456L + 1L;
         String mimeType = "mime_type_1";
 
-        // WHEN
-        // THEN
         testOutputAsAttributes(id, filename, size, createdTime, modifiedTime, mimeType, modifiedTime);
     }
 
     @Test
     void testOutputAsContent() throws Exception {
-        // GIVEN
         String id = "id_1";
         String filename = "file_name_1";
         Long size = 125L;
@@ -137,10 +129,7 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                         "}" +
                         "]");
 
-        // WHEN
         testRunner.run();
-
-        // THEN
         checkContent(ListGoogleDrive.REL_SUCCESS, expectedContents);
     }
 
@@ -172,7 +161,6 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     }
 
     private void testOutputAsAttributes(String id, String filename, Long size, Long createdTime, Long modifiedTime, String mimeType, Long expectedTimestamp) throws IOException {
-        // GIVEN
         mockFetchedGoogleDriveFileList(id, filename, size, createdTime, modifiedTime, mimeType);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
@@ -184,10 +172,8 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
 
         HashSet<Map<String, String>> expectedAttributes = new HashSet<>(asList(inputFlowFileAttributes));
 
-        // WHEN
         testRunner.run();
 
-        // THEN
         checkAttributes(ListGoogleDrive.REL_SUCCESS, expectedAttributes);
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11117](https://issues.apache.org/jira/browse/NIFI-11117)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11117`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11117`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
