### PR TITLE
NIFI-11126 Delete MultiPart files in ListenHTTP after processing

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -244,7 +244,13 @@ public class ListenHTTPServlet extends HttpServlet {
 
             Set<FlowFile> flowFileSet;
             if (StringUtils.isNotBlank(request.getContentType()) && request.getContentType().contains("multipart/form-data")) {
-                flowFileSet = handleMultipartRequest(request, session, foundSubject, foundIssuer);
+                try {
+                    flowFileSet = handleMultipartRequest(request, session, foundSubject, foundIssuer);
+                } finally {
+                    for (final Part part : request.getParts()) {
+                        part.delete();
+                    }
+                }
             } else {
                 flowFileSet = handleRequest(request, session, foundSubject, foundIssuer, destinationIsLegacyNiFi, contentType, in);
             }
@@ -268,9 +274,6 @@ public class ListenHTTPServlet extends HttpServlet {
 
     private Set<FlowFile> handleMultipartRequest(HttpServletRequest request, ProcessSession session, String foundSubject, String foundIssuer)
             throws IOException, IllegalStateException, ServletException {
-        if (isRecordProcessing()) {
-            logger.debug("Record processing will not be utilized while processing multipart request. Request URI: {}", request.getRequestURI());
-        }
         Set<FlowFile> flowFileSet = new HashSet<>();
         String tempDir = System.getProperty("java.io.tmpdir");
         request.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, new MultipartConfigElement(tempDir, multipartRequestMaxSize, multipartRequestMaxSize, multipartReadBufferSize));
@@ -284,7 +287,6 @@ public class ListenHTTPServlet extends HttpServlet {
             flowFile = saveRequestDetailsAsAttributes(request, session, foundSubject, foundIssuer, flowFile);
             flowFile = savePartDetailsAsAttributes(session, part, flowFile, i, requestParts.size());
             flowFileSet.add(flowFile);
-            part.delete();
             i++;
         }
         return flowFileSet;
@@ -330,9 +332,6 @@ public class ListenHTTPServlet extends HttpServlet {
                         hasMoreData.set(false);
                     }
                 } else {
-                    if (isRecordProcessing()) {
-                        logger.debug("Record processing will not be utilized while processing with unpackager. Request URI: {}", request.getRequestURI());
-                    }
                     attributes.putAll(unpackager.unpackageFlowFile(in, bos));
 
                     if (destinationIsLegacyNiFi) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -62,11 +62,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -276,11 +274,9 @@ public class ListenHTTPServlet extends HttpServlet {
         Set<FlowFile> flowFileSet = new HashSet<>();
         String tempDir = System.getProperty("java.io.tmpdir");
         request.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, new MultipartConfigElement(tempDir, multipartRequestMaxSize, multipartRequestMaxSize, multipartReadBufferSize));
-        Collection<Part> requestParts = Collections.unmodifiableCollection(request.getParts());
-        final Iterator<Part> parts = requestParts.iterator();
         int i = 0;
-        while (parts.hasNext()) {
-            Part part = parts.next();
+        final Collection<Part> requestParts = request.getParts();
+        for (final Part part : requestParts) {
             FlowFile flowFile = session.create();
             try (OutputStream flowFileOutputStream = session.write(flowFile)) {
                 StreamUtils.copy(part.getInputStream(), flowFileOutputStream);
@@ -288,6 +284,7 @@ public class ListenHTTPServlet extends HttpServlet {
             flowFile = saveRequestDetailsAsAttributes(request, session, foundSubject, foundIssuer, flowFile);
             flowFile = savePartDetailsAsAttributes(session, part, flowFile, i, requestParts.size());
             flowFileSet.add(flowFile);
+            part.delete();
             i++;
         }
         return flowFileSet;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -696,6 +697,7 @@ public class TestListenHTTP {
         runner.setProperty(ListenHTTP.PORT, Integer.toString(availablePort));
         runner.setProperty(ListenHTTP.BASE_PATH, HTTP_BASE_PATH);
         runner.setProperty(ListenHTTP.RETURN_CODE, Integer.toString(HttpServletResponse.SC_OK));
+        runner.setProperty(ListenHTTP.MULTIPART_READ_BUFFER_SIZE, "10 bytes");
 
         final SSLContextService sslContextService = runner.getControllerService(SSL_CONTEXT_SERVICE_IDENTIFIER, SSLContextService.class);
         final boolean isSecure = (sslContextService != null);
@@ -769,6 +771,13 @@ public class TestListenHTTP {
         mff.assertAttributeExists("http.multipart.fragments.sequence.number");
         mff.assertAttributeEquals("http.multipart.fragments.total.number", "5");
         mff.assertAttributeExists("http.headers.multipart.content-disposition");
+
+        final Path tempDirectoryPath = Paths.get(System.getProperty("java.io.tmpdir"));
+        final long multiPartTempFiles = Files.find(tempDirectoryPath, 1,
+                        (filePath, fileAttributes) -> filePath.getFileName().toString().startsWith("MultiPart")
+                ).count();
+        final String multiPartMessage = String.format("MultiPart files found in temporary directory [%s]", tempDirectoryPath);
+        assertEquals(0, multiPartTempFiles, multiPartMessage);
     }
 
     private byte[] generateRandomBinaryData() {


### PR DESCRIPTION
# Summary

[NIFI-11126](https://issues.apache.org/jira/browse/NIFI-11126) Updates `ListenHTTP` to delete MultiPart elements after processing to avoid leaving files in the system temporary directory.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
