### PR TITLE
NIFI-11140 Upgrade Tomcat from 8.5.82 to 8.5.85 for Flume

### DIFF
--- a/nifi-nar-bundles/nifi-flume-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-flume-bundle/pom.xml
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>8.5.82</version>
+                <version>8.5.85</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11140](https://issues.apache.org/jira/browse/NIFI-11140) Upgrades Apache Tomcat transitive dependencies from 8.5.82 to 8.5.85 for Flume Processors. This update resolves CVE-2022-42252, which only applies to specific Flume configurations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
