### PR TITLE
NIFI-11141 Upgrade Azure SDK BOM from 1.2.6 to 1.2.9

### DIFF
--- a/nifi-commons/nifi-property-protection-azure/pom.xml
+++ b/nifi-commons/nifi-property-protection-azure/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.0</version>
+                <version>1.2.9</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <azure.sdk.bom.version>1.2.6</azure.sdk.bom.version>
+        <azure.sdk.bom.version>1.2.9</azure.sdk.bom.version>
         <microsoft.azure-storage.version>8.6.6</microsoft.azure-storage.version>
         <msal4j.version>1.13.3</msal4j.version>
     </properties>


### PR DESCRIPTION
# Summary

[NIFI-11141](https://issues.apache.org/jira/browse/NIFI-11141) Upgrades the Azure SDK Bill of Materials dependency to 1.2.9. The `nifi-property-protection-azure` module had a limited scope dependency on version 1.2.0, and the `nifi-azure-bundle` included more libraries with SDK version 1.2.6.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
