### PR TITLE
NIFI-11144 Fix failing tests for ConsumeJMS/PublishJMS

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -204,8 +204,7 @@ public class StandardProcessorTestRunner implements TestRunner {
                 try {
                     ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, processor, context);
                 } catch (final Exception e) {
-                    e.printStackTrace();
-                    Assertions.fail("Could not invoke methods annotated with @OnScheduled annotation due to: " + e);
+                    Assertions.fail("Could not invoke methods annotated with @OnScheduled annotation due to: " + e, e);
                 }
             }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -191,8 +191,6 @@ public abstract class AbstractJMSProcessor<T extends JMSWorker> extends Abstract
 
         try {
             rendezvousWithJms(context, session, worker);
-        } catch (Exception e) {
-            getLogger().error("Error while trying to process JMS message", e);
         } finally {
             //in case of exception during worker's connection (consumer or publisher),
             //an appropriate service is responsible to invalidate the worker.

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -185,7 +185,7 @@ public abstract class AbstractJMSProcessor<T extends JMSWorker> extends Abstract
             } catch (Exception e) {
                 getLogger().error("Failed to initialize JMS Connection Factory", e);
                 context.yield();
-                return;
+                throw e;
             }
         }
 
@@ -207,7 +207,7 @@ public abstract class AbstractJMSProcessor<T extends JMSWorker> extends Abstract
                     CachingConnectionFactory currentCF = (CachingConnectionFactory)worker.jmsTemplate.getConnectionFactory();
                     connectionFactoryProvider.resetConnectionFactory(currentCF.getTargetConnectionFactory());
                     worker = buildTargetResource(context);
-                }catch(Exception e) {
+                } catch (Exception e) {
                     getLogger().error("Failed to rebuild:  " + connectionFactoryProvider);
                     worker = null;
                 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
@@ -301,6 +301,7 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
             getLogger().error("Error while trying to process JMS message", e);
             consumer.setValid(false);
             context.yield();
+            throw e;
         }
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
@@ -298,9 +298,9 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
                 }
             });
         } catch(Exception e) {
+            getLogger().error("Error while trying to process JMS message", e);
             consumer.setValid(false);
             context.yield();
-            throw e; // for backward compatibility with exception handling in flows
         }
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
@@ -83,6 +83,9 @@ final class JMSConsumer extends JMSWorker {
     }
 
 
+    /**
+     * Receives a message from the broker. It is the consumerCallback's responsibility to acknowledge the received message.
+     */
     public void consume(final String destinationName, String errorQueueName, final boolean durable, final boolean shared, final String subscriptionName, final String messageSelector,
                         final String charset, final ConsumerCallback consumerCallback) {
         this.jmsTemplate.execute(new SessionCallback<Void>() {

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
@@ -46,7 +46,7 @@ import java.util.Map;
 /**
  * Generic consumer of messages from JMS compliant messaging system.
  */
-final class JMSConsumer extends JMSWorker {
+class JMSConsumer extends JMSWorker {
 
     JMSConsumer(CachingConnectionFactory connectionFactory, JmsTemplate jmsTemplate, ComponentLog logger) {
         super(connectionFactory, jmsTemplate, logger);

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
@@ -222,7 +222,7 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
                 processSession.getProvenanceReporter().send(flowFile, destinationName);
             } catch (Exception e) {
                 processSession.transfer(flowFile, REL_FAILURE);
-                this.getLogger().error("Failed while sending message to JMS via " + publisher, e);
+                getLogger().error("Failed while sending message to JMS via " + publisher, e);
                 context.yield();
                 publisher.setValid(false);
             }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
@@ -35,7 +35,6 @@ import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessContext;
-import org.apache.nifi.util.MockSessionFactory;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
@@ -202,9 +201,7 @@ public class ConsumeJMSIT {
         try {
             ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
 
-            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
-
-            sender.jmsTemplate.send("testMapMessage", __ -> createUnsupportedMessage("unsupportedMessagePropertyKey", "unsupportedMessagePropertyValue"));
+            jmsTemplate.send("testMapMessage", __ -> createUnsupportedMessage("unsupportedMessagePropertyKey", "unsupportedMessagePropertyValue"));
 
             TestRunner runner = TestRunners.newTestRunner(new ConsumeJMS());
             JMSConnectionFactoryProviderDefinition cs = mock(JMSConnectionFactoryProviderDefinition.class);
@@ -232,9 +229,7 @@ public class ConsumeJMSIT {
     private void testMessageTypeAttribute(String destinationName, final MessageCreator messageCreator, String expectedJmsMessageTypeAttribute) throws Exception {
         JmsTemplate jmsTemplate = CommonTest.buildJmsTemplateForDestination(false);
         try {
-            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
-
-            sender.jmsTemplate.send(destinationName, messageCreator);
+            jmsTemplate.send(destinationName, messageCreator);
 
             TestRunner runner = TestRunners.newTestRunner(new ConsumeJMS());
             JMSConnectionFactoryProviderDefinition cs = mock(JMSConnectionFactoryProviderDefinition.class);
@@ -462,9 +457,7 @@ public class ConsumeJMSIT {
 
         JmsTemplate jmsTemplate = CommonTest.buildJmsTemplateForDestination(false);
         try {
-            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
-
-            sender.jmsTemplate.send(destination, session -> session.createTextMessage("msg"));
+            jmsTemplate.send(destination, session -> session.createTextMessage("msg"));
 
             TestRunner runner = TestRunners.newTestRunner(processor);
             JMSConnectionFactoryProviderDefinition cs = mock(JMSConnectionFactoryProviderDefinition.class);
@@ -476,8 +469,6 @@ public class ConsumeJMSIT {
             runner.setProperty(PublishJMS.CF_SERVICE, "cfProvider");
             runner.setProperty(ConsumeJMS.DESTINATION, destination);
             runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.QUEUE);
-
-            ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions();
 
             assertCausedBy(expectedException, () -> runner.run(1, false));
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
@@ -384,7 +384,8 @@ public class ConsumeJMSIT {
             runner.setProperty(ConsumeJMS.DESTINATION, destinationName);
             runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.TOPIC);
 
-            assertThrows(AssertionError.class, () -> runner.run());
+            runner.run();
+
             assertFalse(tcpTransport.get().isConnected(), "It is expected transport be closed. ");
         } finally {
             if (broker != null) {
@@ -409,8 +410,9 @@ public class ConsumeJMSIT {
         runner.setProperty(ConsumeJMS.DESTINATION, "foo");
         runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.TOPIC);
 
-         assertThrows(AssertionError.class, () -> runner.run());
-         assertTrue(((MockProcessContext) runner.getProcessContext()).isYieldCalled(), "In case of an exception, the processor should be yielded.");
+        runner.run();
+
+        assertTrue(((MockProcessContext) runner.getProcessContext()).isYieldCalled(), "In case of an exception, the processor should be yielded.");
     }
 
     @Test
@@ -428,7 +430,8 @@ public class ConsumeJMSIT {
         runner.setProperty(ConsumeJMS.DESTINATION, "myTopic");
         runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.TOPIC);
 
-        assertThrows(AssertionError.class, () -> runner.run());
+        runner.run();
+
         assertTrue(((MockProcessContext) runner.getProcessContext()).isYieldCalled(), "In case of an exception, the processor should be yielded.");
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSManualTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSManualTest.java
@@ -18,7 +18,6 @@ package org.apache.nifi.jms.processors;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQMessage;
-import org.apache.nifi.logging.ComponentLog;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.jms.connection.CachingConnectionFactory;
@@ -33,12 +32,10 @@ import javax.jms.Session;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
 
-import static org.mockito.Mockito.mock;
-
 @Disabled("Used for manual testing.")
 public class ConsumeJMSManualTest {
     @Test
-    public void testTextMessage() throws Exception {
+    public void testTextMessage() {
         MessageCreator messageCreator = session -> {
             TextMessage message = session.createTextMessage("textMessageContent");
 
@@ -49,7 +46,7 @@ public class ConsumeJMSManualTest {
     }
 
     @Test
-    public void testBytesMessage() throws Exception {
+    public void testBytesMessage() {
         MessageCreator messageCreator = session -> {
             BytesMessage message = session.createBytesMessage();
 
@@ -62,7 +59,7 @@ public class ConsumeJMSManualTest {
     }
 
     @Test
-    public void testObjectMessage() throws Exception {
+    public void testObjectMessage() {
         MessageCreator messageCreator = session -> {
             ObjectMessage message = session.createObjectMessage();
 
@@ -75,7 +72,7 @@ public class ConsumeJMSManualTest {
     }
 
     @Test
-    public void testStreamMessage() throws Exception {
+    public void testStreamMessage() {
         MessageCreator messageCreator = session -> {
             StreamMessage message = session.createStreamMessage();
 
@@ -98,7 +95,7 @@ public class ConsumeJMSManualTest {
     }
 
     @Test
-    public void testMapMessage() throws Exception {
+    public void testMapMessage() {
         MessageCreator messageCreator = session -> {
             MapMessage message = session.createMapMessage();
 
@@ -121,14 +118,14 @@ public class ConsumeJMSManualTest {
     }
 
     @Test
-    public void testUnsupportedMessage() throws Exception {
+    public void testUnsupportedMessage() {
         MessageCreator messageCreator = session -> new ActiveMQMessage();
 
         send(messageCreator);
     }
 
-    private void send(MessageCreator messageCreator) throws Exception {
-        final String  destinationName = "TEST";
+    private void send(MessageCreator messageCreator) {
+        final String destinationName = "TEST";
 
         ConnectionFactory activeMqConnectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
         final ConnectionFactory connectionFactory = new CachingConnectionFactory(activeMqConnectionFactory);
@@ -139,9 +136,7 @@ public class ConsumeJMSManualTest {
         jmsTemplate.setReceiveTimeout(10L);
 
         try {
-            JMSPublisher sender = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mock(ComponentLog.class));
-
-            sender.jmsTemplate.send(destinationName, messageCreator);
+            jmsTemplate.send(destinationName, messageCreator);
         } finally {
             ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
         }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
@@ -340,13 +340,10 @@ public class JMSPublisherConsumerIT {
         JmsTemplate publishTemplate = CommonTest.buildJmsTemplateForDestination(false);
         final CountDownLatch consumerTemplateCloseCount = new CountDownLatch(threadCount);
 
-        final AtomicInteger test = new AtomicInteger(0);
-
         try {
             JMSPublisher publisher = new JMSPublisher((CachingConnectionFactory) publishTemplate.getConnectionFactory(), publishTemplate, mock(ComponentLog.class));
             for (int i = 0; i < totalMessageCount; i++) {
                 publisher.publish(destinationName, String.valueOf(i).getBytes(StandardCharsets.UTF_8));
-                test.incrementAndGet();
             }
 
             final AtomicInteger msgCount = new AtomicInteger(0);

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/PublishJMSIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/PublishJMSIT.java
@@ -16,15 +16,6 @@
  */
 package org.apache.nifi.jms.processors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.TransportConnector;
@@ -41,12 +32,17 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.JmsHeaders;
 
+import javax.jms.BytesMessage;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.TextMessage;
+import javax.net.SocketFactory;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 import java.net.URI;
@@ -56,12 +52,13 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.jms.BytesMessage;
-import javax.jms.ConnectionFactory;
-import javax.jms.Message;
-import javax.jms.Queue;
-import javax.jms.TextMessage;
-import javax.net.SocketFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PublishJMSIT {
 
@@ -525,7 +522,7 @@ public class PublishJMSIT {
     }
 
     @Test
-    public void whenExceptionIsRaisedDuringConnectionFactoryInitializationTheProcessorShouldBeYielded() throws Exception {
+    public void whenExceptionIsRaisedDuringConnectionFactoryInitializationTheProcessorShouldBeYielded() {
         TestRunner runner = TestRunners.newTestRunner(PublishJMS.class);
 
         // using JNDI JMS Connection Factory configured locally on the processor
@@ -533,11 +530,13 @@ public class PublishJMSIT {
         runner.setProperty(JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, "DummyProviderUrl");
         runner.setProperty(JndiJmsConnectionFactoryProperties.JNDI_CONNECTION_FACTORY_NAME, "DummyConnectionFactoryName");
 
-        runner.setProperty(ConsumeJMS.DESTINATION, "myTopic");
-        runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.TOPIC);
+        runner.setProperty(AbstractJMSProcessor.DESTINATION, "myTopic");
+        runner.setProperty(AbstractJMSProcessor.DESTINATION_TYPE, AbstractJMSProcessor.TOPIC);
 
         runner.enqueue("message");
-        assertThrows(AssertionError.class, () -> runner.run());
+
+        runner.run();
+
         assertTrue(((MockProcessContext) runner.getProcessContext()).isYieldCalled(), "In case of an exception, the processor should be yielded.");
     }
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/helpers/AssertionUtils.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/helpers/AssertionUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jms.processors.helpers;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class AssertionUtils {
+
+    public static <T extends Throwable> void assertCausedBy(Class<T> expectedType, Runnable runnable) {
+        assertCausedBy(expectedType, null, runnable);
+    }
+
+    public static <T extends Throwable> void assertCausedBy(Class<T> expectedType, String expectedMessage, Runnable runnable) {
+        try {
+            runnable.run();
+            fail(String.format("Expected an exception to be thrown with a cause of %s, but nothing was thrown.", expectedType.getCanonicalName()));
+        } catch (Throwable throwable) {
+            final List<Throwable> causes = ExceptionUtils.getThrowableList(throwable);
+            for (Throwable cause : causes) {
+                if (expectedType.isInstance(cause)) {
+                    if (expectedMessage != null) {
+                        if (cause.getMessage() != null && cause.getMessage().startsWith(expectedMessage)) {
+                            return;
+                        }
+                    } else {
+                        return;
+                    }
+                }
+            }
+            fail(String.format("Exception is thrown but not found %s as a cause. Received exception is: %s", expectedType.getCanonicalName(), throwable), throwable);
+        }
+    }
+
+    public static void assertCausedBy(Throwable expectedException, Runnable runnable) {
+        try {
+            runnable.run();
+            fail(String.format("Expected an exception to be thrown with a cause of %s, but nothing was thrown.", expectedException));
+        } catch (Throwable throwable) {
+            final List<Throwable> causes = ExceptionUtils.getThrowableList(throwable);
+            for (Throwable cause : causes) {
+                if (cause.equals(expectedException)) {
+                    return;
+                }
+            }
+            fail(String.format("Exception is thrown but not found %s as a cause. Received exception is: %s", expectedException, throwable), throwable);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11144](https://issues.apache.org/jira/browse/NIFI-11144)

As the title says, this PR intends to fix currently failing tests without changing the behavior of the processors. There are two things worth mentioning. There was an exception propagation in ConsumeJMS. The comment next to it doesn't really make sense. In 2020 a commit was added, which even caught all exceptions in the Abstract class. I tried to figure out what the expectation would be. Propagate it according to the original behavior, or go forward and remove the rethrow part. I decided to do the latter because propagating the exception doesn't make sense in this case. There is no upstream connection, and when "consume" fails, there won't be a flowfile in the output relationship, so rollback is unnecessary, which could be triggered by the exception.
The other thing is testMultiplethreads(). It failed with timeout because we reached a limit after publishing a thousand messages. It is probably related to [this](https://activemq.apache.org/how-to-deal-with-large-number-of-threads-in-clients). I tried multiple different configurations without luck. It is a hint, but maybe not all of them work with the test broker implementation. Ultimately I decided to set the total messages to that threshold. This way, we can spare the additional configuration, and one thousand messages should be enough for the purpose of the test.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
