### PR TITLE
NIFI-11152 Upgrade Splunk SDK from 1.9.1 to 1.9.3

### DIFF
--- a/nifi-nar-bundles/nifi-splunk-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-splunk-bundle/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>com.splunk</groupId>
                 <artifactId>splunk</artifactId>
-                <version>1.9.1</version>
+                <version>1.9.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11152](https://issues.apache.org/jira/browse/NIFI-11152) Upgrades the Splunk SDK from 1.9.1 to [1.9.3](https://github.com/splunk/splunk-sdk-java/releases/tag/1.9.3) in order to include [Splunk SDK PR 202](https://github.com/splunk/splunk-sdk-java/pull/202), which corrects a `NullPointerException` in `GetSplunk` when using Token Authentication.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
