### PR TITLE
NIFI-11160 Upgrade Apache Tika from 2.6.0 to 2.7.0

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <description>NiFi: Framework Bundle</description>
     <properties>
         <curator.version>5.4.0</curator.version>
-        <tika.version>2.6.0</tika.version>
+        <tika.version>2.7.0</tika.version>
     </properties>
     <modules>
         <module>nifi-framework</module>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>2.6.0</tika.version>
+        <tika.version>2.7.0</tika.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -36,7 +36,7 @@
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
         <jolt.version>0.1.7</jolt.version>
         <org.apache.sshd.version>2.9.2</org.apache.sshd.version>
-        <tika.version>2.6.0</tika.version>
+        <tika.version>2.7.0</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# Summary

[NIFI-11160](https://issues.apache.org/jira/browse/NIFI-11160) Upgrades Apache Tika from 2.6.0 to [2.7.0](https://dist.apache.org/repos/dist/release/tika/2.7.0/CHANGES-2.7.0.txt) to incorporate several bug fixes and improvements, applicable to both framework components and several extension modules.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
