### PR TITLE
NIFI-11161 Simplify KeyedCipherPropertyEncryptor

### DIFF
--- a/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/PropertyEncryptorBuilder.java
+++ b/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/PropertyEncryptorBuilder.java
@@ -17,8 +17,6 @@
 package org.apache.nifi.encrypt;
 
 import org.apache.nifi.security.util.EncryptionMethod;
-import org.apache.nifi.security.util.crypto.AESKeyedCipherProvider;
-import org.apache.nifi.security.util.crypto.KeyedCipherProvider;
 import org.apache.nifi.security.util.crypto.PBECipherProvider;
 
 import javax.crypto.SecretKey;
@@ -66,10 +64,8 @@ public class PropertyEncryptorBuilder {
         if (propertyEncryptionMethod == null) {
             return getPasswordBasedCipherPropertyEncryptor();
         } else {
-            final KeyedCipherProvider keyedCipherProvider = new AESKeyedCipherProvider();
             final SecretKey secretKey = SECRET_KEY_PROVIDER.getSecretKey(propertyEncryptionMethod, password);
-            final EncryptionMethod encryptionMethod = propertyEncryptionMethod.getEncryptionMethod();
-            return new KeyedCipherPropertyEncryptor(keyedCipherProvider, encryptionMethod, secretKey);
+            return new KeyedCipherPropertyEncryptor(secretKey);
         }
     }
 

--- a/nifi-commons/nifi-property-encryptor/src/test/java/org/apache/nifi/encrypt/KeyedCipherPropertyEncryptorTest.java
+++ b/nifi-commons/nifi-property-encryptor/src/test/java/org/apache/nifi/encrypt/KeyedCipherPropertyEncryptorTest.java
@@ -18,9 +18,6 @@ package org.apache.nifi.encrypt;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.nifi.security.util.EncryptionMethod;
-import org.apache.nifi.security.util.crypto.AESKeyedCipherProvider;
-import org.apache.nifi.security.util.crypto.KeyedCipherProvider;
 import org.apache.nifi.util.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,10 +38,6 @@ public class KeyedCipherPropertyEncryptorTest {
 
     private static final int ENCRYPTED_BINARY_LENGTH = 48;
 
-    private static final KeyedCipherProvider CIPHER_PROVIDER = new AESKeyedCipherProvider();
-
-    private static final EncryptionMethod ENCRYPTION_METHOD = EncryptionMethod.AES_GCM;
-
     private static final String KEY_ALGORITHM = "AES";
 
     private static final byte[] STATIC_KEY = StringUtils.repeat("KEY", 8).getBytes(DEFAULT_CHARSET);
@@ -57,7 +50,7 @@ public class KeyedCipherPropertyEncryptorTest {
 
     @BeforeEach
     public void setUp() {
-        encryptor = new KeyedCipherPropertyEncryptor(CIPHER_PROVIDER, ENCRYPTION_METHOD, SECRET_KEY);
+        encryptor = new KeyedCipherPropertyEncryptor(SECRET_KEY);
     }
 
     @Test
@@ -77,18 +70,18 @@ public class KeyedCipherPropertyEncryptorTest {
     @Test
     public void testDecryptEncryptionException() {
         final String encodedProperty = Hex.encodeHexString(PROPERTY.getBytes(DEFAULT_CHARSET));
-        assertThrows(EncryptionException.class, () -> encryptor.decrypt(encodedProperty));
+        assertThrows(Exception.class, () -> encryptor.decrypt(encodedProperty));
     }
 
     @Test
     public void testGetCipherEncryptionException() {
-        encryptor = new KeyedCipherPropertyEncryptor(CIPHER_PROVIDER, ENCRYPTION_METHOD, INVALID_SECRET_KEY);
+        encryptor = new KeyedCipherPropertyEncryptor(INVALID_SECRET_KEY);
         assertThrows(EncryptionException.class, () -> encryptor.encrypt(PROPERTY));
     }
 
     @Test
     public void testEqualsHashCode() {
-        final KeyedCipherPropertyEncryptor equivalentEncryptor = new KeyedCipherPropertyEncryptor(CIPHER_PROVIDER, ENCRYPTION_METHOD, SECRET_KEY);
+        final KeyedCipherPropertyEncryptor equivalentEncryptor = new KeyedCipherPropertyEncryptor(SECRET_KEY);
         assertEquals(encryptor, equivalentEncryptor);
         assertEquals(encryptor.hashCode(), equivalentEncryptor.hashCode());
     }
@@ -96,7 +89,7 @@ public class KeyedCipherPropertyEncryptorTest {
     @Test
     public void testEqualsHashCodeDifferentSecretKey() {
         final SecretKey secretKey = new SecretKeySpec(String.class.getSimpleName().getBytes(StandardCharsets.UTF_8), KEY_ALGORITHM);
-        final KeyedCipherPropertyEncryptor differentEncryptor = new KeyedCipherPropertyEncryptor(CIPHER_PROVIDER, ENCRYPTION_METHOD, secretKey);
+        final KeyedCipherPropertyEncryptor differentEncryptor = new KeyedCipherPropertyEncryptor(secretKey);
         assertNotEquals(encryptor, differentEncryptor);
         assertNotEquals(encryptor.hashCode(), differentEncryptor.hashCode());
     }


### PR DESCRIPTION
# Summary

[NIFI-11161](https://issues.apache.org/jira/browse/NIFI-11161) Simplifies the `KeyedCipherPropertyEncryptor` implementation that supports encryption and decryption of sensitive flow property values.

The existing implementation delegates `Cipher` instantiation to the `AESKeyedCipherProvider`, which includes a number of checks that are not necessary for the `KeyedCipherPropertyEncryptor`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
