### PR TITLE
NIFI-11164 - Remove Java 8 references and update Github Workflows/Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,6 @@ Please indicate the verification steps performed prior to pull request creation.
 ### Build
 
 - [ ] Build completed using `mvn clean install -P contrib-check`
-  - [ ] JDK 8
   - [ ] JDK 11
   - [ ] JDK 17
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,7 +31,6 @@ env:
     -Dmaven.wagon.http.pool=false
   MAVEN_COMPILE_COMMAND: >-
     mvn test-compile
-    --threads 2C
     --show-version
     --no-snapshot-updates
     --no-transfer-progress

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -236,7 +236,7 @@ jobs:
   macos-build-jp:
     timeout-minutes: 120
     runs-on: macos-latest
-    name: MacOS Temurin JDK 8 JP
+    name: MacOS Temurin JDK 17 JP
     steps:
       - name: System Information
         run: |
@@ -253,11 +253,11 @@ jobs:
             ~/.npm
             **/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-      - name: Set up Java 8
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'maven'
       - name: Maven Compile
         env:
@@ -297,7 +297,7 @@ jobs:
   windows-build:
     timeout-minutes: 120
     runs-on: windows-latest
-    name: Windows Zulu JDK 8 FR
+    name: Windows Zulu JDK 11 FR
     steps:
       - name: System Information
         run: |
@@ -316,11 +316,11 @@ jobs:
             ~\AppData\npm-cache
             **\node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-      - name: Set up Java 8
+      - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
           cache: 'maven'
       - name: Maven Compile
         env:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -139,15 +139,15 @@ jobs:
   macos:
     timeout-minutes: 120
     runs-on: macos-latest
-    name: MacOS Java 8
+    name: MacOS Java 11
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Set up Java 8
+      - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 11
           cache: 'maven'
       - name: Build Dependencies
         env:

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Apache NiFi was made for dataflow. It supports highly configurable directed grap
   - Multiple teams can manage and share specific portions of the flow
 
 ## Minimum Recommendations
-* JDK 11.0.16
-* Apache Maven 3.8.6
+* JDK 17.0.6
+* Apache Maven 3.9.0
 
 ## Minimum Requirements
-* JDK 8 Update 251
-* Apache Maven 3.6.0
+* JDK 11.0.16
+* Apache Maven 3.8.6
 
 ## Getting Started
 

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -23,7 +23,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 == System Requirements
 Apache NiFi can run on something as simple as a laptop, but it can also be clustered across many enterprise-class servers. Therefore, the amount of hardware and memory needed will depend on the size and nature of the dataflow involved. The data is stored on disk while NiFi is processing it. So NiFi needs to have sufficient disk space allocated for its various repositories, particularly the content repository, flowfile repository, and provenance repository (see the <<system_properties>> section for more information about these repositories). NiFi has the following minimum system requirements:
 
-* Requires Java 8 or Java 11
+* Requires Java 11 or Java 17
 * Supported Operating Systems:
 ** Linux
 ** Unix
@@ -80,7 +80,7 @@ See the <<system_properties>> section of this guide for more information about c
 
 The binary build of Apache NiFi that is provided by the Apache mirrors does not contain every NAR file that is part of the official release. This is due to size constraints imposed by the mirrors to reduce the expenses associated with hosting such a large project. The Developer Guide link:developer-guide.html#build[has a list] of optional Maven profiles that can be activated to build a binary distribution of NiFi with these extra capabilities.
 
-To execute build, download either Java 8 or Java 11 from https://www.adoptium.net[Adoptium] or whichever distribution of the JDK your team uses (Adoptium is the rebranding of AdoptOpenJDK which is one of the most popular). Java 8 and 11 are the only officially supported JVM releases. Then install https://maven.apache.org[Apache Maven].
+To execute build, download either Java 11 or Java 17 from https://www.adoptium.net[Adoptium] or whichever distribution of the JDK your team uses (Adoptium is the rebranding of AdoptOpenJDK which is one of the most popular). Java 11 and 17 are the only officially supported JVM releases. Then install https://maven.apache.org[Apache Maven].
 
 The next step is to download a copy of the Apache NiFi source code from the https://nifi.apache.org/download.html[NiFi Downloads page]. The reason you need the source build is that it includes a module called `nifi-assembly` which is the Maven module that builds a binary distribution. Expand the archive and run a Maven clean build. The following example shows how to build a distribution that activates the `graph` and `media` bundle profiles to add in support for graph databases and Apache Tika content and metadata extraction.
 
@@ -1987,18 +1987,6 @@ A number of PBE algorithms provided by NiFi impose strict limits on the length o
 By default, the `Allow Insecure Cryptographic Modes` property in `EncryptContent` processor settings is set to `not-allowed`. This means that if a password of fewer than `10` characters is provided, a validation error will occur. 10 characters is a conservative estimate and does not take into consideration full entropy calculations, patterns, etc.
 
 image:allow-weak-crypto.png["Allow Insecure Cryptographic Modes", width=940]
-
-On a JVM with limited strength cryptography, some PBE algorithms limit the maximum password length to 7, and in this case it will not be possible to provide a "safe" password. It is recommended to install the JCE Unlimited Strength Jurisdiction Policy files for the JVM to mitigate this issue.
-
-* link:http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[JCE Unlimited Strength Jurisdiction Policy files for Java 8^]
-
-If on a system where the unlimited strength policies cannot be installed, it is recommended to switch to an algorithm that supports longer passwords (see table above).
-
-[WARNING]
-.Allowing Weak Crypto
-=====================
-If it is not possible to install the unlimited strength jurisdiction policies, the `Allow Weak Crypto` setting can be changed to `allowed`, but *this is _not_ recommended*. Changing this setting explicitly acknowledges the inherent risk in using weak cryptographic configurations.
-=====================
 
 It is preferable to request upstream/downstream systems to switch to link:https://cwiki.apache.org/confluence/display/NIFI/Encryption+Information[keyed encryption^] or use a "strong" <<key-derivation-functions, Key Derivation Function (KDF) supported by NiFi>>.
 

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -2203,7 +2203,7 @@ Divide. This is to preserve backwards compatibility and to not force rounding er
 [.function]
 === math
 
-*Description*: [.description]#ADVANCED FEATURE. This expression is designed to be used by advanced users only. It utilizes Java Reflection to run arbitrary java.lang.Math static methods. The exact API will depend on the version of Java you are running. The Java 8 API can be found here: link:https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html[https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html^]
+*Description*: [.description]#ADVANCED FEATURE. This expression is designed to be used by advanced users only. It utilizes Java Reflection to run arbitrary java.lang.Math static methods. The exact API will depend on the version of Java you are running. The Java 11 API can be found here: link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Math.html[https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Math.html^]
  +
 In order to run the correct method, the parameter types must be correct. The Expression Language "Number" (whole number) type is interpreted as a Java "long". The "Decimal" type is interpreted as a Java "double". Running the desired method may require calling "toNumber()" or "toDecimal()" in order to "cast" the value to the desired type. This also is important to remember when cascading "math()" calls since the return type depends on the method that was run.#
 

--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -2949,13 +2949,6 @@ The `WriteAheadProvenanceRepository` can use the Provenance data stored by the `
 ==== Older Existing NiFi Version
 If you are upgrading from an older version of NiFi to 1.2.0 or later, it is recommended that you do not change the provenance configuration to Write Ahead until you confirm your flows and environment are stable in 1.2.0 first.  This reduces the number of variables in your upgrade and can simplify the debugging process if any issues arise.
 
-==== Bootstrap.conf
-While better performance is achieved with the G1 garbage collector, Java 8 bugs may surface more frequently in the Write Ahead configuration.  It is recommended that the following line is commented out in the _bootstrap.conf_ file in the `conf` directory:
-
-....
-java.arg.13=-XX:+UseG1GC
-....
-
 ==== System Properties
 Many of the same system properties are supported by both the Persistent and Write Ahead configurations, however the default values have been chosen for a Persistent Provenance configuration. The following exceptions and recommendations should be noted when changing to a Write Ahead configuration:
 

--- a/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/JASN1ReaderTest.java
+++ b/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/JASN1ReaderTest.java
@@ -23,6 +23,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.mockito.ArgumentCaptor;
@@ -78,6 +79,7 @@ public class JASN1ReaderTest {
         assertTrue(!testSubject.asnOutDir.toFile().exists());
     }
 
+    @DisabledOnOs({ OS.WINDOWS })
     @Test
     public void testCanLoadClassCompiledFromAsn() throws Exception {
         // GIVEN
@@ -138,6 +140,7 @@ public class JASN1ReaderTest {
         testParseError(asnFile, expectedErrorMessages);
     }
 
+    @DisabledOnOs({ OS.WINDOWS })
     @Test
     /*
      * Checks reported messages of underlying libraries that are explained in additionalDetails.html.
@@ -158,13 +161,13 @@ public class JASN1ReaderTest {
         testCompileError(asnFiles, expectedErrorMessages);
     }
 
-    @EnabledOnOs({ OS.MAC, OS.WINDOWS })
+    @EnabledOnOs({ OS.MAC })
     @Test
     /*
      * Checks reported messages of underlying libraries that are explained in additionalDetails.html.
      * In case of changes to this test additionalDetails.html may need to be updated as well.
      */
-    public void testCantCompileAsnOnMacWindows() throws Exception {
+    public void testCantCompileAsnOnMac() throws Exception {
         // GIVEN
         String asnFiles = Paths.get("src", "test", "resources", "cant_compile_mac_windows.asn").toString();
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -23,7 +23,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 
 NiFi Registry has the following minimum system requirements:
 
-* Requires Java Development Kit (JDK) 8, newer than 1.8.0_45
+* Requires Java Development Kit (JDK) 11, newer than 11.0.16
 
 WARNING: When running Registry with only a JRE you may encounter the following error as Flyway (database migration tool) attempts to utilize a resource from the JDK: +
  +
@@ -965,7 +965,6 @@ See <<kerberos_properties>> for complete documentation.
   Some will provide the local Kerberos ticket to any domain that requests it, while others whitelist the trusted domains. See link:https://docs.spring.io/autorepo/docs/spring-security-kerberos/1.0.2.BUILD-SNAPSHOT/reference/htmlsingle/#browserspnegoconfig[Spring Security Kerberos - Reference Documentation: Appendix E. Configure browsers for SPNEGO Negotiation^] for common browsers.
 * Some browsers (legacy IE) do not support recent encryption algorithms such as AES, and are restricted to legacy algorithms (DES). This should be noted when generating keytabs.
 * The KDC must be configured and a service principal defined for NiFi and a keytab exported. Comprehensive instructions for Kerberos server configuration and administration are beyond the scope of this document (see link:https://web.mit.edu/kerberos/krb5-current/doc/admin/index.html[MIT Kerberos Admin Guide^]), but an example is below.
-* Kerberos tickets may use AES encryption with keys up to 256-bits in length, and therefore unlimited strength encryption policies may be required for the Jave Runtime Environment (JRE) used for NiFi Registry when Kerberos SPNEGO is configured.
 
 Adding a service principal for a server at `nifi.nifi.apache.org` and exporting the keytab from the KDC:
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,11 @@
         <url>https://issues.apache.org/jira/browse/NIFI</url>
     </issueManagement>
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <!-- Set minimum Java version for maven-enforcer-plugin from parent POM -->
-        <minimalJavaBuildVersion>1.8.0-251</minimalJavaBuildVersion>
+        <minimalJavaBuildVersion>11.0.16</minimalJavaBuildVersion>
         <maven.surefire.arguments />
         <!-- Disable maven-site-plugin from parent POM -->
         <maven.site.skip>true</maven.site.skip>


### PR DESCRIPTION
# Summary

[NIFI-11164](https://issues.apache.org/jira/browse/NIFI-11164) - Remove Java 8 references and update Github Workflows/Template

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
