### PR TITLE
NIFI-9972 Azure Blob Storage blob copying

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
@@ -103,9 +103,13 @@ public abstract class AbstractAzureBlobProcessor_v12 extends AbstractProcessor {
     }
 
     protected BlobServiceClient getStorageClient(PropertyContext context, FlowFile flowFile) {
+        return getStorageClient(context, STORAGE_CREDENTIALS_SERVICE, flowFile);
+    }
+
+    protected BlobServiceClient getStorageClient(PropertyContext context, PropertyDescriptor storageCredentialsServiceProperty, FlowFile flowFile) {
         final Map<String, String> attributes = flowFile != null ? flowFile.getAttributes() : Collections.emptyMap();
 
-        final AzureStorageCredentialsService_v12 credentialsService = context.getProperty(STORAGE_CREDENTIALS_SERVICE).asControllerService(AzureStorageCredentialsService_v12.class);
+        final AzureStorageCredentialsService_v12 credentialsService = context.getProperty(storageCredentialsServiceProperty).asControllerService(AzureStorageCredentialsService_v12.class);
         final AzureStorageCredentialsDetails_v12 credentialsDetails = credentialsService.getCredentialsDetails(attributes);
 
         final BlobServiceClient storageClient = clientFactory.getStorageClient(credentialsDetails);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.core.http.HttpAuthorization;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobRange;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.options.BlobUploadFromUrlOptions;
+import com.azure.storage.blob.options.BlockBlobCommitBlockListOptions;
+import com.azure.storage.blob.options.BlockBlobStageBlockFromUrlOptions;
+import com.azure.storage.blob.sas.BlobContainerSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.blob.specialized.BlockBlobClient;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.azure.AbstractAzureBlobProcessor_v12;
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.services.azure.storage.AzureStorageConflictResolutionStrategy;
+import org.apache.nifi.services.azure.storage.AzureStorageCredentialsDetails_v12;
+import org.apache.nifi.services.azure.storage.AzureStorageCredentialsService_v12;
+import org.apache.nifi.services.azure.storage.AzureStorageCredentialsType;
+import reactor.core.publisher.Mono;
+
+import java.text.DecimalFormat;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_STAGE_BLOCK_BYTES_LONG;
+import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_UPLOAD_BLOB_BYTES_LONG;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_CONTAINER;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_ERROR_CODE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_ETAG;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_IGNORED;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_LANG;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_LENGTH;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_MIME_TYPE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_PRIMARY_URI;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_TIMESTAMP;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_BLOBNAME;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_BLOBTYPE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_CONTAINER;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_ERROR_CODE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_ETAG;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_IGNORED;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_LANG;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_LENGTH;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_MIME_TYPE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_PRIMARY_URI;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_TIMESTAMP;
+
+@Tags({"azure", "microsoft", "cloud", "storage", "blob"})
+@SeeAlso({ListAzureBlobStorage_v12.class, FetchAzureBlobStorage_v12.class, DeleteAzureBlobStorage_v12.class, PutAzureBlobStorage_v12.class})
+@CapabilityDescription("Copies a blob in Azure Blob Storage from one account/container to another. The processor uses Azure Blob Storage client library v12.")
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@WritesAttributes({@WritesAttribute(attribute = ATTR_NAME_CONTAINER, description = ATTR_DESCRIPTION_CONTAINER),
+        @WritesAttribute(attribute = ATTR_NAME_BLOBNAME, description = ATTR_DESCRIPTION_BLOBNAME),
+        @WritesAttribute(attribute = ATTR_NAME_PRIMARY_URI, description = ATTR_DESCRIPTION_PRIMARY_URI),
+        @WritesAttribute(attribute = ATTR_NAME_ETAG, description = ATTR_DESCRIPTION_ETAG),
+        @WritesAttribute(attribute = ATTR_NAME_BLOBTYPE, description = ATTR_DESCRIPTION_BLOBTYPE),
+        @WritesAttribute(attribute = ATTR_NAME_MIME_TYPE, description = ATTR_DESCRIPTION_MIME_TYPE),
+        @WritesAttribute(attribute = ATTR_NAME_LANG, description = ATTR_DESCRIPTION_LANG),
+        @WritesAttribute(attribute = ATTR_NAME_TIMESTAMP, description = ATTR_DESCRIPTION_TIMESTAMP),
+        @WritesAttribute(attribute = ATTR_NAME_LENGTH, description = ATTR_DESCRIPTION_LENGTH),
+        @WritesAttribute(attribute = ATTR_NAME_ERROR_CODE, description = ATTR_DESCRIPTION_ERROR_CODE),
+        @WritesAttribute(attribute = ATTR_NAME_IGNORED, description = ATTR_DESCRIPTION_IGNORED)})
+public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
+    private final static int GENERATE_SAS_EXPIRY_HOURS = 24;
+
+    public static final PropertyDescriptor SOURCE_STORAGE_CREDENTIALS_SERVICE = new PropertyDescriptor.Builder()
+            .name("source-storage-credentials-service")
+            .displayName("Source Storage Credentials")
+            .description("Controller Service used to obtain Azure Blob Storage Credentials to read blob data ")
+            .identifiesControllerService(AzureStorageCredentialsService_v12.class)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor SOURCE_CONTAINER = new PropertyDescriptor.Builder()
+            .name("source-container-name")
+            .displayName("Source Container Name")
+            .description("Name of the Azure storage container to copy from.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor SOURCE_BLOB_NAME = new PropertyDescriptor.Builder()
+            .name("source-blob-name")
+            .displayName("Source Blob Name")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .description("The full name of the source blob")
+            .build();
+
+    public static final PropertyDescriptor DESTINATION_STORAGE_CREDENTIALS_SERVICE = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(STORAGE_CREDENTIALS_SERVICE)
+            .displayName("Destination Storage Credentials")
+            .build();
+
+    public static final PropertyDescriptor DESTINATION_CONTAINER = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(AzureStorageUtils.CONTAINER)
+            .displayName("Destination Container Name")
+            .description("Name of the Azure storage container to copy into; defaults to source container name.")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor DESTINATION_BLOB_NAME = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(BLOB_NAME)
+            .displayName("Destination Blob Name")
+            .description("The full name of the destination blob; defaults to source blob name.")
+            .required(false)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+            SOURCE_STORAGE_CREDENTIALS_SERVICE,
+            SOURCE_CONTAINER,
+            SOURCE_BLOB_NAME,
+            DESTINATION_STORAGE_CREDENTIALS_SERVICE,
+            DESTINATION_BLOB_NAME,
+            DESTINATION_CONTAINER,
+            AzureStorageUtils.CONFLICT_RESOLUTION,
+            AzureStorageUtils.CREATE_CONTAINER,
+            AzureStorageUtils.PROXY_CONFIGURATION_SERVICE
+    ));
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    @OnScheduled
+    public void onScheduled(ProcessContext context) {
+        super.onScheduled(context);
+    }
+
+    @OnStopped
+    public void onStopped() {
+        super.onStopped();
+    }
+
+    private static AzureStorageCredentialsService_v12 getCopyFromCredentialsService(ProcessContext context) {
+        return context.getProperty(SOURCE_STORAGE_CREDENTIALS_SERVICE).asControllerService(AzureStorageCredentialsService_v12.class);
+    }
+
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final String sourceContainerName = context.getProperty(SOURCE_CONTAINER).evaluateAttributeExpressions(flowFile).getValue();
+        final String sourceBlobName = context.getProperty(SOURCE_BLOB_NAME).evaluateAttributeExpressions(flowFile).getValue();
+        final String destinationContainerName = Optional.ofNullable(
+                context.getProperty(DESTINATION_CONTAINER).evaluateAttributeExpressions(flowFile).getValue()
+        ).orElse(sourceContainerName);
+        final String destinationBlobName = Optional.ofNullable(
+                context.getProperty(DESTINATION_BLOB_NAME).evaluateAttributeExpressions(flowFile).getValue()
+        ).orElse(sourceBlobName);
+
+        final boolean createContainer = context.getProperty(AzureStorageUtils.CREATE_CONTAINER).asBoolean();
+        final AzureStorageConflictResolutionStrategy conflictResolution = AzureStorageConflictResolutionStrategy.valueOf(context.getProperty(AzureStorageUtils.CONFLICT_RESOLUTION).getValue());
+
+        long startNanos = System.nanoTime();
+        try {
+            BlobServiceClient storageClient = getStorageClient(context, DESTINATION_STORAGE_CREDENTIALS_SERVICE, flowFile);
+            BlobContainerClient containerClient = storageClient.getBlobContainerClient(destinationContainerName);
+            if (createContainer && !containerClient.exists()) {
+                containerClient.create();
+            }
+
+            BlobClient blobClient = containerClient.getBlobClient(destinationBlobName);
+            Map<String, String> attributes = new HashMap<>();
+            applyStandardBlobAttributes(attributes, blobClient);
+            final boolean ignore = conflictResolution == AzureStorageConflictResolutionStrategy.IGNORE_RESOLUTION;
+
+            final BlobRequestConditions destinationRequestConditions = new BlobRequestConditions();
+
+            try {
+                if (conflictResolution != AzureStorageConflictResolutionStrategy.REPLACE_RESOLUTION) {
+                    destinationRequestConditions.setIfNoneMatch("*");
+                }
+
+                final AzureStorageCredentialsService_v12 fromCredentialsService = getCopyFromCredentialsService(context);
+                BlobServiceClient fromStorageClient = getStorageClient(context, SOURCE_STORAGE_CREDENTIALS_SERVICE, flowFile);
+                BlobContainerClient fromContainerClient = fromStorageClient.getBlobContainerClient(sourceContainerName);
+                BlobClient fromBlobClient = fromContainerClient.getBlobClient(sourceBlobName);
+
+                AzureStorageCredentialsDetails_v12 credentialsDetails = fromCredentialsService.getCredentialsDetails(flowFile.getAttributes());
+                String sourceUrl = fromBlobClient.getBlobUrl();
+                final BlobProperties fromBlobProperties = fromBlobClient.getProperties();
+                final long blobSize = fromBlobProperties.getBlobSize();
+
+                final BlobRequestConditions sourceRequestConditions = new BlobRequestConditions();
+                sourceRequestConditions.setIfMatch(fromBlobProperties.getETag());
+
+                HttpAuthorization httpAuthorization;
+                final String sasToken = (credentialsDetails.getCredentialsType() == AzureStorageCredentialsType.ACCOUNT_KEY)
+                        ? generateSas(fromContainerClient)
+                        : credentialsDetails.getSasToken();
+                if (sasToken != null) {
+                    sourceUrl += "?" + sasToken;
+                    httpAuthorization = null;
+                } else {
+                    httpAuthorization = getHttpAuthorization(credentialsDetails);
+                }
+
+                copy(blobClient, httpAuthorization, sourceUrl, blobSize, sourceRequestConditions, destinationRequestConditions);
+                applyBlobMetadata(attributes, blobClient);
+
+                if (ignore) {
+                    attributes.put(ATTR_NAME_IGNORED, "false");
+                }
+            } catch (BlobStorageException e) {
+                final BlobErrorCode errorCode = e.getErrorCode();
+                flowFile = session.putAttribute(flowFile, ATTR_NAME_ERROR_CODE, e.getErrorCode().toString());
+
+                if (errorCode == BlobErrorCode.BLOB_ALREADY_EXISTS && ignore) {
+                    getLogger().info("Blob already exists: remote blob not modified. Transferring {} to success", flowFile);
+                    attributes.put(ATTR_NAME_IGNORED, "true");
+                } else {
+                    throw e;
+                }
+            }
+
+            flowFile = session.putAllAttributes(flowFile, attributes);
+            session.transfer(flowFile, REL_SUCCESS);
+
+            long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            String transitUri = attributes.get(ATTR_NAME_PRIMARY_URI);
+            session.getProvenanceReporter().send(flowFile, transitUri, transferMillis);
+        } catch (Exception e) {
+            getLogger().error("Failed to create blob on Azure Blob Storage", e);
+            flowFile = session.penalize(flowFile);
+            session.transfer(flowFile, REL_FAILURE);
+        }
+    }
+
+    private static String generateSas(final BlobContainerClient fromContainerClient) {
+        BlobContainerSasPermission permissions = new BlobContainerSasPermission().setCreatePermission(true).setWritePermission(true).setAddPermission(true).setReadPermission(true);
+        OffsetDateTime utc = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime expiryTime = utc.plus(CopyAzureBlobStorage_v12.GENERATE_SAS_EXPIRY_HOURS, ChronoUnit.HOURS);
+        BlobServiceSasSignatureValues signatureValues = new BlobServiceSasSignatureValues(expiryTime, permissions);
+        return fromContainerClient.generateSas(signatureValues);
+    }
+
+    private void copy(final BlobClient blobClient,
+                      final HttpAuthorization httpAuthorization,
+                      final String sourceUrl,
+                      long blobSize,
+                      final BlobRequestConditions sourceRequestConditions,
+                      final BlobRequestConditions destinationRequestConditions) {
+        BlockBlobClient blockBlobClient = blobClient.getBlockBlobClient();
+
+        // If the blob size is below the limit, we use the one-shot upload endpoint.
+        if (blobSize < MAX_UPLOAD_BLOB_BYTES_LONG) {
+            final BlobUploadFromUrlOptions options = new BlobUploadFromUrlOptions(sourceUrl);
+            if (httpAuthorization != null) {
+                options.setSourceAuthorization(httpAuthorization);
+            }
+            options.setSourceRequestConditions(sourceRequestConditions);
+            options.setDestinationRequestConditions(destinationRequestConditions);
+            blockBlobClient.uploadFromUrlWithResponse(options, null, Context.NONE);
+            return;
+        }
+
+        final DecimalFormat df = new DecimalFormat("0000000");
+        long offset = 0;
+        int blockId = 1;
+        final List<String> blockIds = new ArrayList<>();
+
+        // Upload each block sequentially until we've uploaded the entire blob.
+        while (true) {
+            long count = Math.min(blobSize - offset, MAX_STAGE_BLOCK_BYTES_LONG);
+            if (count == 0) break;
+
+            final String base64BlockId = Base64.getEncoder().encodeToString(df.format(blockId).getBytes());
+            BlockBlobStageBlockFromUrlOptions blockBlobStageBlockFromUrlOptions = new BlockBlobStageBlockFromUrlOptions(base64BlockId, sourceUrl);
+            blockBlobStageBlockFromUrlOptions.setSourceRange(new BlobRange(offset, count));
+
+            if (httpAuthorization != null) {
+                blockBlobStageBlockFromUrlOptions.setSourceAuthorization(httpAuthorization);
+            }
+            blockBlobStageBlockFromUrlOptions.setSourceRequestConditions(sourceRequestConditions);
+            final int statusCode = blockBlobClient.stageBlockFromUrlWithResponse(blockBlobStageBlockFromUrlOptions, null, Context.NONE).getStatusCode();
+            if (statusCode != 201) {
+                throw new ProcessException(String.format("Failed staging one or more blocks (status: %d)", statusCode));
+            }
+            blockIds.add(base64BlockId);
+            offset += count;
+            blockId++;
+        }
+
+        final BlockBlobCommitBlockListOptions options = new BlockBlobCommitBlockListOptions(blockIds);
+        options.setRequestConditions(destinationRequestConditions);
+        final Response<BlockBlobItem> response = blockBlobClient.commitBlockListWithResponse(options, null, Context.NONE);
+        final int statusCode = response.getStatusCode();
+        if (statusCode != 201) {
+            throw new ProcessException(String.format("Failed committing block list (status: %d)", statusCode));
+        }
+    }
+
+    private static HttpAuthorization getHttpAuthorization(final AzureStorageCredentialsDetails_v12 credentialsDetails) {
+        switch (credentialsDetails.getCredentialsType()) {
+            case ACCESS_TOKEN -> {
+                TokenCredential credential = tokenRequestContext -> Mono.just(credentialsDetails.getAccessToken());
+                return getHttpAuthorizationFromTokenCredential(credential);
+            }
+            case MANAGED_IDENTITY -> {
+                final ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+                        .clientId(credentialsDetails.getManagedIdentityClientId())
+                        .build();
+                return getHttpAuthorizationFromTokenCredential(credential);
+            }
+            case SERVICE_PRINCIPAL -> {
+                final ClientSecretCredential credential = new ClientSecretCredentialBuilder().clientId(
+                                credentialsDetails.getServicePrincipalClientId()
+                        ).clientSecret(credentialsDetails.getServicePrincipalClientSecret())
+                        .tenantId(credentialsDetails.getServicePrincipalTenantId()).build();
+                return getHttpAuthorizationFromTokenCredential(credential);
+            }
+        }
+        return null;
+    }
+
+    private static HttpAuthorization getHttpAuthorizationFromTokenCredential(final TokenCredential credential) {
+        final TokenRequestContext tokenRequestContext = new TokenRequestContext();
+        tokenRequestContext.setScopes(Collections.singletonList("https://storage.azure.com/.default"));
+        final AccessToken accessToken = credential.getToken(tokenRequestContext).block();
+        final String authorization = accessToken.getToken();
+        return new HttpAuthorization("Bearer", authorization);
+    }
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_STAGE_BLOCK_BYTES_LONG;
 import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_UPLOAD_BLOB_BYTES_LONG;
+import static java.net.HttpURLConnection.HTTP_ACCEPTED;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_CONTAINER;
@@ -326,7 +327,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             }
             blockBlobStageBlockFromUrlOptions.setSourceRequestConditions(sourceRequestConditions);
             final int statusCode = blockBlobClient.stageBlockFromUrlWithResponse(blockBlobStageBlockFromUrlOptions, null, Context.NONE).getStatusCode();
-            if (statusCode != 201) {
+            if (statusCode != HTTP_ACCEPTED) {
                 throw new ProcessException(String.format("Failed staging one or more blocks: HTTP %d", statusCode));
             }
             blockIds.add(base64BlockId);
@@ -338,7 +339,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
         options.setRequestConditions(destinationRequestConditions);
         final Response<BlockBlobItem> response = blockBlobClient.commitBlockListWithResponse(options, null, Context.NONE);
         final int statusCode = response.getStatusCode();
-        if (statusCode != 201) {
+        if (statusCode != HTTP_ACCEPTED) {
             throw new ProcessException(String.format("Failed committing block list: HTTP %d", statusCode));
         }
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -225,7 +225,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             }
 
             BlobClient blobClient = containerClient.getBlobClient(destinationBlobName);
-            Map<String, String> attributes = new HashMap<>();
+            final Map<String, String> attributes = new HashMap<>();
             applyStandardBlobAttributes(attributes, blobClient);
             final boolean ignore = conflictResolution == AzureStorageConflictResolutionStrategy.IGNORE_RESOLUTION;
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_STAGE_BLOCK_BYTES_LONG;
 import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_UPLOAD_BLOB_BYTES_LONG;
+import static com.azure.storage.common.implementation.Constants.STORAGE_SCOPE;
 import static java.net.HttpURLConnection.HTTP_ACCEPTED;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
@@ -369,7 +370,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
 
     private static HttpAuthorization getHttpAuthorizationFromTokenCredential(final TokenCredential credential) {
         final TokenRequestContext tokenRequestContext = new TokenRequestContext();
-        tokenRequestContext.setScopes(Collections.singletonList("https://storage.azure.com/.default"));
+        tokenRequestContext.setScopes(Collections.singletonList(STORAGE_SCOPE));
         final AccessToken accessToken = credential.getToken(tokenRequestContext).block();
         final String authorization = accessToken.getToken();
         return new HttpAuthorization("Bearer", authorization);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -239,7 +239,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
                 final BlobRequestConditions sourceRequestConditions = new BlobRequestConditions();
                 sourceRequestConditions.setIfMatch(sourceBlobProperties.getETag());
 
-                HttpAuthorization httpAuthorization;
+                final HttpAuthorization httpAuthorization;
                 final String sasToken = (credentialsDetails.getCredentialsType() == AzureStorageCredentialsType.ACCOUNT_KEY)
                         ? generateSas(sourceContainerClient)
                         : credentialsDetails.getSasToken();

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -197,7 +197,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
     private static AzureStorageCredentialsService_v12 getCopyFromCredentialsService(ProcessContext context) {
         return context.getProperty(SOURCE_STORAGE_CREDENTIALS_SERVICE).asControllerService(AzureStorageCredentialsService_v12.class);
     }
-
+    @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
         FlowFile flowFile = session.get();
         if (flowFile == null) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -216,7 +216,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
         final boolean createContainer = context.getProperty(AzureStorageUtils.CREATE_CONTAINER).asBoolean();
         final AzureStorageConflictResolutionStrategy conflictResolution = AzureStorageConflictResolutionStrategy.valueOf(context.getProperty(AzureStorageUtils.CONFLICT_RESOLUTION).getValue());
 
-        long startNanos = System.nanoTime();
+        final long startNanos = System.nanoTime();
         try {
             BlobServiceClient storageClient = getStorageClient(context, DESTINATION_STORAGE_CREDENTIALS_SERVICE, flowFile);
             BlobContainerClient containerClient = storageClient.getBlobContainerClient(destinationContainerName);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -319,7 +319,10 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             long count = Math.min(blobSize - offset, MAX_STAGE_BLOCK_BYTES_LONG);
             if (count == 0) break;
 
-            final String base64BlockId = Base64.getEncoder().encodeToString(df.format(blockId).getBytes());
+            // The zero-padded block ID must be base64-encoded as per the protocol.
+            final String zeroPadded = df.format(blockId);
+            final String base64BlockId = Base64.getEncoder().encodeToString(zeroPadded.getBytes());
+
             BlockBlobStageBlockFromUrlOptions blockBlobStageBlockFromUrlOptions = new BlockBlobStageBlockFromUrlOptions(base64BlockId, sourceUrl);
             blockBlobStageBlockFromUrlOptions.setSourceRange(new BlobRange(offset, count));
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -351,7 +351,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
         final Response<BlockBlobItem> response = blockBlobClient.commitBlockListWithResponse(options, null, Context.NONE);
         final int statusCode = response.getStatusCode();
         if (statusCode != 201) {
-            throw new ProcessException(String.format("Failed committing block list (status: %d)", statusCode));
+            throw new ProcessException(String.format("Failed committing block list: HTTP %d", statusCode));
         }
     }
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -48,8 +48,6 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
@@ -182,16 +180,6 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return PROPERTIES;
-    }
-
-    @OnScheduled
-    public void onScheduled(ProcessContext context) {
-        super.onScheduled(context);
-    }
-
-    @OnStopped
-    public void onStopped() {
-        super.onStopped();
     }
 
     private static AzureStorageCredentialsService_v12 getCopyFromCredentialsService(ProcessContext context) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -339,7 +339,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             blockBlobStageBlockFromUrlOptions.setSourceRequestConditions(sourceRequestConditions);
             final int statusCode = blockBlobClient.stageBlockFromUrlWithResponse(blockBlobStageBlockFromUrlOptions, null, Context.NONE).getStatusCode();
             if (statusCode != 201) {
-                throw new ProcessException(String.format("Failed staging one or more blocks (status: %d)", statusCode));
+                throw new ProcessException(String.format("Failed staging one or more blocks: HTTP %d", statusCode));
             }
             blockIds.add(base64BlockId);
             offset += count;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
@@ -44,7 +44,8 @@ import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_CONTAINER;
 
 @Tags({"azure", "microsoft", "cloud", "storage", "blob"})
-@SeeAlso({ListAzureBlobStorage_v12.class, FetchAzureBlobStorage_v12.class, PutAzureBlobStorage_v12.class})
+@SeeAlso({ListAzureBlobStorage_v12.class, FetchAzureBlobStorage_v12.class, PutAzureBlobStorage_v12.class,
+        CopyAzureBlobStorage_v12.class})
 @CapabilityDescription("Deletes the specified blob from Azure Blob Storage. The processor uses Azure Blob Storage client library v12.")
 @InputRequirement(Requirement.INPUT_REQUIRED)
 public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
@@ -85,7 +85,8 @@ import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR
 @PrimaryNodeOnly
 @TriggerSerially
 @Tags({ "azure", "microsoft", "cloud", "storage", "blob" })
-@SeeAlso({ FetchAzureBlobStorage_v12.class, PutAzureBlobStorage_v12.class, DeleteAzureBlobStorage_v12.class })
+@SeeAlso({ FetchAzureBlobStorage_v12.class, PutAzureBlobStorage_v12.class, DeleteAzureBlobStorage_v12.class,
+        CopyAzureBlobStorage_v12.class })
 @CapabilityDescription("Lists blobs in an Azure Blob Storage container. Listing details are attached to an empty FlowFile for use with FetchAzureBlobStorage. " +
         "This Processor is designed to run on Primary Node only in a cluster. If the primary node changes, the new Primary Node will pick up where the " +
         "previous node left off without duplicating all of the data. The processor uses Azure Blob Storage client library v12.")

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
@@ -30,6 +30,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.proxy.ProxySpec;
 import org.apache.nifi.proxy.SocksVersion;
+import org.apache.nifi.services.azure.storage.AzureStorageConflictResolutionStrategy;
 import reactor.netty.http.client.HttpClient;
 
 public final class AzureStorageUtils {
@@ -106,6 +107,29 @@ public final class AzureStorageUtils {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(true)
+            .build();
+
+    public static final PropertyDescriptor CREATE_CONTAINER = new PropertyDescriptor.Builder()
+            .name("create-container")
+            .displayName("Create Container")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .description("Specifies whether to check if the container exists and to automatically create it if it does not. " +
+                    "Permission to list containers is required. If false, this check is not made, but the Put operation " +
+                    "will fail if the container does not exist.")
+            .build();
+
+    public static final PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
+            .name("conflict-resolution-strategy")
+            .displayName("Conflict Resolution Strategy")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
+            .allowableValues(AzureStorageConflictResolutionStrategy.class)
+            .defaultValue(AzureStorageConflictResolutionStrategy.FAIL_RESOLUTION.getValue())
+            .description("Specifies whether an existing blob will have its contents replaced upon conflict.")
             .build();
 
     public static final String SAS_TOKEN_BASE_DESCRIPTION = "Shared Access Signature token, including the leading '?'. Specify either SAS token (recommended) or Account Key.";

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -25,6 +25,7 @@ org.apache.nifi.processors.azure.storage.ListAzureBlobStorage_v12
 org.apache.nifi.processors.azure.storage.FetchAzureBlobStorage_v12
 org.apache.nifi.processors.azure.storage.PutAzureBlobStorage_v12
 org.apache.nifi.processors.azure.storage.DeleteAzureBlobStorage_v12
+org.apache.nifi.processors.azure.storage.CopyAzureBlobStorage_v12
 org.apache.nifi.processors.azure.storage.MoveAzureDataLakeStorage
 org.apache.nifi.processors.azure.storage.queue.GetAzureQueueStorage_v12
 org.apache.nifi.processors.azure.storage.queue.PutAzureQueueStorage_v12

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
@@ -53,7 +53,7 @@ import java.util.UUID;
 import static org.apache.nifi.processors.azure.AzureServiceEndpoints.DEFAULT_BLOB_ENDPOINT_SUFFIX;
 
 public abstract class AbstractAzureBlobStorage_v12IT extends AbstractAzureStorageIT {
-
+    protected static final String SERVICE_ID = "credentials-service";
     protected static final String BLOB_NAME = "blob1";
     protected static final byte[] BLOB_DATA = "0123456789".getBytes(StandardCharsets.UTF_8);
     protected static final String KEY_ID_VALUE = "key:id";
@@ -82,7 +82,7 @@ public abstract class AbstractAzureBlobStorage_v12IT extends AbstractAzureStorag
     protected void setUpCredentials() throws Exception {
         String serviceId = "credentials-service";
         AzureStorageCredentialsService_v12 service = new AzureStorageCredentialsControllerService_v12();
-        runner.addControllerService(serviceId, service);
+        runner.addControllerService(SERVICE_ID, service);
         runner.setProperty(service, AzureStorageCredentialsControllerService_v12.ACCOUNT_NAME, getAccountName());
         if (getEndpointSuffix() != null) {
             runner.setProperty(service, AzureStorageCredentialsControllerService_v12.ENDPOINT_SUFFIX, getEndpointSuffix());
@@ -91,7 +91,7 @@ public abstract class AbstractAzureBlobStorage_v12IT extends AbstractAzureStorag
         runner.setProperty(service, AzureStorageCredentialsControllerService_v12.ACCOUNT_KEY, getAccountKey());
         runner.enableControllerService(service);
 
-        runner.setProperty(AbstractAzureBlobProcessor_v12.STORAGE_CREDENTIALS_SERVICE, serviceId);
+        runner.setProperty(AbstractAzureBlobProcessor_v12.STORAGE_CREDENTIALS_SERVICE, SERVICE_ID);
     }
 
     @BeforeEach

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITCopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITCopyAzureBlobStorage_v12.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.nifi.processors.azure.storage.CopyAzureBlobStorage_v12.SOURCE_STORAGE_CREDENTIALS_SERVICE;
+import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_ERROR_CODE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ITCopyAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
+    public static class ITProcessor extends CopyAzureBlobStorage_v12 {
+        public boolean blobMetadataApplied = false;
+        @Override
+        protected void applyBlobMetadata(Map<String, String> attributes, BlobClient blobClient) {
+            super.applyBlobMetadata(attributes, blobClient);
+            blobMetadataApplied = true;
+        }
+    }
+
+    @Override
+    protected Class<? extends Processor> getProcessorClass() {
+        return ITProcessor.class;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        runner.setProperty(CopyAzureBlobStorage_v12.SOURCE_CONTAINER, getContainerName());
+        runner.setProperty(CopyAzureBlobStorage_v12.SOURCE_BLOB_NAME, BLOB_NAME);
+    }
+
+    @ValueSource(booleans={true, false})
+    @ParameterizedTest
+    public void testPutBlobFromUrl(boolean proxied) throws Exception {
+        if (proxied) {
+            configureProxyService();
+        }
+
+        uploadBlob(BLOB_NAME, BLOB_DATA);
+        final String destinationBlobName = BLOB_NAME + "-target";
+        runner.setProperty(CopyAzureBlobStorage_v12.DESTINATION_BLOB_NAME, destinationBlobName);
+        runner.setProperty(SOURCE_STORAGE_CREDENTIALS_SERVICE, SERVICE_ID);
+        runner.setProperty(CopyAzureBlobStorage_v12.SOURCE_BLOB_NAME, BLOB_NAME);
+
+        runProcessor(BLOB_DATA);
+
+        assertSuccess(getContainerName(), destinationBlobName, BLOB_DATA);
+        assertTrue(((ITProcessor) runner.getProcessor()).blobMetadataApplied);
+    }
+
+    private void runProcessor(byte[] data) {
+        runProcessor(data, Collections.emptyMap());
+    }
+
+    private void runProcessor(byte[] data, Map<String, String> attributes) {
+        runner.assertValid();
+        runner.enqueue(data, attributes);
+        runner.run();
+    }
+
+    private MockFlowFile assertSuccess(String containerName, String blobName, byte[] blobData) throws Exception {
+        MockFlowFile flowFile = assertFlowFile(containerName, blobName, blobData);
+        assertAzureBlob(containerName, blobName, blobData);
+        assertProvenanceEvents();
+        return flowFile;
+    }
+
+    private MockFlowFile assertIgnored(String containerName, String blobName) throws Exception {
+        MockFlowFile flowFile = assertFlowFile(containerName, blobName, null);
+        assertProvenanceEvents();
+        return flowFile;
+    }
+
+    private MockFlowFile assertFlowFile(String containerName, String blobName, byte[] blobData) throws Exception {
+        runner.assertAllFlowFilesTransferred(CopyAzureBlobStorage_v12.REL_SUCCESS, 1);
+
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(CopyAzureBlobStorage_v12.REL_SUCCESS).get(0);
+
+        assertFlowFileCommonBlobAttributes(flowFile, containerName, blobName);
+        if (blobData != null) {
+            assertFlowFileResultBlobAttributes(flowFile, blobData.length);
+            flowFile.assertContentEquals(blobData);
+        }
+        return flowFile;
+    }
+
+    private void assertAzureBlob(String containerName, String blobName, byte[] blobData) {
+        BlobContainerClient containerClient = getStorageClient().getBlobContainerClient(containerName);
+        BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+        assertTrue(blobClient.exists());
+        assertEquals(blobData.length, blobClient.getProperties().getBlobSize());
+    }
+
+    private void assertProvenanceEvents() {
+        Set<ProvenanceEventType> expectedEventTypes = Collections.singleton(ProvenanceEventType.SEND);
+
+        Set<ProvenanceEventType> actualEventTypes = runner.getProvenanceEvents().stream()
+                .map(ProvenanceEventRecord::getEventType)
+                .collect(Collectors.toSet());
+        assertEquals(expectedEventTypes, actualEventTypes);
+    }
+
+    private MockFlowFile assertFailure(byte[] blobData, BlobErrorCode errorCode) throws Exception {
+        runner.assertAllFlowFilesTransferred(CopyAzureBlobStorage_v12.REL_FAILURE, 1);
+
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(DeleteAzureBlobStorage_v12.REL_FAILURE).get(0);
+        flowFile.assertContentEquals(blobData);
+        flowFile.assertAttributeEquals(ATTR_NAME_ERROR_CODE, errorCode.toString());
+        return flowFile;
+    }
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITCopyAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITCopyAzureBlobStorage_v12.java
@@ -52,7 +52,7 @@ public class ITCopyAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
 
     @BeforeEach
     public void setUp() {
-        runner.setProperty(CopyAzureBlobStorage_v12.SOURCE_CONTAINER, getContainerName());
+        runner.setProperty(CopyAzureBlobStorage_v12.SOURCE_CONTAINER_NAME, getContainerName());
         runner.setProperty(CopyAzureBlobStorage_v12.SOURCE_BLOB_NAME, BLOB_NAME);
     }
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureBlobStorage_v12.java
@@ -128,7 +128,7 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     public void testPutBlobWithNonExistingContainerAndCreateContainerFalse() throws Exception {
         String containerName = generateContainerName();
         runner.setProperty(AzureStorageUtils.CONTAINER, containerName);
-        runner.setProperty(PutAzureBlobStorage_v12.CREATE_CONTAINER, "false");
+        runner.setProperty(AzureStorageUtils.CREATE_CONTAINER, "false");
 
         runProcessor(BLOB_DATA);
 
@@ -139,7 +139,7 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     public void testPutBlobWithNonExistingContainerAndCreateContainerTrue() throws Exception {
         String containerName = generateContainerName();
         runner.setProperty(AzureStorageUtils.CONTAINER, containerName);
-        runner.setProperty(PutAzureBlobStorage_v12.CREATE_CONTAINER, "true");
+        runner.setProperty(AzureStorageUtils.CREATE_CONTAINER, "true");
 
         try {
             runProcessor(BLOB_DATA);
@@ -174,7 +174,7 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     @Test
     public void testPutBlobToExistingBlobConflictStrategyIgnore() throws Exception {
         uploadBlob(BLOB_NAME, BLOB_DATA);
-        runner.setProperty(PutAzureBlobStorage_v12.CONFLICT_RESOLUTION, AzureStorageConflictResolutionStrategy.IGNORE_RESOLUTION.getValue());
+        runner.setProperty(AzureStorageUtils.CONFLICT_RESOLUTION, AzureStorageConflictResolutionStrategy.IGNORE_RESOLUTION.getValue());
 
         runProcessor(BLOB_DATA);
 
@@ -185,7 +185,7 @@ public class ITPutAzureBlobStorage_v12 extends AbstractAzureBlobStorage_v12IT {
     @Test
     public void testPutBlobToExistingBlobConflictStrategyReplace() throws Exception {
         uploadBlob(BLOB_NAME, BLOB_DATA);
-        runner.setProperty(PutAzureBlobStorage_v12.CONFLICT_RESOLUTION, AzureStorageConflictResolutionStrategy.REPLACE_RESOLUTION.getValue());
+        runner.setProperty(AzureStorageUtils.CONFLICT_RESOLUTION, AzureStorageConflictResolutionStrategy.REPLACE_RESOLUTION.getValue());
 
         runProcessor(BLOB_DATA);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1142,6 +1142,7 @@
                                 !ITPutAzureDataLakeStorage,
                                 !ITFetchAzureDataLakeStorage,
                                 !ITListAzureDataLakeStorage,
+                                !ITCopyAzureBlobStorage_v12,
                                 !ITFetchAzureBlobStorage_v12,
                                 !ITPutAzureBlobStorage_v12,
                                 !ITDeleteAzureDataLakeStorage,


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-9972](https://issues.apache.org/jira/browse/NIFI-9972)

This adds support for the "Put Blob from URL" operation which provides service-to-service copying of blobs – the client is only responsible for the orchestration which copies individual blocks, not for transferring the data in those blocks.

The functionality is added to a new processor `CopyAzureBlobStorage_v12`.

The test case is not comprehensive in the sense that only the built-in credential is tested (account key). Meanwhile, all credentials are indeed supported (defined by the `AzureStorageCredentialsType` enum):

- Account key
- SAS token
- Access token
- Managed identity
- Service principal

The logic of the authentication code is that it's a SAS token (provided directly or derived using an account key) or it's based on OAuth2 (which captures the remaining cases).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
