### PR TITLE
NIFI-11184 Deprecate HashAttribute and CryptographicHashAttribute

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CryptographicHashAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CryptographicHashAttribute.java
@@ -35,6 +35,7 @@ import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -60,6 +61,10 @@ import org.apache.nifi.security.util.crypto.HashService;
         description = "The property name defines the attribute to look for and hash in the incoming flowfile. "
                 + "The property value defines the name to give the generated attribute. "
                 + "Attribute names must be unique.")
+@DeprecationNotice(
+        classNames = "org.apache.nifi.processors.attributes.UpdateAttribute",
+        reason = "UpdateAttribute can be configured using the hash Expression Language function to digest one or more attributes"
+)
 public class CryptographicHashAttribute extends AbstractProcessor {
     public enum PartialAttributePolicy {
         ALLOW,

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HashAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HashAttribute.java
@@ -39,6 +39,7 @@ import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
@@ -115,6 +116,10 @@ import org.apache.nifi.processor.util.StandardValidators;
         + "group, the value of that group will be used when comparing flow file "
         + "attributes. Otherwise, the original flow file attribute's value will be used "
         + "if and only if the value matches the given regular expression.")
+@DeprecationNotice(
+        classNames = "org.apache.nifi.processors.attributes.UpdateAttribute",
+        reason = "UpdateAttribute can be configured using the hash Expression Language function to digest one or more attributes"
+)
 public class HashAttribute extends AbstractProcessor {
 
     public static final PropertyDescriptor HASH_VALUE_ATTRIBUTE = new PropertyDescriptor.Builder()


### PR DESCRIPTION
# Summary

[NIFI-11184](https://issues.apache.org/jira/browse/NIFI-11184) Deprecates `HashAttribute` and `CryptographicHashAttribute` in favor of `UpdateAttribute` with the `hash` Expression Language function.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
