### PR TITLE
NIFI-11191 Refactored HikariCPConnectionPoolTest with Mock Driver

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/pom.xml
@@ -65,45 +65,5 @@
             <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbynet</artifactId>
-            <version>${derby.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyclient</artifactId>
-            <version>${derby.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes combine.children="append">
-                        <exclude>src/test/resources/fake.keytab</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/HikariCPConnectionPoolTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/HikariCPConnectionPoolTest.java
@@ -16,69 +16,28 @@
  */
 package org.apache.nifi.dbcp;
 
-import org.apache.derby.jdbc.EmbeddedDriver;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.NoOpProcessor;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.apache.nifi.util.file.FileUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
 import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 public class HikariCPConnectionPoolTest {
     private final static String SERVICE_ID = HikariCPConnectionPoolTest.class.getSimpleName();
 
-    private static final String DERBY_LOG_PROPERTY = "derby.stream.error.file";
-
-    private static final String DERBY_SHUTDOWN_STATE = "XJ015";
-
     private TestRunner runner;
-
-    private File databaseDirectory;
-
-    @BeforeAll
-    public static void setDerbyLog() {
-        final File derbyLog = new File(getSystemTemporaryDirectory(), "derby.log");
-        derbyLog.deleteOnExit();
-        System.setProperty(DERBY_LOG_PROPERTY, derbyLog.getAbsolutePath());
-    }
-
-    @AfterAll
-    public static void clearDerbyLog() {
-        System.clearProperty(DERBY_LOG_PROPERTY);
-    }
 
     @BeforeEach
     public void setup() {
         runner = TestRunners.newTestRunner(NoOpProcessor.class);
-        databaseDirectory = getEmptyDirectory();
-    }
-
-    @AfterEach
-    public void shutdown() throws IOException {
-        if (databaseDirectory.exists()) {
-            final SQLException exception = assertThrows(SQLException.class, () -> DriverManager.getConnection("jdbc:derby:;shutdown=true"));
-            assertEquals(DERBY_SHUTDOWN_STATE, exception.getSQLState());
-            FileUtils.deleteFile(databaseDirectory, true);
-        }
     }
 
     @Test
@@ -93,7 +52,7 @@ public class HikariCPConnectionPoolTest {
         final HikariCPConnectionPool service = new HikariCPConnectionPool();
         runner.addControllerService(SERVICE_ID, service);
 
-        setDerbyProperties(service);
+        setDatabaseProperties(service);
         runner.setProperty(service, HikariCPConnectionPool.MAX_WAIT_TIME, "0 millis");
 
         runner.enableControllerService(service);
@@ -105,7 +64,7 @@ public class HikariCPConnectionPoolTest {
         final HikariCPConnectionPool service = new HikariCPConnectionPool();
         runner.addControllerService(SERVICE_ID, service);
 
-        setDerbyProperties(service);
+        setDatabaseProperties(service);
         runner.setProperty(service, HikariCPConnectionPool.MAX_CONN_LIFETIME, "1 secs");
 
         runner.enableControllerService(service);
@@ -117,7 +76,7 @@ public class HikariCPConnectionPoolTest {
         final HikariCPConnectionPool service = new HikariCPConnectionPool();
         runner.addControllerService(SERVICE_ID, service);
 
-        setDerbyProperties(service);
+        setDatabaseProperties(service);
         runner.setProperty(service, HikariCPConnectionPool.MIN_IDLE, "-1");
 
         runner.assertNotValid(service);
@@ -128,7 +87,7 @@ public class HikariCPConnectionPoolTest {
         final HikariCPConnectionPool service = new HikariCPConnectionPool();
         runner.addControllerService(SERVICE_ID, service);
 
-        setDerbyProperties(service);
+        setDatabaseProperties(service);
         runner.setProperty(service, HikariCPConnectionPool.MIN_IDLE, "4");
         runner.setProperty(service, HikariCPConnectionPool.MAX_CONN_LIFETIME, "1 secs");
 
@@ -144,10 +103,13 @@ public class HikariCPConnectionPoolTest {
     public void testGetConnection() throws SQLException, InitializationException {
         final HikariCPConnectionPool service = new HikariCPConnectionPool();
         runner.addControllerService(SERVICE_ID, service);
-        setDerbyProperties(service);
+        setDatabaseProperties(service);
         runner.setProperty(service, HikariCPConnectionPool.MAX_TOTAL_CONNECTIONS, "2");
         runner.enableControllerService(service);
         runner.assertValid(service);
+
+        final Connection mockConnection = mock(Connection.class);
+        MockDriver.setConnection(mockConnection);
 
         try (final Connection connection = service.getConnection()) {
             assertNotNull(connection, "First Connection not found");
@@ -158,66 +120,11 @@ public class HikariCPConnectionPoolTest {
         }
     }
 
-    @Test
-    public void testCreateInsertSelect() throws InitializationException, SQLException {
-        final HikariCPConnectionPool service = new HikariCPConnectionPool();
-        runner.addControllerService(SERVICE_ID, service);
-
-        setDerbyProperties(service);
-
-        runner.enableControllerService(service);
-
-        runner.assertValid(service);
-
-        try (final Connection connection = service.getConnection()) {
-            Assertions.assertNotNull(connection);
-            createInsertSelectDrop(connection);
-        }
-    }
-
-    private void createInsertSelectDrop(Connection con) throws SQLException {
-
-        final Statement st = con.createStatement();
-
-        try {
-            String dropTable = "drop table restaurants";
-            st.executeUpdate(dropTable);
-        } catch (final Exception e) {
-            // table may not exist, this is not serious problem.
-        }
-
-        String createTable = "create table restaurants(id integer, name varchar(20), city varchar(50))";
-        st.executeUpdate(createTable);
-
-        st.executeUpdate("insert into restaurants values (1, 'Irifunes', 'San Mateo')");
-        st.executeUpdate("insert into restaurants values (2, 'Estradas', 'Daly City')");
-        st.executeUpdate("insert into restaurants values (3, 'Prime Rib House', 'San Francisco')");
-
-        int nrOfRows = 0;
-        final ResultSet resultSet = st.executeQuery("select * from restaurants");
-        while (resultSet.next()) {
-            nrOfRows++;
-        }
-        Assertions.assertEquals(3, nrOfRows);
-
-        st.close();
-    }
-
-    private void setDerbyProperties(final HikariCPConnectionPool service) {
-        final String url = String.format("jdbc:derby:%s;create=true", databaseDirectory);
-        runner.setProperty(service, HikariCPConnectionPool.DATABASE_URL, url);
-        runner.setProperty(service, HikariCPConnectionPool.DB_DRIVERNAME, EmbeddedDriver.class.getName());
+    private void setDatabaseProperties(final HikariCPConnectionPool service) {
+        runner.setProperty(service, HikariCPConnectionPool.DATABASE_URL, "jdbc:mock");
+        runner.setProperty(service, HikariCPConnectionPool.DB_DRIVERNAME, MockDriver.class.getName());
         runner.setProperty(service, HikariCPConnectionPool.MAX_WAIT_TIME, "5 s");
         runner.setProperty(service, HikariCPConnectionPool.DB_USER, String.class.getSimpleName());
         runner.setProperty(service, HikariCPConnectionPool.DB_PASSWORD, String.class.getName());
-    }
-
-    private File getEmptyDirectory() {
-        final String randomDirectory = String.format("%s-%s", getClass().getSimpleName(), UUID.randomUUID());
-        return Paths.get(getSystemTemporaryDirectory(), randomDirectory).toFile();
-    }
-
-    private static String getSystemTemporaryDirectory() {
-        return System.getProperty("java.io.tmpdir");
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/MockDriver.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/MockDriver.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.dbcp;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class MockDriver implements Driver {
+    private static Connection connection;
+
+    public static void setConnection(final Connection mockConnection) {
+        connection = mockConnection;
+    }
+
+    @Override
+    public Connection connect(final String url, final Properties info) {
+        return connection;
+    }
+
+    @Override
+    public boolean acceptsURL(final String url) {
+        return true;
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(final String url, final Properties info) {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() {
+        return null;
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-11191](https://issues.apache.org/jira/browse/NIFI-11191) Refactors the `HikariCPConnectionPoolTest` class using a `MockDriver` class to avoid intermittent failures related to concurrency and file locking when using Apache Derby.

The existing test class attempted to work around locking issues using specialized temporary file handling for the Derby database and associated the logs. The `MockDriver` approach avoids these issues and focuses the test on confirming whether the Controller Service returns a Connection.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
