### PR TITLE
NIFI-11193 Improve GitFlowPersisenceProvider logging

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -181,16 +181,12 @@ class GitFlowMetaData {
      * @param remoteRepository the URI value of the 'Remote Clone Repository' configuration
      * @throws IOException if creating the repository fails
      */
-    public void remoteRepoExists(String remoteRepository) throws IOException {
+    public void remoteRepoExists(String remoteRepository) throws GitAPIException, IOException {
         final Git git = new Git(FileRepositoryBuilder.create(new File(remoteRepository)));
         final LsRemoteCommand lsCmd = git.lsRemote();
-        try {
-            lsCmd.setRemote(remoteRepository);
-            lsCmd.setCredentialsProvider(this.credentialsProvider);
-            lsCmd.call();
-        } catch (Exception e){
-            throw new IllegalArgumentException("InvalidRemoteRepository : Given remote repository is not valid");
-        }
+        lsCmd.setRemote(remoteRepository);
+        lsCmd.setCredentialsProvider(this.credentialsProvider);
+        lsCmd.call();
     }
 
     /**

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
@@ -94,9 +94,12 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
             flowStorageDir = new File(flowStorageDirValue);
             final boolean localRepoExists = flowMetaData.localRepoExists(flowStorageDir);
             if (remoteRepo != null && !remoteRepo.isEmpty() && !localRepoExists){
+                logger.info("Validating remote repo '%s'...", remoteRepo);
                 flowMetaData.remoteRepoExists(remoteRepo);
+                logger.info("Cloning remote repo '%s' to '%s'...", remoteRepo, flowStorageDirValue);
                 flowMetaData.cloneRepository(flowStorageDir, remoteRepo);
             }
+            logger.info("Loading remote repo '%s'...", remoteRepo);
             flowMetaData.loadGitRepository(flowStorageDir);
             flowMetaData.startPushThread();
             logger.info("Configured GitFlowPersistenceProvider with Flow Storage Directory {}",

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
@@ -99,7 +99,7 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
                 logger.info("Cloning remote repository [{}] to [{}]", remoteRepo, flowStorageDirValue);
                 flowMetaData.cloneRepository(flowStorageDir, remoteRepo);
             }
-            logger.info("Loading remote repo '%s'...", remoteRepo);
+            logger.info("Loading remote repository [{}]", remoteRepo);
             flowMetaData.loadGitRepository(flowStorageDir);
             flowMetaData.startPushThread();
             logger.info("Configured GitFlowPersistenceProvider with Flow Storage Directory {}",

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
@@ -94,7 +94,7 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
             flowStorageDir = new File(flowStorageDirValue);
             final boolean localRepoExists = flowMetaData.localRepoExists(flowStorageDir);
             if (remoteRepo != null && !remoteRepo.isEmpty() && !localRepoExists){
-                logger.info("Validating remote repo '%s'...", remoteRepo);
+                logger.info("Validating remote repository [{}]", remoteRepo);
                 flowMetaData.remoteRepoExists(remoteRepo);
                 logger.info("Cloning remote repo '%s' to '%s'...", remoteRepo, flowStorageDirValue);
                 flowMetaData.cloneRepository(flowStorageDir, remoteRepo);

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
@@ -96,7 +96,7 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
             if (remoteRepo != null && !remoteRepo.isEmpty() && !localRepoExists){
                 logger.info("Validating remote repository [{}]", remoteRepo);
                 flowMetaData.remoteRepoExists(remoteRepo);
-                logger.info("Cloning remote repo '%s' to '%s'...", remoteRepo, flowStorageDirValue);
+                logger.info("Cloning remote repository [{}] to [{}]", remoteRepo, flowStorageDirValue);
                 flowMetaData.cloneRepository(flowStorageDir, remoteRepo);
             }
             logger.info("Loading remote repo '%s'...", remoteRepo);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11193](https://issues.apache.org/jira/browse/NIFI-11193)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
