### PR TITLE
NIFI-11211 Removed deprecated SSLContextService methods

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/pom.xml
@@ -37,10 +37,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-deprecation-log</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
@@ -30,8 +30,6 @@ import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.deprecation.log.DeprecationLogger;
-import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -129,8 +127,6 @@ public class StandardSSLContextService extends AbstractControllerService impleme
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .sensitive(false)
             .build();
-
-    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(StandardSSLContextService.class);
 
     private static final List<PropertyDescriptor> properties;
     protected ConfigurationContext configContext;
@@ -259,39 +255,6 @@ public class StandardSSLContextService extends AbstractControllerService impleme
             getLogger().error("Unable to create SSLContext: {}", e.getLocalizedMessage());
             throw new ProcessException("Unable to create SSLContext", e);
         }
-    }
-
-    /**
-     * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
-     * due to the Client Authentication policy not being applicable when initializing the SSLContext
-     *
-     * @param clientAuth the desired level of client authentication
-     * @return the configured SSLContext
-     * @throws ProcessException if there is a problem configuring the context
-     * @deprecated The {@link #createContext()} method should be used instead
-     */
-    @Deprecated
-    @Override
-    public SSLContext createSSLContext(final org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException {
-        deprecationLogger.warn("{}[id={}] createSSLContext() should be replaced with createContext()", getClass().getSimpleName(), getIdentifier());
-        return createContext();
-    }
-
-    /**
-     * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
-     * due to the use of the deprecated {@link ClientAuth} enum
-     * {@link #createContext()} method is preferred.
-     *
-     * @param clientAuth the desired level of client authentication
-     * @return the configured SSLContext
-     * @throws ProcessException if there is a problem configuring the context
-     * @deprecated The {@link #createContext()} method should be used instead
-     */
-    @Deprecated
-    @Override
-    public SSLContext createSSLContext(final ClientAuth clientAuth) throws ProcessException {
-        deprecationLogger.warn("{}[id={}] createSSLContext() should be replaced with createContext()", getClass().getSimpleName(), getIdentifier());
-        return createContext();
     }
 
     /**

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/src/main/java/org/apache/nifi/ssl/SSLContextService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/src/main/java/org/apache/nifi/ssl/SSLContextService.java
@@ -22,7 +22,6 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.controller.ControllerService;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.security.util.TlsConfiguration;
 
 /**
@@ -37,51 +36,12 @@ public interface SSLContextService extends ControllerService {
     TlsConfiguration createTlsConfiguration();
 
     /**
-     * This enum was removed in 1.12.0 but external custom code has been compiled against it, so it is returned
-     * in 1.12.1. This enum should no longer be used and any dependent code should now reference
-     * ClientAuth moving forward. This enum may be removed in a future release.
-     *
-     */
-    @Deprecated
-    enum ClientAuth {
-        WANT,
-        REQUIRED,
-        NONE
-    }
-
-    /**
      * Create and initialize {@link SSLContext} using configured properties. This method is preferred over deprecated
      * create methods due to not requiring a client authentication policy.
      *
      * @return {@link SSLContext} initialized using configured properties
      */
     SSLContext createContext();
-
-    /**
-     * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
-     * due to {@link org.apache.nifi.security.util.ClientAuth} not being applicable or used when initializing the
-     * {@link SSLContext}
-     *
-     * @param clientAuth the desired level of client authentication
-     * @return the configured SSLContext
-     * @throws ProcessException if there is a problem configuring the context
-     * @deprecated The {@link #createContext()} method should be used instead
-     */
-    @Deprecated
-    SSLContext createSSLContext(org.apache.nifi.security.util.ClientAuth clientAuth) throws ProcessException;
-
-    /**
-     * Returns a configured {@link SSLContext} from the populated configuration values. This method is deprecated
-     * due to the use of the deprecated {@link ClientAuth} enum and the
-     * ({@link #createContext()}) method is preferred.
-     *
-     * @param clientAuth the desired level of client authentication
-     * @return the configured SSLContext
-     * @throws ProcessException if there is a problem configuring the context
-     * @deprecated The {@link #createContext()} method should be used instead
-     */
-    @Deprecated
-    SSLContext createSSLContext(ClientAuth clientAuth) throws ProcessException;
 
     /**
      * Create X.509 Trust Manager using configured properties


### PR DESCRIPTION
# Summary

[NIFI-11211](https://issues.apache.org/jira/browse/NIFI-11211) Removes the `createSSLContext()` methods from the `SSLContextService` Controller Service interface, which were deprecated in NiFi 1.13.0 in favor of the `createContext()` method.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
