### PR TITLE
NIFI-11219 Set Qpid Proton J 0.34.0 for Azure EventHubs

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -29,6 +29,7 @@
         <azure.sdk.bom.version>1.2.9</azure.sdk.bom.version>
         <microsoft.azure-storage.version>8.6.6</microsoft.azure-storage.version>
         <msal4j.version>1.13.3</msal4j.version>
+        <qpid.proton.version>0.34.0</qpid.proton.version>
     </properties>
 
     <modules>
@@ -59,6 +60,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>31.1-jre</version>
+            </dependency>
+            <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
+            <dependency>
+                <groupId>org.apache.qpid</groupId>
+                <artifactId>proton-j</artifactId>
+                <version>${qpid.proton.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11219](https://issues.apache.org/jira/browse/NIFI-11219) Sets the Apache Qpid Proton J transitive dependency version to 0.34.0 in order to address [PROTON-2347](https://issues.apache.org/jira/browse/PROTON-2347). Version 0.34.0 resolves an issue with leaked file handles on socket communication failures for Azure EventHubs components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
