### PR TITLE
NIFI-11232 Fix buffer handling in ContentClaimInputStream

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/io/ContentClaimInputStream.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/io/ContentClaimInputStream.java
@@ -166,7 +166,11 @@ public class ContentClaimInputStream extends InputStream {
         markOffset = currentOffset;
         markReadLimit = readlimit;
         if (bufferedIn == null) {
-            bufferedIn = new BufferedInputStream(delegate);
+            try {
+                bufferedIn = new BufferedInputStream(getDelegate());
+            } catch (IOException ex) {
+                throw new RuntimeException("Failed to read content claim!", ex);
+            }
         }
 
         bufferedIn.mark(readlimit);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/io/TestContentClaimInputStream.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/io/TestContentClaimInputStream.java
@@ -63,7 +63,7 @@ public class TestContentClaimInputStream {
         final byte[] buff = new byte[5];
         StreamUtils.fillBuffer(in, buff);
 
-        Mockito.verify(repo, Mockito.times(1)).read(contentClaim);
+        Mockito.verify(repo).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         final String contentRead = new String(buff);
@@ -85,7 +85,7 @@ public class TestContentClaimInputStream {
         final byte[] buff = new byte[2];
         StreamUtils.fillBuffer(in, buff);
 
-        Mockito.verify(repo, Mockito.times(1)).read(contentClaim);
+        Mockito.verify(repo).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         final String contentRead = new String(buff);
@@ -107,7 +107,7 @@ public class TestContentClaimInputStream {
         final byte[] buff = new byte[5];
 
         final int invocations = 10;
-        for (int i=0; i < invocations; i++) {
+        for (int i = 0; i < invocations; i++) {
             in.mark(5);
 
             StreamUtils.fillBuffer(in, buff, true);
@@ -115,14 +115,14 @@ public class TestContentClaimInputStream {
             final String contentRead = new String(buff);
             assertEquals("hello", contentRead);
 
-            assertEquals(5 * (i+1), in.getBytesConsumed());
+            assertEquals(5 * (i + 1), in.getBytesConsumed());
             assertEquals(5, in.getCurrentOffset());
             assertEquals(-1, in.read());
 
             in.reset();
         }
 
-        Mockito.verify(repo, Mockito.times( 1)).read(contentClaim);
+        Mockito.verify(repo).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         // Ensure that underlying stream is closed
@@ -140,20 +140,20 @@ public class TestContentClaimInputStream {
         final int invocations = 10;
         in.mark(5);
 
-        for (int i=0; i < invocations; i++) {
+        for (int i = 0; i < invocations; i++) {
             StreamUtils.fillBuffer(in, buff, true);
 
             final String contentRead = new String(buff);
             assertEquals("hello", contentRead);
 
-            assertEquals(5 * (i+1), in.getBytesConsumed());
+            assertEquals(5 * (i + 1), in.getBytesConsumed());
             assertEquals(5, in.getCurrentOffset());
             assertEquals(-1, in.read());
 
             in.reset();
         }
 
-        Mockito.verify(repo, Mockito.times( 1)).read(contentClaim);
+        Mockito.verify(repo).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         // Ensure that underlying stream is closed
@@ -169,7 +169,7 @@ public class TestContentClaimInputStream {
         final byte[] buff = new byte[2];
 
         final int invocations = 10;
-        for (int i=0; i < invocations; i++) {
+        for (int i = 0; i < invocations; i++) {
             in.mark(5);
 
             StreamUtils.fillBuffer(in, buff, true);
@@ -177,14 +177,14 @@ public class TestContentClaimInputStream {
             final String contentRead = new String(buff);
             assertEquals("lo", contentRead);
 
-            assertEquals(2 * (i+1), in.getBytesConsumed());
+            assertEquals(2 * (i + 1), in.getBytesConsumed());
             assertEquals(5, in.getCurrentOffset());
             assertEquals(-1, in.read());
 
             in.reset();
         }
 
-        Mockito.verify(repo, Mockito.times( 1)).read(contentClaim);
+        Mockito.verify(repo).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         // Ensure that underlying stream is closed
@@ -202,20 +202,20 @@ public class TestContentClaimInputStream {
         final int invocations = 10;
         in.mark(2);
 
-        for (int i=0; i < invocations; i++) {
+        for (int i = 0; i < invocations; i++) {
             StreamUtils.fillBuffer(in, buff, true);
 
             final String contentRead = new String(buff);
             assertEquals("hello", contentRead);
 
-            assertEquals(5 * (i+1), in.getBytesConsumed());
+            assertEquals(5 * (i + 1), in.getBytesConsumed());
             assertEquals(5, in.getCurrentOffset());
             assertEquals(-1, in.read());
 
             in.reset();
         }
 
-        Mockito.verify(repo, Mockito.times( invocations + 1)).read(contentClaim);
+        Mockito.verify(repo, Mockito.times(invocations + 1)).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         // Ensure that underlying stream is closed
@@ -246,11 +246,11 @@ public class TestContentClaimInputStream {
         final ContentClaimInputStream in = new ContentClaimInputStream(repo, contentClaim, 100L, repo.read(contentClaim), new NopPerformanceTracker());
 
         int invocations = 5;
-        for (int i=0; i < invocations; i++) {
+        for (int i = 0; i < invocations; i++) {
             in.mark(1);
             in.read();
 
-            assertEquals(i+1, in.getBytesConsumed());
+            assertEquals(i + 1, in.getBytesConsumed());
             assertEquals(101, in.getCurrentOffset());
 
             in.reset();
@@ -262,7 +262,7 @@ public class TestContentClaimInputStream {
         in.read(buff);
         in.reset();
 
-        Mockito.verify(repo, Mockito.times( 2)).read(contentClaim);
+        Mockito.verify(repo, Mockito.times(2)).read(contentClaim);
         Mockito.verifyNoMoreInteractions(repo);
 
         in.close();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11232](https://issues.apache.org/jira/browse/NIFI-11232)

Under some circumstances the buffer is not recreated correctly in ContentClaimInputStream leading to a situation where data is read from the buffer and the buffer trying to read from a closed stream. More details in the issue.

One case where this can happen is in a custom processor using Apache Tika. Passing the InputStream created of a flowfile by the processSession to Tika exposes the bug, since it uses the mark and reset feature extensively.

This PR creates a new buffer when the stream is marked to buffer the readLimit (which is the primary cause why it was introduced in NIFI-10888). It also throws the buffer away during reset, if a reset within the buffer is not possible. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
