### PR TITLE
NIFI-11213 Showing version change in older (pre 1.18.0) contained version flows properly

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -34,6 +34,7 @@ import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
 import org.apache.nifi.registry.flow.diff.FlowDifference;
+import org.apache.nifi.registry.flow.diff.FlowDifferenceUtil;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedComponent;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedControllerService;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedProcessor;
@@ -192,22 +193,13 @@ public class FlowDifferenceFilters {
                 final VersionedFlowCoordinates coordinatesB = versionedProcessGroupB.getVersionedFlowCoordinates();
 
                 if (coordinatesA != null && coordinatesB != null) {
-                    String registryUrlA = coordinatesA.getRegistryUrl();
-                    String registryUrlB = coordinatesB.getRegistryUrl();
-
-                    if (registryUrlA != null && registryUrlB != null && !registryUrlA.equals(registryUrlB)) {
-                        if (registryUrlA.endsWith("/")) {
-                            registryUrlA = registryUrlA.substring(0, registryUrlA.length() - 1);
-                        }
-
-                        if (registryUrlB.endsWith("/")) {
-                            registryUrlB = registryUrlB.substring(0, registryUrlB.length() - 1);
-                        }
-
-                        if (registryUrlA.equals(registryUrlB)) {
-                            return true;
-                        }
+                    if (coordinatesA.getStorageLocation() != null || coordinatesB.getStorageLocation() != null) {
+                        return false;
                     }
+
+                    return  !FlowDifferenceUtil.areRegistryStrictlyEqual(coordinatesA, coordinatesB)
+                            && FlowDifferenceUtil.areRegistryUrlsEqual(coordinatesA, coordinatesB)
+                            && coordinatesA.getVersion() == coordinatesB.getVersion();
                 }
             }
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/ConciseEvolvingDifferenceDescriptor.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/ConciseEvolvingDifferenceDescriptor.java
@@ -80,7 +80,7 @@ public class ConciseEvolvingDifferenceDescriptor implements DifferenceDescriptor
                     final VersionedFlowCoordinates coordinatesB = (VersionedFlowCoordinates) valueB;
 
                     // If the two vary only by version, then use a more concise message. If anything else is different, then use a fully explanation.
-                    if (Objects.equals(coordinatesA.getRegistryUrl(), coordinatesB.getRegistryUrl()) && Objects.equals(coordinatesA.getBucketId(), coordinatesB.getBucketId())
+                    if (FlowDifferenceUtil.areRegistryUrlsEqual(coordinatesA, coordinatesB) && Objects.equals(coordinatesA.getBucketId(), coordinatesB.getBucketId())
                             && Objects.equals(coordinatesA.getFlowId(), coordinatesB.getFlowId()) && coordinatesA.getVersion() != coordinatesB.getVersion()) {
 
                         description = String.format("Flow Version changed from %s to %s", coordinatesA.getVersion(), coordinatesB.getVersion());

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowDifferenceUtil.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowDifferenceUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.flow.diff;
+
+import org.apache.nifi.flow.VersionedFlowCoordinates;
+
+public final class FlowDifferenceUtil {
+
+    private FlowDifferenceUtil() {
+        // Not to be instantiated
+    }
+
+    public static boolean areRegistryStrictlyEqual(final VersionedFlowCoordinates coordinatesA, final VersionedFlowCoordinates coordinatesB) {
+        final String registryUrlA = coordinatesA.getRegistryUrl();
+        final String registryUrlB = coordinatesB.getRegistryUrl();
+        return registryUrlA != null && registryUrlB != null && registryUrlA.equals(registryUrlB);
+    }
+
+    public static boolean areRegistryUrlsEqual(final VersionedFlowCoordinates coordinatesA, final VersionedFlowCoordinates coordinatesB) {
+        final String registryUrlA = coordinatesA.getRegistryUrl();
+        final String registryUrlB = coordinatesB.getRegistryUrl();
+
+        if (registryUrlA != null && registryUrlB != null) {
+            if (registryUrlA.equals(registryUrlB)) {
+                return true;
+            }
+
+            final String normalizedRegistryUrlA = registryUrlA.endsWith("/") ? registryUrlA.substring(0, registryUrlA.length() - 1) : registryUrlA;
+            final String normalizedRegistryUrlB = registryUrlB.endsWith("/") ? registryUrlB.substring(0, registryUrlB.length() - 1) : registryUrlB;
+
+            return normalizedRegistryUrlA.equals(normalizedRegistryUrlB);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
# Summary

Contained versioned flows using registryUri to localize flows vere not handled properly when checking for local changes in the flow. This PR aims to solve this issue.

[NIFI-11213](https://issues.apache.org/jira/browse/NIFI-11213)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
