### PR TITLE
NIFI-11257 Enable Maven HTTP pooling and additional retries

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,12 +25,14 @@ env:
     -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
     -Dmaven.wagon.http.retryHandler.class=standard
     -Dmaven.wagon.http.retryHandler.count=5
+    -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
     -Dmaven.wagon.httpconnectionManager.maxPerRoute=5
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
   COMPILE_MAVEN_OPTS: >-
     -Xmx3g
     -Dmaven.wagon.http.retryHandler.class=standard
     -Dmaven.wagon.http.retryHandler.count=5
+    -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
     -Dmaven.wagon.httpconnectionManager.maxPerRoute=5
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
   MAVEN_COMPILE_COMMAND: >-

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,12 +23,16 @@ env:
     -XX:ReservedCodeCacheSize=1g
     -XX:+UseG1GC
     -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
-    -Dhttp.keepAlive=false
-    -Dmaven.wagon.http.pool=false
+    -Dmaven.wagon.http.retryHandler.class=standard
+    -Dmaven.wagon.http.retryHandler.count=5
+    -Dmaven.wagon.httpconnectionManager.maxPerRoute=5
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
   COMPILE_MAVEN_OPTS: >-
     -Xmx3g
-    -Dhttp.keepAlive=false
-    -Dmaven.wagon.http.pool=false
+    -Dmaven.wagon.http.retryHandler.class=standard
+    -Dmaven.wagon.http.retryHandler.count=5
+    -Dmaven.wagon.httpconnectionManager.maxPerRoute=5
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
   MAVEN_COMPILE_COMMAND: >-
     mvn test-compile
     --show-version


### PR DESCRIPTION
# Summary

[NIFI-11257](https://issues.apache.org/jira/browse/NIFI-11257) Updates the Maven Wagon HTTP configuration for GitHub automated builds to enable connection pooling with additional retries.

Earlier Maven configurations disabled HTTP connection pooling attempting to improve stability, but more recent versions of Maven Wagon support a number of [HTTP configuration options](https://maven.apache.org/wagon/wagon-providers/wagon-http/).

The configuration updates switch to the default setting of HTTP connection pooling enabled, but set a time-to-live of 30 seconds for pooled connections. The configuration lowers the maximum connections per route from the default of 20 to 5, in order to reduce the number of simultaneous connections to the Maven Central repository.

Additional changes include setting the number of retry attempts to 5, instead of the default of 3, and using the [StandardHttpRequestRetryHandler](https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/client/StandardHttpRequestRetryHandler.html).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
