### PR TITLE
NIFI-11261 Add Primary Node State handling to GetAzureEventHub

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -29,7 +29,9 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.azure.core.amqp.AmqpClientOptions;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
@@ -49,10 +51,13 @@ import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.annotation.notification.OnPrimaryNodeStateChange;
+import org.apache.nifi.annotation.notification.PrimaryNodeState;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.AbstractProcessor;
@@ -61,6 +66,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.util.StopWatch;
 import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
 
@@ -180,9 +186,15 @@ public class GetAzureEventHub extends AbstractProcessor {
 
     private final Map<String, EventPosition> partitionEventPositions = new ConcurrentHashMap<>();
 
-    private volatile BlockingQueue<String> partitionIds = new LinkedBlockingQueue<>();
+    private final BlockingQueue<String> partitionIds = new LinkedBlockingQueue<>();
+
+    private final AtomicReference<ExecutionNode> configuredExecutionNode = new AtomicReference<>(ExecutionNode.ALL);
+
     private volatile int receiverFetchSize;
+
     private volatile Duration receiverFetchTimeout;
+
+    private EventHubClientBuilder configuredClientBuilder;
 
     private EventHubConsumerClient eventHubConsumerClient;
 
@@ -201,20 +213,40 @@ public class GetAzureEventHub extends AbstractProcessor {
         return AzureEventHubUtils.customValidate(ACCESS_POLICY, POLICY_PRIMARY_KEY, context);
     }
 
+    @OnPrimaryNodeStateChange
+    public void onPrimaryNodeStateChange(final PrimaryNodeState primaryNodeState) {
+        final ExecutionNode executionNode = configuredExecutionNode.get();
+        if (executionNode == ExecutionNode.PRIMARY) {
+            if (PrimaryNodeState.PRIMARY_NODE_REVOKED == primaryNodeState) {
+                closeClient();
+                getLogger().info("Consumer Client closed based on Execution Node [{}] and Primary Node State [{}]", executionNode, primaryNodeState);
+            } else {
+                createClient();
+                getLogger().info("Consumer Client created based on Execution Node [{}] and Primary Node State [{}]", executionNode, primaryNodeState);
+            }
+        } else {
+            getLogger().debug("Consumer Client not changed based on Execution Node [{}]", executionNode);
+        }
+    }
+
     @OnStopped
     public void closeClient() {
+        partitionIds.clear();
         partitionEventPositions.clear();
 
         if (eventHubConsumerClient == null) {
-            getLogger().info("Azure Event Hub Consumer Client not configured");
+            getLogger().debug("Consumer Client not configured");
         } else {
             eventHubConsumerClient.close();
+            getLogger().info("Consumer Client for Event Hub [{}] closed", eventHubConsumerClient.getEventHubName());
         }
     }
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) {
-        eventHubConsumerClient = createEventHubConsumerClient(context);
+        configuredExecutionNode.set(context.getExecutionNode());
+        configuredClientBuilder = createEventHubClientBuilder(context);
+        createClient();
 
         if (context.getProperty(RECEIVER_FETCH_SIZE).isSet()) {
             receiverFetchSize = context.getProperty(RECEIVER_FETCH_SIZE).asInteger();
@@ -226,8 +258,6 @@ public class GetAzureEventHub extends AbstractProcessor {
         } else {
             receiverFetchTimeout = DEFAULT_FETCH_TIMEOUT;
         }
-
-        this.partitionIds = getPartitionIds();
 
         final PropertyValue enqueuedTimeProperty = context.getProperty(ENQUEUE_TIME);
         final Instant initialEnqueuedTime;
@@ -310,7 +340,30 @@ public class GetAzureEventHub extends AbstractProcessor {
         return eventHubConsumerClient.receiveFromPartition(partitionId, receiverFetchSize, eventPosition, receiverFetchTimeout);
     }
 
-    private EventHubConsumerClient createEventHubConsumerClient(final ProcessContext context) {
+    private void createClient() {
+        if (isCreateClientEnabled()) {
+            closeClient();
+            eventHubConsumerClient = configuredClientBuilder.buildConsumerClient();
+            partitionIds.addAll(getPartitionIds());
+            getLogger().info("Consumer Client created for Event Hub [{}] Partitions {}", eventHubConsumerClient.getEventHubName(), partitionIds);
+        }
+    }
+
+    private boolean isCreateClientEnabled() {
+        final boolean enabled;
+
+        final ExecutionNode executionNode = configuredExecutionNode.get();
+        if (ExecutionNode.PRIMARY == executionNode) {
+            final NodeTypeProvider nodeTypeProvider = getNodeTypeProvider();
+            enabled = nodeTypeProvider.isPrimary();
+        } else {
+            enabled = true;
+        }
+
+        return enabled;
+    }
+
+    private EventHubClientBuilder createEventHubClientBuilder(final ProcessContext context) {
         final String namespace = context.getProperty(NAMESPACE).getValue();
         final String eventHubName = context.getProperty(EVENT_HUB_NAME).getValue();
         final String serviceBusEndpoint = context.getProperty(SERVICE_BUS_ENDPOINT).getValue();
@@ -332,7 +385,13 @@ public class GetAzureEventHub extends AbstractProcessor {
             final AzureNamedKeyCredential azureNamedKeyCredential = new AzureNamedKeyCredential(policyName, policyKey);
             eventHubClientBuilder.credential(fullyQualifiedNamespace, eventHubName, azureNamedKeyCredential);
         }
-        return eventHubClientBuilder.buildConsumerClient();
+
+        // Set Azure Event Hub Client Identifier using Processor Identifier instead of default random UUID
+        final AmqpClientOptions clientOptions = new AmqpClientOptions();
+        clientOptions.setIdentifier(getIdentifier());
+        eventHubClientBuilder.clientOptions(clientOptions);
+
+        return eventHubClientBuilder;
     }
 
     private String getTransitUri(final String partitionId) {

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -29,7 +29,7 @@
         <azure.sdk.bom.version>1.2.9</azure.sdk.bom.version>
         <microsoft.azure-storage.version>8.6.6</microsoft.azure-storage.version>
         <msal4j.version>1.13.3</msal4j.version>
-        <qpid.proton.version>0.34.0</qpid.proton.version>
+        <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
# Summary

[NIFI-11261](https://issues.apache.org/jira/browse/NIFI-11261) Adds Primary Node State Change handling to `GetAzureEventHub` to improve Processor behavior in a clustered deployment.

Although `ConsumeAzureEventHub` provides the recommend approach for receiving events, `GetAzureEventHub` can be configured to run on the cluster primary node only to reduce the potential for duplication.

Updates include checking for the Execution Node status and avoiding unnecessary Event Hub Consumer Client creation. The new handler method for Primary Node State changes closes the Consumer Client when a node has its primary status revoked, and creates a new Consumer Client when a node is elected primary.

Additional changes include upgrading the Qpid Proton J dependency from 0.34.0 to [0.34.1](https://qpid.apache.org/releases/qpid-proton-j-0.34.1/release-notes.html) and setting the Consumer Client Identifier to the Processor Identifier for improved connection tracking.

New unit test methods provide basic confirmation of Processor behavior when configured for primary node execution.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
