### PR TITLE
NIFI-11264 Improve logging in list processors and fix ListFile's description

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
@@ -571,7 +571,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
         }
 
         if (entityList == null || entityList.isEmpty()) {
-            getLogger().debug("There is no data to list. Yielding.");
+            getLogger().debug("No data found: yielding");
             context.yield();
             return;
         }
@@ -676,7 +676,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
         }
 
         if (orderedEntries.isEmpty()) {
-            getLogger().debug("There is no data to list. Yielding.");
+            getLogger().debug("There is no data to list: yielding");
             context.yield();
             return;
         }
@@ -739,7 +739,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
                 }
                 justElectedPrimaryNode = false;
                 if (noUpdateRequired) {
-                    getLogger().debug("Updating the timestamp of the last listed entry is not required. Yielding.");
+                    getLogger().debug("No update required for last listed entity: yielding");
                     context.yield();
                     return;
                 }
@@ -763,7 +763,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
         }
 
         if (entityList == null || entityList.isEmpty()) {
-            getLogger().debug(String.format("There is no data to list with the criteria minTimestampToListMillis=%d. Yielding.", minTimestampToListMillis));
+            getLogger().debug("No data found matching minimum timestamp [{}]: yielding", minTimestampToListMillis);
             context.yield();
             return;
         }
@@ -824,7 +824,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
                 final boolean minimalListingLagNotPassed = currentRunTimeNanos - lastRunTimeNanos < listingLagNanos;
 
                 if (minimalListingLagNotPassed) {
-                    getLogger().debug("Minimal listing lag has not passed. Yielding.");
+                    getLogger().debug("Minimal listing lag not passed: yielding");
                     context.yield();
                     return;
                 }
@@ -833,7 +833,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
                         && orderedEntries.get(latestListedEntryTimestampThisCycleMillis).stream().allMatch(entity -> latestIdentifiersProcessed.contains(entity.getIdentifier()));
 
                 if (latestListedEntryIsUpToDate) {
-                    getLogger().debug("Already listed the latest entry. Yielding.");
+                    getLogger().debug("Latest entry already listed with timestamp [{}]: yielding", latestListedEntryTimestampThisCycleMillis);
                     context.yield();
                     return;
                 }
@@ -908,7 +908,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
 
             lastRunTimeNanos = currentRunTimeNanos;
         } else {
-            getLogger().debug("There is no data to list. Yielding.");
+            getLogger().debug("There is no data to list: yielding");
             context.yield();
 
             // lastListingTime = 0 so that we don't continually poll the distributed cache / local file system

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -93,15 +93,16 @@ import static org.apache.nifi.processor.util.StandardValidators.TIME_PERIOD_VALI
 @TriggerSerially
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @Tags({"file", "get", "list", "ingest", "source", "filesystem"})
-@CapabilityDescription("Retrieves a listing of files from the local filesystem. For each file that is listed, " +
-        "creates a FlowFile that represents the file so that it can be fetched in conjunction with FetchFile. This " +
-        "Processor is designed to run on Primary Node only in a cluster. If the primary node changes, the new " +
-        "Primary Node will pick up where the previous node left off without duplicating all of the data. Unlike " +
-        "GetFile, this Processor does not delete any data from the local filesystem.")
+@CapabilityDescription("Retrieves a listing of files from the input directory. For each file listed, creates a FlowFile " +
+        "that represents the file so that it can be fetched in conjunction with FetchFile. This Processor is designed " +
+        "to run on Primary Node only in a cluster when 'Input Directory Location' is set to 'Remote'. If the primary node " +
+        "changes, the new Primary Node will pick up where the previous node left off without duplicating all the data. " +
+        "When 'Input Directory Location' is 'Local', the 'Execution' mode can be anything, and synchronization won't happen. " +
+        "Unlike GetFile, this Processor does not delete any data from the local filesystem.")
 @WritesAttributes({
         @WritesAttribute(attribute="filename", description="The name of the file that was read from filesystem."),
         @WritesAttribute(attribute="path", description="The path is set to the relative path of the file's directory " +
-                "on filesystem compared to the Input Directory property.  For example, if Input Directory is set to " +
+                "on filesystem compared to the Input Directory property. For example, if Input Directory is set to " +
                 "/tmp, then files picked up from /tmp will have the path attribute set to \"/\". If the Recurse " +
                 "Subdirectories property is set to true and a file is picked up from /tmp/abc/1/2/3, then the path " +
                 "attribute will be set to \"abc/1/2/3/\"."),


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11264](https://issues.apache.org/jira/browse/NIFI-11264)

There were a few cases where the ListFile processor yielded, and it was hard to guess the reason without additional logs. I added those missing logs and fixed the description of the ListFile processor.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
