### PR TITLE
NIFI-11274 only add @timestamp to PutElasticsearchRecord document if not null

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -373,7 +373,9 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
                 final Map<String, Object> contentMap = (Map<String, Object>) DataTypeUtils
                         .convertRecordFieldtoObject(record, RecordFieldType.RECORD.getRecordDataType(record.getSchema()));
                 formatDateTimeFields(contentMap, record);
-                contentMap.putIfAbsent("@timestamp", timestamp);
+                if (timestamp != null) {
+                    contentMap.putIfAbsent("@timestamp", timestamp);
+                }
 
                 operationList.add(new IndexOperationRequest(idx, t, id, contentMap, o));
                 originals.add(record);

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/groovy/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.groovy
@@ -30,7 +30,6 @@ import org.apache.nifi.serialization.RecordReaderFactory
 import org.apache.nifi.serialization.record.MockRecordParser
 import org.apache.nifi.serialization.record.MockSchemaRegistry
 import org.apache.nifi.serialization.record.RecordFieldType
-import org.apache.nifi.util.MockFlowFile
 import org.apache.nifi.util.StringUtils
 import org.apache.nifi.util.TestRunner
 import org.apache.nifi.util.TestRunners
@@ -425,7 +424,7 @@ class PutElasticsearchRecordTest {
             [ id: "rec-2", op: "create", index: "bulk_b", type: "message", msg: "Hello" ],
             [ id: "rec-3", op: "update", index: "bulk_a", type: "message", msg: "Hello" ],
             [ id: "rec-4", op: "upsert", index: "bulk_b", type: "message", msg: "Hello" ],
-            [ id: "rec-5", op: "create", index: "bulk_a", type: "message", msg: "Hello" ],
+            [ id: "rec-5", op: "create", index: "bulk_a", type: "message", msg: "Hello", code: null ],
             [ id: "rec-6", op: "delete", index: "bulk_b", type: "message", msg: "Hello", code: 101L ]
         ]))
 
@@ -436,7 +435,7 @@ class PutElasticsearchRecordTest {
             int upsert = items.findAll { it.operation == IndexOperationRequest.Operation.Upsert }.size()
             int delete = items.findAll { it.operation == IndexOperationRequest.Operation.Delete }.size()
             def timestampCount = items.findAll { it.fields.get("@timestamp") == 101L }.size()
-            def noTimestampCount = items.findAll { it.fields.get("@timestamp") == null }.size()
+            def noTimestampCount = items.findAll { !it.fields.containsKey("@timestamp") }.size()
             assertEquals(1, index)
             assertEquals(2, create)
             assertEquals(1, update)
@@ -487,7 +486,7 @@ class PutElasticsearchRecordTest {
 
         clientService.evalClosure = { List<IndexOperationRequest> items ->
             def nullIdCount = items.findAll { it.id == null }.size()
-            def noTimestampCount = items.findAll { it.fields.containsKey("@timestamp") }.size()
+            def noTimestampCount = items.findAll { !it.fields.containsKey("@timestamp") }.size()
             assertEquals(1, nullIdCount)
             assertEquals(1, noTimestampCount)
         }
@@ -512,7 +511,7 @@ class PutElasticsearchRecordTest {
 
         clientService.evalClosure = { List<IndexOperationRequest> items ->
             def nullIdCount = items.findAll { it.id == null }.size()
-            def noTimestampCount = items.findAll { it.fields.containsKey("@timestamp") }.size()
+            def noTimestampCount = items.findAll { !it.fields.containsKey("@timestamp") }.size()
             assertEquals(1, nullIdCount)
             assertEquals(1, noTimestampCount)
         }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11274](https://issues.apache.org/jira/browse/NIFI-11274) only add @timestamp to PutElasticsearchRecord document if not null

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
