### PR TITLE
NIFI-11276 Upgrade nifi-toolkit-api to Swagger Codegen 3

### DIFF
--- a/nifi-toolkit/nifi-toolkit-api/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-api/pom.xml
@@ -35,6 +35,11 @@ language governing permissions and limitations under the License. -->
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>
@@ -64,28 +69,12 @@ language governing permissions and limitations under the License. -->
         </dependency>
     </dependencies>
 
-    <!--
-    Based on execution of swagger-codegen similar to the following.
-    (Double dashes spaced to prevent Maven error.)
-        $ java -jar .../swagger-codegen-cli.jar generate \
-            -i swagger.json \
-            -l java \
-            -o src2 \
-            - -group-id org.apache.nifi \
-            - -artifact-id nifi.client-api \
-            - -artifact-version 1.2.0-SNAPSHOT \
-            - -invoker-package org.apache.nifi.client \
-            - -api-package org.apache.nifi.client.api \
-            - -model-package org.apache.nifi.client.model \
-            - -http-user-agent apache-nifi-swagger-client-java
-     -->
-
     <build>
         <plugins>
             <plugin>
-                <groupId>io.swagger</groupId>
+                <groupId>io.swagger.codegen.v3</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>2.4.27</version>
+                <version>3.0.41</version>
                 <executions>
                     <execution>
                         <goals>
@@ -94,6 +83,8 @@ language governing permissions and limitations under the License. -->
                         <configuration>
                             <inputSpec>${project.parent.parent.basedir}/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/target/swagger-ui/swagger.json</inputSpec>
                             <language>java</language>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
                             <configOptions>
                                 <groupId>org.apache.nifi</groupId>
                                 <artifactId>nifi-api-toolkit</artifactId>
@@ -112,7 +103,6 @@ language governing permissions and limitations under the License. -->
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
# Summary

[NIFI-11276](https://issues.apache.org/jira/browse/NIFI-11276) Upgrades the `nifi-toolkit-api` Maven configuration to use version 3 of the Swagger Codegen Maven Plugin. The plugin supports both version 2 and 3 of the Swagger OpenAPI specification, providing compatibility with current definitions and supporting upgrading to version 3.

Additional changes include disabling unnecessary API and Model class test generation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
