### PR TITLE
NIFI-11279: Allow event stream processing to continue in CaptureChangeMySQL after sync issue

### DIFF
--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/groovy/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQLTest.groovy
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/groovy/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQLTest.groovy
@@ -60,7 +60,6 @@ import org.apache.nifi.util.TestRunner
 import org.apache.nifi.util.TestRunners
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.function.Executable
 
 import javax.net.ssl.SSLContext
 import java.sql.Connection
@@ -74,7 +73,6 @@ import java.util.regex.Pattern
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
@@ -364,7 +362,8 @@ class CaptureChangeMySQLTest {
                 [timestamp: new Date().time, eventType: EventType.XID, nextPosition: 12] as EventHeaderV4,
                 {} as EventData
         ))
-        assertThrows(AssertionError.class, { testRunner.run(1, true, false) } as Executable)
+        // This should not throw an exception, rather warn that a COMMIT event was sent out-of-sync
+        testRunner.run(1, true, false)
     }
 
     @Test
@@ -634,7 +633,8 @@ class CaptureChangeMySQLTest {
                 {} as EventData
         ))
 
-        assertThrows(AssertionError.class, { testRunner.run(1, true, false) } as Executable)
+        // Should not throw an exception
+        testRunner.run(1, true, false)
     }
 
     @Test
@@ -1445,10 +1445,10 @@ class CaptureChangeMySQLTest {
         header2.setTimestamp(new Date().getTime())
         EventData eventData = new EventData() {
         };
-        client.sendEvent(new Event(header2, eventData));
+        client.sendEvent(new Event(header2, eventData))
 
-        // when we ge a xid event without having got a 'begin' event ,throw an exception
-        assertThrows(AssertionError.class, () -> testRunner.run(1, false, false))
+        // when we ge a xid event without having got a 'begin' event , don't throw an exception, just warn the user
+        testRunner.run(1, false, false)
     }
 
     @Test
@@ -1498,7 +1498,6 @@ class CaptureChangeMySQLTest {
         }
 
     }
-
 
     static DistributedMapCacheClientImpl createCacheClient() throws InitializationException {
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -687,37 +687,35 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             // Update local state
             final StateManager stateManager = context.getStateManager();
             if (checkpoint.localState != null) {
-                final StateMap stateMap = stateManager.getState(Scope.LOCAL);
-                final Optional<String> stateVersion = stateMap.getStateVersion();
-                if (!stateVersion.equals(checkpoint.localState.getStateVersion())) {
-                    LOG.debug("Updating State Manager's Local State");
-
-                    try {
+                try {
+                    final StateMap stateMap = stateManager.getState(Scope.LOCAL);
+                    final Optional<String> stateVersion = stateMap.getStateVersion();
+                    if (!stateVersion.equals(checkpoint.localState.getStateVersion())) {
+                        LOG.debug("Updating State Manager's Local State");
                         stateManager.setState(checkpoint.localState.toMap(), Scope.LOCAL);
-                    } catch (final Exception e) {
-                        LOG.warn("Failed to update Local State for {}. If NiFi is restarted before the state is able to be updated, it could result in data duplication.", connectableDescription, e);
+                    } else {
+                        LOG.debug("Will not update State Manager's Local State because the State Manager reports the latest version as {}, which is newer than the session's known version of {}.",
+                                stateVersion, checkpoint.localState.getStateVersion());
                     }
-                } else {
-                    LOG.debug("Will not update State Manager's Local State because the State Manager reports the latest version as {}, which is newer than the session's known version of {}.",
-                            stateVersion, checkpoint.localState.getStateVersion());
+                } catch (final Exception e) {
+                    LOG.warn("Failed to update Local State for {}. If NiFi is restarted before the state is able to be updated, it could result in data duplication.", connectableDescription, e);
                 }
             }
 
             // Update cluster state
             if (checkpoint.clusterState != null) {
-                final StateMap stateMap = stateManager.getState(Scope.CLUSTER);
-                final Optional<String> stateVersion = stateMap.getStateVersion();
-                if (!stateVersion.equals(checkpoint.clusterState.getStateVersion())) {
-                    LOG.debug("Updating State Manager's Cluster State");
-
-                    try {
+                try {
+                    final StateMap stateMap = stateManager.getState(Scope.CLUSTER);
+                    final Optional<String> stateVersion = stateMap.getStateVersion();
+                    if (!stateVersion.equals(checkpoint.clusterState.getStateVersion())) {
+                        LOG.debug("Updating State Manager's Cluster State");
                         stateManager.setState(checkpoint.clusterState.toMap(), Scope.CLUSTER);
-                    } catch (final Exception e) {
-                        LOG.warn("Failed to update Cluster State for {}. If NiFi is restarted before the state is able to be updated, it could result in data duplication.", connectableDescription, e);
+                    } else {
+                        LOG.debug("Will not update State Manager's Cluster State because the State Manager reports the latest version as {}, which is newer than the session's known version of {}.",
+                                stateVersion, checkpoint.clusterState.getStateVersion());
                     }
-                } else {
-                    LOG.debug("Will not update State Manager's Cluster State because the State Manager reports the latest version as {}, which is newer than the session's known version of {}.",
-                            stateVersion, checkpoint.clusterState.getStateVersion());
+                } catch (final Exception e) {
+                    LOG.warn("Failed to update Cluster State for {}. If NiFi is restarted before the state is able to be updated, it could result in data duplication.", connectableDescription, e);
                 }
             }
 


### PR DESCRIPTION
# Summary

[NIFI-11279](https://issues.apache.org/jira/browse/NIFI-11279)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
