### PR TITLE
NIFI-11277 Deprecate bcrypt and scrypt Properties Algorithms

### DIFF
--- a/nifi-commons/nifi-property-encryptor/pom.xml
+++ b/nifi-commons/nifi-property-encryptor/pom.xml
@@ -39,5 +39,10 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>1.21.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/PropertyEncryptionMethod.java
+++ b/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/PropertyEncryptionMethod.java
@@ -23,20 +23,26 @@ import org.apache.nifi.security.util.KeyDerivationFunction;
  * Property Encryption Method enumerates supported values in addition to {@link org.apache.nifi.security.util.EncryptionMethod}
  */
 public enum PropertyEncryptionMethod {
+    @Deprecated
     NIFI_ARGON2_AES_GCM_128(KeyDerivationFunction.ARGON2, EncryptionMethod.AES_GCM,128),
 
     NIFI_ARGON2_AES_GCM_256(KeyDerivationFunction.ARGON2, EncryptionMethod.AES_GCM, 256),
 
+    @Deprecated
     NIFI_BCRYPT_AES_GCM_128(KeyDerivationFunction.BCRYPT, EncryptionMethod.AES_GCM, 128),
 
+    @Deprecated
     NIFI_BCRYPT_AES_GCM_256(KeyDerivationFunction.BCRYPT, EncryptionMethod.AES_GCM, 256),
 
+    @Deprecated
     NIFI_PBKDF2_AES_GCM_128(KeyDerivationFunction.PBKDF2, EncryptionMethod.AES_GCM, 128),
 
     NIFI_PBKDF2_AES_GCM_256(KeyDerivationFunction.PBKDF2, EncryptionMethod.AES_GCM, 256),
 
+    @Deprecated
     NIFI_SCRYPT_AES_GCM_128(KeyDerivationFunction.SCRYPT, EncryptionMethod.AES_GCM, 128),
 
+    @Deprecated
     NIFI_SCRYPT_AES_GCM_256(KeyDerivationFunction.SCRYPT, EncryptionMethod.AES_GCM, 256);
 
     private static final int HASH_LENGTH_DIVISOR = 8;

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -2020,12 +2020,15 @@ Each Key Derivation Function also uses default iteration and cost parameters as 
 === Property Encryption Algorithms
 The following strong encryption methods can be configured in the `nifi.sensitive.props.algorithm` property:
 
-* `NIFI_ARGON2_AES_GCM_128`
 * `NIFI_ARGON2_AES_GCM_256`
+* `NIFI_PBKDF2_AES_GCM_256`
+
+The following sensitive properties algorithms are deprecated and will be removed in subsequent major releases:
+
+* `NIFI_ARGON2_AES_GCM_128`
 * `NIFI_BCRYPT_AES_GCM_128`
 * `NIFI_BCRYPT_AES_GCM_256`
 * `NIFI_PBKDF2_AES_GCM_128`
-* `NIFI_PBKDF2_AES_GCM_256`
 * `NIFI_SCRYPT_AES_GCM_128`
 * `NIFI_SCRYPT_AES_GCM_256`
 


### PR DESCRIPTION
# Summary

[NIFI-11277](https://issues.apache.org/jira/browse/NIFI-11277) Deprecates `bcrypt` and `scrypt` Sensitive Properties Algorithms along with variants using key lengths of 128 bits.

The deprecation warnings leave the following two options as recommended and targeted for support in NiFi 2.0:

- NIFI_ARGON2_AES_GCM_256
- NIFI_PBKDF2_AES_GCM_256

The Administrator's Guide includes updates to reflect this recommendation along with the deprecated algorithms. The `NIFI_ARGON2_AES_GCM_256` option has been available since NiFi 1.12.0 and the `NIFI_PBKDF2_AES_GCM_256` has been the default setting since NiFi 1.14.0.

Reducing the available options to these algorithms provides clearer recommendations for supported options, reducing complexity for both configuration and maintenance in future versions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
