### PR TITLE
NIFI-11252 Added OIDC client secret to the default nifi properties + …

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/main/java/org/apache/nifi/registry/properties/ProtectedNiFiRegistryProperties.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/main/java/org/apache/nifi/registry/properties/ProtectedNiFiRegistryProperties.java
@@ -54,7 +54,8 @@ class ProtectedNiFiRegistryProperties extends NiFiRegistryProperties implements 
     public static final List<String> DEFAULT_SENSITIVE_PROPERTIES = new ArrayList<>(asList(
             NiFiRegistryProperties.SECURITY_KEY_PASSWD,
             NiFiRegistryProperties.SECURITY_KEYSTORE_PASSWD,
-            NiFiRegistryProperties.SECURITY_TRUSTSTORE_PASSWD));
+            NiFiRegistryProperties.SECURITY_TRUSTSTORE_PASSWD,
+            NiFiRegistryProperties.SECURITY_USER_OIDC_CLIENT_SECRET));
 
     public ProtectedNiFiRegistryProperties() {
         this(new NiFiRegistryProperties());

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/java/org/apache/nifi/registry/properties/NiFiRegistryPropertiesLoaderGroovyTest.groovy
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/java/org/apache/nifi/registry/properties/NiFiRegistryPropertiesLoaderGroovyTest.groovy
@@ -37,6 +37,7 @@ class NiFiRegistryPropertiesLoaderGroovyTest extends GroovyTestCase {
     private static final String KEYSTORE_PASSWORD_KEY = NiFiRegistryProperties.SECURITY_KEYSTORE_PASSWD
     private static final String KEY_PASSWORD_KEY = NiFiRegistryProperties.SECURITY_KEY_PASSWD
     private static final String TRUSTSTORE_PASSWORD_KEY = NiFiRegistryProperties.SECURITY_TRUSTSTORE_PASSWD
+    private static final String OIDC_CLIENT_SECRET = NiFiRegistryProperties.SECURITY_USER_OIDC_CLIENT_SECRET
 
     private static final String KEY_HEX_128 = "0123456789ABCDEFFEDCBA9876543210"
     private static final String KEY_HEX_256 = KEY_HEX_128 * 2
@@ -170,6 +171,7 @@ class NiFiRegistryPropertiesLoaderGroovyTest extends GroovyTestCase {
         final def EXPECTED_PLAIN_VALUES = [
                 (KEYSTORE_PASSWORD_KEY): "thisIsABadPassword",
                 (KEY_PASSWORD_KEY): "thisIsABadPassword",
+                (OIDC_CLIENT_SECRET): "thisIsABadPassword",
         ]
 
         // This method is covered in tests above, so safe to use here to retrieve protected properties

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/java/org/apache/nifi/registry/properties/ProtectedNiFiRegistryPropertiesGroovyTest.groovy
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/java/org/apache/nifi/registry/properties/ProtectedNiFiRegistryPropertiesGroovyTest.groovy
@@ -32,11 +32,13 @@ class ProtectedNiFiRegistryPropertiesGroovyTest extends GroovyTestCase {
     private static final String KEYSTORE_PASSWORD_KEY = NiFiRegistryProperties.SECURITY_KEYSTORE_PASSWD
     private static final String KEY_PASSWORD_KEY = NiFiRegistryProperties.SECURITY_KEY_PASSWD
     private static final String TRUSTSTORE_PASSWORD_KEY = NiFiRegistryProperties.SECURITY_TRUSTSTORE_PASSWD
+    private static final String OIDC_CLIENT_SECRET = NiFiRegistryProperties.SECURITY_USER_OIDC_CLIENT_SECRET
 
     private static final def DEFAULT_SENSITIVE_PROPERTIES = [
             KEYSTORE_PASSWORD_KEY,
             KEY_PASSWORD_KEY,
-            TRUSTSTORE_PASSWORD_KEY
+            TRUSTSTORE_PASSWORD_KEY,
+            OIDC_CLIENT_SECRET
     ]
 
     private static final String KEY_HEX_128 = "0123456789ABCDEFFEDCBA9876543210"
@@ -302,7 +304,7 @@ class ProtectedNiFiRegistryPropertiesGroovyTest extends GroovyTestCase {
                 loadFromResourceFile("/conf/nifi-registry.with_sensitive_props_protected_aes_128.properties", KEY_HEX_128)
 
         double percentProtected = getPercentOfSensitivePropertiesProtected(properties)
-        assert percentProtected == 67.0D
+        assert percentProtected == 75.0D
     }
 
     @Test
@@ -400,6 +402,10 @@ class ProtectedNiFiRegistryPropertiesGroovyTest extends GroovyTestCase {
             !unprotectedNiFiProperties.getProperty(it).endsWith(ApplicationPropertiesProtector.PROTECTED_KEY_SUFFIX)
         }
         assert unprotectedNiFiProperties.hashCode() != hashCode
+
+        assert unprotectedNiFiProperties.getProperty(OIDC_CLIENT_SECRET) == "thisIsABadOidcSecret"
+        assert unprotectedNiFiProperties.getProperty(KEY_PASSWORD_KEY) == "thisIsABadKeyPassword"
+        assert unprotectedNiFiProperties.getProperty(KEYSTORE_PASSWORD_KEY) == "thisIsABadKeystorePassword"
     }
 
     @Test

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.properties
@@ -38,6 +38,14 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 # kerberos properties
 nifi.registry.kerberos.krb5.file=/path/to/krb5.conf
 nifi.registry.kerberos.spnego.authentication.expiration=12 hours

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_additional_sensitive_keys.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_additional_sensitive_keys.properties
@@ -38,6 +38,14 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 # providers properties #
 nifi.registry.providers.configuration.file=
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_fully_protected_aes_128.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_fully_protected_aes_128.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=6WUpex+VZiN05LXu||joWJMuoSzYniEC7IAoingTimlG7+RGk8I2irl/WTlIuMcg
+nifi.registry.security.user.oidc.client.secret.protected=aes/gcm/128
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_128.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_128.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=6WUpex+VZiN05LXu||joWJMuoSzYniEC7IAoingTimlG7+RGk8I2irl/WTlIuMcg
+nifi.registry.security.user.oidc.client.secret.protected=aes/gcm/128
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=nifi.registry.web.http.port

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_128_password.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_128_password.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=oa6Aaz5tlFprPuKt||IlVgftF2VqvBIambkP5HVDbRoyKzZl8wwKSw4O9tjHTALA
+nifi.registry.security.user.oidc.client.secret.protected=aes/gcm/128
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=nifi.registry.web.http.port

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_256.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_256.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=3EsY6PJqU2xrL4rB||HsLYTYE/UAUsnrOmMG0f7UZdmhSvL2qh4Iix7PDDw31OZpCO
+nifi.registry.security.user.oidc.client.secret.protected=aes/gcm/256
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=nifi.registry.web.http.port

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_multiple_malformed.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_multiple_malformed.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=6WUpex+VZiN05LXu||thisIsAnIntentionallyMalformedCipherValue
+nifi.registry.security.user.oidc.client.secret.protected=aes/gcm/256
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_single_malformed.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_aes_single_malformed.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=6WUpex+VZiN05LXu||joWJMuoSzYniEC7IAoingTimlG7+RGk8I2irl/WTlIuMcg
+nifi.registry.security.user.oidc.client.secret.protected=aes/gcm/128
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_unknown.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_protected_unknown.properties
@@ -40,4 +40,13 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=3EsY6PJqU2xrL4rB||HsLYTYE/UAUsnrOmMG0f7UZdmhSvL2qh4Iix7PDDw31OZpCO
+nifi.registry.security.user.oidc.client.secret.protected=unknown
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=nifi.registry.web.http.port, nifi.registry.web.http.host

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_unprotected.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_unprotected.properties
@@ -38,4 +38,12 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=thisIsABadOidcSecret
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=nifi.registry.web.http.port, nifi.registry.web.http.host

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_unprotected_extra_line.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/test/resources/conf/nifi-registry.with_sensitive_props_unprotected_extra_line.properties
@@ -39,4 +39,12 @@ nifi.registry.security.authorizer=
 nifi.registry.security.identity.providers.configuration.file=
 nifi.registry.security.identity.provider=
 
+# OpenId Connect SSO Properties #
+nifi.registry.security.user.oidc.discovery.url=
+nifi.registry.security.user.oidc.connect.timeout=
+nifi.registry.security.user.oidc.read.timeout=
+nifi.registry.security.user.oidc.client.id=
+nifi.registry.security.user.oidc.client.secret=thisIsABadOidcSecret
+nifi.registry.security.user.oidc.preferred.jwsalgorithm=
+
 nifi.registry.sensitive.props.additional.keys=nifi.registry.web.http.port, nifi.registry.web.http.host


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11252](https://issues.apache.org/jira/browse/NIFI-11252)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
