### PR TITLE
NIFI-11293 Upgrade Log4j 2 from 2.18.0 to 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.19</aspectj.version>
         <jersey.bom.version>2.36</jersey.bom.version>
-        <log4j2.version>2.18.0</log4j2.version>
+        <log4j2.version>2.20.0</log4j2.version>
         <logback.version>1.3.5</logback.version>
         <mockito.version>3.12.4</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>


### PR DESCRIPTION
# Summary

[NIFI-11293](https://issues.apache.org/jira/browse/NIFI-11293) Upgrades Log4j 2 API dependencies from 2.18.0 to [2.20.0](https://logging.apache.org/log4j/2.x/release-notes/2.20.0.html).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
