### PR TITLE
NIFI-11300 - upgrade json-smart to 2.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <jaxb.runtime.version>2.3.5</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
-        <json.smart.version>2.4.8</json.smart.version>
+        <json.smart.version>2.4.10</json.smart.version>
         <nifi.groovy.version>3.0.14</nifi.groovy.version>
         <groovy.eclipse.batch.version>3.0.8-01</groovy.eclipse.batch.version>
         <surefire.version>3.0.0-M8</surefire.version>


### PR DESCRIPTION
# Summary

[NIFI-11300](https://issues.apache.org/jira/browse/NIFI-11300) - Upgrade json-smart to 2.4.10

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
