### PR TITLE
NIFI-11311 update maven-antrun-plugin and rationalise version across all modules

### DIFF
--- a/minifi/minifi-c2/minifi-c2-docker/pom.xml
+++ b/minifi/minifi-c2/minifi-c2-docker/pom.xml
@@ -17,14 +17,13 @@ limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.apache.nifi.minifi</groupId>
         <artifactId>minifi-c2</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.apache.nifi.minifi</groupId>
     <artifactId>minifi-c2-docker</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -35,13 +34,12 @@ limitations under the License.
 
     <profiles>
         <!-- Profile for building official Docker images. Not bound to build phases since that would require anyone build to have the Docker engine installed on their machine -->       
-        <profile>                                   
+        <profile>
             <id>docker</id>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <id>copy-assembly-for-docker</id>

--- a/minifi/minifi-docker/pom.xml
+++ b/minifi/minifi-docker/pom.xml
@@ -17,14 +17,13 @@ limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.apache.nifi.minifi</groupId>
         <artifactId>minifi</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.apache.nifi.minifi</groupId>
     <artifactId>minifi-docker</artifactId>
     <packaging>pom</packaging>
 
@@ -36,13 +35,12 @@ limitations under the License.
 
     <profiles>
         <!-- Profile for building official Docker images. Not bound to build phases since that would require anyone build to have the Docker engine installed on their machine -->       
-        <profile>                                   
+        <profile>
             <id>docker</id>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <id>copy-scripts-for-docker</id>

--- a/nifi-docker/dockermaven/pom.xml
+++ b/nifi-docker/dockermaven/pom.xml
@@ -62,7 +62,6 @@
                     <!-- Copy generated artifact to nifi-docker -->
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <id>copy-scripts-for-docker</id>

--- a/nifi-maven-archetypes/nifi-processor-bundle-archetype/pom.xml
+++ b/nifi-maven-archetypes/nifi-processor-bundle-archetype/pom.xml
@@ -58,7 +58,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/pom.xml
@@ -113,7 +113,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>copy-rest-api-doc</id>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -171,7 +171,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>bundle-swagger-ui</id>

--- a/nifi-registry/nifi-registry-docker-maven/dockermaven/pom.xml
+++ b/nifi-registry/nifi-registry-docker-maven/dockermaven/pom.xml
@@ -46,7 +46,6 @@
                     <!-- Copy generated artifacts -->
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <id>copy-for-docker</id>

--- a/nifi-toolkit/nifi-toolkit-assembly/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-assembly/pom.xml
@@ -144,7 +144,6 @@ language governing permissions and limitations under the License. -->
                     <!-- Copy generated artifact to nifi-docker -->
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <id>copy-for-docker</id>

--- a/pom.xml
+++ b/pom.xml
@@ -825,6 +825,11 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
                     <version>2.5.0</version>


### PR DESCRIPTION
# Summary

[NIFI-11311](https://issues.apache.org/jira/browse/NIFI-11311) update maven-antrun-plugin and rationalise version across all modules

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
