### PR TITLE
NIFI-11305: Fixed out-of-order handling of binlog client shutdown in CaptureChangeMySQL

### DIFF
--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/BinlogEventListener.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/BinlogEventListener.java
@@ -18,6 +18,8 @@ package org.apache.nifi.cdc.mysql.event;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * An event listener wrapper for MYSQL binlog events generated from the mysql-binlog-connector.
  */
 public class BinlogEventListener implements BinaryLogClient.EventListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(BinlogEventListener.class);
 
     private final AtomicBoolean stopNow = new AtomicBoolean(false);
     private static final int QUEUE_OFFER_TIMEOUT_MSEC = 100;
@@ -57,9 +61,9 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                 }
             }
 
-            throw new RuntimeException("Stopped while waiting to enqueue event");
+            logger.info("Stopped while waiting to enqueue event");
         } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while adding event to the queue");
+            logger.warn("Interrupted while adding event to the queue", e);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -719,6 +719,12 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
 
             connect(hosts, username, password, serverId, createEnrichmentConnection, driverLocation, driverName, connectTimeout, sslContextService, sslMode);
         } catch (IOException | IllegalStateException e) {
+            if (eventListener != null) {
+                eventListener.stop();
+                if (binlogClient != null) {
+                    binlogClient.unregisterEventListener(eventListener);
+                }
+            }
             context.yield();
             binlogClient = null;
             throw new ProcessException(e.getMessage(), e);
@@ -901,6 +907,12 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
             }
         }
         if (!binlogClient.isConnected()) {
+            if (eventListener != null) {
+                eventListener.stop();
+                if (binlogClient != null) {
+                    binlogClient.unregisterEventListener(eventListener);
+                }
+            }
             binlogClient.disconnect();
             binlogClient = null;
             throw new IOException("Could not connect binlog client to any of the specified hosts due to: " + lastConnectException.getMessage(), lastConnectException);
@@ -915,9 +927,18 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
                 // Ensure connection can be created.
                 getJdbcConnection();
             } catch (SQLException e) {
-                binlogClient.disconnect();
-                binlogClient = null;
-                throw new IOException("Error creating binlog enrichment JDBC connection to any of the specified hosts", e);
+                getLogger().error("Error creating binlog enrichment JDBC connection to any of the specified hosts", e);
+                if (eventListener != null) {
+                    eventListener.stop();
+                    if (binlogClient != null) {
+                        binlogClient.unregisterEventListener(eventListener);
+                    }
+                }
+                if (binlogClient != null) {
+                    binlogClient.disconnect();
+                    binlogClient = null;
+                }
+                return;
             }
         }
 
@@ -1245,14 +1266,14 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
 
     protected void stop() throws CDCException {
         try {
-            if (binlogClient != null) {
-                binlogClient.disconnect();
-            }
             if (eventListener != null) {
                 eventListener.stop();
                 if (binlogClient != null) {
                     binlogClient.unregisterEventListener(eventListener);
                 }
+            }
+            if (binlogClient != null) {
+                binlogClient.disconnect();
             }
 
             if (currentSession != null) {


### PR DESCRIPTION
# Summary

[NIFI-11305](https://issues.apache.org/jira/browse/NIFI-11305)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
