### PR TITLE
NIFI-11323: Fixed last modified change detection of dynamicallyModifi…

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/classloader/ClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/classloader/ClassLoaderUtils.java
@@ -155,13 +155,17 @@ public class ClassLoaderUtils {
     }
 
     private static long getLastModified(String url) {
-        File file = null;
+        long lastModified = 0;
         try {
-            file = new File(new URI(url));
+            final URI uri = new URI(url);
+            if (uri.getScheme().equals("file")) {
+                final File file = new File(uri);
+                lastModified = file.lastModified();
+            }
         } catch (URISyntaxException e) {
             LOGGER.error("Error getting last modified date for " + url);
         }
-        return file != null ? file.lastModified() : 0;
+        return lastModified;
     }
 
     protected static ClassLoader createModuleClassLoader(URL[] modules, ClassLoader parentClassLoader) {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.FilenameFilter;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -114,9 +113,18 @@ public class TestClassLoaderUtils {
     }
 
     @Test
-    public void testGenerateAdditionalUrlsFingerprint() throws MalformedURLException, URISyntaxException {
+    public void testGenerateAdditionalUrlsFingerprintForFileUrl() throws MalformedURLException {
         final Set<URL> urls = new HashSet<>();
         URL testUrl = Paths.get("src/test/resources/TestClassLoaderUtils/TestSuccess.jar").toUri().toURL();
+        urls.add(testUrl);
+        String testFingerprint = ClassLoaderUtils.generateAdditionalUrlsFingerprint(urls, null);
+        assertNotNull(testFingerprint);
+    }
+
+    @Test
+    public void testGenerateAdditionalUrlsFingerprintForHttpUrl() throws MalformedURLException {
+        final Set<URL> urls = new HashSet<>();
+        URL testUrl = new URL("http://myhost/TestSuccess.jar");
         urls.add(testUrl);
         String testFingerprint = ClassLoaderUtils.generateAdditionalUrlsFingerprint(urls, null);
         assertNotNull(testFingerprint);


### PR DESCRIPTION
…esClasspath resources

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11323](https://issues.apache.org/jira/browse/NIFI-11323)

All URLs were treated as file URLs which led to `java.lang.IllegalArgumentException: URI scheme is not "file"`

Last modified time is checked for file:// URLs. No change detection for http(s):// URLs.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
