### PR TITLE
NIFI-11319 Fixing TestStatelessBootstrap::testClassNotAllowed

### DIFF
--- a/nifi-stateless/nifi-stateless-bootstrap/src/test/java/org/apache/nifi/stateless/bootstrap/TestStatelessBootstrap.java
+++ b/nifi-stateless/nifi-stateless-bootstrap/src/test/java/org/apache/nifi/stateless/bootstrap/TestStatelessBootstrap.java
@@ -66,7 +66,7 @@ public class TestStatelessBootstrap {
         final String classToLoad = "org.apache.nifi.stateless.bootstrap.RunStatelessFlow";
 
         // A directory for NARs, jars, etc. that are allowed by the AllowListClassLoader
-        final File narDirectory = new File("target");
+        final File narDirectory = new File("target/generated-sources");
 
         // Create a URLClassLoader to use for the System ClassLoader. This will load the classes from the target/ directory.
         // Then create an AllowListClassLoader that will not allow these classes through.


### PR DESCRIPTION
The test was broken. My understaning is that the test supposed to ensure that classes from outside the allowed NAR directory should not be loaded expect if they are part of a spefic set of classes (java or jdk "modules"). The original configuration of the test used the "target" folder as NAR folder, which contained every product of the build, including the class "org.apache.nifi.stateless.bootstrap.RunStatelessFlow" used as test subject, thus the class was loaded and the test broke. I narrowed down the "nar folder" in order to not have the test subject included, this I would believe solves the issue.

[NIFI-11319](https://issues.apache.org/jira/browse/NIFI-11319)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
