### PR TITLE
NIFI-11294 - Add support for component state as checkpointing strategy

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -100,7 +100,7 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
         + "In clustered environment, ConsumeAzureEventHub processor instances form a consumer group and the messages are distributed among the cluster nodes "
         + "(each message is processed on one cluster node only).")
 @InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
-@Stateful(scopes = {Scope.CLUSTER}, description = "Used to store partitions offsets when component state is configured as the checkpointing strategy.")
+@Stateful(scopes = {Scope.CLUSTER}, description = "Used to store partition ownership and offsets when component state is configured as the checkpointing strategy.")
 @TriggerSerially
 @WritesAttributes({
         @WritesAttribute(attribute = "eventhub.enqueued.timestamp", description = "The time (in milliseconds since epoch, UTC) at which the message was enqueued in the event hub"),

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -450,12 +450,6 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor {
                             return session.getState(Scope.CLUSTER);
                         }
 
-                        public void setState(Map<String, String> map) throws IOException {
-                            final ProcessSession session = processSessionFactory.createSession();
-                            session.setState(map, Scope.CLUSTER);
-                            session.commitAsync();
-                        }
-
                         public boolean replaceState(StateMap oldValue, Map<String, String> newValue) throws IOException {
                             final ProcessSession session = processSessionFactory.createSession();
                             if (!session.replaceState(oldValue, newValue, Scope.CLUSTER)) {
@@ -583,10 +577,6 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor {
                                 new ComponentStateCheckpointStore.State() {
                                     public StateMap getState() throws IOException {
                                         return session.getState(Scope.CLUSTER);
-                                    }
-
-                                    public void setState(Map<String, String> map) throws IOException {
-                                        session.setState(map, Scope.CLUSTER);
                                     }
 
                                     public boolean replaceState(StateMap oldValue, Map<String, String> newValue) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/CheckpointStrategy.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/CheckpointStrategy.java
@@ -1,0 +1,32 @@
+package org.apache.nifi.processors.azure.eventhub.utils;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum CheckpointStrategy implements DescribedValue {
+    AZURE_BLOB_STORAGE("azure-blob-storage", "Use Azure Blob Storage to store partition checkpoints and ownership"),
+    COMPONENT_STATE("component-state", "Use component state to store partition checkpoints");
+
+    private final String label;
+    private final String description;
+
+    CheckpointStrategy(String label, String description) {
+        this.label = label;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return this.name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return label;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/CheckpointStrategy.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/CheckpointStrategy.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.processors.azure.eventhub.utils;
 
 import org.apache.nifi.components.DescribedValue;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
@@ -68,9 +68,9 @@ public class ComponentStateCheckpointStore implements CheckpointStore {
                         String entryConsumerGroup = parts[2];
                         String partitionId = parts[3];
 
-                        if (entryFullyQualifiedNamespace.equals(fullyQualifiedNamespace) &&
-                                entryEventHubName.equals(eventHubName) &&
-                                entryConsumerGroup.equals(consumerGroup)) {
+                        if (entryFullyQualifiedNamespace.equals(fullyQualifiedNamespace)
+                                && entryEventHubName.equals(eventHubName)
+                                && entryConsumerGroup.equals(consumerGroup)) {
                             return null;
                         }
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
@@ -71,15 +71,14 @@ public class ComponentStateCheckpointStore implements CheckpointStore {
                         if (entryFullyQualifiedNamespace.equals(fullyQualifiedNamespace)
                                 && entryEventHubName.equals(eventHubName)
                                 && entryConsumerGroup.equals(consumerGroup)) {
-                            return null;
+                            return new Checkpoint()
+                                    .setFullyQualifiedNamespace(fullyQualifiedNamespace)
+                                    .setEventHubName(eventHubName)
+                                    .setConsumerGroup(consumerGroup)
+                                    .setPartitionId(partitionId)
+                                    .setOffset(Long.parseLong(entry.getValue()));
                         }
-
-                        return new Checkpoint()
-                                .setFullyQualifiedNamespace(fullyQualifiedNamespace)
-                                .setEventHubName(eventHubName)
-                                .setConsumerGroup(consumerGroup)
-                                .setPartitionId(partitionId)
-                                .setOffset(Long.parseLong(entry.getValue()));
+                        return null;
                     }
             );
         } catch (IOException e) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.eventhub.utils;
+
+import com.azure.messaging.eventhubs.CheckpointStore;
+import com.azure.messaging.eventhubs.models.Checkpoint;
+import com.azure.messaging.eventhubs.models.PartitionOwnership;
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.components.state.StateMap;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessSessionFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ComponentStateCheckpointStore implements CheckpointStore {
+    private final ProcessSessionFactory processSessionFactory;
+
+    public ComponentStateCheckpointStore(ProcessSessionFactory processSessionFactory) {
+        this.processSessionFactory = processSessionFactory;
+    }
+
+    @Override
+    public Flux<PartitionOwnership> listOwnership(String fullyQualifiedNamespace, String eventHubName, String consumerGroup) {
+        return listCheckpoints(fullyQualifiedNamespace, eventHubName, consumerGroup).map(
+                checkpoint -> new PartitionOwnership()
+                        .setFullyQualifiedNamespace(fullyQualifiedNamespace)
+                        .setEventHubName(eventHubName)
+                        .setConsumerGroup(consumerGroup)
+        );
+    }
+
+    @Override
+    public Flux<PartitionOwnership> claimOwnership(List<PartitionOwnership> requestedPartitionOwnerships) {
+        return Flux.fromIterable(requestedPartitionOwnerships);
+    }
+
+    @Override
+    public Flux<Checkpoint> listCheckpoints(String fullyQualifiedNamespace, String eventHubName, String consumerGroup) {
+        final ProcessSession session = processSessionFactory.createSession();
+        try {
+            StateMap stateMap = session.getState(Scope.CLUSTER);
+            return Flux.fromIterable(stateMap.toMap().entrySet()).mapNotNull(
+                    entry -> {
+                        String[] parts = entry.getKey().split("/", 4);
+                        if (parts.length < 4) {
+                            return null;
+                        }
+                        String entryFullyQualifiedNamespace = parts[0];
+                        String entryEventHubName = parts[1];
+                        String entryConsumerGroup = parts[2];
+                        String partitionId = parts[3];
+
+                        if (entryFullyQualifiedNamespace.equals(fullyQualifiedNamespace) &&
+                                entryEventHubName.equals(eventHubName) &&
+                                entryConsumerGroup.equals(consumerGroup)) {
+                            return null;
+                        }
+
+                        return new Checkpoint()
+                                .setFullyQualifiedNamespace(fullyQualifiedNamespace)
+                                .setEventHubName(eventHubName)
+                                .setConsumerGroup(consumerGroup)
+                                .setPartitionId(partitionId)
+                                .setOffset(Long.parseLong(entry.getValue()));
+                    }
+            );
+        } catch (IOException e) {
+            return Flux.error(e);
+        }
+    }
+
+    @Override
+    public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
+        final ProcessSession session = processSessionFactory.createSession();
+        try {
+            StateMap stateMap = session.getState(Scope.CLUSTER);
+            Map<String, String> map = new HashMap<>(stateMap.toMap());
+            Long offset = checkpoint.getOffset();
+            String key = String.format(
+                    "%s/%s/%s/%s",
+                    checkpoint.getFullyQualifiedNamespace(),
+                    checkpoint.getEventHubName(),
+                    checkpoint.getConsumerGroup(),
+                    checkpoint.getPartitionId()
+            );
+            if (offset == null) {
+                map.remove(key);
+            } else {
+                map.put(key, offset.toString());
+            }
+            session.setState(map, Scope.CLUSTER);
+            session.commitAsync();
+        } catch (IOException e) {
+            return Mono.error(e);
+        }
+        return Mono.empty();
+    }
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/ComponentStateCheckpointStore.java
@@ -18,99 +18,212 @@ package org.apache.nifi.processors.azure.eventhub.utils;
 
 import com.azure.messaging.eventhubs.CheckpointStore;
 import com.azure.messaging.eventhubs.models.Checkpoint;
+import com.azure.messaging.eventhubs.models.PartitionContext;
 import com.azure.messaging.eventhubs.models.PartitionOwnership;
+import org.apache.nifi.components.state.StateMap;
+import org.apache.nifi.processor.exception.ProcessException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 public class ComponentStateCheckpointStore implements CheckpointStore {
     public interface State {
-        Map<String, String> getState() throws IOException;
-        void setState(Map<String, String> map) throws IOException;
+        StateMap getState() throws IOException;
+        void setState(Map<String, String> value) throws IOException;
+        boolean replaceState(StateMap oldValue, Map<String, String> newValue) throws IOException;
     }
+
+    private final String identifier;
     private final State state;
 
-    public ComponentStateCheckpointStore(State state) {
+    private static final String KEY_CHECKPOINT = "checkpoint";
+    private static final String KEY_OWNERSHIP = "ownership";
+
+    public ComponentStateCheckpointStore(String identifier, State state) {
+        this.identifier = identifier;
         this.state = state;
     }
 
-    @Override
     public Flux<PartitionOwnership> listOwnership(String fullyQualifiedNamespace, String eventHubName, String consumerGroup) {
-        return listCheckpoints(fullyQualifiedNamespace, eventHubName, consumerGroup).map(
-                checkpoint -> new PartitionOwnership()
-                        .setFullyQualifiedNamespace(fullyQualifiedNamespace)
-                        .setEventHubName(eventHubName)
-                        .setConsumerGroup(consumerGroup)
+        return Flux.defer(
+                () -> {
+                    Map<String, String> map;
+                    try {
+                        map = state.getState().toMap();
+                    } catch (IOException e) {
+                        return Flux.error(e);
+                    }
+                    List<PartitionOwnership> ownerships = getEntries(map, KEY_OWNERSHIP, this::convertOwnership);
+                    return Flux.fromIterable(ownerships).filter(
+                            ownership ->
+                                    ownership.getFullyQualifiedNamespace().equals(fullyQualifiedNamespace)
+                                    && ownership.getEventHubName().equals(eventHubName)
+                                    && ownership.getConsumerGroup().equals(consumerGroup)
+                    );
+                }
         );
     }
 
-    @Override
     public Flux<PartitionOwnership> claimOwnership(List<PartitionOwnership> requestedPartitionOwnerships) {
-        return Flux.fromIterable(requestedPartitionOwnerships);
-    }
-
-    @Override
-    public Flux<Checkpoint> listCheckpoints(String fullyQualifiedNamespace, String eventHubName, String consumerGroup) {
-        try {
-            Map<String, String> stateMap = state.getState();
-            return Flux.fromIterable(stateMap.entrySet()).mapNotNull(
-                    entry -> {
-                        String[] parts = entry.getKey().split("/", 4);
-                        if (parts.length < 4) {
-                            return null;
-                        }
-                        String entryFullyQualifiedNamespace = parts[0];
-                        String entryEventHubName = parts[1];
-                        String entryConsumerGroup = parts[2];
-                        String partitionId = parts[3];
-
-                        if (entryFullyQualifiedNamespace.equals(fullyQualifiedNamespace)
-                                && entryEventHubName.equals(eventHubName)
-                                && entryConsumerGroup.equals(consumerGroup)) {
-                            return new Checkpoint()
-                                    .setFullyQualifiedNamespace(fullyQualifiedNamespace)
-                                    .setEventHubName(eventHubName)
-                                    .setConsumerGroup(consumerGroup)
-                                    .setPartitionId(partitionId)
-                                    .setOffset(Long.parseLong(entry.getValue()));
-                        }
-                        return null;
+        return Flux.fromIterable(requestedPartitionOwnerships).flatMap(
+                partitionOwnership -> {
+                    final StateMap oldState;
+                    try {
+                        oldState = state.getState();
+                    } catch (IOException e) {
+                        return Mono.error(e);
                     }
-            );
-        } catch (IOException e) {
-            return Flux.error(e);
-        }
+
+                    String key = makeKey(
+                            KEY_OWNERSHIP,
+                            partitionOwnership.getFullyQualifiedNamespace(),
+                            partitionOwnership.getEventHubName(),
+                            partitionOwnership.getConsumerGroup(),
+                            partitionOwnership.getPartitionId()
+                    );
+
+                    final Map<String, String> newState = new HashMap<>(oldState.toMap());
+                    long timestamp = System.currentTimeMillis();
+                    String eTag = identifier + "/" + timestamp;
+                    newState.put(key, eTag);
+                    final boolean success;
+                    try {
+                        success = state.replaceState(oldState, newState);
+                    } catch (IOException e) {
+                        return Mono.error(e);
+                    }
+
+                    if (success) {
+                        return Mono.just(partitionOwnership.setETag(eTag));
+                    }
+
+                    return Mono.empty();
+                }
+        );
     }
 
-    @Override
-    public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
-        try {
-            Map<String, String> map = new HashMap<>(state.getState());
-            Long offset = checkpoint.getOffset();
-            String key = String.format(
-                    "%s/%s/%s/%s",
-                    checkpoint.getFullyQualifiedNamespace(),
-                    checkpoint.getEventHubName(),
-                    checkpoint.getConsumerGroup(),
-                    checkpoint.getPartitionId()
-            );
-            if (offset == null) {
-                map.remove(key);
-            } else {
-                map.put(key, offset.toString());
+    public Flux<Checkpoint> listCheckpoints(String fullyQualifiedNamespace, String eventHubName, String consumerGroup) {
+        return Flux.defer(() -> {
+            Map<String, String> stateMap;
+            try {
+                stateMap = state.getState().toMap();
+            } catch (IOException e) {
+                return Flux.error(e);
             }
 
-            // Note that we do not commit here because there is an implicit
-            // agreement that the process session factory will provide a session
-            // that is automatically committed (this is done by the processor).
+            List<Checkpoint> checkpoints = getEntries(stateMap, KEY_CHECKPOINT, this::convertCheckpoint);
+            return Flux.fromIterable(checkpoints).filter(
+                    checkpoint ->
+                            checkpoint.getFullyQualifiedNamespace().equals(fullyQualifiedNamespace)
+                                    && checkpoint.getEventHubName().equals(eventHubName)
+                                    && checkpoint.getConsumerGroup().equals(consumerGroup)
+            );
+        });
+    }
+
+    public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
+        Map<String, String> stateMap;
+        try {
+            stateMap = state.getState().toMap();
+        } catch (IOException e) {
+            return Mono.error(e);
+        }
+
+        Map<String, String> map = new HashMap<>(stateMap);
+        Long offset = checkpoint.getOffset();
+        String key = makeKey(
+                KEY_CHECKPOINT,
+                checkpoint.getFullyQualifiedNamespace(),
+                checkpoint.getEventHubName(),
+                checkpoint.getConsumerGroup(),
+                checkpoint.getPartitionId()
+        );
+        if (offset == null) {
+            map.remove(key);
+        } else {
+            map.put(key, offset.toString());
+        }
+
+        try {
             state.setState(map);
         } catch (IOException e) {
             return Mono.error(e);
         }
+
+        // Note that we do not commit here because there is an implicit
+        // agreement that the process session factory will provide a session
+        // that is automatically committed (this is done by the processor).
         return Mono.empty();
+    }
+
+    private Checkpoint convertCheckpoint(PartitionContext context, String value) {
+        return new Checkpoint()
+                .setFullyQualifiedNamespace(context.getFullyQualifiedNamespace())
+                .setEventHubName(context.getEventHubName())
+                .setConsumerGroup(context.getConsumerGroup())
+                .setPartitionId(context.getPartitionId())
+                .setOffset(Long.parseLong(value));
+    }
+
+    private PartitionOwnership convertOwnership(PartitionContext context, String value) {
+        final String[] parts = value.split("/", 2);
+        if (parts.length != 2) {
+            throw new ProcessException(String.format("Invalid ownership value: %s", value));
+        }
+        return new PartitionOwnership()
+                .setFullyQualifiedNamespace(context.getFullyQualifiedNamespace())
+                .setEventHubName(context.getEventHubName())
+                .setConsumerGroup(context.getConsumerGroup())
+                .setPartitionId(context.getPartitionId())
+                .setETag(value)
+                .setOwnerId(parts[0])
+                .setLastModifiedTime(Long.parseLong(parts[1])
+                );
+    }
+
+    private <T> List<T> getEntries(final Map<String, String> map, String kind, BiFunction<PartitionContext, String, T> extract) throws ProcessException {
+        final List<T> result = new ArrayList<>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            final String key = entry.getKey();
+            final String[] parts = key.split("/", 5);
+            if (parts.length != 5) {
+                throw new ProcessException(
+                        String.format("Invalid %s key: %s", kind, entry.getKey())
+                );
+            }
+            if (!parts[0].equals(kind)) {
+                continue;
+            }
+            final String fullyQualifiedNamespace = parts[1];
+            final String eventHubName = parts[2];
+            final String consumerGroup = parts[3];
+            final String partitionId = parts[4];
+            PartitionContext partitionContext = new PartitionContext(
+                    fullyQualifiedNamespace,
+                    eventHubName,
+                    consumerGroup,
+                    partitionId
+            );
+            final T item = extract.apply(partitionContext, entry.getValue());
+            result.add(item);
+        }
+        return result;
+    }
+
+    private String makeKey(String kind, String fullyQualifiedNamespace, String eventHubName, String consumerGroup, String partitionId) {
+        return String.format(
+                "%s/%s/%s/%s/%s",
+                kind,
+                fullyQualifiedNamespace,
+                eventHubName,
+                consumerGroup,
+                partitionId
+        );
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
@@ -74,9 +74,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
@@ -325,7 +325,7 @@ public class TestConsumeAzureEventHub {
     @EnumSource(CheckpointStrategy.class)
     @ParameterizedTest
     public void testReceiveAllRecordFailure(CheckpointStrategy strategy) throws Exception {
-        setProperties(CheckpointStrategy.COMPONENT_STATE);
+        setProperties(strategy);
 
         final List<EventData> events = getEvents(FIRST_CONTENT);
         setupRecordReader(events, 0, null);
@@ -357,7 +357,7 @@ public class TestConsumeAzureEventHub {
     @EnumSource(CheckpointStrategy.class)
     @ParameterizedTest
     public void testReceiveRecordWriterFailure(CheckpointStrategy strategy) throws Exception {
-        setProperties(CheckpointStrategy.COMPONENT_STATE);
+        setProperties(strategy);
 
         final List<EventData> events = getEvents(FIRST_CONTENT, SECOND_CONTENT, THIRD_CONTENT, FOURTH_CONTENT);
         setupRecordReader(events, -1, SECOND_CONTENT);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
@@ -74,8 +74,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TestConsumeAzureEventHub {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/utils/TestComponentStateCheckpointStore.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/utils/TestComponentStateCheckpointStore.java
@@ -33,6 +33,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 class TestComponentStateCheckpointStore {
     private static final String EVENT_HUB_NAMESPACE = "NAMESPACE";
@@ -60,7 +62,7 @@ class TestComponentStateCheckpointStore {
                 EVENT_HUB_NAME,
                 CONSUMER_GROUP
         ).blockFirst();
-        assert listed.getETag().equals(claimed.getETag());
+        assertEquals(listed.getETag(), claimed.getETag());
     }
 
     @Test
@@ -69,7 +71,7 @@ class TestComponentStateCheckpointStore {
         var claimed = checkpointStore.claimOwnership(List.of(
                 partitionOwnership
         )).blockFirst();
-        assert claimed == null;
+        assertNull(claimed);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/utils/TestComponentStateCheckpointStore.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/utils/TestComponentStateCheckpointStore.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.eventhub.utils;
+
+import com.azure.messaging.eventhubs.models.Checkpoint;
+import com.azure.messaging.eventhubs.models.PartitionOwnership;
+import org.apache.nifi.components.state.StateMap;
+import org.apache.nifi.processors.azure.eventhub.utils.ComponentStateCheckpointStore.State;
+import org.apache.nifi.state.MockStateMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.assertThrows;
+
+class TestComponentStateCheckpointStore {
+    private static final String EVENT_HUB_NAMESPACE = "NAMESPACE";
+    private static final String EVENT_HUB_NAME = "NAME";
+    private static final String CONSUMER_GROUP = "CONSUMER";
+    private static final String PARTITION_ID = "1";
+    private static final long OFFSET = 1234;
+
+    final static String IDENTIFIER = "id";
+    ComponentStateCheckpointStore checkpointStore;
+    Checkpoint checkpoint;
+    PartitionOwnership partitionOwnership;
+
+    boolean failToReplaceState = false;
+    boolean throwIOExceptionOnGetState = false;
+    boolean throwIOExceptionOnReplaceState = false;
+
+    @Test
+    public void testClaimOwnershipSuccess() {
+        var claimed = checkpointStore.claimOwnership(List.of(
+            partitionOwnership
+        )).blockFirst();
+        var listed = checkpointStore.listOwnership(
+                EVENT_HUB_NAMESPACE,
+                EVENT_HUB_NAME,
+                CONSUMER_GROUP
+        ).blockFirst();
+        assert listed.getETag().equals(claimed.getETag());
+    }
+
+    @Test
+    public void testClaimOwnershipReplaceStateFailure() {
+        failToReplaceState = true;
+        var claimed = checkpointStore.claimOwnership(List.of(
+                partitionOwnership
+        )).blockFirst();
+        assert claimed == null;
+    }
+
+    @Test
+    public void testClaimOwnershipGetStateIOException() {
+        throwIOExceptionOnGetState = true;
+        assertThrows(RuntimeException.class, () ->
+            checkpointStore.claimOwnership(List.of(
+                partitionOwnership
+        )).blockFirst());
+    }
+
+    @Test
+    public void testClaimOwnershipReplaceStateIOException() {
+        throwIOExceptionOnReplaceState = true;
+        assertThrows(RuntimeException.class, () ->
+            checkpointStore.claimOwnership(List.of(
+                partitionOwnership
+        )).blockFirst());
+    }
+
+    @Test
+    public void testUpdateCheckpointSuccess() {
+        checkpointStore.updateCheckpoint(checkpoint).block();
+        var checkpoint = checkpointStore.listCheckpoints(
+                EVENT_HUB_NAMESPACE,
+                EVENT_HUB_NAME,
+                CONSUMER_GROUP
+        ).blockFirst();
+        assert checkpoint.getOffset().equals(this.checkpoint.getOffset());
+    }
+    @BeforeEach
+    public void setupProcessor() {
+        final Map<String, String> store = new HashMap<>();
+        final Lock lock = new ReentrantLock();
+        final LongAdder version = new LongAdder();
+        final State state = new State() {
+            public StateMap getState() throws IOException {
+                if (throwIOExceptionOnGetState) {
+                    throw new IOException();
+                }
+                lock.lock();
+                try {
+                    return new MockStateMap(store, version.longValue());
+                } finally {
+                    lock.unlock();
+                }
+            }
+
+            public boolean replaceState(StateMap oldValue, Map<String, String> newValue) throws IOException {
+                if (failToReplaceState) {
+                    return false;
+                }
+                if (throwIOExceptionOnReplaceState) {
+                    throw new IOException();
+                }
+                lock.lock();
+                try {
+                    if (oldValue.toMap().equals(store)) {
+                        store.clear();
+                        store.putAll(newValue);
+                        version.increment();
+                        return true;
+                    }
+                    return false;
+                } finally {
+                    lock.unlock();
+                }
+            }
+        };
+        checkpointStore = new ComponentStateCheckpointStore(IDENTIFIER, state);
+        partitionOwnership = new PartitionOwnership()
+                .setFullyQualifiedNamespace(EVENT_HUB_NAMESPACE)
+                .setEventHubName(EVENT_HUB_NAME)
+                .setConsumerGroup(CONSUMER_GROUP);
+        checkpoint = new Checkpoint()
+                .setFullyQualifiedNamespace(EVENT_HUB_NAMESPACE)
+                .setEventHubName(EVENT_HUB_NAME)
+                .setConsumerGroup(CONSUMER_GROUP)
+                .setPartitionId(PARTITION_ID)
+                .setOffset(OFFSET);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-11294](https://issues.apache.org/jira/browse/NIFI-11294) ConsumeAzureEventHub should default to processor state for checkpointing

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
