### PR TITLE
NIFI-11254 Upgrade SnakeYAML from 1.33 to 2.0

### DIFF
--- a/minifi/minifi-commons/minifi-commons-schema/src/main/java/org/apache/nifi/minifi/commons/schema/serialization/ConfigRepresenter.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/main/java/org/apache/nifi/minifi/commons/schema/serialization/ConfigRepresenter.java
@@ -17,11 +17,13 @@
 
 package org.apache.nifi.minifi.commons.schema.serialization;
 
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
 public class ConfigRepresenter extends Representer {
     public ConfigRepresenter() {
+        super(new DumperOptions());
         nullRepresenter = data -> representScalar(Tag.NULL, "");
     }
 }

--- a/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/src/main/java/org/apache/nifi/rules/RulesFactory.java
+++ b/nifi-nar-bundles/nifi-easyrules-bundle/nifi-easyrules-service/src/main/java/org/apache/nifi/rules/RulesFactory.java
@@ -22,6 +22,7 @@ import org.jeasy.rules.support.reader.JsonRuleDefinitionReader;
 import org.jeasy.rules.support.RuleDefinition;
 import org.jeasy.rules.support.reader.RuleDefinitionReader;
 import org.jeasy.rules.support.reader.YamlRuleDefinitionReader;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -116,7 +117,7 @@ public class RulesFactory {
 
     private static List<Rule> yamlToRules(InputStream rulesInputStream) throws FileNotFoundException {
         List<Rule> rules = new ArrayList<>();
-        Yaml yaml = new Yaml(new Constructor(Rule.class));
+        Yaml yaml = new Yaml(new Constructor(Rule.class, new LoaderOptions()));
         for (Object object : yaml.loadAll(rulesInputStream)) {
             if (object instanceof Rule) {
                 rules.add((Rule) object);

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <logback.version>1.3.5</logback.version>
         <mockito.version>4.11.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <netty.4.version>4.1.90.Final</netty.4.version>
         <spring.version>5.3.26</spring.version>
         <spring.security.version>5.8.2</spring.security.version>


### PR DESCRIPTION
# Summary

[NIFI-11254](https://issues.apache.org/jira/browse/NIFI-11254) Upgrades SnakeYAML direct and transitive dependencies from 1.33 to [2.0](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes) in order to address potential deserialization vulnerabilities described in CVE-2022-1471.

Initial [automated builds](https://github.com/exceptionfactory/nifi/actions/runs/4505175682) completed on all platforms for the main branch. Running the same changes on a local fork of the `support/nifi-1.x` with Java 1.8 also succeeded.

Code changes required updates to the MiNiFi Schema ConfigRepresentator to specify a default `DumperOptions`, and updating the `nifi-easyrules-service` `RulesFactory` with a default `LoaderOptions`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
