### PR TITLE
NIFI-11345 Adjust Iceberg test to avoid expensive duplicative runs

### DIFF
--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHiveCatalog.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHiveCatalog.java
@@ -129,7 +129,7 @@ public class TestPutIcebergWithHiveCatalog {
 
     @DisabledOnOs(WINDOWS)
     @ParameterizedTest
-    @ValueSource(strings = {"avro", "orc", "parquet"})
+    @ValueSource(strings = {"avro"})
     public void onTriggerPartitioned(String fileFormat) throws Exception {
         PartitionSpec spec = PartitionSpec.builderFor(USER_SCHEMA)
                 .bucket("department", 3)
@@ -167,7 +167,7 @@ public class TestPutIcebergWithHiveCatalog {
 
     @DisabledOnOs(WINDOWS)
     @ParameterizedTest
-    @ValueSource(strings = {"avro", "orc", "parquet"})
+    @ValueSource(strings = {"orc"})
     public void onTriggerIdentityPartitioned(String fileFormat) throws Exception {
         PartitionSpec spec = PartitionSpec.builderFor(USER_SCHEMA)
                 .identity("department")
@@ -205,7 +205,7 @@ public class TestPutIcebergWithHiveCatalog {
 
     @DisabledOnOs(WINDOWS)
     @ParameterizedTest
-    @ValueSource(strings = {"avro", "orc", "parquet"})
+    @ValueSource(strings = {"parquet"})
     public void onTriggerMultiLevelIdentityPartitioned(String fileFormat) throws Exception {
         PartitionSpec spec = PartitionSpec.builderFor(USER_SCHEMA)
                 .identity("name")
@@ -248,7 +248,7 @@ public class TestPutIcebergWithHiveCatalog {
 
     @DisabledOnOs(WINDOWS)
     @ParameterizedTest
-    @ValueSource(strings = {"avro", "orc", "parquet"})
+    @ValueSource(strings = {"avro"})
     public void onTriggerUnPartitioned(String fileFormat) throws Exception {
         runner = TestRunners.newTestRunner(processor);
         initRecordReader();


### PR DESCRIPTION
# Summary

[NIFI-11345](https://issues.apache.org/jira/browse/NIFI-11345) Adjusts `TestPutIcebergWithHiveCatalog` to reduce the total running time from over 60 seconds to around 20 seconds. The Iceberg module is one of the slowest extension modules for unit tests due to this test class. Instead of running the same test method for all three supported formats (Avro, ORC, and Parquet), the changes use a single format for a single method. This ensures the same basic test behavior while exercising each format across different test methods.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
