### PR TITLE
NIFI-11347 Upgrade OWASP Dependency Check from 8.0.2 to 8.2.1

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -40,11 +40,6 @@
         <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes>Spark 2.13 used in nifi-spark-receiver is not impacted by Spark Server vulnerabilities</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.spark/spark\-.+?_2\.13@.*$</packageUrl>
-        <cpe>cpe:/a:apache:spark</cpe>
-    </suppress>
-    <suppress>
         <notes>Apache Hive vulnerabilities do not apply to Flume Hive Sink</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sinks/flume\-hive\-sink@.*$</packageUrl>
         <cpe>cpe:/a:apache:hive</cpe>
@@ -80,34 +75,9 @@
         <cve>CVE-2017-10355</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Avatica</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/avatica\-core@.*$</packageUrl>
-        <cve>CVE-2020-13955</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Avatica</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\/calcite-avatica@.*$</packageUrl>
-        <cve>CVE-2020-13955</cve>
-    </suppress>
-    <suppress>
         <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Druid</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\/calcite-druid@.*$</packageUrl>
         <cve>CVE-2020-13955</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2020-13955 applies to Apache Calcite Core not Apache Calcite Avatica subproject</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica\/avatica(-metrics)?@.*$</packageUrl>
-        <cve>CVE-2020-13955</cve>
-    </suppress>
-    <suppress>
-        <notes>OpenTSDB vulnerabilities do not apply to HBase Async library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.hbase/asynchbase@.*$</packageUrl>
-        <cpe>cpe:/a:opentsdb:opentsdb</cpe>
-    </suppress>
-    <suppress>
-        <notes>Eclipse Equinox vulnerabilities do not apply to DataNucleus core library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.datanucleus/datanucleus\-core@.*$</packageUrl>
-        <cpe>cpe:/a:eclipse:equinox</cpe>
     </suppress>
     <suppress>
         <notes>CVE-2018-8025 applies to HBase Server not HBase Client</notes>
@@ -118,11 +88,6 @@
         <notes>CVE-2019-0212 applies to HBase Server not HBase Client</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-client@.*$</packageUrl>
         <cve>CVE-2019-0212</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2014-3643 applies to Jersey Server not Jersey Core</notes>
-        <packageUrl regex="true">^pkg:maven/com\.sun\.jersey/jersey\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2014-3643</vulnerabilityName>
     </suppress>
     <suppress>
         <notes>CVE-2007-6465 applies to Ganglia Server not Ganglia client libraries</notes>
@@ -175,23 +140,83 @@
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
-        <notes>CVE-2022-45046 description notes that the initial issue was not a security vulnerability</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.camel/camel\-salesforce@.*$</packageUrl>
-        <cve>CVE-2022-45046</cve>
+        <notes>Elasticsearch Server vulnerabilities do not apply to elasticsearch-rest-client-sniffer</notes>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch\.client/elasticsearch\-.*?\-client-sniffer@.*$</packageUrl>
+        <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
-        <notes>CVE-2020-36632 applies to JavaScript module named hughsk/flat not flatbuffers</notes>
-        <packageUrl regex="true">^pkg:maven/com\.vlkan/flatbuffers@.*$</packageUrl>
-        <cve>CVE-2020-36632</cve>
+        <notes>CVE-2022-34271 applies to Atlas Server not the Atlas client library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.atlas/.*$</packageUrl>
+        <cve>CVE-2022-34271</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2018-8015 applies to Apache ORC not to Apache Iceberg</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg\-orc@.*$</packageUrl>
-        <cve>CVE-2018-8015</cve>
+        <notes>CVE-2022-30187 applies to Azure Blob not the EventHubs Checkpoint Store Blob library</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-messaging\-eventhubs\-checkpointstore\-blob@.*$</packageUrl>
+        <cve>CVE-2022-30187</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2022-39135 applies to Calcite not Calcite Avatica</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/.*?@.*$</packageUrl>
+        <notes>CVE-2022-39135 applies to Apache Calcite core not the Calcite Druid library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite/calcite\-druid@.*$</packageUrl>
         <cve>CVE-2022-39135</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-8016 applies to Apache Cassandra server not the client library</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2018-8016</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-1000873 applies to Jackson Java 8 Time modules not Jackson Annotations</notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@.*$</packageUrl>
+        <cve>CVE-2018-1000873</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-34371 applies to Neo4j server not the driver library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.opencypher\.gremlin/cypher\-gremlin\-neo4j\-driver@.*$</packageUrl>
+        <cve>CVE-2021-34371</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2010-1151 applies to mod_auth_shadow in Apache HTTP Server not the FTP server library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/.*$</packageUrl>
+        <cve>CVE-2010-1151</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-14335 applies to H2 running with a web server console enabled</notes>
+        <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+        <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-31160 included in hadoop-client-api is not used</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\-ui@.*$</packageUrl>
+        <cve>CVE-2022-31160</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-37533 applies to the Commons Net FTP Client which is not used in the version bundled with hadoop-client-runtime for Accumulo</notes>
+        <packageUrl regex="true">^pkg:maven/commons\-net/commons\-net@.*$</packageUrl>
+        <cve>CVE-2021-37533</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-0341 applies to Android not OkHttp</notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp/okhttp@.*$</packageUrl>
+        <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-25613 applies to an LDAP backend class for Apache Kerby not the Token Provider library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.kerby/token\-provider@.*$</packageUrl>
+        <cve>CVE-2023-25613</cve>
+    </suppress>
+    <suppress>
+        <notes>The Jetty Apache JSP library is not subject to Apache Tomcat vulnerabilities</notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cpe>cpe:/a:apache:tomcat</cpe>
+    </suppress>
+    <suppress>
+        <notes>Google BigQuery Storage is not the same as the gGRPC framework library</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc\-google\-cloud\-bigquerystorage\-.*$</packageUrl>
+        <cpe>cpe:/a:grpc:grpc</cpe>
+    </suppress>
+    <suppress>
+        <notes>Google PubSubLite is not the same as the gRPC framework library</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc\-google\-cloud\-pubsublite\-v1@.*$</packageUrl>
+        <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -79,6 +79,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ivy</groupId>
+                    <artifactId>ivy</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
@@ -94,6 +94,14 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ivy</groupId>
+                    <artifactId>ivy</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -116,6 +124,18 @@
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ivy</groupId>
+                    <artifactId>ivy</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
@@ -161,6 +161,10 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ivy</groupId>
+                    <artifactId>ivy</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
@@ -147,6 +147,14 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ivy</groupId>
+                    <artifactId>ivy</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -61,6 +61,12 @@
                 <artifactId>hadoop-common</artifactId>
                 <version>${ranger.hadoop.version}</version>
             </dependency>
+            <!-- Override SolrJ 8.6.3 from Ranger -->
+            <dependency>
+                <groupId>org.apache.solr</groupId>
+                <artifactId>solr-solrj</artifactId>
+                <version>8.11.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
@@ -60,6 +60,12 @@
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>
             </dependency>
+            <!-- Override SolrJ 8.6.3 from Ranger -->
+            <dependency>
+                <groupId>org.apache.solr</groupId>
+                <artifactId>solr-solrj</artifactId>
+                <version>8.11.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1164,7 +1164,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.0.2</version>
+                        <version>8.2.1</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>
@@ -1178,6 +1178,7 @@
                                     <skipSystemScope>true</skipSystemScope>
                                     <!-- Disable .NET Assembly Analyzer to avoid non-applicable errors -->
                                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                                    <skipProvidedScope>true</skipProvidedScope>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
# Summary

[NIFI-11347](https://issues.apache.org/jira/browse/NIFI-11347) Upgrades the OWASP Dependency Check Plugin from 8.0.2 to 8.2.1.

Changes include updating the vulnerability suppression configuration, excluding Apache Ivy and Groovy from several modules, and upgrading Apache Solr dependencies for Ranger from 8.6.3 to 8.11.1.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
