### PR TITLE
NIFI-11348 Upgrade JRuby from 9.3.9.0 to 9.4.2.0

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
-            <version>9.3.9.0</version>
+            <version>9.4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11348](https://issues.apache.org/jira/browse/NIFI-11348) Upgrades Scripting bundle dependency on JRuby from 9.3.9.0 to [9.4.2.0](https://github.com/jruby/jruby/releases/tag/9.4.2.0). JRuby [9.4.0.0](https://github.com/jruby/jruby/releases/tag/9.4.0.0) introduced support for Ruby 3.1, and additional changes since that version have included a number of bug fixes and transitive dependency upgrades.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
