### PR TITLE
NIFI-11355 Upgrade Couchbase Client from 2.5.8 to 2.7.23

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -219,4 +219,14 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc\-google\-cloud\-pubsublite\-v1@.*$</packageUrl>
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
+    <suppress>
+        <notes>CVE-2020-9040 applies to Couchbase Server not the client library</notes>
+        <packageUrl regex="true">^pkg:maven/com\.couchbase\.client/core\-io@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-9040</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-41881 applies to HA Proxy components in Netty which are not used in Couchbase or other components</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>2.5.8</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-couchbase-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/pom.xml
@@ -31,4 +31,18 @@
         <module>nifi-couchbase-processors</module>
         <module>nifi-couchbase-nar</module>
     </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>java-client</artifactId>
+                <version>2.7.23</version>
+            </dependency>
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>core-io</artifactId>
+                <version>1.7.24</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-11355](https://issues.apache.org/jira/browse/NIFI-11355) Upgrades the Couchbase Client library from 2.5.8 to [2.7.23](https://docs-archive.couchbase.com/java-sdk/2.7/sdk-release-notes.html#version-2-7-23-31-january-2022) and suppresses vulnerability findings related to Couchbase Server.

Separate work will be necessary to refactor and upgrade Couchbase components to the current version 3 of the SDK.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
