### PR TITLE
NIFI-11363 Fix precision number handling in Flow Encryption Commands

### DIFF
--- a/nifi-commons/nifi-flow-encryptor/src/main/java/org/apache/nifi/flow/encryptor/JsonFlowEncryptor.java
+++ b/nifi-commons/nifi-flow-encryptor/src/main/java/org/apache/nifi/flow/encryptor/JsonFlowEncryptor.java
@@ -82,7 +82,7 @@ public class JsonFlowEncryptor extends AbstractFlowEncryptor {
                     generator.writeNumber(parser.getIntValue());
                     break;
                 case VALUE_NUMBER_FLOAT:
-                    generator.writeNumber(parser.getFloatValue());
+                    generator.writeRawValue(parser.getValueAsString());
                     break;
                 case VALUE_TRUE:
                     generator.writeBoolean(true);

--- a/nifi-commons/nifi-flow-encryptor/src/test/java/org/apache/nifi/flow/encryptor/StandardFlowEncryptorTest.java
+++ b/nifi-commons/nifi-flow-encryptor/src/test/java/org/apache/nifi/flow/encryptor/StandardFlowEncryptorTest.java
@@ -143,7 +143,7 @@ public class StandardFlowEncryptorTest {
 
     private String getSampleFlowJson(final String password) {
         Objects.requireNonNull(password);
-        return String.format("{\"properties\":{\"username\":\"sample_username\",\"password\":\"%s\"}}", password);
+        return String.format("{\"properties\":{\"username\":\"sample_username\",\"password\":\"%s\",\"position\":1.123456789123456789}}", password);
     }
 
     private String getSampleFlowXml(final String password) {


### PR DESCRIPTION
# Summary

[NIFI-11363](https://issues.apache.org/jira/browse/NIFI-11363) Corrects handling of double precision numbers in flow encryption commands including `encrypt-config.sh`, `set-sensitive-properties-key`, and `set-sensitive-properties-algorithm`.

The JSON parsing process used a method to return a Java `float` value when encountering the JSON `VALUE_NUMBER_FLOAT` type, which resulted in loss of precision under certain circumstances, such as position coordinates for Processors.

The correction returns the parsed value as a string and uses the `writeRawValue()` method to avoid any number conversion while processing values.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
