### PR TITLE
NIFI-11365 Correct OIDC Redirect URI resolution for reverse proxies

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/OidcSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/OidcSecurityConfiguration.java
@@ -38,6 +38,7 @@ import org.apache.nifi.web.security.oidc.OidcConfigurationException;
 import org.apache.nifi.web.security.oidc.OidcUrlPath;
 import org.apache.nifi.web.security.oidc.client.web.AuthorizedClientExpirationCommand;
 import org.apache.nifi.web.security.oidc.client.web.OidcBearerTokenRefreshFilter;
+import org.apache.nifi.web.security.oidc.client.web.StandardOAuth2AuthorizationRequestResolver;
 import org.apache.nifi.web.security.oidc.client.web.converter.AuthenticationResultConverter;
 import org.apache.nifi.web.security.oidc.client.web.converter.AuthorizedClientConverter;
 import org.apache.nifi.web.security.oidc.client.web.StandardAuthorizationRequestRepository;
@@ -187,7 +188,8 @@ public class OidcSecurityConfiguration {
      */
     @Bean
     public OAuth2AuthorizationRequestRedirectFilter oAuth2AuthorizationRequestRedirectFilter() {
-        final OAuth2AuthorizationRequestRedirectFilter filter = new OAuth2AuthorizationRequestRedirectFilter(clientRegistrationRepository());
+        final StandardOAuth2AuthorizationRequestResolver authorizationRequestResolver = new StandardOAuth2AuthorizationRequestResolver(clientRegistrationRepository());
+        final OAuth2AuthorizationRequestRedirectFilter filter = new OAuth2AuthorizationRequestRedirectFilter(authorizationRequestResolver);
         filter.setAuthorizationRequestRepository(authorizationRequestRepository());
         filter.setRequestCache(nullRequestCache);
         return filter;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/StandardOAuth2AuthorizationRequestResolver.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/StandardOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.oidc.client.web;
+
+import org.apache.nifi.web.util.RequestUriBuilder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.Objects;
+
+/**
+ * Authorization Request Resolver supports handling of headers from reverse proxy servers
+ */
+public class StandardOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+    private final OAuth2AuthorizationRequestResolver resolver;
+
+    /**
+     * Resolver constructor delegates to the Spring Security Default Resolver and uses the default Request Base URI
+     *
+     * @param clientRegistrationRepository Client Registration Repository
+     */
+    public StandardOAuth2AuthorizationRequestResolver(final ClientRegistrationRepository clientRegistrationRepository) {
+        Objects.requireNonNull(clientRegistrationRepository, "Repository required");
+        resolver = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+    }
+
+    /**
+     * Resolve Authorization Request delegating to default resolver
+     *
+     * @param request HTTP Servlet Request
+     * @return OAuth2 Authorization Request or null when not resolved
+     */
+    @Override
+    public OAuth2AuthorizationRequest resolve(final HttpServletRequest request) {
+        final OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
+        return getResolvedAuthorizationRequest(authorizationRequest, request);
+    }
+
+    /**
+     * Resolve Authorization Request delegating to default resolver
+     *
+     * @param request HTTP Servlet Request
+     * @param clientRegistrationId Client Registration Identifier
+     * @return OAuth2 Authorization Request or null when not resolved
+     */
+    @Override
+    public OAuth2AuthorizationRequest resolve(final HttpServletRequest request, final String clientRegistrationId) {
+        final OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request, clientRegistrationId);
+        return getResolvedAuthorizationRequest(authorizationRequest, request);
+    }
+
+    private OAuth2AuthorizationRequest getResolvedAuthorizationRequest(final OAuth2AuthorizationRequest authorizationRequest, final HttpServletRequest request) {
+        final OAuth2AuthorizationRequest resolvedAuthorizationRequest;
+
+        if (authorizationRequest == null) {
+            resolvedAuthorizationRequest = null;
+        } else {
+            final String redirectUri = authorizationRequest.getRedirectUri();
+            if (redirectUri == null) {
+                resolvedAuthorizationRequest = authorizationRequest;
+            } else {
+                final String requestBasedRedirectUri = getRequestBasedRedirectUri(redirectUri, request);
+                resolvedAuthorizationRequest = OAuth2AuthorizationRequest.from(authorizationRequest).redirectUri(requestBasedRedirectUri).build();
+            }
+        }
+
+        return resolvedAuthorizationRequest;
+    }
+
+    private String getRequestBasedRedirectUri(final String redirectUri, final HttpServletRequest request) {
+        final String redirectUriPath = UriComponentsBuilder.fromUriString(redirectUri).build().getPath();
+        final URI baseUri =  RequestUriBuilder.fromHttpServletRequest(request).path(redirectUriPath).build();
+        return UriComponentsBuilder.fromUriString(redirectUri)
+                .scheme(baseUri.getScheme())
+                .host(baseUri.getHost())
+                .port(baseUri.getPort())
+                .replacePath(baseUri.getPath())
+                .build()
+                .toUriString();
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-11365](https://issues.apache.org/jira/browse/NIFI-11365) Corrects OpenID Connect Redirect URI resolution for NiFi deployments running behind a reverse proxy server. This fixes a regression introduced as a result of refactoring implemented for [NIFI-4890](https://issues.apache.org/jira/browse/NIFI-4890).

Changes include introducing an Authorization Request Resolver that delegates to the standard framework `RequestUriBuilder` for building a Redirect URI that considers allowed `X-Proxy` headers.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
