### PR TITLE
NIFI-11371 Upgrade Ranger from 2.3.0 to 2.4.0

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -106,17 +106,17 @@
     </suppress>
     <suppress>
         <notes>Elasticsearch Server vulnerabilities do not apply to Elasticsearch Plugin</notes>
-        <packageUrl regex="true">^pkg:maven/org\.elasticsearch\.plugin/.*?@7.6.0$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch\.plugin/.*?@7.*$</packageUrl>
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
         <notes>Elasticsearch Server vulnerabilities do not apply to elasticsearch-core</notes>
-        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch\-core@7.6.0$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch\-core@7.*$</packageUrl>
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
         <notes>Elasticsearch Server vulnerabilities do not apply to elasticsearch</notes>
-        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@7.6.0$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@7.*$</packageUrl>
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
@@ -130,8 +130,13 @@
         <cve>CVE-2020-7014</cve>
     </suppress>
     <suppress>
+        <notes>CVE-2021-22145 applies to Elasticsearch Server not client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@.*$</packageUrl>
+        <vulnerabilityName>CVE-2021-22145</vulnerabilityName>
+    </suppress>
+    <suppress>
         <notes>Elasticsearch Server vulnerabilities do not apply to elasticsearch libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch\-.*?@7.6.0$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch\-.*?@7.*$</packageUrl>
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <org.bouncycastle.version>1.71</org.bouncycastle.version>
         <testcontainers.version>1.17.6</testcontainers.version>
         <org.slf4j.version>2.0.7</org.slf4j.version>
-        <ranger.version>2.3.0</ranger.version>
+        <ranger.version>2.4.0</ranger.version>
         <jetty.version>9.4.50.v20221201</jetty.version>
         <jackson.bom.version>2.14.2</jackson.bom.version>
         <avro.version>1.11.1</avro.version>


### PR DESCRIPTION
# Summary

[NIFI-11371](https://issues.apache.org/jira/browse/NIFI-11371) Upgrades Apache Ranger dependencies from 2.3.0 to [2.4.0](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.4.0+-+Release+Notes) incorporating bug fixes and transitive dependency upgrades. The update applies to NiFi and NiFi Registry Ranger plugins.

Additional updates include adjusting false positive vulnerability suppressions to cover Elasticsearch client transitive dependency updates from Ranger.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
