### PR TITLE
NIFI-11408 enable user to disable gzip compression with PutGCSObject

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
@@ -194,6 +194,16 @@ public class PutGCSObject extends AbstractGCSProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor GZIPCONTENT = new PropertyDescriptor
+            .Builder().name("gzip.content")
+            .displayName("Allow GZIP Compression")
+            .description("Signals to the GCS Blob Writer whether GZIP compression during transfer is desired. " +
+                    "False means dont gzip and can boost performance in many cases.")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .defaultValue("False")
+            .allowableValues("True", "False")
+            .defaultValue("True")
+            .build();
     public static final AllowableValue ACL_ALL_AUTHENTICATED_USERS = new AllowableValue(
             ALL_AUTHENTICATED_USERS.name(), "All Authenticated Users", "Gives the bucket or object owner OWNER " +
             "permission, and gives all authenticated Google account holders READER and WRITER permissions. " +
@@ -299,6 +309,7 @@ public class PutGCSObject extends AbstractGCSProcessor {
         descriptors.add(ENCRYPTION_KEY);
         descriptors.add(OVERWRITE);
         descriptors.add(CONTENT_DISPOSITION_TYPE);
+        descriptors.add(GZIPCONTENT);
         return Collections.unmodifiableList(descriptors);
     }
 
@@ -388,6 +399,11 @@ public class PutGCSObject extends AbstractGCSProcessor {
                                 .evaluateAttributeExpressions(ff).getValue();
                         if (encryptionKey != null) {
                             blobWriteOptions.add(Storage.BlobWriteOption.encryptionKey(encryptionKey));
+                        }
+
+                        final boolean gzipCompress = context.getProperty(GZIPCONTENT).asBoolean();
+                        if (!gzipCompress){
+                            blobWriteOptions.add(Storage.BlobWriteOption.disableGzipContent());
                         }
 
                         final HashMap<String, String> userMetadata = new HashMap<>();

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
@@ -195,14 +195,13 @@ public class PutGCSObject extends AbstractGCSProcessor {
             .build();
 
     public static final PropertyDescriptor GZIPCONTENT = new PropertyDescriptor
-            .Builder().name("gzip.content")
-            .displayName("Allow GZIP Compression")
+            .Builder().name("gzip.content.enabled")
+            .displayName("GZIP Compression Enabled")
             .description("Signals to the GCS Blob Writer whether GZIP compression during transfer is desired. " +
-                    "False means dont gzip and can boost performance in many cases.")
+                    "False means do not gzip and can boost performance in many cases.")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-            .defaultValue("False")
-            .allowableValues("True", "False")
-            .defaultValue("True")
+            .allowableValues(Boolean.TRUE.toString(), Boolean.FALSE.toString())
+            .defaultValue(Boolean.TRUE.toString())
             .build();
     public static final AllowableValue ACL_ALL_AUTHENTICATED_USERS = new AllowableValue(
             ALL_AUTHENTICATED_USERS.name(), "All Authenticated Users", "Gives the bucket or object owner OWNER " +

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
@@ -180,7 +180,7 @@ public class PutGCSObjectTest extends AbstractGCSTest {
         runner.setProperty(PutGCSObject.ENCRYPTION_KEY, ENCRYPTION_KEY);
         runner.setProperty(PutGCSObject.OVERWRITE, String.valueOf(OVERWRITE));
         runner.setProperty(PutGCSObject.CONTENT_DISPOSITION_TYPE, CONTENT_DISPOSITION_TYPE);
-
+        runner.setProperty(PutGCSObject.GZIPCONTENT, "False");
         runner.assertValid();
 
         when(storage.createFrom(blobInfoArgumentCaptor.capture(),

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
@@ -180,7 +180,7 @@ public class PutGCSObjectTest extends AbstractGCSTest {
         runner.setProperty(PutGCSObject.ENCRYPTION_KEY, ENCRYPTION_KEY);
         runner.setProperty(PutGCSObject.OVERWRITE, String.valueOf(OVERWRITE));
         runner.setProperty(PutGCSObject.CONTENT_DISPOSITION_TYPE, CONTENT_DISPOSITION_TYPE);
-        runner.setProperty(PutGCSObject.GZIPCONTENT, "False");
+        runner.setProperty(PutGCSObject.GZIPCONTENT, Boolean.FALSE.toString());
         runner.assertValid();
 
         when(storage.createFrom(blobInfoArgumentCaptor.capture(),


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
