### PR TITLE
NIFI-11415 - Upgrade Saxon-HE to 12.1

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -554,7 +554,7 @@ limitations under the License.
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>9.6.0-5</version>
+                <version>12.1</version>
             </dependency>
             <dependency>
                 <groupId>stax</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -169,7 +169,7 @@
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>10.6</version>
+                <version>12.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.jms</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11415](https://issues.apache.org/jira/browse/NIFI-11415)

Upgrade Saxon-HE to 12.1

Note that 12.0 was not working with JDK 8 but it's fixed in 12.1. Consequently the change can be back-ported into NiFi 1.X if desired.

https://www.saxonica.com/documentation12/#!changes/all/9.6-12

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
