### PR TITLE
NIFI-11421 Upgrade Parquet to 1.13.0 and MockFtpServer to 3.1.0

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -103,7 +103,7 @@
             <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-hadoop-bundle</artifactId>
-                <version>1.12.3</version>
+                <version>1.13.0</version>
             </dependency>
             <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
             <dependency>

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.12.3</version>
+            <version>1.13.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -210,7 +210,7 @@
             <dependency>
                 <groupId>org.mockftpserver</groupId>
                 <artifactId>MockFtpServer</artifactId>
-                <version>2.7.1</version>
+                <version>3.1.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
# Summary

[NIFI-11421](https://issues.apache.org/jira/browse/NIFI-11421)

org.mockftpserver:MockFtpServer from 2.7.1 to 3.1.0
https://github.com/dx42/MockFtpServer/blob/master/CHANGELOG.md

org.apache.parquet:parquet-avro from 1.12.3 to 1.13.0
org.apache.parquet:parquet-hadoop-bundle from 1.12.3 to 1.13.0
https://github.com/apache/parquet-mr/blob/master/CHANGES.md

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
