### PR TITLE
NIFI-11428 - Upgrade groovy to 3.0.17 and spock-core to 2.3

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <scripting.groovy.version>3.0.13</scripting.groovy.version>
+        <scripting.groovy.version>3.0.17</scripting.groovy.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -40,7 +40,7 @@
         <flyway.version>8.5.13</flyway.version>
         <flyway.tests.version>7.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
-        <groovy.eclipse.compiler.version>3.4.0-01</groovy.eclipse.compiler.version>
+        <groovy.eclipse.compiler.version>3.7.0</groovy.eclipse.compiler.version>
         <jaxb.version>2.3.2</jaxb.version>
         <jgit.version>6.5.0.202303070854-r</jgit.version>
         <org.apache.sshd.version>2.9.2</org.apache.sshd.version>
@@ -181,7 +181,7 @@
             <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-core</artifactId>
-                <version>2.1-M2-groovy-3.0</version>
+                <version>2.3-groovy-3.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/pom.xml
@@ -120,6 +120,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Woodstox provides optimized XML processing over standard JRE capabilities -->
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.5.0</version>
+        </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>

--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -32,7 +32,7 @@
         <module>nifi-toolkit-api</module>
     </modules>
     <properties>
-        <toolkit.groovy.version>3.0.8</toolkit.groovy.version>
+        <toolkit.groovy.version>3.0.17</toolkit.groovy.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
             <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-core</artifactId>
-                <version>2.1-M2-groovy-3.0</version>
+                <version>2.3-groovy-3.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
# Summary

[NIFI-11428](https://issues.apache.org/jira/browse/NIFI-11428)

Some dependencies already on Groovy 3 but not on 3.0.17.

Also upgrading spock-core to use 2.3-groovy-3.0

https://spockframework.org/spock/docs/2.3/release_notes.html

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
