### PR TITLE
NIFI-11440: Speed up Hive Metastore based unit tests

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/src/main/java/org/apache/nifi/hive/metastore/ThriftMetastore.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/src/main/java/org/apache/nifi/hive/metastore/ThriftMetastore.java
@@ -19,15 +19,15 @@ package org.apache.nifi.hive.metastore;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /** A JUnit Extension that creates a Hive Metastore Thrift service backed by a Hive Metastore using an in-memory Derby database. */
-public class ThriftMetastore implements BeforeEachCallback, AfterEachCallback {
+public class ThriftMetastore implements BeforeAllCallback, AfterAllCallback {
 
     private final MetastoreCore metastoreCore;
 
@@ -43,12 +43,12 @@ public class ThriftMetastore implements BeforeEachCallback, AfterEachCallback {
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
+    public void beforeAll(ExtensionContext context) throws Exception {
         metastoreCore.initialize(configOverrides);
     }
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterAll(ExtensionContext context) {
         metastoreCore.shutdown();
     }
 

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/test/java/org/apache/nifi/processors/hive/TestTriggerHiveMetaStoreEvent.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/test/java/org/apache/nifi/processors/hive/TestTriggerHiveMetaStoreEvent.java
@@ -37,6 +37,8 @@ import org.apache.nifi.hive.metastore.ThriftMetastore;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,13 +73,18 @@ public class TestTriggerHiveMetaStoreEvent {
     );
 
     @RegisterExtension
-    public ThriftMetastore metastore = new ThriftMetastore()
+    public static ThriftMetastore metastore = new ThriftMetastore()
             .withConfigOverrides(Collections.singletonMap(TRANSACTIONAL_EVENT_LISTENERS.getVarname(), "org.apache.hive.hcatalog.listener.DbNotificationListener"));
 
     @BeforeEach
     public void setUp() {
         processor = new TriggerHiveMetaStoreEvent();
         metaStoreClient = metastore.getMetaStoreClient();
+    }
+
+    @AfterEach
+    public void tearDown() throws TException {
+        metaStoreClient.dropTable(TEST_DATABASE_NAME, TEST_TABLE_NAME);
     }
 
     private void initUnPartitionedTable() throws Exception {

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/test/java/org/apache/nifi/processors/hive/TestTriggerHiveMetaStoreEvent.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/test/java/org/apache/nifi/processors/hive/TestTriggerHiveMetaStoreEvent.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
+@DisabledOnOs(WINDOWS)
 public class TestTriggerHiveMetaStoreEvent {
 
     private TestRunner runner;
@@ -98,7 +99,6 @@ public class TestTriggerHiveMetaStoreEvent {
         createPartition(table, Lists.newArrayList("2018", "march"));
     }
 
-    @DisabledOnOs(WINDOWS)
     @Test
     public void testInsertOnUnPartitionedTable() throws Exception {
         initUnPartitionedTable();
@@ -133,7 +133,6 @@ public class TestTriggerHiveMetaStoreEvent {
         assertEquals(insertMessage.getTable(), TEST_TABLE_NAME);
     }
 
-    @DisabledOnOs(WINDOWS)
     @Test
     public void testInsertOnPartitionedTable() throws Exception {
         initPartitionedTable();
@@ -169,7 +168,6 @@ public class TestTriggerHiveMetaStoreEvent {
         assertEquals(insertMessage.getTable(), TEST_TABLE_NAME);
     }
 
-    @DisabledOnOs(WINDOWS)
     @Test
     public void testAddPartition() throws Exception {
         initPartitionedTable();
@@ -211,7 +209,6 @@ public class TestTriggerHiveMetaStoreEvent {
         assertDoesNotThrow(() -> metaStoreClient.getPartition(TEST_DATABASE_NAME, TEST_TABLE_NAME, Arrays.asList("2017", "june")));
     }
 
-    @DisabledOnOs(WINDOWS)
     @Test
     public void testDropPartition() throws Exception {
         initPartitionedTable();
@@ -253,7 +250,6 @@ public class TestTriggerHiveMetaStoreEvent {
         assertThrows(NoSuchObjectException.class, () -> metaStoreClient.getPartition(TEST_DATABASE_NAME, TEST_TABLE_NAME, Arrays.asList("2017", "june")));
     }
 
-    @DisabledOnOs(WINDOWS)
     @Test
     public void testUnknownEventType() throws Exception {
         initUnPartitionedTable();

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHiveCatalog.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHiveCatalog.java
@@ -60,6 +60,7 @@ import static org.apache.nifi.processors.iceberg.util.IcebergTestUtils.validateN
 import static org.apache.nifi.processors.iceberg.util.IcebergTestUtils.validatePartitionFolders;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
+@DisabledOnOs(WINDOWS)
 public class TestPutIcebergWithHiveCatalog {
 
     private TestRunner runner;
@@ -133,7 +134,6 @@ public class TestPutIcebergWithHiveCatalog {
         runner.setProperty(PutIceberg.CATALOG, "catalog-service");
     }
 
-    @DisabledOnOs(WINDOWS)
     @ParameterizedTest
     @ValueSource(strings = {"avro"})
     public void onTriggerPartitioned(String fileFormat) throws Exception {
@@ -171,7 +171,6 @@ public class TestPutIcebergWithHiveCatalog {
                 "department_bucket=0", "department_bucket=1", "department_bucket=2"));
     }
 
-    @DisabledOnOs(WINDOWS)
     @ParameterizedTest
     @ValueSource(strings = {"orc"})
     public void onTriggerIdentityPartitioned(String fileFormat) throws Exception {
@@ -209,7 +208,6 @@ public class TestPutIcebergWithHiveCatalog {
                 "department=Finance", "department=Marketing", "department=Sales"));
     }
 
-    @DisabledOnOs(WINDOWS)
     @ParameterizedTest
     @ValueSource(strings = {"parquet"})
     public void onTriggerMultiLevelIdentityPartitioned(String fileFormat) throws Exception {
@@ -252,7 +250,6 @@ public class TestPutIcebergWithHiveCatalog {
         ));
     }
 
-    @DisabledOnOs(WINDOWS)
     @ParameterizedTest
     @ValueSource(strings = {"avro"})
     public void onTriggerUnPartitioned(String fileFormat) throws Exception {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11440](https://issues.apache.org/jira/browse/NIFI-11440)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
