### PR TITLE
NIFI-11461 Improve User and Group Tenants Search

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -128,6 +128,7 @@ import org.apache.nifi.web.api.entity.SnippetEntity;
 import org.apache.nifi.web.api.entity.StartVersionControlRequestEntity;
 import org.apache.nifi.web.api.entity.StatusHistoryEntity;
 import org.apache.nifi.web.api.entity.TemplateEntity;
+import org.apache.nifi.web.api.entity.TenantsEntity;
 import org.apache.nifi.web.api.entity.UserEntity;
 import org.apache.nifi.web.api.entity.UserGroupEntity;
 import org.apache.nifi.web.api.entity.VariableRegistryEntity;
@@ -1959,6 +1960,14 @@ public interface NiFiServiceFacade {
      * @return The user transfer objects
      */
     Set<UserEntity> getUsers();
+
+    /**
+     * Search for User and Group Tenants based on provided query string
+     *
+     * @param query Search query where null or empty returns unfiltered results
+     * @return Tenants Entity with zero or more matched Users and User Groups
+     */
+    TenantsEntity searchTenants(String query);
 
     /**
      * Updates the specified user.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/TenantsResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/TenantsResource.java
@@ -35,10 +35,8 @@ import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.NiFiServiceFacade;
 import org.apache.nifi.web.Revision;
 import org.apache.nifi.web.api.dto.RevisionDTO;
-import org.apache.nifi.web.api.dto.TenantDTO;
 import org.apache.nifi.web.api.dto.UserDTO;
 import org.apache.nifi.web.api.dto.UserGroupDTO;
-import org.apache.nifi.web.api.entity.TenantEntity;
 import org.apache.nifi.web.api.entity.TenantsEntity;
 import org.apache.nifi.web.api.entity.UserEntity;
 import org.apache.nifi.web.api.entity.UserGroupEntity;
@@ -64,9 +62,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Set;
 
 @Path("tenants")
@@ -941,53 +937,7 @@ public class TenantsResource extends ApplicationResource {
             tenants.authorize(authorizer, RequestAction.READ, NiFiUserUtils.getNiFiUser());
         });
 
-        final List<TenantEntity> userMatches = new ArrayList<>();
-        final List<TenantEntity> userGroupMatches = new ArrayList<>();
-
-        // get the users
-        for (final UserEntity userEntity : serviceFacade.getUsers()) {
-            final UserDTO user = userEntity.getComponent();
-            if (StringUtils.isBlank(value) || StringUtils.containsIgnoreCase(user.getIdentity(), value)) {
-                final TenantDTO tenant = new TenantDTO();
-                tenant.setId(user.getId());
-                tenant.setIdentity(user.getIdentity());
-                tenant.setConfigurable(user.getConfigurable());
-
-                final TenantEntity entity = new TenantEntity();
-                entity.setPermissions(userEntity.getPermissions());
-                entity.setRevision(userEntity.getRevision());
-                entity.setId(userEntity.getId());
-                entity.setComponent(tenant);
-
-                userMatches.add(entity);
-            }
-        }
-
-        // get the user groups
-        for (final UserGroupEntity userGroupEntity : serviceFacade.getUserGroups()) {
-            final UserGroupDTO userGroup = userGroupEntity.getComponent();
-            if (StringUtils.isBlank(value) || StringUtils.containsIgnoreCase(userGroup.getIdentity(), value)) {
-                final TenantDTO tenant = new TenantDTO();
-                tenant.setId(userGroup.getId());
-                tenant.setIdentity(userGroup.getIdentity());
-                tenant.setConfigurable(userGroup.getConfigurable());
-
-                final TenantEntity entity = new TenantEntity();
-                entity.setPermissions(userGroupEntity.getPermissions());
-                entity.setRevision(userGroupEntity.getRevision());
-                entity.setId(userGroupEntity.getId());
-                entity.setComponent(tenant);
-
-                userGroupMatches.add(entity);
-            }
-        }
-
-        // build the response
-        final TenantsEntity results = new TenantsEntity();
-        results.setUsers(userMatches);
-        results.setUserGroups(userGroupMatches);
-
-        // generate an 200 - OK response
+        final TenantsEntity results = serviceFacade.searchTenants(value);
         return noCache(Response.ok(results)).build();
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-policy-management.js
@@ -152,6 +152,7 @@
 
         // configure the user auto complete
         $.widget('nf.userSearchAutocomplete', $.ui.autocomplete, {
+            delay: 500,
             reset: function () {
                 this.term = null;
             },


### PR DESCRIPTION
# Summary

[NIFI-11461](https://issues.apache.org/jira/browse/NIFI-11461) Improves the performance of the User and Group Tenants Search REST Resource method with the addition of a `searchTenants` method to the `NiFiServiceFacade`.

The previous implementation called `getUsers()` and `getUserGroups()` in the Tenants Resource, which requires retrieving all users and all group members before evaluating the query.

The new implementation passes the query string to the `NiFiServiceFacade.searchTenants()` method and applies the filtering criteria prior to additional object creation. This approach reduces the number of method calls significantly for large numbers of users and groups.

Additional changes include adjusting the user interface autocomplete delay from the default 300 ms to 500 ms, minimizing the number of HTTP requests in some scenarios.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
