### PR TITLE
NIFI-11472 Make PutFTP processor more multithread friendly

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
@@ -395,7 +395,7 @@ public class FTPTransfer implements FileTransfer {
         if (!cdSuccessful) {
             if (client.makeDirectory(remoteDirectory)) {
                 logger.debug("Remote Directory not found: created directory [{}]", remoteDirectory);
-            } else {
+            } else if (!setWorkingDirectory(remoteDirectory)) { // Double check that the dir exists as it might have been created in another thread
                 throw new IOException("Failed to create remote directory " + remoteDirectory);
             }
         }


### PR DESCRIPTION
Add an extra check during directory creation to see if directory wasn't already created in another thread.

From Issue:

Problem happens when a PutFTP is set to run several concurrent tasks and two (or more ) FlowFiles come in and both need to create the same directory. One of them will create directory and succeed immediately while the other will try to create directory, but fail since it already exist, throw an error, the FlowFile will then be penalized and on second run will succeed.

While it is not the biggest error, as files are getting transferred in the end, but the bulletins and errors are annoying, especially in production environment where you don't want to get unnecessary errors.

We found that the solution involves a simple change to the FTPTransfer.java class in:
nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
On line 398 and ensureDirectoryExists method you can simply add another if check which double checks that the directory exists when it fails to create one.
```java
final boolean cdSuccessful = setWorkingDirectory(remoteDirectory);

if (!cdSuccessful) {    
  if (client.makeDirectory(remoteDirectory)) {        
    logger.debug("Remote Directory not found: created directory [{}]", remoteDirectory);    
  } else if (!setWorkingDirectory(remoteDirectory)) { 
         // Double check that the dir exists as it might have been created in another thread        
    throw new IOException("Failed to create remote directory " + remoteDirectory);    
  }
}
```

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11472](https://issues.apache.org/jira/browse/NIFI-11472)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
