### PR TITLE
NIFI-11473 Flow version change in NiFi should not stop a component wh…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -217,6 +217,10 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                 }
             }
 
+            if (diff.getDifferenceType() == DifferenceType.POSITION_CHANGED) {
+                continue;
+            }
+
             final VersionedComponent component = diff.getComponentA() == null ? diff.getComponentB() : diff.getComponentA();
             updatedVersionedComponentIds.add(component.getIdentifier());
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -5461,6 +5461,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
             .filter(diff -> !FlowDifferenceFilters.isScheduledStateNew(diff))
             .filter(diff -> !FlowDifferenceFilters.isLocalScheduleStateChange(diff))
             .filter(diff -> !FlowDifferenceFilters.isPropertyMissingFromGhostComponent(diff, flowManager))
+            .filter(difference -> difference.getDifferenceType() != DifferenceType.POSITION_CHANGED)
             .map(difference -> {
                 final VersionedComponent localComponent = difference.getComponentA();
 


### PR DESCRIPTION
…en only position is changed

# Summary
When going from one flow version to another and the position of a component is changing, but not its configuration, the component should not be stopped.

[NIFI-11473](https://issues.apache.org/jira/browse/NIFI-11473)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
