### PR TITLE
NIFI-11479 Upgrade JanusGraph from 0.5.3 to 0.6.3

### DIFF
--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -26,6 +26,8 @@
     <packaging>jar</packaging>
     <properties>
         <gremlin.version>3.6.2</gremlin.version>
+        <janusgraph.version>0.6.3</janusgraph.version>
+        <guava.version>31.1-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -50,6 +52,12 @@
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-groovy</artifactId>
                 <version>${gremlin.version}</version>
+            </dependency>
+            <!-- Override Guava 29.0 from JanusGraph 0.6.3 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -79,7 +87,7 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>
-            <version>0.5.3</version>
+            <version>${janusgraph.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -94,7 +102,7 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-inmemory</artifactId>
-            <version>0.5.3</version>
+            <version>${janusgraph.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11479](https://issues.apache.org/jira/browse/NIFI-11479) Upgrades JanusGraph from 0.5.3 to [0.6.3](https://github.com/JanusGraph/janusgraph/releases/tag/v0.6.3) in the `nifi-graph-test-clients` module and also overrides the transitive dependency version of Guava from 29.0 to 31.1.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
