### PR TITLE
NIFI-11493: Fix properties dynamically modifying the classpath with default values

### DIFF
--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/DefaultedDynamicallyModifyClasspath.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/DefaultedDynamicallyModifyClasspath.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.tests.system;
+
+import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.resource.ResourceCardinality;
+import org.apache.nifi.components.resource.ResourceType;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.BufferedWriter;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@RequiresInstanceClassLoading
+public class DefaultedDynamicallyModifyClasspath extends AbstractProcessor {
+
+    static final PropertyDescriptor URLS = new PropertyDescriptor.Builder()
+            .name("URLs to Load")
+            .description("URLs to load onto the classpath")
+            .required(false)
+            .defaultValue("lib/bootstrap/commons-lang3-3.12.0.jar")
+            .dynamicallyModifiesClasspath(true)
+            .identifiesExternalResource(ResourceCardinality.MULTIPLE, ResourceType.URL, ResourceType.FILE, ResourceType.DIRECTORY)
+            .build();
+
+    static final PropertyDescriptor CLASS_TO_LOAD = new PropertyDescriptor.Builder()
+            .name("Class to Load")
+            .description("The name of the Class to load")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+    static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles are routed to this relationship if the specified class can be loaded")
+            .build();
+    static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("FlowFiles are routed to this relationship if the specified class cannot be loaded")
+            .build();
+
+
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Arrays.asList(URLS, CLASS_TO_LOAD);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE));
+    }
+
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final String classToLoad = context.getProperty(CLASS_TO_LOAD).getValue();
+        try {
+            final Class<?> clazz = Class.forName(classToLoad);
+            try (final OutputStream out = session.write(flowFile);
+                 final OutputStreamWriter streamWriter = new OutputStreamWriter(out);
+                 final BufferedWriter writer = new BufferedWriter(streamWriter)) {
+
+                writer.write(clazz.getName());
+                writer.newLine();
+                writer.write(clazz.getClassLoader().toString());
+            }
+
+            session.transfer(flowFile, REL_SUCCESS);
+        } catch (final Exception e) {
+            session.transfer(flowFile, REL_FAILURE);
+        }
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -21,6 +21,7 @@ org.apache.nifi.processors.tests.system.DependOnProperties
 org.apache.nifi.processors.tests.system.DoNotTransferFlowFile
 org.apache.nifi.processors.tests.system.Duplicate
 org.apache.nifi.processors.tests.system.DynamicallyModifyClasspath
+org.apache.nifi.processors.tests.system.DefaultedDynamicallyModifyClasspath
 org.apache.nifi.processors.tests.system.EnsureProcessorConfigurationCorrect
 org.apache.nifi.processors.tests.system.EvaluatePropertiesWithDifferentELScopes
 org.apache.nifi.processors.tests.system.FakeProcessor

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/DefaultedDynamicClassPathModificationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/DefaultedDynamicClassPathModificationIT.java
@@ -47,6 +47,7 @@ class DefaultedDynamicClassPathModificationIT extends NiFiSystemIT {
         getClientUtil().waitForValidProcessor(defaultedModifyClasspathProcessor.getId());
 
         // Create a FlowFile
+        getClientUtil().waitForValidProcessor(generateFlowFileProcessor.getId());
         getClientUtil().startProcessor(generateFlowFileProcessor);
         waitForQueueCount(defaultedModifyClasspathInputConnection.getId(), 1);
 
@@ -63,6 +64,7 @@ class DefaultedDynamicClassPathModificationIT extends NiFiSystemIT {
 
         // Feed another FlowFile through. Upon restart, in order to modify, we need to get the most up-to-date revision so will first fetch the Processor
         final ProcessorEntity generateAfterRestart = getNifiClient().getProcessorClient().getProcessor(generateFlowFileProcessor.getId());
+        getClientUtil().waitForValidProcessor(generateAfterRestart.getId());
         getClientUtil().startProcessor(generateAfterRestart);
 
         // Depending on whether or not the flow was written out with the processor running, the Modify processor may or may not be running. Ensure that it is running.

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/DefaultedDynamicClassPathModificationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/DefaultedDynamicClassPathModificationIT.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.tests.system.processor;
+
+import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.web.api.entity.ConnectionEntity;
+import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+class DefaultedDynamicClassPathModificationIT extends NiFiSystemIT {
+
+    private ProcessorEntity generateFlowFileProcessor;
+    private ProcessorEntity defaultedModifyClasspathProcessor;
+
+    private ConnectionEntity defaultedModifyClasspathInputConnection;
+    private ConnectionEntity successConnection;
+    private ConnectionEntity failureConnection;
+
+    @Test
+    void testLoadsClassFromDefaultedDynamicModification() throws NiFiClientException, IOException, InterruptedException {
+        createFlow();
+
+        // Update modify to have the appropriate URL, don't update URL to load to let it on default value
+        final Map<String, String> propertyMap = new HashMap<>();
+        propertyMap.put("Class to Load", "org.apache.commons.lang3.StringUtils");
+        getClientUtil().updateProcessorProperties(defaultedModifyClasspathProcessor, propertyMap);
+        getClientUtil().waitForValidProcessor(defaultedModifyClasspathProcessor.getId());
+
+        // Create a FlowFile
+        getClientUtil().startProcessor(generateFlowFileProcessor);
+        waitForQueueCount(defaultedModifyClasspathInputConnection.getId(), 1);
+
+        // Wait for a FlowFile to be routed to success
+        getClientUtil().startProcessor(defaultedModifyClasspathProcessor);
+        waitForQueueCount(successConnection.getId(), 1);
+
+        getClientUtil().stopProcessor(generateFlowFileProcessor);
+        getClientUtil().waitForStoppedProcessor(generateFlowFileProcessor.getId());
+
+        // Restart and ensure that everything works as expected after restart
+        getNiFiInstance().stop();
+        getNiFiInstance().start(true);
+
+        // Feed another FlowFile through. Upon restart, in order to modify, we need to get the most up-to-date revision so will first fetch the Processor
+        final ProcessorEntity generateAfterRestart = getNifiClient().getProcessorClient().getProcessor(generateFlowFileProcessor.getId());
+        getClientUtil().startProcessor(generateAfterRestart);
+
+        // Depending on whether or not the flow was written out with the processor running, the Modify processor may or may not be running. Ensure that it is running.
+        getClientUtil().waitForValidationCompleted(defaultedModifyClasspathProcessor);
+        final ProcessorEntity modifyAfterRestart = getNifiClient().getProcessorClient().getProcessor(defaultedModifyClasspathProcessor.getId());
+        final String modifyRunStatus = modifyAfterRestart.getStatus().getRunStatus();
+        if (!"Running".equalsIgnoreCase(modifyRunStatus)) {
+            getClientUtil().startProcessor(modifyAfterRestart);
+        }
+
+        // We now expect 2 FlowFiles to be in the success route
+        waitForQueueCount(successConnection.getId(), 2);
+    }
+
+    // We have several tests running the same flow but with different configuration. Since we need to reference the ProcessorEntities and ConnectionEntities, we have a method
+    // that creates the flow and stores the entities are member variables
+    private void createFlow() throws NiFiClientException, IOException {
+        generateFlowFileProcessor = getClientUtil().createProcessor("GenerateFlowFile");
+        defaultedModifyClasspathProcessor = getClientUtil().createProcessor("DefaultedDynamicallyModifyClasspath");
+        ProcessorEntity terminateSuccess = getClientUtil().createProcessor("TerminateFlowFile");
+        ProcessorEntity terminateFailure = getClientUtil().createProcessor("TerminateFlowFile");
+
+        defaultedModifyClasspathInputConnection = getClientUtil().createConnection(generateFlowFileProcessor, defaultedModifyClasspathProcessor, "success");
+        successConnection = getClientUtil().createConnection(defaultedModifyClasspathProcessor, terminateSuccess, "success");
+        failureConnection = getClientUtil().createConnection(defaultedModifyClasspathProcessor, terminateFailure, "failure");
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

- Fixes PropertyDescriptors that dynamically modifies the classpath to work with default values
- Added new system test

[NIFI-11493](https://issues.apache.org/jira/browse/NIFI-11493)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
