### PR TITLE
NIFI-11502 - Upgrade json-path to 2.8.0

### DIFF
--- a/nifi-commons/nifi-expression-language/pom.xml
+++ b/nifi-commons/nifi-expression-language/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathDeleteEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathDeleteEvaluator.java
@@ -50,9 +50,7 @@ public class JsonPathDeleteEvaluator extends JsonPathBaseEvaluator {
         } catch (PathNotFoundException pnf) {
             // it is valid for a path not to be found, keys may not be there
             // do not spam the error log for this, instead we can log debug if enabled
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("PathNotFoundException for JsonPath " + compiledJsonPath.getPath(), pnf);
-            }
+            LOGGER.debug("JSON Path not found: {}", compiledJsonPath.getPath(), pnf);
             result = documentContext.jsonString();
         } catch (Exception e) {
             // assume the path did not match anything in the document

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathDeleteEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathDeleteEvaluator.java
@@ -20,14 +20,19 @@ import org.apache.nifi.attribute.expression.language.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 
 /**
  * JsonPathDeleteEvaluator allows delete elements at the specified path
  */
 public class JsonPathDeleteEvaluator extends JsonPathBaseEvaluator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonPathDeleteEvaluator.class);
 
     public JsonPathDeleteEvaluator(final Evaluator<String> subject, final Evaluator<String> jsonPathExp) {
         super(subject, jsonPathExp);
@@ -42,6 +47,13 @@ public class JsonPathDeleteEvaluator extends JsonPathBaseEvaluator {
         String result = null;
         try {
             result = documentContext.delete(compiledJsonPath).jsonString();
+        } catch (PathNotFoundException pnf) {
+            // it is valid for a path not to be found, keys may not be there
+            // do not spam the error log for this, instead we can log debug if enabled
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("PathNotFoundException for JsonPath " + compiledJsonPath.getPath(), pnf);
+            }
+            result = documentContext.jsonString();
         } catch (Exception e) {
             // assume the path did not match anything in the document
             return EMPTY_RESULT;

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathUpdateEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathUpdateEvaluator.java
@@ -57,9 +57,7 @@ public abstract class JsonPathUpdateEvaluator extends JsonPathBaseEvaluator {
         } catch (PathNotFoundException pnf) {
             // it is valid for a path not to be found, keys may not be there
             // do not spam the error log for this, instead we can log debug if enabled
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("PathNotFoundException for JsonPath " + compiledJsonPath.getPath(), pnf);
-            }
+            LOGGER.debug("JSON Path not found: {}", compiledJsonPath.getPath(), pnf);
             result = documentContext.jsonString();
         } catch (Exception e) {
             LOGGER.error("Failed to update attribute " + e.getLocalizedMessage(), e);

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathUpdateEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/JsonPathUpdateEvaluator.java
@@ -18,6 +18,8 @@ package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.nifi.attribute.expression.language.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.Evaluator;
@@ -52,6 +54,13 @@ public abstract class JsonPathUpdateEvaluator extends JsonPathBaseEvaluator {
         String result;
         try {
             result = updateAttribute(documentContext, compiledJsonPath, value).jsonString();
+        } catch (PathNotFoundException pnf) {
+            // it is valid for a path not to be found, keys may not be there
+            // do not spam the error log for this, instead we can log debug if enabled
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("PathNotFoundException for JsonPath " + compiledJsonPath.getPath(), pnf);
+            }
+            result = documentContext.jsonString();
         } catch (Exception e) {
             LOGGER.error("Failed to update attribute " + e.getLocalizedMessage(), e);
             // assume the path did not match anything in the document

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/pom.xml
@@ -89,7 +89,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -184,7 +184,7 @@
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.6.0</version>
+                <version>2.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tika</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11502](https://issues.apache.org/jira/browse/NIFI-11502) Upgrade json-path to 2.8.0

https://github.com/json-path/JsonPath/releases

Upgrade json-smart to fix https://www.cve.org/CVERecord?id=CVE-2023-1370

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
