### PR TITLE
NIFI-11523 Refining schema handling for ScriptedTransfromRecord

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
@@ -137,6 +137,7 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
 
         final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
         final RecordSetWriterFactory writerFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
+        final Map<String, String> originalAttributes = flowFile.getAttributes();
 
         final RecordCounts counts = new RecordCounts();
         try {
@@ -165,10 +166,8 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
                             record.incorporateInactiveFields();
 
                             if (writer == null) {
-                                final RecordSchema writerSchema;
-                                writerSchema = record.getSchema();
-
                                 try {
+                                    final RecordSchema writerSchema = writerFactory.getSchema(originalAttributes, record.getSchema());
                                     writer = writerFactory.createWriter(getLogger(), writerSchema, out, flowFile);
                                 } catch (SchemaNotFoundException e) {
                                     throw new IOException(e);


### PR DESCRIPTION
Current implementatin of the TestScriptedTransformRecord uses record schema for the writer, regardless of the writer's schema settings. The change involves a test change as the tes writer behaves differetly then the real implementations.

# Summary

[NIFI-11523](https://issues.apache.org/jira/browse/NIFI-11523)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
