### PR TITLE
NIFI-10976 Add Previous Cluster State Provider configuration

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -306,6 +306,7 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String STATE_MANAGEMENT_CONFIG_FILE = "nifi.state.management.configuration.file";
     public static final String STATE_MANAGEMENT_LOCAL_PROVIDER_ID = "nifi.state.management.provider.local";
     public static final String STATE_MANAGEMENT_CLUSTER_PROVIDER_ID = "nifi.state.management.provider.cluster";
+    public static final String STATE_MANAGEMENT_CLUSTER_PROVIDER_PREVIOUS_ID = "nifi.state.management.provider.cluster.previous";
     public static final String STATE_MANAGEMENT_START_EMBEDDED_ZOOKEEPER = "nifi.state.management.embedded.zookeeper.start";
     public static final String STATE_MANAGEMENT_ZOOKEEPER_PROPERTIES = "nifi.state.management.embedded.zookeeper.properties";
 

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -2619,15 +2619,32 @@ in the cluster. This allows one node to pick up where another node left off, or 
 
 [[state_providers]]
 === Configuring State Providers
-When a component decides to store or retrieve state, it does so by providing a "Scope" - either Node-local or Cluster-wide. The
-mechanism that is used to store and retrieve this state is then determined based on this Scope, as well as the configured State
-Providers. The _nifi.properties_ file contains three different properties that are relevant to configuring these State Providers.
+When a component decides to store or retrieve state, it does so by providing a `Scope`, either `Local` to the node or
+applicable to the entire `Cluster`. Component implementation code and configuration properties determine the requested
+Scope, which the framework provides according to the State Management configuration. The `nifi.properties` configuration
+contains several properties for managing these State Providers.
 
 |====
 |*Property*|*Description*
-|`nifi.state.management.configuration.file`|The first is the property that specifies an external XML file that is used for configuring the local and/or cluster-wide State Providers. This XML file may contain configurations for multiple providers
-|`nifi.state.management.provider.local`|The property that provides the identifier of the local State Provider configured in this XML file
-|`nifi.state.management.provider.cluster`|Similarly, the property provides the identifier of the cluster-wide State Provider configured in this XML file.
+|`nifi.state.management.configuration.file`|The configuration file specifies the path to an external XML file that the
+framework uses to configure State Providers. This XML file may contain configurations for multiple providers.
+|`nifi.state.management.provider.local`|The Local Provider stores current Local State information. The property value
+identifies a Local Provider in the State Management configuration that the framework will use for storing and retrieving
+Local State for requesting components.
+|`nifi.state.management.provider.cluster`|The Cluster Provider stores current Cluster State information. The property
+value identifies a Cluster Provider in the State Management configuration that the framework will use for storing and
+retrieving Cluster State for requesting components.
+|`nifi.state.management.provider.cluster.previous`|The Previous Cluster State Provider enables population of the current
+Cluster State from an existing Provider. The property value identifies a Cluster Provider in the State Management
+configuration that the framework will use as the initial source of Cluster State when the current Cluster State Provider
+is has no information stored.
+
+The framework enumerates the Current Cluster Provider when a node becomes Primary, and proceeds to check the Previous
+Cluster Provider when the Current Cluster Provider does not contain any component information. The Previous Cluster
+Provider property value can be set to blank after cluster startup following a successful Cluster State restore from
+backup.
+
+The default value is blank.
 |====
 
 This XML file consists of a top-level `state-management` element, which has one or more `local-provider` and zero or more `cluster-provider`

--- a/nifi-framework-api/src/main/java/org/apache/nifi/components/state/StateProvider.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/components/state/StateProvider.java
@@ -18,6 +18,8 @@
 package org.apache.nifi.components.state;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.nifi.components.ConfigurableComponent;
@@ -130,4 +132,23 @@ public interface StateProvider extends ConfigurableComponent {
      * @return the {@link Scope}s supported by the configuration
      */
     Scope[] getSupportedScopes();
+
+    /**
+     * Indicates whether the State Provider supports enumerating component identifiers with stored state information
+     *
+     * @return Component enumeration supported status
+     */
+    default boolean isComponentEnumerationSupported() {
+        return false;
+    }
+
+    /**
+     * Get Component Identifiers with associated state stored in the Provider
+     *
+     * @return Collection of Component Identifiers with stored state defaults to empty
+     * @throws IOException Thrown on failures to retrieve component identifiers
+     */
+    default Collection<String> getStoredComponentIds() throws IOException {
+        return Collections.emptyList();
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
@@ -227,6 +227,16 @@ public class WriteAheadLocalStateProvider extends AbstractStateProvider {
         return new Scope[]{Scope.LOCAL};
     }
 
+    @Override
+    public boolean isComponentEnumerationSupported() {
+        return true;
+    }
+
+    @Override
+    public Collection<String> getStoredComponentIds() {
+        return Collections.unmodifiableCollection(componentProviders.keySet());
+    }
+
     private static class ComponentProvider {
         private final AtomicLong versionGenerator;
         private final WriteAheadRepository<StateMapUpdate> wal;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/AbstractTestStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/AbstractTestStateProvider.java
@@ -23,8 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.nifi.components.state.StateMap;
@@ -48,8 +50,16 @@ public abstract class AbstractTestStateProvider {
 
     @Test
     public void testSetAndGet() throws IOException {
+        final Collection<String> initialStoredComponentIds = getProvider().getStoredComponentIds();
+        assertTrue(initialStoredComponentIds.isEmpty());
+
         getProvider().setState(Collections.singletonMap("testSetAndGet", "value"), componentId);
         assertEquals("value", getProvider().getState(componentId).get("testSetAndGet"));
+
+        final Collection<String> storedComponentIds = getProvider().getStoredComponentIds();
+        final Iterator<String> componentIds = storedComponentIds.iterator();
+        assertTrue(componentIds.hasNext());
+        assertEquals(componentId, componentIds.next());
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/test/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/test/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProviderTest.java
@@ -35,7 +35,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 
@@ -220,6 +222,24 @@ class KubernetesConfigMapStateProviderTest {
 
         final RecordedRequest request = kubernetesMockServer.getLastRequest();
         assertEquals(HttpMethod.DELETE.name(), request.getMethod());
+    }
+
+    @Test
+    void testSetStateGetStoredComponentIds() throws IOException {
+        setContext();
+        provider.initialize(context);
+
+        final Collection<String> initialStoredComponentIds = provider.getStoredComponentIds();
+        assertTrue(initialStoredComponentIds.isEmpty());
+
+        final Map<String, String> state = Collections.singletonMap(STATE_PROPERTY, STATE_VALUE);
+        provider.setState(state, COMPONENT_ID);
+
+        final Collection<String> storedComponentIds = provider.getStoredComponentIds();
+        final Iterator<String> componentIds = storedComponentIds.iterator();
+
+        assertTrue(componentIds.hasNext());
+        assertEquals(COMPONENT_ID, componentIds.next());
     }
 
     private void setContext() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -53,6 +53,7 @@
         <nifi.state.management.embedded.zookeeper.properties>./conf/zookeeper.properties</nifi.state.management.embedded.zookeeper.properties>
         <nifi.state.management.provider.local>local-provider</nifi.state.management.provider.local>
         <nifi.state.management.provider.cluster>zk-provider</nifi.state.management.provider.cluster>
+        <nifi.state.management.provider.cluster.previous/>
 
         <nifi.flowfile.repository.implementation>org.apache.nifi.controller.repository.WriteAheadFlowFileRepository</nifi.flowfile.repository.implementation>
         <nifi.flowfile.repository.wal.implementation>org.apache.nifi.wali.SequentialAccessWriteAheadLog</nifi.flowfile.repository.wal.implementation>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -61,6 +61,8 @@ nifi.state.management.configuration.file=${nifi.state.management.configuration.f
 nifi.state.management.provider.local=${nifi.state.management.provider.local}
 # The ID of the cluster-wide state provider. This will be ignored if NiFi is not clustered but must be populated if running in a cluster.
 nifi.state.management.provider.cluster=${nifi.state.management.provider.cluster}
+# The Previous Cluster State Provider from which the framework will load Cluster State when the current Cluster Provider has no entries
+nifi.state.management.provider.cluster.previous=${nifi.state.management.provider.cluster.previous}
 # Specifies whether or not this instance of NiFi should run an embedded ZooKeeper server
 nifi.state.management.embedded.zookeeper.start=${nifi.state.management.embedded.zookeeper.start}
 # Properties file that provides the ZooKeeper properties to use if <nifi.state.management.embedded.zookeeper.start> is set to true

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/components/state/HashMapStateProvider.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/components/state/HashMapStateProvider.java
@@ -153,6 +153,16 @@ public class HashMapStateProvider implements StateProvider {
         return "stateless-state-provider";
     }
 
+    @Override
+    public boolean isComponentEnumerationSupported() {
+        return true;
+    }
+
+    @Override
+    public Collection<String> getStoredComponentIds() {
+        return Collections.unmodifiableCollection(getAllComponentsState().keySet());
+    }
+
     private String getIncrementedVersion(final String currentVersion) {
         final long versionNumber = Long.parseLong(currentVersion);
         final long version = versionNumber + VERSION_INCREMENT;


### PR DESCRIPTION
# Summary

[NIFI-10976](https://issues.apache.org/jira/browse/NIFI-10976) Adds a Previous Cluster State Provider to support migrating from one Cluster State Provider implementation to another.

The new Previous Cluster Provider property enables conditional transfer of Cluster State from a previous Cluster State Provider to the configured Cluster State Provider. This approaches supports migration scenarios such as moving from ZooKeeper to Kubernetes ConfigMaps or Redis. The implementation is a one-way operation that copies from the Previous Provider to the Current Provider when the Current Provider does not have any state information. After the initial state transfer, the framework ignores the Previous Provider when the Current Provider contains stored informaiton.

Changes include new methods on the `StateProvider` interface to support enumeration of stored Component Identifiers. The default interface methods indicate that enumeration is not supported, so State Provider implementations must implement both new methods to support transferring state from a previous provider.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
