### PR TITLE
NIFI-11537: Add support for Iceberg tables to UpdateHive3Table

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/DefaultHiveStorageHandlerConfig.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/DefaultHiveStorageHandlerConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util.hive;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DefaultHiveStorageHandlerConfig implements StorageHandlerConfig {
+
+    @Override
+    public String getStorageHandlerClassName() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getTablePropertiesMap() {
+        return Collections.emptyMap();
+    }
+}

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/IcebergStorageHandlerConfig.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/IcebergStorageHandlerConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util.hive;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergStorageHandlerConfig implements StorageHandlerConfig {
+
+    static final String ICEBERG_STORAGE_HANDLER_CLASSNAME = "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler";
+
+    // This is not a static map in case we need a constructor for additional configuration such as a catalog name
+    private final Map<String,String> tablePropertiesMap = new HashMap<>();
+
+    public IcebergStorageHandlerConfig() {
+        tablePropertiesMap.put("engine.hive.enabled", "true");
+    }
+
+    @Override
+    public String getStorageHandlerClassName() {
+        return ICEBERG_STORAGE_HANDLER_CLASSNAME;
+    }
+
+    @Override
+    public Map<String, String> getTablePropertiesMap() {
+        return Collections.unmodifiableMap(tablePropertiesMap);
+    }
+}

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/StorageHandlerConfig.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/StorageHandlerConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util.hive;
+
+import java.util.Map;
+
+/**
+ * This interface is used to provide storage-handler-specific configuration information
+ */
+public interface StorageHandlerConfig {
+
+    /**
+     * Returns the class name associated with the storage handler implementation
+     * @return the storage handler class name
+     */
+    String getStorageHandlerClassName();
+
+    /**
+     * Returns a map of the table properties needed to support this storage handler implementation
+     * @return the table property map
+     */
+    Map<String,String> getTablePropertiesMap();
+}


### PR DESCRIPTION
# Summary

[NIFI-11537](https://issues.apache.org/jira/browse/NIFI-11537) This PR adds a Create Table Storage Handler property to UpdateHive3Table with initial options default (to do nothing) and Iceberg (to generate a CREATE TABLE statement specific to Iceberg-backed tables.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11537`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11537`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
