### PR TITLE
NIFI-11547: Fix DBCPConnectionPool verification

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/pom.xml
@@ -53,5 +53,9 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/AbstractDBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/AbstractDBCPConnectionPool.java
@@ -76,17 +76,17 @@ public abstract class AbstractDBCPConnectionPool extends AbstractControllerServi
                     .build());
         }
 
-        final BasicDataSource dataSource = new BasicDataSource();
+        final BasicDataSource basicDataSource = new BasicDataSource();
         try {
             final DataSourceConfiguration configuration = getDataSourceConfiguration(context);
-            configureDataSource(context, dataSource, configuration);
+            configureDataSource(context, basicDataSource, configuration);
             results.add(new ConfigVerificationResult.Builder()
                     .verificationStepName("Configure Data Source")
                     .outcome(SUCCESSFUL)
                     .explanation("Successfully configured data source")
                     .build());
 
-            try (final Connection conn = getConnection(dataSource, kerberosUser)) {
+            try (final Connection conn = getConnection(basicDataSource, kerberosUser)) {
                 results.add(new ConfigVerificationResult.Builder()
                         .verificationStepName("Establish Connection")
                         .outcome(SUCCESSFUL)
@@ -114,7 +114,7 @@ public abstract class AbstractDBCPConnectionPool extends AbstractControllerServi
                     .build());
         } finally {
             try {
-                shutdown(dataSource, kerberosUser);
+                shutdown(basicDataSource, kerberosUser);
             } catch (final SQLException e) {
                 verificationLogger.error("Failed to shut down data source", e);
             }
@@ -157,30 +157,30 @@ public abstract class AbstractDBCPConnectionPool extends AbstractControllerServi
 
     protected abstract DataSourceConfiguration getDataSourceConfiguration(final ConfigurationContext context);
 
-    protected void configureDataSource(final ConfigurationContext context, final BasicDataSource dataSource, final DataSourceConfiguration configuration) {
+    protected void configureDataSource(final ConfigurationContext context, final BasicDataSource basicDataSource, final DataSourceConfiguration configuration) {
         final Driver driver = getDriver(configuration.getDriverName(), configuration.getUrl());
 
-        dataSource.setDriver(driver);
-        dataSource.setMaxWaitMillis(configuration.getMaxWaitMillis());
-        dataSource.setMaxTotal(configuration.getMaxTotal());
-        dataSource.setMinIdle(configuration.getMinIdle());
-        dataSource.setMaxIdle(configuration.getMaxIdle());
-        dataSource.setMaxConnLifetimeMillis(configuration.getMaxConnLifetimeMillis());
-        dataSource.setTimeBetweenEvictionRunsMillis(configuration.getTimeBetweenEvictionRunsMillis());
-        dataSource.setMinEvictableIdleTimeMillis(configuration.getMinEvictableIdleTimeMillis());
-        dataSource.setSoftMinEvictableIdleTimeMillis(configuration.getSoftMinEvictableIdleTimeMillis());
+        basicDataSource.setDriver(driver);
+        basicDataSource.setMaxWaitMillis(configuration.getMaxWaitMillis());
+        basicDataSource.setMaxTotal(configuration.getMaxTotal());
+        basicDataSource.setMinIdle(configuration.getMinIdle());
+        basicDataSource.setMaxIdle(configuration.getMaxIdle());
+        basicDataSource.setMaxConnLifetimeMillis(configuration.getMaxConnLifetimeMillis());
+        basicDataSource.setTimeBetweenEvictionRunsMillis(configuration.getTimeBetweenEvictionRunsMillis());
+        basicDataSource.setMinEvictableIdleTimeMillis(configuration.getMinEvictableIdleTimeMillis());
+        basicDataSource.setSoftMinEvictableIdleTimeMillis(configuration.getSoftMinEvictableIdleTimeMillis());
 
         final String validationQuery = configuration.getValidationQuery();
         if (StringUtils.isNotBlank(validationQuery)) {
-            dataSource.setValidationQuery(validationQuery);
-            dataSource.setTestOnBorrow(true);
+            basicDataSource.setValidationQuery(validationQuery);
+            basicDataSource.setTestOnBorrow(true);
         }
 
-        dataSource.setUrl(configuration.getUrl());
-        dataSource.setUsername(configuration.getUserName());
-        dataSource.setPassword(configuration.getPassword());
+        basicDataSource.setUrl(configuration.getUrl());
+        basicDataSource.setUsername(configuration.getUserName());
+        basicDataSource.setPassword(configuration.getPassword());
 
-        getConnectionProperties(context).forEach(dataSource::addConnectionProperty);
+        getConnectionProperties(context).forEach(basicDataSource::addConnectionProperty);
     }
 
     protected Map<String, String> getConnectionProperties(final ConfigurationContext context) {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/AbstractDBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/AbstractDBCPConnectionPool.java
@@ -79,7 +79,7 @@ public abstract class AbstractDBCPConnectionPool extends AbstractControllerServi
         final BasicDataSource dataSource = new BasicDataSource();
         try {
             final DataSourceConfiguration configuration = getDataSourceConfiguration(context);
-            configureDataSource(context, configuration);
+            configureDataSource(context, dataSource, configuration);
             results.add(new ConfigVerificationResult.Builder()
                     .verificationStepName("Configure Data Source")
                     .outcome(SUCCESSFUL)
@@ -140,7 +140,7 @@ public abstract class AbstractDBCPConnectionPool extends AbstractControllerServi
         kerberosUser = getKerberosUser(context);
         loginKerberos(kerberosUser);
         final DataSourceConfiguration configuration = getDataSourceConfiguration(context);
-        configureDataSource(context, configuration);
+        configureDataSource(context, dataSource, configuration);
     }
 
     private void loginKerberos(KerberosUser kerberosUser) throws InitializationException {
@@ -157,7 +157,7 @@ public abstract class AbstractDBCPConnectionPool extends AbstractControllerServi
 
     protected abstract DataSourceConfiguration getDataSourceConfiguration(final ConfigurationContext context);
 
-    protected void configureDataSource(final ConfigurationContext context, final DataSourceConfiguration configuration) {
+    protected void configureDataSource(final ConfigurationContext context, final BasicDataSource dataSource, final DataSourceConfiguration configuration) {
         final Driver driver = getDriver(configuration.getDriverName(), configuration.getUrl());
 
         dataSource.setDriver(driver);

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/test/java/org/apache/nifi/dbcp/AbstractDBCPConnectionPoolTest.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/test/java/org/apache/nifi/dbcp/AbstractDBCPConnectionPoolTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.dbcp;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.dbcp.utils.DBCPProperties;
+import org.apache.nifi.dbcp.utils.DataSourceConfiguration;
+import org.apache.nifi.kerberos.KerberosUserService;
+import org.apache.nifi.logging.ComponentLog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractDBCPConnectionPoolTest {
+
+    private static final int MAX_TOTAL = 1;
+
+    private static final int TIMEOUT = 0;
+
+    @Mock
+    Driver driver;
+
+    @Mock
+    Connection connection;
+
+    @Mock
+    DataSourceConfiguration dataSourceConfiguration;
+
+    @Mock
+    ConfigurationContext configurationContext;
+
+    @Mock
+    ComponentLog componentLog;
+
+    @Mock
+    PropertyValue kerberosUserServiceProperty;
+
+    @Mock
+    KerberosUserService kerberosUserService;
+
+    @Test
+    void testVerifySuccessful() throws SQLException {
+        final AbstractDBCPConnectionPool connectionPool = new MockDBCPConnectionPool();
+
+        when(dataSourceConfiguration.getMaxTotal()).thenReturn(MAX_TOTAL);
+        when(configurationContext.getProperty(eq(DBCPProperties.KERBEROS_USER_SERVICE))).thenReturn(kerberosUserServiceProperty);
+        when(kerberosUserServiceProperty.asControllerService(eq(KerberosUserService.class))).thenReturn(kerberosUserService);
+        when(driver.connect(any(), any())).thenReturn(connection);
+        when(connection.isValid(eq(TIMEOUT))).thenReturn(true);
+
+        final List<ConfigVerificationResult> results = connectionPool.verify(configurationContext, componentLog, Collections.emptyMap());
+
+        assertOutcomeSuccessful(results);
+    }
+
+    private void assertOutcomeSuccessful(final List<ConfigVerificationResult> results) {
+        assertNotNull(results);
+        final Iterator<ConfigVerificationResult> resultsFound = results.iterator();
+
+        assertTrue(resultsFound.hasNext());
+        final ConfigVerificationResult firstResult = resultsFound.next();
+        assertEquals(ConfigVerificationResult.Outcome.SUCCESSFUL, firstResult.getOutcome(), firstResult.getExplanation());
+
+        assertTrue(resultsFound.hasNext());
+        final ConfigVerificationResult secondResult = resultsFound.next();
+        assertEquals(ConfigVerificationResult.Outcome.SUCCESSFUL, secondResult.getOutcome(), secondResult.getExplanation());
+
+        assertFalse(resultsFound.hasNext());
+    }
+
+    private class MockDBCPConnectionPool extends AbstractDBCPConnectionPool {
+
+        @Override
+        protected Driver getDriver(final String driverName, final String url) {
+            return driver;
+        }
+
+        @Override
+        protected DataSourceConfiguration getDataSourceConfiguration(final ConfigurationContext context) {
+            return dataSourceConfiguration;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11547](https://issues.apache.org/jira/browse/NIFI-11547)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
