### PR TITLE
NIFI-11554 Upgrade OpenSAML from 3.4.6 to 4.3.0

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
-import org.springframework.security.saml2.provider.service.authentication.OpenSamlAuthenticationProvider;
+import org.springframework.security.saml2.provider.service.authentication.OpenSaml4AuthenticationProvider;
 import org.springframework.security.saml2.provider.service.authentication.logout.OpenSamlLogoutRequestValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.OpenSamlLogoutResponseValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequestValidator;
@@ -55,16 +55,16 @@ import org.springframework.security.saml2.provider.service.metadata.Saml2Metadat
 import org.springframework.security.saml2.provider.service.registration.InMemoryRelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
-import org.springframework.security.saml2.provider.service.servlet.filter.Saml2WebSsoAuthenticationFilter;
-import org.springframework.security.saml2.provider.service.servlet.filter.Saml2WebSsoAuthenticationRequestFilter;
+import org.springframework.security.saml2.provider.service.web.authentication.Saml2WebSsoAuthenticationFilter;
+import org.springframework.security.saml2.provider.service.web.Saml2WebSsoAuthenticationRequestFilter;
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
 import org.springframework.security.saml2.provider.service.web.Saml2AuthenticationRequestRepository;
 import org.springframework.security.saml2.provider.service.web.Saml2AuthenticationTokenConverter;
 import org.springframework.security.saml2.provider.service.web.Saml2MetadataFilter;
-import org.springframework.security.saml2.provider.service.web.authentication.OpenSaml3AuthenticationRequestResolver;
+import org.springframework.security.saml2.provider.service.web.authentication.OpenSaml4AuthenticationRequestResolver;
 import org.springframework.security.saml2.provider.service.web.authentication.Saml2AuthenticationRequestResolver;
-import org.springframework.security.saml2.provider.service.web.authentication.logout.OpenSaml3LogoutRequestResolver;
-import org.springframework.security.saml2.provider.service.web.authentication.logout.OpenSaml3LogoutResponseResolver;
+import org.springframework.security.saml2.provider.service.web.authentication.logout.OpenSaml4LogoutRequestResolver;
+import org.springframework.security.saml2.provider.service.web.authentication.logout.OpenSaml4LogoutResponseResolver;
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutRequestFilter;
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutRequestRepository;
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutRequestResolver;
@@ -218,26 +218,24 @@ public class SamlAuthenticationSecurityConfiguration {
     /**
      * Spring Security OpenSAML Authentication Provider for processing SAML 2 login responses
      *
-     * @return OpenSAML 3 Authentication Provider required for compatibility with Java 8
+     * @return OpenSAML 4 Authentication Provider compatible with Java 11
      */
-    @SuppressWarnings("deprecation")
     @Bean
-    public OpenSamlAuthenticationProvider openSamlAuthenticationProvider() {
-        final OpenSamlAuthenticationProvider provider = new OpenSamlAuthenticationProvider();
+    public OpenSaml4AuthenticationProvider openSamlAuthenticationProvider() {
+        final OpenSaml4AuthenticationProvider provider = new OpenSaml4AuthenticationProvider();
         final ResponseAuthenticationConverter responseAuthenticationConverter = new ResponseAuthenticationConverter(properties.getSamlGroupAttributeName());
         provider.setResponseAuthenticationConverter(responseAuthenticationConverter);
         return provider;
     }
 
     /**
-     * Spring Security SAML 2 Authentication Request Resolver uses OpenSAML 3 for compatibility with Java 8
+     * Spring Security SAML 2 Authentication Request Resolver uses OpenSAML 4
      *
-     * @return OpenSAML 3 version of SAML 2 Authentication Request Resolver
+     * @return OpenSAML 4 version of SAML 2 Authentication Request Resolver
      */
-    @SuppressWarnings("deprecation")
     @Bean
     public Saml2AuthenticationRequestResolver saml2AuthenticationRequestResolver() {
-        return new OpenSaml3AuthenticationRequestResolver(relyingPartyRegistrationResolver());
+        return new OpenSaml4AuthenticationRequestResolver(relyingPartyRegistrationResolver());
     }
 
     /**
@@ -261,25 +259,23 @@ public class SamlAuthenticationSecurityConfiguration {
     }
 
     /**
-     * Spring Security SAML 2 Logout Request Resolver uses OpenSAML 3 for compatibility with Java 8
+     * Spring Security SAML 2 Logout Request Resolver uses OpenSAML 4
      *
-     * @return OpenSAML 3 version of SAML 2 Logout Request Resolver
+     * @return OpenSAML 4 version of SAML 2 Logout Request Resolver
      */
-    @SuppressWarnings("deprecation")
     @Bean
     public Saml2LogoutRequestResolver saml2LogoutRequestResolver() {
-        return new OpenSaml3LogoutRequestResolver(relyingPartyRegistrationResolver());
+        return new OpenSaml4LogoutRequestResolver(relyingPartyRegistrationResolver());
     }
 
     /**
-     * Spring Security SAML 2 Logout Response Resolver uses OpenSAML 3 for compatibility with Java 8
+     * Spring Security SAML 2 Logout Response Resolver uses OpenSAML 4
      *
-     * @return OpenSAML 3 version of SAML 2 Logout Response Resolver
+     * @return OpenSAML 4 version of SAML 2 Logout Response Resolver
      */
-    @SuppressWarnings("deprecation")
     @Bean
     public Saml2LogoutResponseResolver saml2LogoutResponseResolver() {
-        return new OpenSaml3LogoutResponseResolver(relyingPartyRegistrationResolver());
+        return new OpenSaml4LogoutResponseResolver(relyingPartyRegistrationResolver());
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/registration/StandardSaml2CredentialProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/registration/StandardSaml2CredentialProvider.java
@@ -70,7 +70,7 @@ public class StandardSaml2CredentialProvider implements Saml2CredentialProvider 
         try {
             return keyStore.getKey(alias, keyPassword);
         } catch (final GeneralSecurityException e) {
-            throw new Saml2Exception(String.format("Loading Key [%s] failed", alias));
+            throw new Saml2Exception(String.format("Loading Key [%s] failed", alias), e);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/service/authentication/ResponseAuthenticationConverter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/service/authentication/ResponseAuthenticationConverter.java
@@ -24,8 +24,8 @@ import org.opensaml.saml.saml2.core.Assertion;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.saml2.provider.service.authentication.OpenSamlAuthenticationProvider;
-import org.springframework.security.saml2.provider.service.authentication.OpenSamlAuthenticationProvider.ResponseToken;
+import org.springframework.security.saml2.provider.service.authentication.OpenSaml4AuthenticationProvider;
+import org.springframework.security.saml2.provider.service.authentication.OpenSaml4AuthenticationProvider.ResponseToken;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
 
@@ -39,8 +39,7 @@ import java.util.stream.Collectors;
  * Converter from SAML 2 Response Token to SAML 2 Authentication for Spring Security
  */
 public class ResponseAuthenticationConverter implements Converter<ResponseToken, Saml2Authentication> {
-    @SuppressWarnings("deprecation")
-    private static final Converter<ResponseToken, Saml2Authentication> defaultConverter = OpenSamlAuthenticationProvider.createDefaultResponseAuthenticationConverter();
+    private static final Converter<ResponseToken, Saml2Authentication> defaultConverter = OpenSaml4AuthenticationProvider.createDefaultResponseAuthenticationConverter();
 
     private final String groupAttributeName;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <curator.version>5.5.0</curator.version>
         <tika.version>2.8.0</tika.version>
+        <org.opensaml.version>4.3.0</org.opensaml.version>
     </properties>
     <modules>
         <module>nifi-framework</module>
@@ -33,6 +34,19 @@
         <module>nifi-headless-server-nar</module>
         <module>nifi-framework-external-resource-utils</module>
     </modules>
+    <repositories>
+        <!-- Shibboleth Repository required for OpenSAML -->
+        <repository>
+            <id>shibboleth</id>
+            <url>https://build.shibboleth.net/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -424,6 +438,22 @@
                 <groupId>org.springframework.security.kerberos</groupId>
                 <artifactId>spring-security-kerberos-core</artifactId>
                 <version>1.0.1.RELEASE</version>
+            </dependency>
+            <!-- Override OpenSAML to version 4 for Spring Security SAML -->
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-core</artifactId>
+                <version>${org.opensaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-saml-api</artifactId>
+                <version>${org.opensaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-saml-impl</artifactId>
+                <version>${org.opensaml.version}</version>
             </dependency>
             <!-- Override xmlsec from spring-security-saml2-service-provider -->
             <dependency>


### PR DESCRIPTION
# Summary

[NIFI-11554](https://issues.apache.org/jira/browse/NIFI-11554) Upgrades [OpenSAML](https://shibboleth.atlassian.net/wiki/spaces/OSAML/overview) from 3.4.6 to 4.3.0 and replaces deprecated Spring Security components with current supported versions.

OpenSAML 4 requires Java 11 and replaces OpenSAML 3, which has reached end of life according to project documentation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
