### PR TITLE
NIFI-11109 Allow registry client's class in flow.xml/json to not change when underlying nar for nifi-flow-registry-client-nar is missing

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -522,7 +522,7 @@ public class ExtensionBuilder {
                     validationContextFactory,
                     serviceProvider,
                     componentType,
-                    simpleClassName,
+                    type,
                     componentVarRegistry,
                     reloadComponent,
                     extensionManager,


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11109](https://issues.apache.org/jira/browse/NIFI-11109)
If nifi registry client comes up in "ghost" mode.  It can never be restored.   This resolves this situation.

To verify fix:
Start nifi
configure registry client (i.e. Global Menu -> Controller Settings -> Registry Clients)
Verify there are no warnings associated with registry client
Stop nifi
move  nifi-flow-registry-client-nar (found in lib directory) to another directory
Start nifi
Verify registry client (at above mentioned location) does not work (i.e. it will have a warning as it is now in ghost mode)
Restore  nifi-flow-registry-client-nar to lib directory
Restart nifi
Verify earlier warning is gone and registry client is restored

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
