### PR TITLE
NIFI-10889-Update-woodstox-core-to-6.5.0

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -2348,9 +2348,9 @@ The following binary components are provided under the Apache Software License v
       OkHttp 3.12.2
       Copyright 2019 Square, Inc.
 
-  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:jar:6.1.1 - https://github.com/FasterXML/woodstox)
+  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:jar:6.5.0 - https://github.com/FasterXML/woodstox)
     The following NOTICE information applies:
-      Woodstox Core 6.1.1
+      Woodstox Core 6.5.0
       Copyright 2015, FasterXML, LLC
 
   (ASLv2) Non Blocking Reactive Foundation For The JVM (io.projectreactor:reactor-core:jar:3.3.5.RELEASE - https://github.com/reactor/reactor-core)

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-nar/src/main/resources/META-INF/NOTICE
@@ -180,9 +180,9 @@ The following binary components are provided under the Apache Software License v
         OkHttp 3.12.2
         Copyright 2019 Square, Inc.
 
-  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:jar:6.1.1 - https://github.com/FasterXML/woodstox)
+  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:jar:6.5.0 - https://github.com/FasterXML/woodstox)
       The following NOTICE information applies:
-        Woodstox Core 6.1.1
+        Woodstox Core 6.5.0
         Copyright 2015, FasterXML, LLC
 
   (ASLv2) Non Blocking Reactive Foundation For The JVM (io.projectreactor:reactor-core:jar:3.3.5.RELEASE - https://github.com/reactor/reactor-core)

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors-nar/src/main/resources/META-INF/NOTICE
@@ -322,9 +322,9 @@ Apache Software License v2
       Nimbus JOSE+JWT
       Copyright 2021, Connect2id Ltd.
 
-  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:bundle:5.3.0 - https://github.com/FasterXML/woodstox)
+  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:bundle:6.5.0 - https://github.com/FasterXML/woodstox)
       The following NOTICE information applies:
-        Woodstox Core 5.3.0
+        Woodstox Core 6.5.0
         Copyright 2015, FasterXML, LLC
 
   (ASLv2) Joda Time

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-services-api-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-services-api-nar/src/main/resources/META-INF/NOTICE
@@ -318,9 +318,9 @@ Apache Software License v2
       Nimbus JOSE+JWT
       Copyright 2021, Connect2id Ltd.
 
-  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:bundle:5.3.0 - https://github.com/FasterXML/woodstox)
+  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:bundle:6.5.0 - https://github.com/FasterXML/woodstox)
       The following NOTICE information applies:
-        Woodstox Core 5.3.0
+        Woodstox Core 6.5.0
         Copyright 2015, FasterXML, LLC
 
   (ASLv2) Joda Time

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/pom.xml
@@ -39,7 +39,7 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
-        <!-- Override woodstox-core 6.2.4 from Solr 8.11.1 -->
+        <!-- Override woodstox-core 6.5.0 from Solr 8.11.1 -->
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -85,7 +85,7 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.31</version>
             </dependency>
-            <!-- Override woodstox-core 5.3.0 from HBase -->
+            <!-- Override woodstox-core 5.4.0 from HBase -->
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
