### PR TITLE
NIFI-11580 set DistributedCacheClient to use daemon threads for clean shutdown

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CacheClientChannelPoolFactory.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CacheClientChannelPoolFactory.java
@@ -26,6 +26,7 @@ import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.channel.pool.FixedChannelPool;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.nifi.event.transport.netty.channel.pool.InitializingChannelPoolHandler;
 import org.apache.nifi.remote.VersionNegotiatorFactory;
 import org.apache.nifi.ssl.SSLContextService;
@@ -70,7 +71,7 @@ public class CacheClientChannelPoolFactory {
                                          final SSLContextService sslContextService,
                                          final VersionNegotiatorFactory factory) {
         final SSLContext sslContext = (sslContextService == null) ? null : sslContextService.createContext();
-        final EventLoopGroup group = new NioEventLoopGroup();
+        final EventLoopGroup group = new NioEventLoopGroup(new DefaultThreadFactory("DMCNioEventLoopGroup", true));
         final Bootstrap bootstrap = new Bootstrap();
         final CacheClientChannelInitializer initializer = new CacheClientChannelInitializer(sslContext, factory, Duration.ofMillis(timeoutMillis), Duration.ofMillis(timeoutMillis));
         bootstrap.group(group)

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CacheClientChannelPoolFactory.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CacheClientChannelPoolFactory.java
@@ -42,6 +42,7 @@ import java.time.Duration;
 public class CacheClientChannelPoolFactory {
 
     private static final int MAX_PENDING_ACQUIRES = 1024;
+    private static final boolean DAEMON_THREAD_ENABLED = true;
 
     private int maxConnections = Runtime.getRuntime().availableProcessors() * 2;
 
@@ -63,15 +64,17 @@ public class CacheClientChannelPoolFactory {
      * @param sslContextService the SSL context (if any) associated with requests to the service; if not specified,
      *                          communications will not be encrypted
      * @param factory           creator of object used to broker the version of the distributed cache protocol with the service
+     * @param poolName          channel pool name, used for threads name prefix
      * @return a channel pool object from which {@link Channel} objects may be obtained
      */
     public ChannelPool createChannelPool(final String hostname,
                                          final int port,
                                          final int timeoutMillis,
                                          final SSLContextService sslContextService,
-                                         final VersionNegotiatorFactory factory) {
+                                         final VersionNegotiatorFactory factory,
+                                         final String poolName) {
         final SSLContext sslContext = (sslContextService == null) ? null : sslContextService.createContext();
-        final EventLoopGroup group = new NioEventLoopGroup(new DefaultThreadFactory("DMCNioEventLoopGroup", true));
+        final EventLoopGroup group = new NioEventLoopGroup(new DefaultThreadFactory(poolName, DAEMON_THREAD_ENABLED));
         final Bootstrap bootstrap = new Bootstrap();
         final CacheClientChannelInitializer initializer = new CacheClientChannelInitializer(sslContext, factory, Duration.ofMillis(timeoutMillis), Duration.ofMillis(timeoutMillis));
         bootstrap.group(group)

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedCacheClient.java
@@ -45,14 +45,17 @@ public class DistributedCacheClient {
      * @param sslContextService the SSL context (if any) associated with requests to the service; if not specified,
      *                          communications will not be encrypted
      * @param factory           creator of object used to broker the version of the distributed cache protocol with the service
+     * @param identifier        uniquely identifies this client
      */
     protected DistributedCacheClient(final String hostname,
                                      final int port,
                                      final int timeoutMillis,
                                      final SSLContextService sslContextService,
-                                     final VersionNegotiatorFactory factory) {
+                                     final VersionNegotiatorFactory factory,
+                                     final String identifier) {
+        String poolName = String.format("%s[%s]", getClass().getSimpleName(), identifier);
         this.channelPool = new CacheClientChannelPoolFactory().createChannelPool(
-                hostname, port, timeoutMillis, sslContextService, factory);
+                hostname, port, timeoutMillis, sslContextService, factory, poolName);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClientService.java
@@ -114,6 +114,7 @@ public class DistributedMapCacheClientService extends AbstractControllerService 
                 context.getProperty(COMMUNICATIONS_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue(),
                 context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class),
                 versionNegotiatorFactory,
+                this.getIdentifier(),
                 getLogger());
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClientService.java
@@ -100,7 +100,8 @@ public class DistributedSetCacheClientService extends AbstractControllerService 
                 context.getProperty(PORT).asInteger(),
                 context.getProperty(COMMUNICATIONS_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue(),
                 context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class),
-                versionNegotiatorFactory);
+                versionNegotiatorFactory,
+                this.getIdentifier());
     }
 
     @OnDisabled

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/NettyDistributedMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/NettyDistributedMapCacheClient.java
@@ -53,6 +53,7 @@ public class NettyDistributedMapCacheClient extends DistributedCacheClient {
      * @param sslContextService the SSL context (if any) associated with requests to the service; if not specified,
      *                          communications will not be encrypted
      * @param factory           creator of object used to broker the version of the distributed cache protocol with the service
+     * @param identifier        uniquely identifies this client
      * @param log               Component Log from instantiating Services
      */
     public NettyDistributedMapCacheClient(
@@ -61,9 +62,10 @@ public class NettyDistributedMapCacheClient extends DistributedCacheClient {
             final int timeoutMillis,
             final SSLContextService sslContextService,
             final VersionNegotiatorFactory factory,
+            final String identifier,
             final ComponentLog log
     ) {
-        super(hostname, port, timeoutMillis, sslContextService, factory);
+        super(hostname, port, timeoutMillis, sslContextService, factory, identifier);
         this.log = Objects.requireNonNull(log, "Component Log required");
     }
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/NettyDistributedSetCacheClient.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/NettyDistributedSetCacheClient.java
@@ -40,14 +40,17 @@ public class NettyDistributedSetCacheClient extends DistributedCacheClient {
      * @param sslContextService the SSL context (if any) associated with requests to the service; if not specified,
      *                          communications will not be encrypted
      * @param factory           creator of object used to broker the version of the distributed cache protocol with the service
+     * @param identifier        uniquely identifies this client
      */
     public NettyDistributedSetCacheClient(
             final String hostname,
             final int port,
             final int timeoutMillis,
             final SSLContextService sslContextService,
-            final VersionNegotiatorFactory factory) {
-        super(hostname, port, timeoutMillis, sslContextService, factory);
+            final VersionNegotiatorFactory factory,
+            final String identifier
+    ) {
+        super(hostname, port, timeoutMillis, sslContextService, factory, identifier);
     }
 
     /**


### PR DESCRIPTION
# Summary

[NIFI-11580](https://issues.apache.org/jira/browse/NIFI-11580)
I verified this fixes the nifi shutdown problem with DistributedMapCacheClientService on nifi-2.0.0-SNAPSHOT and nifi-1.22.0-SNAPSHOT

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [n/a] Documentation formatting appears as expected in rendered files
