### PR TITLE
NIFI-11582 Deprecate GetIgniteCache and PutIgniteCache Processors

### DIFF
--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/GetIgniteCache.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/GetIgniteCache.java
@@ -28,6 +28,7 @@ import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -54,6 +55,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 @WritesAttributes({
     @WritesAttribute(attribute = GetIgniteCache.IGNITE_GET_FAILED_REASON_ATTRIBUTE_KEY, description = "The reason for getting entry from cache"),
     })
+@DeprecationNotice(reason = "Apache Ignite 1 is no longer supported")
 public class GetIgniteCache extends AbstractIgniteCacheProcessor {
 
     /** Flow file attribute keys and messages */

--- a/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/PutIgniteCache.java
+++ b/nifi-nar-bundles/nifi-ignite-bundle/nifi-ignite-processors/src/main/java/org/apache/nifi/processors/ignite/cache/PutIgniteCache.java
@@ -37,6 +37,7 @@ import org.apache.nifi.annotation.behavior.SystemResource;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -77,6 +78,7 @@ import org.apache.nifi.stream.io.StreamUtils;
     })
 @SeeAlso({GetIgniteCache.class})
 @SystemResourceConsideration(resource = SystemResource.MEMORY)
+@DeprecationNotice(reason = "Apache Ignite 1 is no longer supported")
 public class PutIgniteCache extends AbstractIgniteCacheProcessor {
 
     /**


### PR DESCRIPTION
# Summary

[NIFI-11582](https://issues.apache.org/jira/browse/NIFI-11582) Deprecates the `GetIgniteCache` and `PutIgniteCache` Processors for subsequent removal. Both Processors depend on the previous version of Apache Ignite, and the [2.0 Migration Guide](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+2.0+Migration+Guide) highlights a number of important changes.

The Processors have not been maintained since their introduction in 2016 and they depend on a Spring XML configuration, which is not an optimal solution for component configuration. New versions of the Processors could be written for Apache Ignite 2.0 that do not have the Spring Framework dependencies, but they should not be based on the current components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
