### PR TITLE
NIFI-11584: Allow ProcessSession to manage its own input streams and …

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
@@ -735,7 +735,11 @@ public interface ProcessSession {
      *             FlowFile content; if an attempt is made to access the InputStream
      *             provided to the given InputStreamCallback after this method completed its
      *             execution
+     *
+     * @deprecated Restricting the ProcessSession's ability to manage its own streams should not be used. The need for this
+     * capability was obviated by the introduction of the {@link #migrate(ProcessSession, Collection)} and {@link #migrate(ProcessSession)} methods.
      */
+    @Deprecated
     void read(FlowFile source, boolean allowSessionStreamManagement, InputStreamCallback reader) throws FlowFileAccessException;
 
     /**

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -453,7 +453,7 @@ public class MergeContent extends BinFiles {
         String groupId = correlationAttributeName == null ? null : flowFile.getAttribute(correlationAttributeName);
 
         // when MERGE_STRATEGY is Defragment and correlationAttributeName is null then bin by fragment.identifier
-        if (groupId == null && MERGE_STRATEGY_DEFRAGMENT.equals(context.getProperty(MERGE_STRATEGY).getValue())) {
+        if (groupId == null && MERGE_STRATEGY_DEFRAGMENT.getValue().equals(context.getProperty(MERGE_STRATEGY).getValue())) {
             groupId = flowFile.getAttribute(FRAGMENT_ID_ATTRIBUTE);
         }
 
@@ -462,7 +462,7 @@ public class MergeContent extends BinFiles {
 
     @Override
     protected void setUpBinManager(final BinManager binManager, final ProcessContext context) {
-        if (MERGE_STRATEGY_DEFRAGMENT.equals(context.getProperty(MERGE_STRATEGY).getValue())) {
+        if (MERGE_STRATEGY_DEFRAGMENT.getValue().equals(context.getProperty(MERGE_STRATEGY).getValue())) {
             binManager.setFileCountAttribute(FRAGMENT_COUNT_ATTRIBUTE);
         } else {
             binManager.setFileCountAttribute(null);
@@ -505,7 +505,7 @@ public class MergeContent extends BinFiles {
         final List<FlowFile> contents = bin.getContents();
         final ProcessSession binSession = bin.getSession();
 
-        if (MERGE_STRATEGY_DEFRAGMENT.equals(context.getProperty(MERGE_STRATEGY).getValue())) {
+        if (MERGE_STRATEGY_DEFRAGMENT.getValue().equals(context.getProperty(MERGE_STRATEGY).getValue())) {
             final String error = getDefragmentValidationError(bin.getContents());
 
             // Fail the flow files and commit them
@@ -648,12 +648,7 @@ public class MergeContent extends BinFiles {
                         final Iterator<FlowFile> itr = contents.iterator();
                         while (itr.hasNext()) {
                             final FlowFile flowFile = itr.next();
-                            bin.getSession().read(flowFile, false, new InputStreamCallback() {
-                                @Override
-                                public void process(final InputStream in) throws IOException {
-                                    StreamUtils.copy(in, out);
-                                }
-                            });
+                            bin.getSession().read(flowFile, in -> StreamUtils.copy(in, out));
 
                             if (itr.hasNext()) {
                                 if (demarcator != null) {
@@ -694,7 +689,7 @@ public class MergeContent extends BinFiles {
 
         private byte[] getDelimiterContent(final ProcessContext context, final List<FlowFile> wrappers, final PropertyDescriptor descriptor) throws IOException {
             final String delimiterStrategyValue = context.getProperty(DELIMITER_STRATEGY).getValue();
-            if (DELIMITER_STRATEGY_FILENAME.equals(delimiterStrategyValue)) {
+            if (DELIMITER_STRATEGY_FILENAME.getValue().equals(delimiterStrategyValue)) {
                 return getDelimiterFileContent(context, wrappers, descriptor);
             } else {
                 return getDelimiterTextContent(context, wrappers, descriptor);
@@ -881,7 +876,7 @@ public class MergeContent extends BinFiles {
                             final OutputStream out = new NonCloseableOutputStream(bufferedOut);
 
                             for (final FlowFile flowFile : contents) {
-                                bin.getSession().read(flowFile, false, new InputStreamCallback() {
+                                bin.getSession().read(flowFile, new InputStreamCallback() {
                                     @Override
                                     public void process(final InputStream rawIn) throws IOException {
                                         try (final InputStream in = new BufferedInputStream(rawIn)) {
@@ -919,7 +914,7 @@ public class MergeContent extends BinFiles {
 
         private final int compressionLevel;
 
-        private List<FlowFile> unmerged = new ArrayList<>();
+        private final List<FlowFile> unmerged = new ArrayList<>();
 
         public ZipMerge(final int compressionLevel) {
             this.compressionLevel = compressionLevel;
@@ -986,7 +981,7 @@ public class MergeContent extends BinFiles {
 
     private class AvroMerge implements MergeBin {
 
-        private List<FlowFile> unmerged = new ArrayList<>();
+        private final List<FlowFile> unmerged = new ArrayList<>();
 
         @Override
         public FlowFile merge(final Bin bin, final ProcessContext context) {
@@ -1007,7 +1002,7 @@ public class MergeContent extends BinFiles {
                     public void process(final OutputStream rawOut) throws IOException {
                         try (final OutputStream out = new BufferedOutputStream(rawOut)) {
                             for (final FlowFile flowFile : contents) {
-                                bin.getSession().read(flowFile, false, new InputStreamCallback() {
+                                bin.getSession().read(flowFile, new InputStreamCallback() {
                                     @Override
                                     public void process(InputStream in) throws IOException {
                                         boolean canMerge = true;


### PR DESCRIPTION
…deprecated method that reads from flowfile without allowing it

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
