### PR TITLE
NIFI-11614 Improve Validation for JndiJmsConnectionFactoryProvider

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.cf.JndiJmsConnectionFactoryProvider/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.cf.JndiJmsConnectionFactoryProvider/additionalDetails.html
@@ -21,9 +21,9 @@
 </head>
 
 <body>
-<h2>Description:</h2>
+<h2>Capabilities</h2>
 <p>
-    This ControllerService allows users to reference a JMS Connection Factory that has already been established and
+    This Controller Service allows users to reference a JMS Connection Factory that has already been established and
     made available via Java Naming and Directory Interface (JNDI) Server. Please see documentation from your JMS Vendor in order
     to understand the appropriate values to configure for this service.
 </p>
@@ -55,7 +55,7 @@ ConnectionFactory connectionFactory = initialContext.lookup(JNDI_CONNECTION_FACT
 </p>
 
 
-<h2>Example:</h2>
+<h2>Example Configuration</h2>
 
 <p>
     As an example, the following configuration may be used to connect to Active MQ's JMS Broker, using the Connection Factory provided via their embedded JNDI server:
@@ -90,6 +90,78 @@ ConnectionFactory connectionFactory = initialContext.lookup(JNDI_CONNECTION_FACT
     The above example assumes that there exists a host that is accessible with hostname "jms-broker" and that is running Apache ActiveMQ on port 61616 and also that
     the jar(s) containing the org.apache.activemq.jndi.ActiveMQInitialContextFactory class and the other JMS client classes can be found within the /opt/apache-activemq-5.15.2/lib/ directory.
 </p>
+
+<h2>Property Validation</h2>
+
+<p>
+  The following component properties include additional validation to restrict allowed values:
+</p>
+
+<ul>
+  <li>JNDI Initial Context Factory Class</li>
+  <li>JNDI Provider URL</li>
+</ul>
+
+<h3>JNDI Initial Context Factory Class Validation</h3>
+
+<p>
+  The default validation for <code>JNDI Initial Context Factory Class</code> disallows the following class values:
+</p>
+
+<ul>
+  <li><code>com.sun.jndi.ldap.LdapCtxFactory</code></li>
+</ul>
+
+<p>
+  Specialized configurations can retrieve JNDI JMS settings from an LDAP server, requiring the use of the LDAP Context Factory.
+  Property validation for the Context Factory Class can be adjusted using Java System properties.
+</p>
+<p>
+  The following Java System property can be configured to override the default disallowed Context Factory Class:
+</p>
+
+<ul>
+  <li>
+    <code>org.apache.nifi.jms.cf.jndi.context.factory.disallowed</code>
+  </li>
+</ul>
+
+<h3>JNDI Provider URL Validation</h3>
+
+<p>
+  The default validation for <code>JNDI Provider URL</code> allows the following URL schemes:
+</p>
+
+<ul>
+  <li>file</li>
+  <li>jgroups</li>
+  <li>ssl</li>
+  <li>t3</li>
+  <li>tcp</li>
+  <li>udp</li>
+  <li>vm</li>
+</ul>
+
+<p>
+  The following Java System property can be configured to override the default allowed URL schemes:
+</p>
+
+<ul>
+  <li>
+    <code>org.apache.nifi.jms.cf.jndi.provider.url.schemes.allowed</code>
+  </li>
+</ul>
+
+<p>
+  The System property must contain a space-separated list of URL schemes. This property can be configured in the application
+  <code>bootstrap.conf</code> as follows:
+</p>
+
+<ul>
+  <li>
+    <code>java.arg.jndiJmsUrlSchemesAllowed=-Dorg.apache.nifi.jms.cf.jndi.provider.url.schemes.allowed=ssl tcp</code>
+  </li>
+</ul>
 
 </body>
 </html>

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.cf.JndiJmsConnectionFactoryProvider/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/resources/docs/org.apache.nifi.jms.cf.JndiJmsConnectionFactoryProvider/additionalDetails.html
@@ -98,32 +98,7 @@ ConnectionFactory connectionFactory = initialContext.lookup(JNDI_CONNECTION_FACT
 </p>
 
 <ul>
-  <li>JNDI Initial Context Factory Class</li>
   <li>JNDI Provider URL</li>
-</ul>
-
-<h3>JNDI Initial Context Factory Class Validation</h3>
-
-<p>
-  The default validation for <code>JNDI Initial Context Factory Class</code> disallows the following class values:
-</p>
-
-<ul>
-  <li><code>com.sun.jndi.ldap.LdapCtxFactory</code></li>
-</ul>
-
-<p>
-  Specialized configurations can retrieve JNDI JMS settings from an LDAP server, requiring the use of the LDAP Context Factory.
-  Property validation for the Context Factory Class can be adjusted using Java System properties.
-</p>
-<p>
-  The following Java System property can be configured to override the default disallowed Context Factory Class:
-</p>
-
-<ul>
-  <li>
-    <code>org.apache.nifi.jms.cf.jndi.context.factory.disallowed</code>
-  </li>
 </ul>
 
 <h3>JNDI Provider URL Validation</h3>
@@ -137,6 +112,7 @@ ConnectionFactory connectionFactory = initialContext.lookup(JNDI_CONNECTION_FACT
   <li>jgroups</li>
   <li>ssl</li>
   <li>t3</li>
+  <li>t3s</li>
   <li>tcp</li>
   <li>udp</li>
   <li>vm</li>

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProviderTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProviderTest.java
@@ -39,6 +39,8 @@ public class JndiJmsConnectionFactoryProviderTest {
 
     private static final String TEST_PROVIDER_URL = "test://127.0.0.1";
 
+    private static final String HOST_PORT_URL = "127.0.0.1:1024";
+
     private static final String ALLOWED_URL_SCHEMES = "tcp test";
 
     private static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
@@ -103,6 +105,15 @@ public class JndiJmsConnectionFactoryProviderTest {
         setFactoryProperties();
 
         runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, TEST_PROVIDER_URL);
+
+        runner.assertValid(provider);
+    }
+
+    @Test
+    void testPropertiesHostPortUrl() {
+        setFactoryProperties();
+
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, HOST_PORT_URL);
 
         runner.assertValid(provider);
     }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProviderTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProviderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jms.cf;
+
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JndiJmsConnectionFactoryProviderTest {
+
+    private static final String SERVICE_ID = JndiJmsConnectionFactoryProvider.class.getSimpleName();
+
+    private static final String CONTEXT_FACTORY = "ContextFactory";
+
+    private static final String FACTORY_NAME = "ConnectionFactory";
+
+    private static final String TCP_PROVIDER_URL = "tcp://127.0.0.1";
+
+    private static final String LDAP_PROVIDER_URL = "ldap://127.0.0.1";
+
+    private static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+
+    private TestRunner runner;
+
+    private JndiJmsConnectionFactoryProvider provider;
+
+    @BeforeEach
+    void setRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(NoOpProcessor.class);
+        provider = new JndiJmsConnectionFactoryProvider();
+        runner.addControllerService(SERVICE_ID, provider);
+    }
+
+    @Test
+    void testPropertiesValid() {
+        setFactoryProperties();
+
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, TCP_PROVIDER_URL);
+
+        runner.assertValid(provider);
+    }
+
+    @Test
+    void testPropertiesInvalidUrlNotConfigured() {
+        setFactoryProperties();
+
+        runner.assertNotValid(provider);
+    }
+
+    @Test
+    void testPropertiesInvalidUrlScheme() {
+        setFactoryProperties();
+
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, LDAP_PROVIDER_URL);
+
+        runner.assertNotValid(provider);
+    }
+
+    @Test
+    void testPropertiesInvalidContextFactory() {
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_INITIAL_CONTEXT_FACTORY, LDAP_CONTEXT_FACTORY);
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_CONNECTION_FACTORY_NAME, FACTORY_NAME);
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, TCP_PROVIDER_URL);
+
+        runner.assertNotValid(provider);
+    }
+
+    private void setFactoryProperties() {
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_INITIAL_CONTEXT_FACTORY, CONTEXT_FACTORY);
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_CONNECTION_FACTORY_NAME, FACTORY_NAME);
+    }
+}

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProviderTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProviderTest.java
@@ -20,6 +20,8 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.NoOpProcessor;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,11 +37,25 @@ public class JndiJmsConnectionFactoryProviderTest {
 
     private static final String LDAP_PROVIDER_URL = "ldap://127.0.0.1";
 
+    private static final String TEST_PROVIDER_URL = "test://127.0.0.1";
+
+    private static final String ALLOWED_URL_SCHEMES = "tcp test";
+
     private static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
 
     private TestRunner runner;
 
     private JndiJmsConnectionFactoryProvider provider;
+
+    @BeforeAll
+    static void setProperties() {
+        System.setProperty(JndiJmsConnectionFactoryProperties.URL_SCHEMES_ALLOWED_PROPERTY, ALLOWED_URL_SCHEMES);
+    }
+
+    @AfterAll
+    static void clearProperties() {
+        System.clearProperty(JndiJmsConnectionFactoryProperties.URL_SCHEMES_ALLOWED_PROPERTY);
+    }
 
     @BeforeEach
     void setRunner() throws InitializationException {
@@ -80,6 +96,15 @@ public class JndiJmsConnectionFactoryProviderTest {
         runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, TCP_PROVIDER_URL);
 
         runner.assertNotValid(provider);
+    }
+
+    @Test
+    void testPropertiesUrlSchemeSystemProperty() {
+        setFactoryProperties();
+
+        runner.setProperty(provider, JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL, TEST_PROVIDER_URL);
+
+        runner.assertValid(provider);
     }
 
     private void setFactoryProperties() {


### PR DESCRIPTION
# Summary

[NIFI-11614](https://issues.apache.org/jira/browse/NIFI-11614) Improves property validation for the `JndiJmsConnectionFactoryProvider` Controller Service with a set of allowed URL schemes and disallowed Context Factory classes.

The current implementation only checks for a configured value with standard properties, but the new validation narrows the scope to provide better validation prior to enabling the provider.

The initial set of allowed URL schemes is based on the [ActiveMQ Using JMS](https://activemq.apache.org/components/artemis/documentation/latest/using-jms.html) documentation. The new URL validation narrows the scope of potential values, which should be noted in migration guidance, providing a clearer set of supported values

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
