### PR TITLE
NIFI-11595: StateProvider.replace() supports creating the initial state

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
@@ -271,11 +271,6 @@ public class WriteAheadLocalStateProvider extends AbstractStateProvider {
 
         // see above explanation as to why this method is synchronized.
         public synchronized boolean replace(final StateMap oldValue, final Map<String, String> newValue) throws IOException {
-            if (!stateMap.getStateVersion().isPresent()) {
-                // state has never been set so return false
-                return false;
-            }
-
             if (stateMap != oldValue) {
                 return false;
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/AbstractTestStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/state/providers/AbstractTestStateProvider.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProvider;
@@ -160,15 +161,21 @@ public abstract class AbstractTestStateProvider {
 
     @Test
     public void testReplaceWithNonExistingValue() throws Exception {
+        final String key = "testReplaceWithNonExistingValue";
+        final String value = "value";
         final StateProvider provider = getProvider();
         StateMap stateMap = provider.getState(componentId);
         assertNotNull(stateMap);
 
         final Map<String, String> newValue = new HashMap<>();
-        newValue.put("value", "value");
+        newValue.put(key, value);
 
         final boolean replaced = provider.replace(stateMap, newValue, componentId);
-        assertFalse(replaced);
+        assertTrue(replaced);
+
+        StateMap map = provider.getState(componentId);
+        assertEquals(value, map.get(key));
+        assertTrue(map.getStateVersion().isPresent());
     }
 
     @Test
@@ -196,6 +203,50 @@ public abstract class AbstractTestStateProvider {
 
         final boolean replaced = provider.replace(stateMap, newValue, componentId);
         assertFalse(replaced);
+    }
+
+    @Test
+    void testReplaceConcurrentCreate() throws IOException {
+        final StateProvider provider = getProvider();
+
+        final StateMap stateMap1 = provider.getState(componentId);
+        final StateMap stateMap2 = provider.getState(componentId);
+
+        final boolean replaced1 = provider.replace(stateMap1, Collections.emptyMap(), componentId);
+
+        assertTrue(replaced1);
+
+        final StateMap replacedStateMap = provider.getState(componentId);
+        final Optional<String> replacedVersion = replacedStateMap.getStateVersion();
+        assertTrue(replacedVersion.isPresent());
+        assertEquals("0", replacedVersion.get());
+
+        final boolean replaced2 = provider.replace(stateMap2, Collections.emptyMap(), componentId);
+
+        assertFalse(replaced2);
+    }
+
+    @Test
+    void testReplaceConcurrentUpdate() throws IOException {
+        final StateProvider provider = getProvider();
+
+        provider.setState(Collections.singletonMap("key", "0"), componentId);
+
+        final StateMap stateMap1 = provider.getState(componentId);
+        final StateMap stateMap2 = provider.getState(componentId);
+
+        final boolean replaced1 = provider.replace(stateMap1, Collections.singletonMap("key", "1"), componentId);
+
+        assertTrue(replaced1);
+
+        final StateMap replacedStateMap = provider.getState(componentId);
+        final Optional<String> replacedVersion = replacedStateMap.getStateVersion();
+        assertTrue(replacedVersion.isPresent());
+        assertEquals("1", replacedVersion.get());
+
+        final boolean replaced2 = provider.replace(stateMap2, Collections.singletonMap("key", "2"), componentId);
+
+        assertFalse(replaced2);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/StandardOidcAuthorizedClientRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/StandardOidcAuthorizedClientRepository.java
@@ -236,17 +236,10 @@ public class StandardOidcAuthorizedClientRepository implements OAuth2AuthorizedC
     private synchronized void updateState(final String principalId, final Consumer<Map<String, String>> stateConsumer) {
         try {
             final StateMap stateMap = getStateMap();
-            final Map<String, String> currentStateMap = stateMap.toMap();
-            final Map<String, String> updated = new LinkedHashMap<>(currentStateMap);
+            final Map<String, String> updated = new LinkedHashMap<>(stateMap.toMap());
             stateConsumer.accept(updated);
 
-            final boolean completed;
-            if (currentStateMap.isEmpty()) {
-                stateManager.setState(updated, SCOPE);
-                completed = true;
-            } else {
-                completed = stateManager.replace(stateMap, updated, SCOPE);
-            }
+            final boolean completed = stateManager.replace(stateMap, updated, SCOPE);
 
             if (completed) {
                 logger.info("Identity [{}] OIDC Authorized Client update completed", principalId);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/client/web/StandardOidcAuthorizedClientRepositoryTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/client/web/StandardOidcAuthorizedClientRepositoryTest.java
@@ -149,7 +149,7 @@ class StandardOidcAuthorizedClientRepositoryTest {
         repository.saveAuthorizedClient(authorizedClient, principal, request, response);
 
         verify(authorizedClientConverter).getEncoded(isA(OidcAuthorizedClient.class));
-        verify(stateManager).setState(stateMapCaptor.capture(), eq(SCOPE));
+        verify(stateManager).replace(eq(stateMap), stateMapCaptor.capture(), eq(SCOPE));
 
         final Map<String, String> updatedStateMap = stateMapCaptor.getValue();
         final String encodedClient = updatedStateMap.get(IDENTITY);
@@ -165,7 +165,7 @@ class StandardOidcAuthorizedClientRepositoryTest {
 
         repository.removeAuthorizedClient(REGISTRATION_ID, principal, request, response);
 
-        verify(stateManager).setState(stateMapCaptor.capture(), eq(SCOPE));
+        verify(stateManager).replace(eq(stateMap), stateMapCaptor.capture(), eq(SCOPE));
         final Map<String, String> updatedStateMap = stateMapCaptor.getValue();
         assertTrue(updatedStateMap.isEmpty());
     }

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/state/RedisStateProvider.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/state/RedisStateProvider.java
@@ -198,7 +198,7 @@ public class RedisStateProvider extends AbstractConfigurableComponent implements
         boolean updated = false;
 
         while (!updated && attempted < this.maxAttempts) {
-            updated = replace(currStateMap, state, componentId, true);
+            updated = replace(currStateMap, state, componentId);
             attempted++;
         }
 
@@ -224,10 +224,6 @@ public class RedisStateProvider extends AbstractConfigurableComponent implements
 
     @Override
     public boolean replace(final StateMap oldValue, final Map<String, String> newValue, final String componentId) throws IOException {
-        return replace(oldValue, newValue, componentId, false);
-    }
-
-    private boolean replace(final StateMap oldValue, final Map<String, String> newValue, final String componentId, final boolean allowReplaceMissing) throws IOException {
         return withConnection(redisConnection -> {
 
             boolean replaced = false;
@@ -241,12 +237,6 @@ public class RedisStateProvider extends AbstractConfigurableComponent implements
             final byte[] currValue = redisConnection.get(key);
             final RedisStateMap currStateMap = serDe.deserialize(currValue);
             final Optional<String> currentVersion = currStateMap == null ? Optional.empty() : currStateMap.getStateVersion();
-
-            // the replace API expects that you can't call replace on a non-existing value, so unwatch and return
-            if (!allowReplaceMissing && !currentVersion.isPresent()) {
-                redisConnection.unwatch();
-                return false;
-            }
 
             // start a transaction
             redisConnection.multi();
@@ -286,7 +276,7 @@ public class RedisStateProvider extends AbstractConfigurableComponent implements
 
         while (!updated && attempted < this.maxAttempts) {
             final StateMap currStateMap = getState(componentId);
-            updated = replace(currStateMap, Collections.emptyMap(), componentId, true);
+            updated = replace(currStateMap, Collections.emptyMap(), componentId);
 
             final String result = updated ? "successful" : "unsuccessful";
             logger.debug("Attempt # {} to clear state for component {} was {}", attempted + 1, componentId, result);

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/state/ITRedisStateProvider.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/state/ITRedisStateProvider.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -202,15 +203,21 @@ public class ITRedisStateProvider {
 
     @Test
     public void testReplaceWithNonExistingValue() throws Exception {
+        final String key = "testReplaceWithNonExistingValue";
+        final String value = "value";
         final StateProvider provider = getProvider();
         StateMap stateMap = provider.getState(componentId);
         assertNotNull(stateMap);
 
         final Map<String, String> newValue = new HashMap<>();
-        newValue.put("value", "value");
+        newValue.put(key, value);
 
         final boolean replaced = provider.replace(stateMap, newValue, componentId);
-        assertFalse(replaced);
+        assertTrue(replaced);
+
+        StateMap map = provider.getState(componentId);
+        assertEquals(value, map.get(key));
+        assertTrue(map.getStateVersion().isPresent());
     }
 
     @Test
@@ -238,6 +245,50 @@ public class ITRedisStateProvider {
 
         final boolean replaced = provider.replace(stateMap, newValue, componentId);
         assertFalse(replaced);
+    }
+
+    @Test
+    void testReplaceConcurrentCreate() throws IOException {
+        final StateProvider provider = getProvider();
+
+        final StateMap stateMap1 = provider.getState(componentId);
+        final StateMap stateMap2 = provider.getState(componentId);
+
+        final boolean replaced1 = provider.replace(stateMap1, Collections.emptyMap(), componentId);
+
+        assertTrue(replaced1);
+
+        final StateMap replacedStateMap = provider.getState(componentId);
+        final Optional<String> replacedVersion = replacedStateMap.getStateVersion();
+        assertTrue(replacedVersion.isPresent());
+        assertEquals("0", replacedVersion.get());
+
+        final boolean replaced2 = provider.replace(stateMap2, Collections.emptyMap(), componentId);
+
+        assertFalse(replaced2);
+    }
+
+    @Test
+    void testReplaceConcurrentUpdate() throws IOException {
+        final StateProvider provider = getProvider();
+
+        provider.setState(Collections.singletonMap("key", "0"), componentId);
+
+        final StateMap stateMap1 = provider.getState(componentId);
+        final StateMap stateMap2 = provider.getState(componentId);
+
+        final boolean replaced1 = provider.replace(stateMap1, Collections.singletonMap("key", "1"), componentId);
+
+        assertTrue(replaced1);
+
+        final StateMap replacedStateMap = provider.getState(componentId);
+        final Optional<String> replacedVersion = replacedStateMap.getStateVersion();
+        assertTrue(replacedVersion.isPresent());
+        assertEquals("1", replacedVersion.get());
+
+        final boolean replaced2 = provider.replace(stateMap2, Collections.singletonMap("key", "2"), componentId);
+
+        assertFalse(replaced2);
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11595](https://issues.apache.org/jira/browse/NIFI-11595)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
