### PR TITLE
NIFI-11628: Fixed Object[] + Throwable argument substitution in Simpl…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
@@ -91,7 +91,8 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.warn(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.WARN, componentMessage, arguments);
             } else {
-                logger.warn(componentMessage, arguments, t);
+                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
+                logger.warn(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
                 logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -158,7 +159,8 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.trace(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.TRACE, componentMessage, arguments);
             } else {
-                logger.trace(componentMessage, arguments, t);
+                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
+                logger.trace(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
                 logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -245,7 +247,8 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.info(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.INFO, componentMessage, arguments);
             } else {
-                logger.info(componentMessage, arguments, t);
+                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
+                logger.info(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
                 logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -312,7 +315,8 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.error(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.ERROR, componentMessage, arguments);
             } else {
-                logger.error(componentMessage, arguments, t);
+                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
+                logger.error(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
                 logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -369,7 +373,8 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.debug(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.DEBUG, componentMessage, arguments);
             } else {
-                logger.debug(componentMessage, arguments, t);
+                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
+                logger.debug(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
                 logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -531,6 +536,10 @@ public class SimpleProcessLogger implements ComponentLog {
 
     private Object[] insertComponent(final Object[] originalArgs) {
         return ArrayUtils.insert(0, originalArgs, component);
+    }
+
+    private Object[] insertThrowable(final Object[] originalArgs, final Throwable throwable) {
+        return ArrayUtils.insert(originalArgs.length, originalArgs, throwable);
     }
 
     private Object[] addCauses(final Object[] arguments, final Throwable throwable) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/SimpleProcessLogger.java
@@ -91,8 +91,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.warn(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.WARN, componentMessage, arguments);
             } else {
-                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
-                logger.warn(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
+                logger.warn(componentMessage, addThrowable(arguments, t));
                 logRepository.addLogMessage(LogLevel.WARN, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -159,8 +158,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.trace(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.TRACE, componentMessage, arguments);
             } else {
-                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
-                logger.trace(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
+                logger.trace(componentMessage, addThrowable(arguments, t));
                 logRepository.addLogMessage(LogLevel.TRACE, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -247,8 +245,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.info(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.INFO, componentMessage, arguments);
             } else {
-                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
-                logger.info(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
+                logger.info(componentMessage, addThrowable(arguments, t));
                 logRepository.addLogMessage(LogLevel.INFO, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -315,8 +312,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.error(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.ERROR, componentMessage, arguments);
             } else {
-                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
-                logger.error(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
+                logger.error(componentMessage, addThrowable(arguments, t));
                 logRepository.addLogMessage(LogLevel.ERROR, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -373,8 +369,7 @@ public class SimpleProcessLogger implements ComponentLog {
                 logger.debug(componentMessage, arguments);
                 logRepository.addLogMessage(LogLevel.DEBUG, componentMessage, arguments);
             } else {
-                final Object[] argumentsWithThrowable = insertThrowable(arguments, t);
-                logger.debug(componentMessage, setFormattedThrowable(argumentsWithThrowable, t));
+                logger.debug(componentMessage, addThrowable(arguments, t));
                 logRepository.addLogMessage(LogLevel.DEBUG, getCausesMessage(msg), addCauses(arguments, t), t);
             }
         }
@@ -538,8 +533,8 @@ public class SimpleProcessLogger implements ComponentLog {
         return ArrayUtils.insert(0, originalArgs, component);
     }
 
-    private Object[] insertThrowable(final Object[] originalArgs, final Throwable throwable) {
-        return ArrayUtils.insert(originalArgs.length, originalArgs, throwable);
+    private Object[] addThrowable(final Object[] originalArgs, final Throwable throwable) {
+        return ArrayUtils.add(originalArgs, throwable);
     }
 
     private Object[] addCauses(final Object[] arguments, final Throwable throwable) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
@@ -229,19 +229,19 @@ public class TestSimpleProcessLogger {
 
             switch (logLevel) {
                 case TRACE:
-                    verify(logger).trace(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    verify(logger).trace(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION));
                     break;
                 case DEBUG:
-                    verify(logger).debug(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    verify(logger).debug(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION));
                     break;
                 case INFO:
-                    verify(logger).info(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    verify(logger).info(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION));
                     break;
                 case WARN:
-                    verify(logger).warn(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    verify(logger).warn(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION));
                     break;
                 case ERROR:
-                    verify(logger).error(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    verify(logger).error(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION));
                     break;
                 default:
                     continue;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/processor/TestSimpleProcessLogger.java
@@ -200,7 +200,36 @@ public class TestSimpleProcessLogger {
 
             switch (logLevel) {
                 case TRACE:
-                    verify(logger).trace(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT),  eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    verify(logger).trace(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    break;
+                case DEBUG:
+                    verify(logger).debug(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    break;
+                case INFO:
+                    verify(logger).info(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    break;
+                case WARN:
+                    verify(logger).warn(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    break;
+                case ERROR:
+                    verify(logger).error(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
+                    break;
+                default:
+                    continue;
+            }
+
+            verify(logRepository).addLogMessage(eq(logLevel), eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT_AND_CAUSES), eq(componentValueCausesArguments), eq(EXCEPTION));
+        }
+    }
+
+    @Test
+    public void testLogLevelMessageArgumentsArrayThrowable() {
+        for (final LogLevel logLevel : LogLevel.values()) {
+            componentLog.log(logLevel, LOG_ARGUMENTS_MESSAGE, VALUE_ARGUMENTS, EXCEPTION);
+
+            switch (logLevel) {
+                case TRACE:
+                    verify(logger).trace(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));
                     break;
                 case DEBUG:
                     verify(logger).debug(eq(LOG_ARGUMENTS_MESSAGE_WITH_COMPONENT), eq(component), eq(FIRST), eq(SECOND), eq(EXCEPTION_STRING), eq(EXCEPTION));


### PR DESCRIPTION
…eProcessLogger

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11628](https://issues.apache.org/jira/browse/NIFI-11628)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
