### PR TITLE
NIFI-11629 Add Socket Write Timeout to InvokeHTTP

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -242,6 +242,15 @@ public class InvokeHTTP extends AbstractProcessor {
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor SOCKET_WRITE_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("Socket Write Timeout")
+            .displayName("Socket Write Timeout")
+            .description("Maximum time to wait for write operations while sending requests from a socket connection to the HTTP URL.")
+            .required(true)
+            .defaultValue("15 secs")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .build();
+
     public static final PropertyDescriptor SOCKET_IDLE_TIMEOUT = new PropertyDescriptor.Builder()
             .name("idle-timeout")
             .displayName("Socket Idle Timeout")
@@ -505,6 +514,7 @@ public class InvokeHTTP extends AbstractProcessor {
             SSL_CONTEXT_SERVICE,
             SOCKET_CONNECT_TIMEOUT,
             SOCKET_READ_TIMEOUT,
+            SOCKET_WRITE_TIMEOUT,
             SOCKET_IDLE_TIMEOUT,
             SOCKET_IDLE_CONNECTIONS,
             PROXY_CONFIGURATION_SERVICE,
@@ -731,6 +741,7 @@ public class InvokeHTTP extends AbstractProcessor {
         okHttpClientBuilder.followRedirects(context.getProperty(RESPONSE_REDIRECTS_ENABLED).asBoolean());
         okHttpClientBuilder.connectTimeout((context.getProperty(SOCKET_CONNECT_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue()), TimeUnit.MILLISECONDS);
         okHttpClientBuilder.readTimeout(context.getProperty(SOCKET_READ_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue(), TimeUnit.MILLISECONDS);
+        okHttpClientBuilder.writeTimeout(context.getProperty(SOCKET_WRITE_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue(), TimeUnit.MILLISECONDS);
         okHttpClientBuilder.connectionPool(
                 new ConnectionPool(
                         context.getProperty(SOCKET_IDLE_CONNECTIONS).asInteger(),


### PR DESCRIPTION
# Summary

[NIFI-11629](https://issues.apache.org/jira/browse/NIFI-11629) Adds a new `Socket Write Timeout` property to `InvokeHTTP` with a default value of 15 seconds.

The new timeout provides a way to set the [writeTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/) on the OkHttp client, which defaults to 10 seconds when not otherwise configured. The new default value of 15 seconds matches the default `Socket Read Timeout` property on `InvokeHTTP` and should be sufficient for standard use cases. Supporting a longer write timeout will enable compensating potential issues when sending large requests over slow network connections.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
