### PR TITLE
NIFI-11630 Deprecate ECMAScript and python Script Engines

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-record-serialization-service-api</artifactId>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
@@ -22,6 +22,8 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.resource.ResourceReferences;
 import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -37,6 +39,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,6 +58,10 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
  */
 public class ScriptingComponentHelper {
     private static final String UNKNOWN_VERSION = "UNKNOWN";
+
+    private static final List<String> DEPRECATED_LANGUAGE_NAMES = Arrays.asList("python", "ECMAScript");
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(ScriptingComponentHelper.class);
 
     public PropertyDescriptor SCRIPT_ENGINE;
 
@@ -276,6 +283,10 @@ public class ScriptingComponentHelper {
         } else {
             modules = context.getProperty(ScriptingComponentUtils.MODULES).evaluateAttributeExpressions().asResources().flattenRecursively();
         }
+
+        if (DEPRECATED_LANGUAGE_NAMES.contains(scriptEngineName)) {
+            deprecationLogger.warn("Support for Script Engine Language [{}] is deprecated", scriptEngineName);
+        }
     }
 
     public void stop() {
@@ -290,6 +301,14 @@ public class ScriptingComponentHelper {
         final String engineVersion = defaultIfBlank(factory.getEngineVersion(), UNKNOWN_VERSION);
 
         final String description = String.format("%s %s [%s %s]", languageName, languageVersion, factory.getEngineName(), engineVersion);
-        return new AllowableValue(languageName, languageName, description);
+
+        final String displayName;
+        if (DEPRECATED_LANGUAGE_NAMES.contains(languageName)) {
+            displayName = String.format("%s DEPRECATED", languageName);
+        } else {
+            displayName = languageName;
+        }
+
+        return new AllowableValue(languageName, displayName, description);
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-11630](https://issues.apache.org/jira/browse/NIFI-11630) Deprecates the `ECMAScript` and `python` Script Engine options for scripted components.

The [JEP 335](https://openjdk.org/jeps/335) deprecated the Nashorn engine for Java 11 and Java 17 does not include Nashorn.

The current main branch includes framework support for native Python Processors, providing a better alternative to scripted components based on [Jython](https://www.jython.org/).

The deprecation includes adding `DEPRECATED` to the Script Engine property display name and logging a deprecation warning when starting a component that uses one of the deprecated Script Engines.

Subsequent efforts can remove these Script Engine options from the main branch while this pull request target the support branch for version 1 releases.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
