### PR TITLE
NIFI-11593: Fix hiding logic for properties

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1727,7 +1727,7 @@
                                                     const paramReference = getExistingParametersReferenced(propertyValue);
                                                     // if parameter references exist, loop through all and interpolate the value in the propertyValue string
                                                     if (paramReference.length > 0) {
-                                                        paramReference.forEach((param) => {
+                                                        paramReference.forEach(function (param) {
                                                             // handle null values by replacing with an empty string instead
                                                             propertyValue = propertyValue.replace('#{' + param.name + '}', nfCommon.isDefinedAndNotNull(param.value) ? param.value : '');
                                                         });
@@ -1968,7 +1968,7 @@
                                         const paramReference = getExistingParametersReferenced(propertyValue);
                                         // if parameter references exist, loop through all and interpolate the value in the propertyValue string
                                         if (paramReference.length > 0) {
-                                            paramReference.forEach((param) => {
+                                            paramReference.forEach(function (param) {
                                                 // handle null values by replacing with an empty string instead
                                                 propertyValue = propertyValue.replace('#{' + param.name + '}', nfCommon.isDefinedAndNotNull(param.value) ? param.value : '');
                                             });

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -1722,20 +1722,25 @@
                                                 // Get the current property value to compare with the dependent value
                                                 var propertyValue = property.value;
 
-                                                var referencingParameter = null;
-
                                                 // check if the property references a parameter
                                                 if (!_.isEmpty(currentParameters)) {
                                                     const paramReference = getExistingParametersReferenced(propertyValue);
+                                                    // if parameter references exist, loop through all and interpolate the value in the propertyValue string
                                                     if (paramReference.length > 0) {
-                                                        referencingParameter = paramReference[0].value;
+                                                        paramReference.forEach((param) => {
+                                                            // handle null values by replacing with an empty string instead
+                                                            propertyValue = propertyValue.replace('#{' + param.name + '}', nfCommon.isDefinedAndNotNull(param.value) ? param.value : '');
+                                                        });
                                                     }
                                                 }
 
                                                 // Test the dependentValues array against the current value of the property
-                                                // If not, then mark the current property hidden attribute is true
-                                                if (propertyValue != null && dependency.hasOwnProperty("dependentValues")) {
-                                                    hidden = !dependency.dependentValues.includes(referencingParameter || propertyValue);
+                                                if (propertyValue) {
+                                                    if (dependency.dependentValues) {
+                                                        hidden = !dependency.dependentValues.includes(propertyValue);
+                                                    } else {
+                                                        hidden = false;
+                                                    }
                                                 } else {
                                                     hidden = true;
                                                 }
@@ -1748,7 +1753,7 @@
                                                 return false;
                                             }
                                         }
-                                    })
+                                    });
                                 });
                             }
                         } else {
@@ -1955,22 +1960,28 @@
                             if (property.property === dependency.propertyName) {
                                 dependent = true;
                                 if (property.hidden === false) {
-                                    // Get the property value by propertyName
-                                    var propertyValue = properties[dependency.propertyName];
-                                    var referencingParameter = null;
+                                    // Get the current property value to compare with the dependent value
+                                    var propertyValue = property.value;
 
                                     // check if the property references a parameter
                                     if (!_.isEmpty(currentParameters)) {
                                         const paramReference = getExistingParametersReferenced(propertyValue);
+                                        // if parameter references exist, loop through all and interpolate the value in the propertyValue string
                                         if (paramReference.length > 0) {
-                                            referencingParameter = paramReference[0].value;
+                                            paramReference.forEach((param) => {
+                                                // handle null values by replacing with an empty string instead
+                                                propertyValue = propertyValue.replace('#{' + param.name + '}', nfCommon.isDefinedAndNotNull(param.value) ? param.value : '');
+                                            });
                                         }
                                     }
 
-                                    // Test the dependentValues against the current value of the property
-                                    // If not, then mark the current property hidden attribute is true
-                                    if (propertyValue != null && dependency.hasOwnProperty("dependentValues")) {
-                                        hidden = !dependency.dependentValues.includes(referencingParameter || propertyValue);
+                                    // Test the dependentValues array against the current value of the property
+                                    if (propertyValue) {
+                                        if (dependency.dependentValues) {
+                                            hidden = !dependency.dependentValues.includes(propertyValue);
+                                        } else {
+                                            hidden = false;
+                                        }
                                     } else {
                                         hidden = true;
                                     }
@@ -1978,10 +1989,12 @@
                                     hidden = true;
                                 }
                                 if (hidden) {
+                                    // It is sufficient to have found a single instance of not meeting the
+                                    // requirement for a dependent value in order to hide a property
                                     return false;
                                 }
                             }
-                        })
+                        });
                     });
                 }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11593](https://issues.apache.org/jira/browse/NIFI-11593)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
