### PR TITLE
NIFI-11645 Upgrade Guava from 31.1 to 32.0.0

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -439,7 +439,7 @@ limitations under the License.
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
+                <version>32.0.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-commons/nifi-property-protection-gcp/pom.xml
+++ b/nifi-commons/nifi-property-protection-gcp/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>nifi-property-protection-gcp</artifactId>
     <properties>
         <gcp.sdk.version>26.15.0</gcp.sdk.version>
+        <guava.version>32.0.0-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -49,6 +50,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <!-- Override Guava 31.1 from google-cloud-kms -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
@@ -20,6 +20,7 @@
 
     <properties>
         <accumulo.version>2.1.0</accumulo.version>
+        <guava.version>32.0.0-jre</guava.version>
     </properties>
 
     <artifactId>nifi-accumulo-bundle</artifactId>
@@ -84,6 +85,12 @@
                         <artifactId>log4j-1.2-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- Override Guava 31.1 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <atlas.version>2.3.0</atlas.version>
+        <guava.version>32.0.0-jre</guava.version>
     </properties>
 
     <modules>
@@ -115,6 +116,12 @@
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- Override Guava 25.1 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/pom.xml
@@ -39,4 +39,15 @@
         <module>nifi-aws-parameter-value-providers</module>
         <module>nifi-aws-parameter-providers</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Guava 31.0.1 from amazon-kinesis-client -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.0-jre</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
+                <version>32.0.0-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>32.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -24,6 +24,7 @@
     <description>NiFi: Framework Bundle</description>
     <properties>
         <curator.version>5.5.0</curator.version>
+        <guava.version>32.0.0-jre</guava.version>
         <tika.version>2.8.0</tika.version>
         <org.opensaml.version>4.3.0</org.opensaml.version>
     </properties>
@@ -530,6 +531,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -38,6 +38,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Override Guava 31.1 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.0-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <gremlin.version>3.6.4</gremlin.version>
         <janusgraph.version>0.6.3</janusgraph.version>
-        <guava.version>31.1-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>32.0.0-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -21,6 +21,9 @@
     </parent>
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
+    <properties>
+        <guava.version>32.0.0-jre</guava.version>
+    </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>
         <module>nifi-sql-reporting-nar</module>
@@ -37,6 +40,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.23.0</version>
+            </dependency>
+            <!-- Override Guava 31.1. from calcite-core -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -294,7 +294,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
+                <version>32.0.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
+                <version>32.0.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,6 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
+        <guava.version>32.0.0-jre</guava.version>
         <jline.version>3.23.0</jline.version>
     </properties>
 
@@ -79,6 +80,12 @@
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Override Guava 31.1 through nifi-framework-core -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11645](https://issues.apache.org/jira/browse/NIFI-11645) Upgrades multiple direct and transitive references to Google Guava from 31.1 to 32.0.0.

[Guava 32.0.0](https://github.com/google/guava/releases/tag/v32.0.0) maintains binary compatibility with earlier versions and addresses CVE-2020-8908 and [CVE-2023-2976](https://ossindex.sonatype.org/vulnerability/CVE-2023-2976).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
