### PR TITLE
NIFI-11646: Deprecate Lua and Ruby script engines

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
@@ -39,8 +39,8 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -59,7 +59,8 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 public class ScriptingComponentHelper {
     private static final String UNKNOWN_VERSION = "UNKNOWN";
 
-    private static final List<String> DEPRECATED_LANGUAGE_NAMES = Collections.singletonList("ECMAScript");
+    private static final List<String> DEPRECATED_LANGUAGE_NAMES =
+            Arrays.asList("ECMAScript", "lua", "ruby");
 
     private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(ScriptingComponentHelper.class);
 


### PR DESCRIPTION
# Summary

[NIFI-11646](https://issues.apache.org/jira/browse/NIFI-11646) This PR follows [NIFI-11630](https://issues.apache.org/jira/browse/NIFI-11630) but deprecates the Lua and Ruby script engines which are slated for removal from NiFi 2.0.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
