### PR TITLE
NIFI-11653 Add Connection URL Validation for Database Services

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/utils/DBCPProperties.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/utils/DBCPProperties.java
@@ -20,6 +20,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.resource.ResourceCardinality;
 import org.apache.nifi.components.resource.ResourceType;
+import org.apache.nifi.dbcp.ConnectionUrlValidator;
 import org.apache.nifi.dbcp.DBCPValidator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.kerberos.KerberosUserService;
@@ -37,7 +38,7 @@ public final class DBCPProperties {
             .description("A database connection URL used to connect to a database. May contain database system name, host, port, database name and some parameters."
                     + " The exact syntax of a database connection URL is specified by your DBMS.")
             .defaultValue(null)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(new ConnectionUrlValidator())
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/pom.xml
@@ -32,5 +32,10 @@
             <artifactId>nifi-utils</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/src/main/java/org/apache/nifi/dbcp/ConnectionUrlValidator.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/src/main/java/org/apache/nifi/dbcp/ConnectionUrlValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.dbcp;
+
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Database Connection URL Validator supports system attribute expressions and evaluates URL formatting
+ */
+public class ConnectionUrlValidator implements Validator {
+    private static final Set<String> UNSUPPORTED_SCHEMES = Collections.singleton("jdbc:h2");
+
+    @Override
+    public ValidationResult validate(final String subject, final String input, final ValidationContext context) {
+        final ValidationResult.Builder builder = new ValidationResult.Builder().subject(subject).input(input);
+
+        if (input == null || input.isEmpty()) {
+            builder.valid(false);
+            builder.explanation("Connection URL required");
+        } else {
+            final String url = context.newPropertyValue(input).evaluateAttributeExpressions().getValue();
+
+            if (isUrlUnsupported(url)) {
+                builder.valid(false);
+                builder.explanation(String.format("Connection URL starts with an unsupported scheme %s", UNSUPPORTED_SCHEMES));
+            } else {
+                builder.valid(true);
+                builder.explanation("Connection URL is valid");
+            }
+        }
+
+        return builder.build();
+    }
+
+    private boolean isUrlUnsupported(final String url) {
+        boolean unsupported = false;
+
+        for (final String unsupportedScheme : UNSUPPORTED_SCHEMES) {
+            if (url.startsWith(unsupportedScheme)) {
+                unsupported = true;
+                break;
+            }
+        }
+
+        return unsupported;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/src/test/java/org/apache/nifi/dbcp/ConnectionUrlValidatorTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/src/test/java/org/apache/nifi/dbcp/ConnectionUrlValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.dbcp;
+
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.util.MockProcessContext;
+import org.apache.nifi.util.MockValidationContext;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectionUrlValidatorTest {
+
+    private static final String SUBJECT = "Database URL";
+
+    private static final String EMPTY = "";
+
+    private static final String UNSUPPORTED_URL = "jdbc:h2:file";
+
+    private static final String VENDOR_URL = "jdbc:vendor";
+
+    private ValidationContext validationContext;
+
+    private ConnectionUrlValidator validator;
+
+    @BeforeEach
+    void setValidator() {
+        validator = new ConnectionUrlValidator();
+
+        final MockProcessContext processContext = (MockProcessContext) TestRunners.newTestRunner(NoOpProcessor.class).getProcessContext();
+        validationContext = new MockValidationContext(processContext);
+    }
+
+    @Test
+    void testValidateEmpty() {
+        final ValidationResult result = validator.validate(SUBJECT, EMPTY, validationContext);
+
+        assertNotNull(result);
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void testValidateUnsupportedUrl() {
+        final ValidationResult result = validator.validate(SUBJECT, UNSUPPORTED_URL, validationContext);
+
+        assertNotNull(result);
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void testValidateSupportedUrl() {
+        final ValidationResult result = validator.validate(SUBJECT, VENDOR_URL, validationContext);
+
+        assertNotNull(result);
+        assertTrue(result.isValid());
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
@@ -57,6 +57,8 @@ public class DBCPServiceTest {
 
     private static final String DERBY_SHUTDOWN_STATE = "XJ015";
 
+    private static final String INVALID_CONNECTION_URL = "jdbc:h2";
+
     private TestRunner runner;
 
     private File databaseDirectory;
@@ -97,6 +99,14 @@ public class DBCPServiceTest {
             assertEquals(DERBY_SHUTDOWN_STATE, exception.getSQLState());
             FileUtils.deleteFile(databaseDirectory, true);
         }
+    }
+
+    @Test
+    public void testConnectionUrlInvalid() {
+        runner.assertValid(service);
+
+        runner.setProperty(service, DBCPProperties.DATABASE_URL, INVALID_CONNECTION_URL);
+        runner.assertNotValid(service);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
@@ -76,7 +76,7 @@ public class HikariCPConnectionPool extends AbstractControllerService implements
             .description("A database connection URL used to connect to a database. May contain database system name, host, port, database name and some parameters."
                     + " The exact syntax of a database connection URL is specified by your DBMS.")
             .defaultValue(null)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(new ConnectionUrlValidator())
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/HikariCPConnectionPoolTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/HikariCPConnectionPoolTest.java
@@ -33,11 +33,25 @@ import static org.mockito.Mockito.mock;
 public class HikariCPConnectionPoolTest {
     private final static String SERVICE_ID = HikariCPConnectionPoolTest.class.getSimpleName();
 
+    private static final String INVALID_CONNECTION_URL = "jdbc:h2";
+
     private TestRunner runner;
 
     @BeforeEach
     public void setup() {
         runner = TestRunners.newTestRunner(NoOpProcessor.class);
+    }
+
+    @Test
+    public void testConnectionUrlInvalid() throws InitializationException {
+        final HikariCPConnectionPool service = new HikariCPConnectionPool();
+
+        runner.addControllerService(SERVICE_ID, service);
+        setDatabaseProperties(service);
+        runner.assertValid(service);
+
+        runner.setProperty(service, HikariCPConnectionPool.DATABASE_URL, INVALID_CONNECTION_URL);
+        runner.assertNotValid(service);
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-11653](https://issues.apache.org/jira/browse/NIFI-11653) Adds a Connection URL Validator for Database URL properties in the DBCP and HikariCP Connection Pool Controller Services. The Connection URL Validator introduces the concept of unsupported URL schemes for JDBC connections with an initial value listing H2.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
