### PR TITLE
NIFI-11647: Support UUID type in DataTypeUtils.getSQLTypeValue

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -2150,6 +2150,7 @@ public class DataTypeUtils {
             case SHORT:
                 return Types.SMALLINT;
             case STRING:
+            case UUID:
                 return Types.VARCHAR;
             case ENUM:
                 return Types.OTHER;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
@@ -93,6 +93,8 @@ public class PutDatabaseRecordTest {
     private static final String createPersonsSchema2 = "CREATE TABLE SCHEMA2.PERSONS (id2 integer primary key, name varchar(100)," +
             " code integer CONSTRAINT CODE_RANGE CHECK (code >= 0 AND code < 1000), dt date)";
 
+    private static final String createUUIDSchema = "CREATE TABLE UUID_TEST (id integer primary key, name VARCHAR(100))";
+
     private final static String DB_LOCATION = "target/db_pdr";
 
     TestRunner runner;
@@ -1798,6 +1800,46 @@ public class PutDatabaseRecordTest {
         assertEquals("hearts", rs.getString(2));
         assertFalse(rs.next());
 
+        stmt.close();
+        conn.close();
+    }
+
+    @Test
+    void testInsertUUIDColumn() throws InitializationException, ProcessException, SQLException {
+        // Manually create and drop the tables and schemas
+        final Connection conn = dbcp.getConnection();
+        final Statement stmt = conn.createStatement();
+        stmt.execute(createUUIDSchema);
+
+        final MockRecordParser parser = new MockRecordParser();
+        runner.addControllerService("parser", parser);
+        runner.enableControllerService(parser);
+
+        parser.addSchemaField("id", RecordFieldType.INT);
+        parser.addSchemaField("name", RecordFieldType.UUID);
+
+        parser.addRecord(1, "425085a0-03ef-11ee-be56-0242ac120002");
+        parser.addRecord(2, "56a000e4-03ef-11ee-be56-0242ac120002");
+
+        runner.setProperty(PutDatabaseRecord.RECORD_READER_FACTORY, "parser");
+        runner.setProperty(PutDatabaseRecord.STATEMENT_TYPE, PutDatabaseRecord.INSERT_TYPE);
+        runner.setProperty(PutDatabaseRecord.TABLE_NAME, "UUID_TEST");
+
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        runner.assertTransferCount(PutDatabaseRecord.REL_SUCCESS, 1);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM UUID_TEST");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertEquals("425085a0-03ef-11ee-be56-0242ac120002", rs.getString(2));
+        assertTrue(rs.next());
+        assertEquals(2, rs.getInt(1));
+        assertEquals("56a000e4-03ef-11ee-be56-0242ac120002", rs.getString(2));
+        assertFalse(rs.next());
+
+        // Drop the schemas here so as not to interfere with other tests
+        stmt.execute("drop table UUID_TEST");
         stmt.close();
         conn.close();
     }


### PR DESCRIPTION
# Summary

[NIFI-11647](https://issues.apache.org/jira/browse/NIFI-11647) This PR adds the UUID type to DataTypeUtils.getSQLTypeValue(), mapping it to SQL VARCHAR type. This fixes an issue with PutDatabaseRecord when inserting fields/columns with a UUID type.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
