### PR TITLE
NIFI-11655: Fixed float and double handling in GenerateRecord

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
@@ -59,6 +59,7 @@ import org.apache.nifi.serialization.record.type.MapDataType;
 import org.apache.nifi.serialization.record.type.RecordDataType;
 import org.apache.nifi.util.StringUtils;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -310,9 +311,13 @@ public class GenerateRecord extends AbstractProcessor {
                 return (char) faker.number().numberBetween(Character.MIN_VALUE, Character.MAX_VALUE);
             case DATE:
                 return FakerUtils.getFakeData(DEFAULT_DATE_PROPERTY_NAME, faker);
-            case DECIMAL:
             case DOUBLE:
+                return faker.number().randomDouble(6, Long.MIN_VALUE, Long.MAX_VALUE);
             case FLOAT:
+                final double randomDouble = faker.number().randomDouble(6, Long.MIN_VALUE, Long.MAX_VALUE);
+                final BigDecimal asBigDecimal = new BigDecimal(randomDouble);
+                return asBigDecimal.floatValue();
+            case DECIMAL:
                 return faker.number().randomDouble(((DecimalDataType) recordField.getDataType()).getScale(), Long.MIN_VALUE, Long.MAX_VALUE);
             case INT:
                 return faker.number().numberBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestGenerateRecord/nested_nullable.avsc
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestGenerateRecord/nested_nullable.avsc
@@ -18,7 +18,13 @@
           }, {
             "name": "Name",
             "type": ["null", "string"]
-          }]
+          }, {
+              "name": "TestFloat",
+              "type": ["null", "float"]
+          }, {
+              "name": "TestDouble",
+              "type": ["null", "double"]
+            }]
         }]
       }, {
         "name": "EventID",


### PR DESCRIPTION
# Summary

[NIFI-11655](https://issues.apache.org/jira/browse/NIFI-11655) This PR fixes how floats and doubles are generated when using the Schema Text property in GenerateRecord. The bug was that all types were coerced to DecimalDataType which is not compatible for float and double types. The PR handles each of the types separately, and test data was added to exercise this fix.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-11655`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-11655`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
