### PR TITLE
NIFI-11666 Add Exception to Error Log for ModifyCompression

### DIFF
--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/ModifyCompression.java
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/ModifyCompression.java
@@ -277,7 +277,7 @@ public class ModifyCompression extends AbstractProcessor {
             session.transfer(flowFile, REL_SUCCESS);
         } catch (final RuntimeException e) {
             getLogger().error("Input Compression [{}] Size [{}] Output Compression [{}] Failed {}",
-                    inputCompressionStrategy, inputFileSize, outputCompressionStrategy, flowFile);
+                    inputCompressionStrategy, inputFileSize, outputCompressionStrategy, flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
         }
     }

--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/test/java/org/apache/nifi/processors/compress/TestModifyCompression.java
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/test/java/org/apache/nifi/processors/compress/TestModifyCompression.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.compress;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processors.compress.property.CompressionStrategy;
 import org.apache.nifi.processors.compress.property.FilenameStrategy;
+import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -28,9 +29,12 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestModifyCompression {
@@ -292,6 +296,12 @@ class TestModifyCompression {
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_FAILURE, 1);
 
         runner.getFlowFilesForRelationship(ModifyCompression.REL_FAILURE).get(0).assertContentEquals(data);
+
+        final LogMessage errorMessage = runner.getLogger().getErrorMessages().iterator().next();
+        assertNotNull(errorMessage);
+
+        final Optional<Object> exceptionFound = Arrays.stream(errorMessage.getArgs()).filter(Exception.class::isInstance).findFirst();
+        assertTrue(exceptionFound.isPresent());
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-11666](https://issues.apache.org/jira/browse/NIFI-11666) Adds the Exception argument to the error log in ModifyCompression to provide cause information for processing failures.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
