### PR TITLE
NIFI-11679 Refactor EncryptedRepoContentAccessIT Configuration

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/EncryptedRepoContentAccessIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/EncryptedRepoContentAccessIT.java
@@ -17,17 +17,65 @@
 
 package org.apache.nifi.tests.system.repositories;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class EncryptedRepoContentAccessIT extends ContentAccessIT {
+    private static final String KEYSTORE_CREDENTIALS = UUID.randomUUID().toString();
+
+    private static final String KEYSTORE_NAME = "repository.p12";
+
+    private static final String KEY_ID = "primary-key";
+
+    private static final String KEYSTORE_TYPE = "PKCS12";
+
+    private static final int KEY_LENGTH = 32;
+
+    private static final String KEY_ALGORITHM = "AES";
+
+    private static Path keyStorePath;
+
+    @BeforeAll
+    public static void setRepositoryKeystore(@TempDir final Path temporaryDirectory) throws GeneralSecurityException, IOException {
+        keyStorePath = temporaryDirectory.resolve(KEYSTORE_NAME);
+
+        final SecureRandom secureRandom = new SecureRandom();
+        final byte[] key = new byte[KEY_LENGTH];
+        secureRandom.nextBytes(key);
+        final SecretKeySpec secretKeySpec = new SecretKeySpec(key, KEY_ALGORITHM);
+
+        final KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+        keyStore.load(null);
+
+        final KeyStore.SecretKeyEntry secretKeyEntry = new KeyStore.SecretKeyEntry(secretKeySpec);
+        final KeyStore.PasswordProtection passwordProtection = new KeyStore.PasswordProtection(KEYSTORE_CREDENTIALS.toCharArray());
+        keyStore.setEntry(KEY_ID, secretKeyEntry, passwordProtection);
+
+        try (final OutputStream outputStream = Files.newOutputStream(keyStorePath)) {
+            keyStore.store(outputStream, KEYSTORE_CREDENTIALS.toCharArray());
+        }
+    }
+
     @Override
     protected Map<String, String> getNifiPropertiesOverrides() {
         final Map<String, String> encryptedRepoProperties = new HashMap<>();
-        encryptedRepoProperties.put("nifi.content.repository.implementation", "org.apache.nifi.controller.repository.crypto.EncryptedFileSystemRepository");
-        encryptedRepoProperties.put("nifi.content.repository.encryption.key", "0123456789ABCDEFFEDCBA9876543210");
-        encryptedRepoProperties.put("nifi.content.repository.encryption.key.id", "k1");
-        encryptedRepoProperties.put("nifi.content.repository.encryption.key.provider.implementation", "StaticKeyProvider");
+        encryptedRepoProperties.put("nifi.repository.encryption.protocol.version", "1");
+        encryptedRepoProperties.put("nifi.repository.encryption.key.id", KEY_ID);
+        encryptedRepoProperties.put("nifi.repository.encryption.key.provider", "KEYSTORE");
+        encryptedRepoProperties.put("nifi.repository.encryption.key.provider.keystore.location", keyStorePath.toString());
+        encryptedRepoProperties.put("nifi.repository.encryption.key.provider.keystore.password", KEYSTORE_CREDENTIALS);
         return encryptedRepoProperties;
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-11679](https://issues.apache.org/jira/browse/NIFI-11679) Refactors the `EncryptedRepoContentAccessIT` system test using a generated secret key for repository encryption and using the recommended KeyStore-backed encryption properties.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
