### PR TITLE
NIFI-11691: Support VARBINARY and LONGVARBINARY types in PutDatabaseRecord

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -886,13 +886,15 @@ public class PutDatabaseRecord extends AbstractProcessor {
                 try {
                     ps.setBytes(index, byteArray);
                 } catch (SQLException e) {
-                    throw new IOException("Unable to parse binary data " + value, e.getCause());
+                    throw new IOException("Unable to parse binary data with size" + byteArray.length, e.getCause());
                 }
             } else {
+                byte[] byteArray = new byte[0];
                 try {
-                    ps.setBytes(index, value.toString().getBytes(StandardCharsets.UTF_8));
+                    byteArray = value.toString().getBytes(StandardCharsets.UTF_8);
+                    ps.setBytes(index, byteArray);
                 } catch (SQLException e) {
-                    throw new IOException("Unable to parse binary data " + value, e.getCause());
+                    throw new IOException("Unable to parse binary data with size" + byteArray.length, e.getCause());
                 }
             }
         } else {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -750,13 +750,13 @@ public class PutDatabaseRecord extends AbstractProcessor {
                                     targetDataType = DataTypeUtils.getDataTypeFromSQLTypeValue(fieldSqlType);
                                 }
                                 if (targetDataType != null) {
-                                    if (sqlType == Types.BLOB || sqlType == Types.BINARY) {
+                                    if (sqlType == Types.BLOB || sqlType == Types.BINARY || sqlType == Types.VARBINARY || sqlType == Types.LONGVARBINARY) {
                                         if (currentValue instanceof Object[]) {
                                             // Convert Object[Byte] arrays to byte[]
                                             Object[] src = (Object[]) currentValue;
                                             if (src.length > 0) {
                                                 if (!(src[0] instanceof Byte)) {
-                                                    throw new IllegalTypeConversionException("Cannot convert value " + currentValue + " to BLOB/BINARY");
+                                                    throw new IllegalTypeConversionException("Cannot convert value " + currentValue + " to BLOB/BINARY/VARBINARY/LONGVARBINARY");
                                                 }
                                             }
                                             byte[] dest = new byte[src.length];
@@ -767,7 +767,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
                                         } else if (currentValue instanceof String) {
                                             currentValue = ((String) currentValue).getBytes(StandardCharsets.UTF_8);
                                         } else if (currentValue != null && !(currentValue instanceof byte[])) {
-                                            throw new IllegalTypeConversionException("Cannot convert value " + currentValue + " to BLOB/BINARY");
+                                            throw new IllegalTypeConversionException("Cannot convert value " + currentValue + " to BLOB/BINARY/VARBINARY/LONGVARBINARY");
                                         }
                                     } else {
                                         currentValue = DataTypeUtils.convertType(
@@ -866,6 +866,33 @@ public class PutDatabaseRecord extends AbstractProcessor {
                     ps.setClob(index, clob);
                 } catch (SQLException e) {
                     throw new IOException("Unable to parse data as CLOB/String " + value, e.getCause());
+                }
+            }
+        } else if (sqlType == Types.VARBINARY || sqlType == Types.LONGVARBINARY) {
+            if (fieldSqlType == Types.ARRAY || fieldSqlType == Types.VARCHAR) {
+                if (!(value instanceof byte[])) {
+                    if (value == null) {
+                        try {
+                            ps.setNull(index, Types.BLOB);
+                            return;
+                        } catch (SQLException e) {
+                            throw new IOException("Unable to setNull() on prepared statement" , e);
+                        }
+                    } else {
+                        throw new IOException("Expected VARBINARY/LONGVARBINARY to be of type byte[] but is instead " + value.getClass().getName());
+                    }
+                }
+                byte[] byteArray = (byte[]) value;
+                try {
+                    ps.setBytes(index, byteArray);
+                } catch (SQLException e) {
+                    throw new IOException("Unable to parse binary data " + value, e.getCause());
+                }
+            } else {
+                try {
+                    ps.setBytes(index, value.toString().getBytes(StandardCharsets.UTF_8));
+                } catch (SQLException e) {
+                    throw new IOException("Unable to parse binary data " + value, e.getCause());
                 }
             }
         } else {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -94,6 +95,8 @@ public class PutDatabaseRecordTest {
             " code integer CONSTRAINT CODE_RANGE CHECK (code >= 0 AND code < 1000), dt date)";
 
     private static final String createUUIDSchema = "CREATE TABLE UUID_TEST (id integer primary key, name VARCHAR(100))";
+
+    private static final String createLongVarBinarySchema = "CREATE TABLE LONGVARBINARY_TEST (id integer primary key, name LONG VARCHAR FOR BIT DATA)";
 
     private final static String DB_LOCATION = "target/db_pdr";
 
@@ -1840,6 +1843,48 @@ public class PutDatabaseRecordTest {
 
         // Drop the schemas here so as not to interfere with other tests
         stmt.execute("drop table UUID_TEST");
+        stmt.close();
+        conn.close();
+    }
+
+    @Test
+    void testInsertLongVarBinaryColumn() throws InitializationException, ProcessException, SQLException {
+        // Manually create and drop the tables and schemas
+        final Connection conn = dbcp.getConnection();
+        final Statement stmt = conn.createStatement();
+        stmt.execute(createLongVarBinarySchema);
+
+        final MockRecordParser parser = new MockRecordParser();
+        runner.addControllerService("parser", parser);
+        runner.enableControllerService(parser);
+
+        parser.addSchemaField("id", RecordFieldType.INT);
+        parser.addSchemaField("name", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType()).getFieldType());
+
+        byte[] longVarBinaryValue1 = new byte[] {97,98,99};
+        byte[] longVarBinaryValue2 = new byte[] {100,101,102};
+        parser.addRecord(1, longVarBinaryValue1);
+        parser.addRecord(2, longVarBinaryValue2);
+
+        runner.setProperty(PutDatabaseRecord.RECORD_READER_FACTORY, "parser");
+        runner.setProperty(PutDatabaseRecord.STATEMENT_TYPE, PutDatabaseRecord.INSERT_TYPE);
+        runner.setProperty(PutDatabaseRecord.TABLE_NAME, "LONGVARBINARY_TEST");
+
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        runner.assertTransferCount(PutDatabaseRecord.REL_SUCCESS, 1);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM LONGVARBINARY_TEST");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertArrayEquals(longVarBinaryValue1, rs.getBytes(2));
+        assertTrue(rs.next());
+        assertEquals(2, rs.getInt(1));
+        assertArrayEquals(longVarBinaryValue2, rs.getBytes(2));
+        assertFalse(rs.next());
+
+        // Drop the schemas here so as not to interfere with other tests
+        stmt.execute("drop table LONGVARBINARY_TEST");
         stmt.close();
         conn.close();
     }


### PR DESCRIPTION
# Summary

[NIFI-11691](https://issues.apache.org/jira/browse/NIFI-11691) This PR adds support for the java.sql.Types VARBINARY and LONGVARBINARY in PutDatabaseRecord. It converts the record field value to `byte[]` and then calls `setBytes()` when setting the parameter value in the PreparedStatement

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
