### PR TITLE
NIFI-11635 Upgrade IoTDB from 1.0.1 to 1.1.1

### DIFF
--- a/nifi-nar-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/pom.xml
@@ -82,6 +82,11 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
+                <!-- Exclude IoTDB Consensus to avoid SNAPSHOT versions of Apache Ratis -->
+                <exclusion>
+                    <groupId>org.apache.iotdb</groupId>
+                    <artifactId>iotdb-consensus</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -94,6 +99,11 @@
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <!-- Exclude IoTDB Consensus to avoid SNAPSHOT versions of Apache Ratis -->
+                <exclusion>
+                    <groupId>org.apache.iotdb</groupId>
+                    <artifactId>iotdb-consensus</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nifi-nar-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/src/main/java/org/apache/nifi/processors/QueryIoTDBRecord.java
+++ b/nifi-nar-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/src/main/java/org/apache/nifi/processors/QueryIoTDBRecord.java
@@ -16,7 +16,7 @@
  */
 package org.apache.nifi.processors;
 
-import org.apache.iotdb.session.SessionDataSet;
+import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Field;
 import org.apache.iotdb.tsfile.read.common.RowRecord;

--- a/nifi-nar-bundles/nifi-iotdb-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iotdb-bundle/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <iotdb.sdk.version>1.0.1</iotdb.sdk.version>
+        <iotdb.sdk.version>1.1.1</iotdb.sdk.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11635](https://issues.apache.org/jira/browse/NIFI-11635) Upgrades Apache IoTDB dependencies from 1.0.1 to [1.1.1](https://github.com/apache/iotdb/releases/tag/v1.1.1) with test dependency exclusions to avoid SNAPSHOT versions of transitive Apache Ratis libraries from `iotdb-consensus`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
