### PR TITLE
NIFI-11699: Fixed dynamic properties in SnowflakeComputingConnectionPool

### DIFF
--- a/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/test/java/org/apache/nifi/processors/snowflake/SnowflakeConfigAware.java
+++ b/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/test/java/org/apache/nifi/processors/snowflake/SnowflakeConfigAware.java
@@ -31,7 +31,6 @@ import org.apache.nifi.util.TestRunner;
 public interface SnowflakeConfigAware {
 
     Path filePath = Paths.get("???");
-    String stagedFilePath = "???";
 
     String organizationName = "???";
     String accountName = "???";

--- a/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/test/java/org/apache/nifi/processors/snowflake/SnowflakePipeIT.java
+++ b/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/test/java/org/apache/nifi/processors/snowflake/SnowflakePipeIT.java
@@ -85,7 +85,7 @@ class SnowflakePipeIT implements SnowflakeConfigAware {
                     false);
         }
 
-        final Map<String, String> attributes = Collections.singletonMap(SnowflakeAttributes.ATTRIBUTE_STAGED_FILE_PATH, uuid + "/" + stagedFilePath);
+        final Map<String, String> attributes = Collections.singletonMap(SnowflakeAttributes.ATTRIBUTE_STAGED_FILE_PATH, uuid + "/" + fileName);
         runner.enqueue("", attributes);
 
         runner.run();
@@ -114,7 +114,7 @@ class SnowflakePipeIT implements SnowflakeConfigAware {
                     false);
         }
 
-        final String stagedFilePathAttribute = uuid + "/" + stagedFilePath;
+        final String stagedFilePathAttribute = uuid + "/" + fileName;
 
         final StagedFileWrapper stagedFile = new StagedFileWrapper(stagedFilePathAttribute);
         ingestManagerProviderService.getIngestManager().ingestFile(stagedFile, null);

--- a/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-services/pom.xml
+++ b/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-services/pom.xml
@@ -81,5 +81,14 @@
             <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kerberos-user-service-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Also fixed driver class name handling (caused IT test failure). Other test fixes to make IT tests work.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11699](https://issues.apache.org/jira/browse/NIFI-11699)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
