### PR TITLE
NIFI-11712 Remove java.net.preferIPv4Stack from bootstrap.conf

### DIFF
--- a/minifi/minifi-bootstrap/src/test/resources/MINIFI-516/bootstrap.conf
+++ b/minifi/minifi-bootstrap/src/test/resources/MINIFI-516/bootstrap.conf
@@ -113,8 +113,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-bootstrap/src/test/resources/bootstrap-provenance-reporting/bootstrap.conf.configured
+++ b/minifi/minifi-bootstrap/src/test/resources/bootstrap-provenance-reporting/bootstrap.conf.configured
@@ -110,8 +110,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-bootstrap/src/test/resources/bootstrap-provenance-reporting/bootstrap.conf.default
+++ b/minifi/minifi-bootstrap/src/test/resources/bootstrap-provenance-reporting/bootstrap.conf.default
@@ -110,8 +110,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-bootstrap/src/test/resources/bootstrap-ssl-ctx/bootstrap.conf.configured
+++ b/minifi/minifi-bootstrap/src/test/resources/bootstrap-ssl-ctx/bootstrap.conf.configured
@@ -100,8 +100,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-bootstrap/src/test/resources/bootstrap-ssl-ctx/bootstrap.conf.configured.invalid
+++ b/minifi/minifi-bootstrap/src/test/resources/bootstrap-ssl-ctx/bootstrap.conf.configured.invalid
@@ -100,8 +100,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-bootstrap/src/test/resources/bootstrap-ssl-ctx/bootstrap.conf.default
+++ b/minifi/minifi-bootstrap/src/test/resources/bootstrap-ssl-ctx/bootstrap.conf.default
@@ -100,8 +100,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-bootstrap/src/test/resources/bootstrap.conf
+++ b/minifi/minifi-bootstrap/src/test/resources/bootstrap.conf
@@ -113,8 +113,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-c2/minifi-c2-assembly/src/main/resources/bin/c2.bat
+++ b/minifi/minifi-c2/minifi-c2-assembly/src/main/resources/bin/c2.bat
@@ -35,7 +35,7 @@ set LIB_DIR=%~dp0..\conf;%~dp0..\lib
 
 set C2_SERVER_HOME=%~sdp0..\
 
-SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% -Djava.net.preferIPv4Stack=true org.apache.nifi.minifi.c2.jetty.JettyServer
+SET JAVA_PARAMS=-cp %LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.c2.jetty.JettyServer
 
 cmd.exe /C "%JAVA_EXE%" %JAVA_PARAMS% %*
 

--- a/minifi/minifi-c2/minifi-c2-assembly/src/main/resources/bin/c2.sh
+++ b/minifi/minifi-c2/minifi-c2-assembly/src/main/resources/bin/c2.sh
@@ -114,9 +114,9 @@ run() {
     echo
 
   if [ "$1" = "debug" ]; then
-    "${JAVA}" -cp "${CLASSPATH}"  -Xms12m -Xmx128m -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 -Djava.net.preferIPv4Stack=true org.apache.nifi.minifi.c2.jetty.JettyServer $@
+    "${JAVA}" -cp "${CLASSPATH}"  -Xms12m -Xmx128m -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 org.apache.nifi.minifi.c2.jetty.JettyServer $@
   else
-    "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx128m -Djava.net.preferIPv4Stack=true org.apache.nifi.minifi.c2.jetty.JettyServer $@
+    "${JAVA}" -cp "${CLASSPATH}" -Xms12m -Xmx128m org.apache.nifi.minifi.c2.jetty.JettyServer $@
   fi
    return $?
 }

--- a/minifi/minifi-integration-tests/src/test/resources/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/bootstrap.conf
@@ -83,8 +83,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge1/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge1/bootstrap.conf
@@ -90,8 +90,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge2/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge2/bootstrap.conf
@@ -83,8 +83,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge3/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/hierarchical/minifi-edge3/bootstrap.conf
@@ -93,8 +93,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-integration-tests/src/test/resources/c2/protocol/minifi-edge1/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/protocol/minifi-edge1/bootstrap.conf
@@ -109,8 +109,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 # java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-integration-tests/src/test/resources/c2/protocol/minifi-edge2/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/protocol/minifi-edge2/bootstrap.conf
@@ -109,8 +109,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 # java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-integration-tests/src/test/resources/c2/protocol/minifi-edge3/bootstrap.conf
+++ b/minifi/minifi-integration-tests/src/test/resources/c2/protocol/minifi-edge3/bootstrap.conf
@@ -109,8 +109,6 @@ java.arg.3=-Xmx256m
 # Enable Remote Debugging
 # java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/bootstrap.conf
@@ -112,8 +112,6 @@ java.arg.3=-Xmx${minifi.jvm.heap.mb}m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
@@ -41,8 +41,6 @@ java.arg.3=-Xmx${nifi.jvm.heap.max}
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/bootstrap.conf
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/resources/access-control/bootstrap.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/bootstrap.conf
@@ -44,8 +44,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/resources/conf/secure-ldap/bootstrap.conf
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/resources/conf/secure-ldap/bootstrap.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_empty_root_key.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_empty_root_key.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key_128.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key_128.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key_password.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key_password.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key_password_128.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/bootstrap_with_root_key_password_128.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_default.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_default.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_with_empty_root_key.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_with_empty_root_key.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_with_root_key_128.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_with_root_key_128.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_with_root_key_from_password_128.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_with_root_key_from_password_128.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_without_root_key.conf
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/test/resources/nifi-registry/bootstrap_without_root_key.conf
@@ -38,8 +38,6 @@ java.arg.3=-Xmx512m
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 
-java.arg.4=-Djava.net.preferIPv4Stack=true
-
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol


### PR DESCRIPTION
# Summary

[NIFI-11712](https://issues.apache.org/jira/browse/NIFI-11712) Removes the `java.net.preferIPv4Stack` property from the default `bootstrap.conf` and related scripts.

The Java [Networking Properties](https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html) describes IPv4 and IPv6 configuration options, noting that the default behavior supports both protocol versions. With various improvements in library support, disabling IPv6 should not be the default setting for new installations of NiFi 2.0.

Removing this default setting does not prevent deployments from adding this property as necessary

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
