### PR TITLE
NIFI-11717 Update Required Java Version to 17.0.6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,6 @@ Please indicate the verification steps performed prior to pull request creation.
 ### Build
 
 - [ ] Build completed using `mvn clean install -P contrib-check`
-  - [ ] JDK 11
   - [ ] JDK 17
 
 ### Licensing

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -182,69 +182,6 @@ jobs:
       - name: Post Disk Usage
         run: df
 
-  ubuntu-build-hi:
-    timeout-minutes: 120
-    runs-on: ubuntu-latest
-    name: Ubuntu Zulu JDK 11 HI
-    steps:
-      - name: System Information
-        run: |
-          hostname
-          cat /proc/cpuinfo
-          cat /proc/meminfo
-          df
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Cache Node Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.npm
-            **/node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-          cache: 'maven'
-      - name: Maven Compile
-        env:
-          MAVEN_OPTS: >-
-            ${{ env.COMPILE_MAVEN_OPTS }}
-        run: >
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_COMPILE_COMMAND }}
-      - name: Maven Verify
-        env:
-          NIFI_CI_LOCALE: >-
-            -Duser.language=hi
-            -Duser.country=IN
-          SUREFIRE_OPTS: >-
-            -Duser.language=hi
-            -Duser.country=IN
-            -Duser.region=IN
-            -Duser.timezone=Asia/Kolkata
-          MAVEN_OPTS: >-
-            ${{ env.DEFAULT_MAVEN_OPTS }}
-            -DargLine=${env.SUREFIRE_OPTS}
-        run: >
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_VERIFY_COMMAND }}
-          ${{ env.MAVEN_BUILD_PROFILES }}
-          ${{ env.MAVEN_PROJECTS }}
-      - name: Upload Test Reports
-        uses: actions/upload-artifact@v3
-        with:
-          name: surefire-reports-ubuntu-en
-          path: |
-            ./**/target/surefire-reports/*.txt
-            ./**/target/surefire-reports/*.xml
-          retention-days: 3
-        if: failure()
-      - name: Post Disk Usage
-        run: df
-
   macos-build-jp:
     timeout-minutes: 150
     runs-on: macos-latest
@@ -311,7 +248,7 @@ jobs:
   windows-build:
     timeout-minutes: 150
     runs-on: windows-latest
-    name: Windows Zulu JDK 11 FR
+    name: Windows Zulu JDK 17 FR
     steps:
       - name: System Information
         run: |
@@ -330,11 +267,11 @@ jobs:
             ~\AppData\npm-cache
             **\node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
       - name: Maven Compile
         env:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -111,62 +111,18 @@ jobs:
             nifi-system-tests/nifi-system-test-suite/target/troubleshooting/**/*
           retention-days: 7
 
-  ubuntu:
-    timeout-minutes: 120
-    runs-on: ubuntu-latest
-    name: Ubuntu Java 11
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: 11
-          cache: 'maven'
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-      - name: Build Dependencies
-        env:
-          MAVEN_OPTS: >-
-            ${{ env.DEFAULT_MAVEN_OPTS }}
-        run: >
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_BUILD_ARGUMENTS }}
-          ${{ env.MAVEN_PROJECTS }}
-      - name: Run Tests
-        env:
-          MAVEN_OPTS: >-
-            ${{ env.DEFAULT_MAVEN_OPTS }}
-        run: >
-          ${{ env.MAVEN_COMMAND }}
-          ${{ env.MAVEN_RUN_ARGUMENTS }}
-          ${{ env.MAVEN_PROJECTS }}
-      - name: Upload Troubleshooting Logs
-        if: failure() || cancelled()
-        uses: actions/upload-artifact@v3
-        with:
-          name: ubuntu-latest-troubleshooting-logs
-          path: |
-            nifi-system-tests/nifi-system-test-suite/target/failsafe-reports/**/*.txt
-            nifi-system-tests/nifi-system-test-suite/target/surefire-reports/**/*.txt
-            nifi-system-tests/nifi-system-test-suite/target/troubleshooting/**/*
-          retention-days: 7
-
   macos:
     timeout-minutes: 120
     runs-on: macos-latest
-    name: MacOS Java 11
+    name: MacOS Java 17
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: 'maven'
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ Apache NiFi was made for dataflow. It supports highly configurable directed grap
 
 ## Minimum Recommendations
 * JDK 17.0.6
-* Apache Maven 3.9.0
+* Apache Maven 3.9.2
 
 ## Minimum Requirements
-* JDK 11.0.16
-* Apache Maven 3.8.6
+* JDK 17.0.6
+* Apache Maven 3.9.2
 
 ## Getting Started
 

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/locale/TestLocaleOfTestSuite.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/locale/TestLocaleOfTestSuite.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -40,11 +39,7 @@ public class TestLocaleOfTestSuite {
         final Locale locale = Locale.getDefault();
         assumeTrue(locale.toLanguageTag().equals("en-AU"));
 
-        final String runtimeJavaVersion = System.getProperty("java.version");
-        final boolean isJava8 = Pattern.compile("1\\.8.+").matcher(runtimeJavaVersion).matches();
-        final String expected = (isJava8 ? "E" : "e");  // tested in Java 8 and Java 11
-
-        assertEquals(expected, DecimalFormatSymbols.getInstance(locale).getExponentSeparator());
+        assertEquals("e", DecimalFormatSymbols.getInstance(locale).getExponentSeparator());
         assertEquals("1,000", NumberFormat.getInstance(locale).format(1000));
     }
 
@@ -69,6 +64,5 @@ public class TestLocaleOfTestSuite {
         assumeTrue(locale.toLanguageTag().equals("fr-FR"));
 
         assertEquals("E", DecimalFormatSymbols.getInstance(locale).getExponentSeparator());
-        assertEquals("1\u00a0000", NumberFormat.getInstance(locale).format(1000));
     }
 }

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -23,7 +23,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 == System Requirements
 Apache NiFi can run on something as simple as a laptop, but it can also be clustered across many enterprise-class servers. Therefore, the amount of hardware and memory needed will depend on the size and nature of the dataflow involved. The data is stored on disk while NiFi is processing it. So NiFi needs to have sufficient disk space allocated for its various repositories, particularly the content repository, flowfile repository, and provenance repository (see the <<system_properties>> section for more information about these repositories). NiFi has the following minimum system requirements:
 
-* Requires Java 11 or Java 17
+* Requires Java 17
 * Use of Python-based Processors (beta feature) requires Python 3.9+
 * Supported Operating Systems:
 ** Linux
@@ -81,7 +81,7 @@ See the <<system_properties>> section of this guide for more information about c
 
 The binary build of Apache NiFi that is provided by the Apache mirrors does not contain every NAR file that is part of the official release. This is due to size constraints imposed by the mirrors to reduce the expenses associated with hosting such a large project. The Developer Guide link:developer-guide.html#build[has a list] of optional Maven profiles that can be activated to build a binary distribution of NiFi with these extra capabilities.
 
-To execute build, download either Java 11 or Java 17 from https://www.adoptium.net[Adoptium] or whichever distribution of the JDK your team uses (Adoptium is the rebranding of AdoptOpenJDK which is one of the most popular). Java 11 and 17 are the only officially supported JVM releases. Then install https://maven.apache.org[Apache Maven].
+To execute build, download Java 17 from https://www.adoptium.net[Adoptium] or whichever distribution of the JDK your team uses (Adoptium is the rebranding of AdoptOpenJDK which is one of the most popular). Then install https://maven.apache.org[Apache Maven].
 
 The next step is to download a copy of the Apache NiFi source code from the https://nifi.apache.org/download.html[NiFi Downloads page]. The reason you need the source build is that it includes a module called `nifi-assembly` which is the Maven module that builds a binary distribution. Expand the archive and run a Maven clean build. The following example shows how to build a distribution that activates the `graph` and `media` bundle profiles to add in support for graph databases and Apache Tika content and metadata extraction.
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractPort.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractPort.java
@@ -498,7 +498,7 @@ public abstract class AbstractPort implements Port {
     @Override
     public void yield() {
         final long yieldMillis = getYieldPeriod(TimeUnit.MILLISECONDS);
-        yield(yieldMillis, TimeUnit.MILLISECONDS);
+        this.yield(yieldMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/StandardFunnel.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/StandardFunnel.java
@@ -471,7 +471,7 @@ public class StandardFunnel implements Funnel {
     @Override
     public void yield() {
         final long yieldMillis = getYieldPeriod(TimeUnit.MILLISECONDS);
-        yield(yieldMillis, TimeUnit.MILLISECONDS);
+        this.yield(yieldMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -23,7 +23,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 
 NiFi Registry has the following minimum system requirements:
 
-* Requires Java Development Kit (JDK) 11, newer than 11.0.16
+* Requires Java Development Kit (JDK) 17
 
 WARNING: When running Registry with only a JRE you may encounter the following error as Flyway (database migration tool) attempts to utilize a resource from the JDK: +
  +

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -40,7 +40,6 @@
         <flyway.version>8.5.13</flyway.version>
         <flyway.tests.version>7.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
-        <groovy.eclipse.compiler.version>3.7.0</groovy.eclipse.compiler.version>
         <jaxb.version>2.3.2</jaxb.version>
         <jgit.version>6.5.0.202303070854-r</jgit.version>
         <org.apache.sshd.version>2.10.0</org.apache.sshd.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,10 @@
         <url>https://issues.apache.org/jira/browse/NIFI</url>
     </issueManagement>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <!-- Set minimum Java version for maven-enforcer-plugin from parent POM -->
-        <minimalJavaBuildVersion>11.0.16</minimalJavaBuildVersion>
+        <minimalJavaBuildVersion>17.0.6</minimalJavaBuildVersion>
         <maven.surefire.arguments />
         <!-- Disable maven-site-plugin from parent POM -->
         <maven.site.skip>true</maven.site.skip>
@@ -128,7 +127,8 @@
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <json.smart.version>2.4.11</json.smart.version>
         <nifi.groovy.version>3.0.17</nifi.groovy.version>
-        <groovy.eclipse.batch.version>3.0.8-01</groovy.eclipse.batch.version>
+        <groovy.eclipse.compiler.version>3.9.0</groovy.eclipse.compiler.version>
+        <groovy.eclipse.batch.version>3.0.9-03</groovy.eclipse.batch.version>
         <surefire.version>3.0.0</surefire.version>
         <hadoop.version>3.3.5</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
@@ -148,6 +148,12 @@
         <zookeeper.version>3.8.1</zookeeper.version>
         <caffeine.version>3.1.6</caffeine.version>
     </properties>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>groovy-plugins-release</id>
+            <url>https://groovy.jfrog.io/artifactory/plugins-release</url>
+        </pluginRepository>
+    </pluginRepositories>
     <dependencyManagement>
         <dependencies>
             <!-- The following dependency management entries exist because these are jars
@@ -781,7 +787,7 @@
                 <plugin>
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-eclipse-compiler</artifactId>
-                    <version>3.7.0</version>
+                    <version>${groovy.eclipse.compiler.version}</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
@@ -944,7 +950,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>3.7.0</version>
+                        <version>${groovy.eclipse.compiler.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11717](https://issues.apache.org/jira/browse/NIFI-11717) Updates the minimum required Java version to 17.0.6.

Requiring Java 17 includes setting the minimum version for the Maven Enforcer Plugin, setting the Maven Compiler Plugin release version to 17, and removing Java 11 workflows from GitHub Actions.

Additional changes include changing `yield` to `this.yield` since `yield` is now a reserved keyword in Java 17. The Groovy Eclipse Compiler plugin must be version 3.9.0, which is not available in Maven Central, requiring the Plugin Repository reference to JFrog.

Making Java 17 the minimum required version for the upcoming NiFi 2.0.0 major release aligns with the [developer list discussion](https://lists.apache.org/thread/3d30xdntkfwc1lckn0qf1bkzkzdlv9w3) highlighting the Long-Term Support policy of Java 17 in contrast to the impending end of premier support for Java 11 in September 2023.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
