### PR TITLE
NIFI-11729 Upgrade OWASP Dependency Check from 8.2.1 to 8.3.1

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -20,11 +20,6 @@
         <cpe regex="true">^cpe:.*$</cpe>
     </suppress>
     <suppress>
-        <notes>Jetty SSLEngine is incorrectly identified with Jetty Server</notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jetty/jetty\-sslengine@.*$</packageUrl>
-        <cpe regex="true">^cpe:.*$</cpe>
-    </suppress>
-    <suppress>
         <notes>CVE-2022-45868 requires running H2 from a command not applicable to project references</notes>
         <packageUrl regex="true">^pkg:maven/com\.h2database/h2@2.*$</packageUrl>
         <vulnerabilityName>CVE-2022-45868</vulnerabilityName>
@@ -150,11 +145,6 @@
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
     </suppress>
     <suppress>
-        <notes>CVE-2022-34271 applies to Atlas Server not the Atlas client library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.atlas/.*$</packageUrl>
-        <cve>CVE-2022-34271</cve>
-    </suppress>
-    <suppress>
         <notes>CVE-2022-30187 applies to Azure Blob not the EventHubs Checkpoint Store Blob library</notes>
         <packageUrl regex="true">^pkg:maven/com\.azure/azure\-messaging\-eventhubs\-checkpointstore\-blob@.*$</packageUrl>
         <cve>CVE-2022-30187</cve>
@@ -165,19 +155,9 @@
         <cve>CVE-2022-39135</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2018-8016 applies to Apache Cassandra server not the client library</notes>
-        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
-        <cve>CVE-2018-8016</cve>
-    </suppress>
-    <suppress>
         <notes>CVE-2018-1000873 applies to Jackson Java 8 Time modules not Jackson Annotations</notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@.*$</packageUrl>
         <cve>CVE-2018-1000873</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2021-34371 applies to Neo4j server not the driver library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.opencypher\.gremlin/cypher\-gremlin\-neo4j\-driver@.*$</packageUrl>
-        <cve>CVE-2021-34371</cve>
     </suppress>
     <suppress>
         <notes>CVE-2010-1151 applies to mod_auth_shadow in Apache HTTP Server not the FTP server library</notes>
@@ -188,21 +168,6 @@
         <notes>CVE-2018-14335 applies to H2 running with a web server console enabled</notes>
         <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
         <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes>CVE-2022-31160 included in hadoop-client-api is not used</notes>
-        <packageUrl regex="true">^pkg:javascript/jquery\-ui@.*$</packageUrl>
-        <cve>CVE-2022-31160</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2021-37533 applies to the Commons Net FTP Client which is not used in the version bundled with hadoop-client-runtime for Accumulo</notes>
-        <packageUrl regex="true">^pkg:maven/commons\-net/commons\-net@.*$</packageUrl>
-        <cve>CVE-2021-37533</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2021-0341 applies to Android not OkHttp</notes>
-        <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp/okhttp@.*$</packageUrl>
-        <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
     </suppress>
     <suppress>
         <notes>CVE-2023-25613 applies to an LDAP backend class for Apache Kerby not the Token Provider library</notes>
@@ -258,5 +223,40 @@
         <notes>Hadoop vulnerabilities do not apply to HBase Hadoop2 compatibility library</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-hadoop2\-compat@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-45688 applies to hutools-json not org.json</notes>
+        <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
+        <cve>CVE-2022-45688</cve>
+    </suppress>
+    <suppress>
+        <notes>The Jackson maintainers dispute the applicability of CVE-2023-35116 based on cyclic nature of reported concern</notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-25194 applies to Kafka Connect workers not client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka.*?@.*$</packageUrl>
+        <cve>CVE-2023-25194</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-34917 applies to Kafka brokers not client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka.*?@.*$</packageUrl>
+        <cve>CVE-2022-34917</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-25613 applies to the LDAP Identity Backend for Kerby Server which is not used in runtime NiFi configurations</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.kerby/kerb.*?@.*$</packageUrl>
+        <cve>CVE-2023-25613</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-24823 applies to Netty HTTP decoding which is not applicable to Apache Kudu clients</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*?@.*$</packageUrl>
+        <cve>CVE-2022-24823</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2022-41915 applies to Netty HTTP decoding which is not applicable to Apache Kudu clients</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*?@.*$</packageUrl>
+        <cve>CVE-2022-41915</cve>
     </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
@@ -129,6 +129,10 @@
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1154,7 +1154,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.2.1</version>
+                        <version>8.3.1</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-11729](https://issues.apache.org/jira/browse/NIFI-11729) Upgrades the OWASP Dependency Check plugin from 8.2.1 to [8.3.1](https://github.com/jeremylong/DependencyCheck/releases) and adds several suppression notes for false positive findings. Upgrading 8.3.1 also obviates several suppressions as the plugin now incorporates corrections to avoid those findings.

Additional changes include excluding the JUnit 4 dependency from RethinkDB and Hive 3 JDBC modules.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
