### PR TITLE
NIFI-11709 Upgrade Guava from 32.0.0 to 32.0.1

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -443,7 +443,7 @@ limitations under the License.
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-commons/nifi-property-protection-gcp/pom.xml
+++ b/nifi-commons/nifi-property-protection-gcp/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-property-protection-gcp</artifactId>
     <properties>
         <gcp.sdk.version>26.15.0</gcp.sdk.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <accumulo.version>2.1.0</accumulo.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
     </properties>
 
     <artifactId>nifi-accumulo-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <atlas.version>2.3.0</atlas.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
     </properties>
 
     <modules>

--- a/nifi-nar-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/pom.xml
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <description>NiFi: Framework Bundle</description>
     <properties>
         <curator.version>5.5.0</curator.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <tika.version>2.8.0</tika.version>
         <org.opensaml.version>4.3.0</org.opensaml.version>
     </properties>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <gremlin.version>3.6.4</gremlin.version>
         <janusgraph.version>0.6.3</janusgraph.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -44,6 +44,12 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.31</version>
             </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
@@ -82,6 +82,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
@@ -115,6 +115,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -96,6 +96,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -22,7 +22,7 @@
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
     </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -294,7 +294,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -91,6 +91,12 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>5.4.0</version>
             </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
@@ -72,6 +72,12 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.31</version>
             </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <jline.version>3.23.0</jline.version>
     </properties>
 


### PR DESCRIPTION
# Summary

[NIFI-11709](https://issues.apache.org/jira/browse/NIFI-11709) Upgrades Guava library references from 32.0.0 to 32.0.1. Additional changes include overriding Guava 27 in several transitive dependencies. [Guava 23.1](https://github.com/google/guava/releases/tag/v23.1) introduced a new policy that avoids removing API methods, with the exception of those annotated with `@Beta` to provide better compatibility between versions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
