### PR TITLE
NIFI-11739: Add ability to ignore missing fields in PutIceberg

### DIFF
--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/UnmatchedColumnBehavior.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/UnmatchedColumnBehavior.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.processors.iceberg;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum UnmatchedColumnBehavior implements DescribedValue {
+    IGNORE_UNMATCHED_COLUMN("Ignore Unmatched Columns",
+            "Any column in the database that does not have a field in the document will be assumed to not be required.  No notification will be logged"),
+
+    WARNING_UNMATCHED_COLUMN("Warn on Unmatched Columns",
+            "Any column in the database that does not have a field in the document will be assumed to not be required.  A warning will be logged"),
+
+    FAIL_UNMATCHED_COLUMN("Fail on Unmatched Columns",
+            "A flow will fail if any column in the database that does not have a field in the document.  An error will be logged");
+
+
+    private final String displayName;
+    private final String description;
+
+    UnmatchedColumnBehavior(final String displayName, final String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
@@ -268,8 +268,10 @@ public class GenericDataConverters {
             for (DataConverter<?, ?> converter : converters) {
                 final Optional<RecordField> recordField = recordSchema.getField(converter.getSourceFieldName());
                 if (recordField.isEmpty()) {
-                    Types.NestedField missingField = schema.field(converter.getTargetFieldName());
-                    getters.put(converter.getTargetFieldName(), createFieldGetter(convertSchemaTypeToDataType(missingField.type()), missingField.name(), missingField.isOptional()));
+                    final Types.NestedField missingField = schema.field(converter.getTargetFieldName());
+                    if (missingField != null) {
+                        getters.put(converter.getTargetFieldName(), createFieldGetter(convertSchemaTypeToDataType(missingField.type()), missingField.name(), missingField.isOptional()));
+                    }
                 } else {
                     final RecordField field = recordField.get();
                     // creates a record field accessor for every data converter
@@ -345,6 +347,6 @@ public class GenericDataConverters {
                 Types.MapType mapType = schemaType.asMapType();
                 return RecordFieldType.MAP.getMapDataType(convertSchemaTypeToDataType(mapType.valueType()), mapType.isValueOptional());
         }
-        return null;
+        throw new IllegalArgumentException("Invalid or unsupported type: " + schemaType);
     }
 }

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
@@ -21,9 +21,11 @@ import org.apache.commons.lang3.Validate;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
 
@@ -265,9 +267,14 @@ public class GenericDataConverters {
 
             for (DataConverter<?, ?> converter : converters) {
                 final Optional<RecordField> recordField = recordSchema.getField(converter.getSourceFieldName());
-                final RecordField field = recordField.get();
-                // creates a record field accessor for every data converter
-                getters.put(converter.getTargetFieldName(), createFieldGetter(field.getDataType(), field.getFieldName(), field.isNullable()));
+                if (recordField.isEmpty()) {
+                    Types.NestedField missingField = schema.field(converter.getTargetFieldName());
+                    getters.put(converter.getTargetFieldName(), createFieldGetter(convertSchemaTypeToDataType(missingField.type()), missingField.name(), missingField.isOptional()));
+                } else {
+                    final RecordField field = recordField.get();
+                    // creates a record field accessor for every data converter
+                    getters.put(converter.getTargetFieldName(), createFieldGetter(field.getDataType(), field.getFieldName(), field.isNullable()));
+                }
             }
         }
 
@@ -289,5 +296,55 @@ public class GenericDataConverters {
         private <S, T> T convert(Record record, DataConverter<S, T> converter) {
             return converter.convert((S) getters.get(converter.getTargetFieldName()).getFieldOrNull(record));
         }
+    }
+
+    public static DataType convertSchemaTypeToDataType(Type schemaType) {
+        switch (schemaType.typeId()) {
+            case BOOLEAN:
+                return RecordFieldType.BOOLEAN.getDataType();
+            case INTEGER:
+                return RecordFieldType.INT.getDataType();
+            case LONG:
+                return RecordFieldType.LONG.getDataType();
+            case FLOAT:
+                return RecordFieldType.FLOAT.getDataType();
+            case DOUBLE:
+                return RecordFieldType.DOUBLE.getDataType();
+            case DATE:
+                return RecordFieldType.DATE.getDataType();
+            case TIME:
+                return RecordFieldType.TIME.getDataType();
+            case TIMESTAMP:
+                return RecordFieldType.TIMESTAMP.getDataType();
+            case STRING:
+                return RecordFieldType.STRING.getDataType();
+            case UUID:
+                return RecordFieldType.UUID.getDataType();
+            case FIXED:
+            case BINARY:
+                return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType());
+            case DECIMAL:
+                return RecordFieldType.DECIMAL.getDataType();
+            case STRUCT:
+                // Build a record type from the struct type
+                Types.StructType structType = schemaType.asStructType();
+                List<Types.NestedField> fields = structType.fields();
+                List<RecordField> recordFields = new ArrayList<>(fields.size());
+                for (Types.NestedField field : fields) {
+                    DataType dataType = convertSchemaTypeToDataType(field.type());
+                    recordFields.add(new RecordField(field.name(), dataType, field.isOptional()));
+                }
+                RecordSchema recordSchema = new SimpleRecordSchema(recordFields);
+                return RecordFieldType.RECORD.getRecordDataType(recordSchema);
+            case LIST:
+                // Build a list type from the elements
+                Types.ListType listType = schemaType.asListType();
+                return RecordFieldType.ARRAY.getArrayDataType(convertSchemaTypeToDataType(listType.elementType()), listType.isElementOptional());
+            case MAP:
+                // Build a map type from the elements
+                Types.MapType mapType = schemaType.asMapType();
+                return RecordFieldType.MAP.getMapDataType(convertSchemaTypeToDataType(mapType.valueType()), mapType.isValueOptional());
+        }
+        return null;
     }
 }

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/IcebergRecordConverter.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/IcebergRecordConverter.java
@@ -55,9 +55,6 @@ public class IcebergRecordConverter {
         return converter.convert(record);
     }
 
-    public IcebergRecordConverter(Schema schema, RecordSchema recordSchema, FileFormat fileFormat) {
-        this(schema, recordSchema, fileFormat, UnmatchedColumnBehavior.FAIL_UNMATCHED_COLUMN, null);
-    }
 
     @SuppressWarnings("unchecked")
     public IcebergRecordConverter(Schema schema, RecordSchema recordSchema, FileFormat fileFormat, UnmatchedColumnBehavior unmatchedColumnBehavior, ComponentLog logger) {
@@ -186,7 +183,7 @@ public class IcebergRecordConverter {
                 // If the field is missing, use the expected type from the schema (converted to a DataType)
                 final Types.NestedField schemaField = schema.findField(fieldId);
                 final Type schemaFieldType = schemaField.type();
-                if(schemaField.isRequired()) {
+                if (schemaField.isRequired()) {
                     // Iceberg requires a non-null value for required fields
                     throw new IllegalArgumentException("Iceberg requires a non-null value for required fields, field: "
                             + schemaField.name() + ", type: " + schemaFieldType);

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
@@ -111,7 +111,7 @@ public class PutIceberg extends AbstractIcebergProcessor {
     static final PropertyDescriptor UNMATCHED_COLUMN_BEHAVIOR = new PropertyDescriptor.Builder()
             .name("unmatched-column-behavior")
             .displayName("Unmatched Column Behavior")
-            .description("If an incoming record does not have a field mapping for all of the database table's columns, this property specifies how to handle the situation")
+            .description("If an incoming record does not have a field mapping for all of the database table's columns, this property specifies how to handle the situation.")
             .allowableValues(UnmatchedColumnBehavior.class)
             .defaultValue(UnmatchedColumnBehavior.FAIL_UNMATCHED_COLUMN.getValue())
             .required(true)
@@ -278,7 +278,6 @@ public class PutIceberg extends AbstractIcebergProcessor {
 
             final WriteResult result = taskWriter.complete();
             appendDataFiles(context, flowFile, table, result);
-            taskWriter.close();
         } catch (Exception e) {
             getLogger().error("Exception occurred while writing iceberg records. Removing uncommitted data files", e);
             try {

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
@@ -33,7 +33,6 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
-import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
@@ -365,40 +364,5 @@ public class PutIceberg extends AbstractIcebergProcessor {
         Tasks.foreach(dataFiles)
                 .retry(3)
                 .run(file -> table.io().deleteFile(file.path().toString()));
-    }
-
-    public enum UnmatchedColumnBehavior implements DescribedValue {
-        IGNORE_UNMATCHED_COLUMN("Ignore Unmatched Columns",
-                "Any column in the database that does not have a field in the document will be assumed to not be required.  No notification will be logged"),
-
-        WARNING_UNMATCHED_COLUMN("Warn on Unmatched Columns",
-                "Any column in the database that does not have a field in the document will be assumed to not be required.  A warning will be logged"),
-
-        FAIL_UNMATCHED_COLUMN("Fail on Unmatched Columns",
-                "A flow will fail if any column in the database that does not have a field in the document.  An error will be logged");
-
-
-        private final String displayName;
-        private final String description;
-
-        UnmatchedColumnBehavior(final String displayName, final String description) {
-            this.displayName = displayName;
-            this.description = description;
-        }
-
-        @Override
-        public String getValue() {
-            return name();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return displayName;
-        }
-
-        @Override
-        public String getDescription() {
-            return description;
-        }
     }
 }

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestDataFileActions.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestDataFileActions.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.Types;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.mock.MockComponentLogger;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.iceberg.catalog.IcebergCatalogFactory;
 import org.apache.nifi.processors.iceberg.catalog.TestHadoopCatalogService;
@@ -79,10 +81,12 @@ public class TestDataFileActions {
     );
 
     private PutIceberg icebergProcessor;
+    private ComponentLog logger;
 
     @BeforeEach
     public void setUp() {
         icebergProcessor = new PutIceberg();
+        logger = new MockComponentLogger();
     }
 
     @DisabledOnOs(WINDOWS)
@@ -103,7 +107,7 @@ public class TestDataFileActions {
         IcebergTaskWriterFactory taskWriterFactory = new IcebergTaskWriterFactory(table, new Random().nextLong(), FileFormat.PARQUET, null);
         TaskWriter<Record> taskWriter = taskWriterFactory.create();
 
-        IcebergRecordConverter recordConverter = new IcebergRecordConverter(table.schema(), abortSchema, FileFormat.PARQUET);
+        IcebergRecordConverter recordConverter = new IcebergRecordConverter(table.schema(), abortSchema, FileFormat.PARQUET, UnmatchedColumnBehavior.IGNORE_UNMATCHED_COLUMN, logger);
 
         for (MapRecord record : recordList) {
             taskWriter.write(recordConverter.convert(record));

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.apache.nifi.mock.MockComponentLogger;
 import org.apache.nifi.processors.iceberg.converter.ArrayElementGetter;
 import org.apache.nifi.processors.iceberg.converter.IcebergRecordConverter;
 import org.apache.nifi.processors.iceberg.converter.RecordFieldGetter;
@@ -56,6 +57,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.apache.nifi.processors.iceberg.PutIceberg.UnmatchedColumnBehavior;
 
 import java.io.File;
 import java.io.IOException;
@@ -240,6 +243,24 @@ public class TestIcebergRecordConverter {
         return new SimpleRecordSchema(fields);
     }
 
+    private static RecordSchema getPrimitivesSchemaMissingFields() {
+        List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("string", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("double", RecordFieldType.DOUBLE.getDataType()));
+        fields.add(new RecordField("decimal", RecordFieldType.DECIMAL.getDecimalDataType(10, 2)));
+        fields.add(new RecordField("boolean", RecordFieldType.BOOLEAN.getDataType()));
+        fields.add(new RecordField("fixed", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
+        fields.add(new RecordField("binary", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
+        fields.add(new RecordField("date", RecordFieldType.DATE.getDataType()));
+        fields.add(new RecordField("time", RecordFieldType.TIME.getDataType()));
+        fields.add(new RecordField("timestamp", RecordFieldType.TIMESTAMP.getDataType()));
+        fields.add(new RecordField("timestampTz", RecordFieldType.TIMESTAMP.getDataType()));
+        fields.add(new RecordField("uuid", RecordFieldType.UUID.getDataType()));
+        fields.add(new RecordField("choice", RecordFieldType.CHOICE.getChoiceDataType(RecordFieldType.STRING.getDataType(), RecordFieldType.INT.getDataType())));
+
+        return new SimpleRecordSchema(fields);
+    }
+
     private static RecordSchema getPrimitivesAsCompatiblesSchema() {
         List<RecordField> fields = new ArrayList<>();
         fields.add(new RecordField("string", RecordFieldType.INT.getDataType()));
@@ -370,6 +391,29 @@ public class TestIcebergRecordConverter {
         return new MapRecord(getPrimitivesSchema(), values);
     }
 
+    private static Record setupPrimitivesTestRecordMissingFields() {
+        LocalDate localDate = LocalDate.of(2017, 4, 4);
+        LocalTime localTime = LocalTime.of(14, 20, 33);
+        LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("string", "Test String");
+        values.put("double", 3.14159D);
+        values.put("decimal", new BigDecimal("12345678.12"));
+        values.put("boolean", true);
+        values.put("fixed", "hello".getBytes());
+        values.put("binary", "hello".getBytes());
+        values.put("date", localDate);
+        values.put("time", Time.valueOf(localTime));
+        values.put("timestamp", Timestamp.from(offsetDateTime.toInstant()));
+        values.put("timestampTz", Timestamp.valueOf(localDateTime));
+        values.put("uuid", UUID.fromString("0000-00-00-00-000000"));
+        values.put("choice", "10");
+
+        return new MapRecord(getPrimitivesSchemaMissingFields(), values);
+    }
+
     private static Record setupCompatiblePrimitivesTestRecord() {
 
         Map<String, Object> values = new HashMap<>();
@@ -433,11 +477,11 @@ public class TestIcebergRecordConverter {
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testPrimitives(FileFormat format) throws IOException {
+    @Test
+    public void testPrimitives() throws IOException {
         RecordSchema nifiSchema = getPrimitivesSchema();
         Record record = setupPrimitivesTestRecord();
+        final FileFormat format = PARQUET;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(PRIMITIVES_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -467,8 +511,52 @@ public class TestIcebergRecordConverter {
         assertEquals(LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000), resultRecord.get(12, LocalDateTime.class));
         assertEquals(Integer.valueOf(10), resultRecord.get(14, Integer.class));
 
-        if (format.equals(PARQUET)) {
-            assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, resultRecord.get(13, byte[].class));
+        assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, resultRecord.get(13, byte[].class));
+    }
+
+    @DisabledOnOs(WINDOWS)
+    @ParameterizedTest
+    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
+    public void testPrimitivesIgnoreMissingFields(FileFormat format) throws IOException {
+        RecordSchema nifiSchema = getPrimitivesSchemaMissingFields();
+        Record record = setupPrimitivesTestRecordMissingFields();
+        MockComponentLogger mockComponentLogger = new MockComponentLogger();
+
+        IcebergRecordConverter recordConverter = new IcebergRecordConverter(PRIMITIVES_SCHEMA, nifiSchema, format, UnmatchedColumnBehavior.IGNORE_UNMATCHED_COLUMN, mockComponentLogger);
+        GenericRecord genericRecord = recordConverter.convert(record);
+
+        writeTo(format, PRIMITIVES_SCHEMA, genericRecord, tempFile);
+
+        List<GenericRecord> results = readFrom(format, PRIMITIVES_SCHEMA, tempFile.toInputFile());
+
+        assertEquals(results.size(), 1);
+        GenericRecord resultRecord = results.get(0);
+
+        LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
+
+        assertEquals("Test String", resultRecord.get(0, String.class));
+        assertNull(resultRecord.get(1, Integer.class));
+        assertNull(resultRecord.get(2, Float.class));
+        assertNull(resultRecord.get(3, Long.class));
+        assertEquals(Double.valueOf(3.14159D), resultRecord.get(4, Double.class));
+        assertEquals(new BigDecimal("12345678.12"), resultRecord.get(5, BigDecimal.class));
+        assertEquals(Boolean.TRUE, resultRecord.get(6, Boolean.class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(7, byte[].class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, ByteBuffer.class).array());
+        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(9, LocalDate.class));
+        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(10, LocalTime.class));
+        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(11, OffsetDateTime.class));
+        assertEquals(LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000), resultRecord.get(12, LocalDateTime.class));
+        assertEquals(Integer.valueOf(10), resultRecord.get(14, Integer.class));
+
+        if (format.equals(FileFormat.PARQUET)) {
+            // Parquet uses a conversion to the byte values of numeric characters such as "0" -> byte value 0
+            UUID uuid = UUID.fromString("0000-00-00-00-000000");
+            ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
+            byteBuffer.putLong(uuid.getMostSignificantBits());
+            byteBuffer.putLong(uuid.getLeastSignificantBits());
+            assertArrayEquals(byteBuffer.array(), resultRecord.get(13, byte[].class));
         } else {
             assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(13, UUID.class));
         }
@@ -504,9 +592,68 @@ public class TestIcebergRecordConverter {
     @DisabledOnOs(WINDOWS)
     @ParameterizedTest
     @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testCompatiblePrimitives(FileFormat format) throws IOException {
+    public void testPrimitivesWarnMissingFields(FileFormat format) throws IOException {
+        RecordSchema nifiSchema = getPrimitivesSchemaMissingFields();
+        Record record = setupPrimitivesTestRecordMissingFields();
+        MockComponentLogger mockComponentLogger = new MockComponentLogger();
+
+        IcebergRecordConverter recordConverter = new IcebergRecordConverter(PRIMITIVES_SCHEMA, nifiSchema, format, UnmatchedColumnBehavior.WARNING_UNMATCHED_COLUMN, mockComponentLogger);
+        GenericRecord genericRecord = recordConverter.convert(record);
+
+        writeTo(format, PRIMITIVES_SCHEMA, genericRecord, tempFile);
+
+        List<GenericRecord> results = readFrom(format, PRIMITIVES_SCHEMA, tempFile.toInputFile());
+
+        assertEquals(results.size(), 1);
+        GenericRecord resultRecord = results.get(0);
+
+        LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
+
+        assertEquals("Test String", resultRecord.get(0, String.class));
+        assertNull(resultRecord.get(1, Integer.class));
+        assertNull(resultRecord.get(2, Float.class));
+        assertNull(resultRecord.get(3, Long.class));
+        assertEquals(Double.valueOf(3.14159D), resultRecord.get(4, Double.class));
+        assertEquals(new BigDecimal("12345678.12"), resultRecord.get(5, BigDecimal.class));
+        assertEquals(Boolean.TRUE, resultRecord.get(6, Boolean.class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(7, byte[].class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, ByteBuffer.class).array());
+        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(9, LocalDate.class));
+        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(10, LocalTime.class));
+        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(11, OffsetDateTime.class));
+        assertEquals(LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000), resultRecord.get(12, LocalDateTime.class));
+        assertEquals(Integer.valueOf(10), resultRecord.get(14, Integer.class));
+
+        if (format.equals(FileFormat.PARQUET)) {
+            // Parquet uses a conversion to the byte values of numeric characters such as "0" -> byte value 0
+            UUID uuid = UUID.fromString("0000-00-00-00-000000");
+            ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
+            byteBuffer.putLong(uuid.getMostSignificantBits());
+            byteBuffer.putLong(uuid.getLeastSignificantBits());
+            assertArrayEquals(byteBuffer.array(), resultRecord.get(13, byte[].class));
+        } else {
+            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(13, UUID.class));
+        }
+    }
+
+    @DisabledOnOs(WINDOWS)
+    @ParameterizedTest
+    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
+    public void testPrimitivesFailMissingFields(FileFormat format) throws IOException {
+        RecordSchema nifiSchema = getPrimitivesSchemaMissingFields();
+        MockComponentLogger mockComponentLogger = new MockComponentLogger();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new IcebergRecordConverter(PRIMITIVES_SCHEMA, nifiSchema, format, UnmatchedColumnBehavior.FAIL_UNMATCHED_COLUMN, mockComponentLogger));
+    }
+
+    @DisabledOnOs(WINDOWS)
+    @Test
+    public void testCompatiblePrimitives() throws IOException {
         RecordSchema nifiSchema = getPrimitivesAsCompatiblesSchema();
         Record record = setupCompatiblePrimitivesTestRecord();
+        final FileFormat format = PARQUET;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(COMPATIBLE_PRIMITIVES_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -536,19 +683,15 @@ public class TestIcebergRecordConverter {
         assertEquals(expectedLocalDateTimestamp, resultRecord.get(11, LocalDateTime.class));
         assertEquals(Integer.valueOf(10), resultRecord.get(13, Integer.class));
 
-        if (format.equals(PARQUET)) {
-            assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, resultRecord.get(12, byte[].class));
-        } else {
-            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(12, UUID.class));
-        }
+        assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, resultRecord.get(12, byte[].class));
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testStruct(FileFormat format) throws IOException {
+    @Test
+    public void testStruct() throws IOException {
         RecordSchema nifiSchema = getStructSchema();
         Record record = setupStructTestRecord();
+        final FileFormat format = FileFormat.ORC;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(STRUCT_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -574,11 +717,11 @@ public class TestIcebergRecordConverter {
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testList(FileFormat format) throws IOException {
+    @Test
+    public void testList() throws IOException {
         RecordSchema nifiSchema = getListSchema();
         Record record = setupListTestRecord();
+        final FileFormat format = FileFormat.AVRO;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(LIST_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -593,7 +736,7 @@ public class TestIcebergRecordConverter {
 
         assertEquals(1, resultRecord.size());
         assertInstanceOf(List.class, resultRecord.get(0));
-        List nestedList = resultRecord.get(0, List.class);
+        List<?> nestedList = resultRecord.get(0, List.class);
 
         assertEquals(2, nestedList.size());
         assertInstanceOf(List.class, nestedList.get(0));
@@ -604,11 +747,11 @@ public class TestIcebergRecordConverter {
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testMap(FileFormat format) throws IOException {
+    @Test
+    public void testMap() throws IOException {
         RecordSchema nifiSchema = getMapSchema();
         Record record = setupMapTestRecord();
+        final FileFormat format = PARQUET;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(MAP_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -633,21 +776,21 @@ public class TestIcebergRecordConverter {
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testSchemaMismatch(FileFormat format) {
+    @Test
+    public void testSchemaMismatch() {
         RecordSchema nifiSchema = getPrimitivesSchema();
+        final FileFormat format = FileFormat.ORC;
 
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new IcebergRecordConverter(CASE_INSENSITIVE_SCHEMA, nifiSchema, format));
         assertTrue(e.getMessage().contains("Cannot find field with name 'FIELD1' in the record schema"), e.getMessage());
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testCaseInsensitiveFieldMapping(FileFormat format) throws IOException {
+    @Test
+    public void testCaseInsensitiveFieldMapping() throws IOException {
         RecordSchema nifiSchema = getCaseInsensitiveSchema();
         Record record = setupCaseInsensitiveTestRecord();
+        final FileFormat format = FileFormat.AVRO;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(CASE_INSENSITIVE_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -667,11 +810,11 @@ public class TestIcebergRecordConverter {
     }
 
     @DisabledOnOs(WINDOWS)
-    @ParameterizedTest
-    @EnumSource(value = FileFormat.class, names = {"AVRO", "ORC", "PARQUET"})
-    public void testUnorderedFieldMapping(FileFormat format) throws IOException {
+    @Test
+    public void testUnorderedFieldMapping() throws IOException {
         RecordSchema nifiSchema = getUnorderedSchema();
         Record record = setupUnorderedTestRecord();
+        final FileFormat format = PARQUET;
 
         IcebergRecordConverter recordConverter = new IcebergRecordConverter(UNORDERED_SCHEMA, nifiSchema, format);
         GenericRecord genericRecord = recordConverter.convert(record);
@@ -698,7 +841,7 @@ public class TestIcebergRecordConverter {
         assertEquals("value5", resultRecord.get(2, String.class));
 
         assertInstanceOf(Map.class, resultRecord.get(3));
-        Map map = resultRecord.get(3, Map.class);
+        Map<?,?> map = resultRecord.get(3, Map.class);
         assertEquals("map value1", map.get("key1"));
         assertEquals("map value2", map.get("key2"));
     }


### PR DESCRIPTION
# Summary

[NIFI-11739](https://issues.apache.org/jira/browse/NIFI-11739) This PR adds the "Unmatched Column Behavior" property to PutIceberg that is in other table-based processors such as PutDatabaseRecord. If a column exists in the target table but is not a field in the incoming records, use the data type from the target table and a value of null. If the property is set to Fail (the default and current behavior), the FlowFile will fail. If Warn, a log warning is issued. If Ignore, the aforementioned behavior is employed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
