### PR TITLE
NIFI-11741: Add guava lib to nifi-ranger-resource project, in order t…

### DIFF
--- a/nifi-assembly/src/main/assembly/ranger.xml
+++ b/nifi-assembly/src/main/assembly/ranger.xml
@@ -58,6 +58,7 @@
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.slf4j:jcl-over-slf4j</include>
                 <include>org.apache.commons:commons-lang3</include>
+                <include>com.google.guava:guava</include>
             </includes>
         </dependencySet>
         <!-- Write out scripts from nifi-ranger-resources to ext/ranger/scripts -->

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
@@ -32,10 +32,6 @@
             <version>3.12.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/pom.xml
@@ -32,6 +32,10 @@
             <version>3.12.0</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>


### PR DESCRIPTION
…o include it into the ext/ranger/install/lib/ directory during assembly the artifact

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11741](https://issues.apache.org/jira/browse/NIFI-11741)

Fix No class def found error. It happens if nifi build with include-ranger option and try to use credentialsbuilder

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-11741) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

After the fix, if I executed ```java -cp "nifi-assembly/target/nifi-2.0.0-SNAPSHOT-bin/nifi-2.0.0-SNAPSHOT/ext/ranger/install/lib/*" org.apache.ranger.credentialapi.buildks create sslTrustStore -value "test" -provider "jceks://file/<<absolute_path>>/test2.jceks"``` the no class def found error doesn't happened anymore.

### Build

  - [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
