### PR TITLE
NIFI-11492 Allow authorization to proceed based on request groups eve…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization-providers/src/test/java/org/apache/nifi/authorization/StandardManagedAuthorizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-authorization-providers/src/test/java/org/apache/nifi/authorization/StandardManagedAuthorizerTest.java
@@ -367,6 +367,59 @@ public class StandardManagedAuthorizerTest {
     }
 
     @Test
+    public void testAuthorizationByRequestGroupsAndUserNotInUserGroupProvider() {
+        final String userIdentity = "userIdentity1";
+        final String groupIdentifier = "groupIdentifier1";
+
+        // group membership will come from the groups on the request
+        final Group group = new Group.Builder()
+                .identifier(groupIdentifier)
+                .name(groupIdentifier)
+                .build();
+
+        final AccessPolicy policy = new AccessPolicy.Builder()
+                .identifier("1")
+                .resource(TEST_RESOURCE.getIdentifier())
+                .addGroup(groupIdentifier)
+                .action(RequestAction.READ)
+                .build();
+
+        final ConfigurableUserGroupProvider userGroupProvider = mock(ConfigurableUserGroupProvider.class);
+        when(userGroupProvider.getUserAndGroups(userIdentity)).thenReturn(new UserAndGroups() {
+            // user does not exist in UGP
+            @Override
+            public User getUser() {
+                return null;
+            }
+
+            // no groups for the user in the UGP, groups come from request
+            @Override
+            public Set<Group> getGroups() {
+                return Collections.emptySet();
+            }
+        });
+
+        final ConfigurableAccessPolicyProvider accessPolicyProvider = mock(ConfigurableAccessPolicyProvider.class);
+        when(accessPolicyProvider.getAccessPolicy(TEST_RESOURCE.getIdentifier(), RequestAction.READ)).thenReturn(policy);
+        when(accessPolicyProvider.getUserGroupProvider()).thenReturn(userGroupProvider);
+        when(userGroupProvider.getGroupByName(group.getName())).thenReturn(group);
+
+        // simulate groups being passed in on request from NiFiUser getAllGroups()
+        final AuthorizationRequest request = new AuthorizationRequest.Builder()
+                .identity(userIdentity)
+                .groups(Collections.singleton(group.getName()))
+                .resource(TEST_RESOURCE)
+                .action(RequestAction.READ)
+                .accessAttempt(true)
+                .anonymous(false)
+                .build();
+
+        final StandardManagedAuthorizer managedAuthorizer = getStandardManagedAuthorizer(accessPolicyProvider);
+        assertEquals(AuthorizationResult.approved(), managedAuthorizer.authorize(request));
+    }
+
+
+    @Test
     public void testResourceNotFound() {
         final String userIdentity = "userIdentity1";
 
@@ -391,13 +444,7 @@ public class StandardManagedAuthorizerTest {
     @Test
     public void testUnauthorizedDueToUnknownUser() {
         final String userIdentifier = "userIdentifier1";
-        final String userIdentity = "userIdentity1";
         final String notUser1Identity = "not userIdentity1";
-
-        final User user = new User.Builder()
-                .identity(userIdentity)
-                .identifier(userIdentifier)
-                .build();
 
         final AccessPolicy policy = new AccessPolicy.Builder()
                 .identifier("1")


### PR DESCRIPTION
…n if user does not exist

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11492](https://issues.apache.org/jira/browse/NIFI-NIFI-11492)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
