### PR TITLE
NIFI-11745 Upgrade QuestDb to version 7

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>6.7-jdk8</version>
+            <version>7.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/QuestDbDatabaseManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/QuestDbDatabaseManager.java
@@ -21,11 +21,6 @@ import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.griffin.SqlExecutionContextImpl;
-import org.apache.nifi.util.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -33,6 +28,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.nifi.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The database manager is responsible for checking and maintaining the health of the database during startup.
@@ -149,7 +147,7 @@ public final class QuestDbDatabaseManager {
             final CairoEngine engine = new CairoEngine(configuration);
             final SqlCompiler compiler = new SqlCompiler(engine)
         ) {
-            final SqlExecutionContext context = new SqlExecutionContextImpl(engine, 1);
+            final SqlExecutionContext context = SqlExecutionContextFactory.getInstance(engine);
 
             // Node status tables
             compiler.compile(QuestDbQueries.CREATE_GARBAGE_COLLECTION_STATUS, context);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/QuestDbWritingTemplate.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/QuestDbWritingTemplate.java
@@ -54,7 +54,7 @@ public abstract class QuestDbWritingTemplate<T> {
         }
 
         try (
-            final TableWriter tableWriter = engine.getWriter(context.getCairoSecurityContext(), engine.getTableToken(tableName), "adding rows")
+            final TableWriter tableWriter = engine.getWriter(engine.getTableTokenIfExists(tableName), "adding rows")
         ) {
             addRows(tableWriter, entries);
             tableWriter.commit();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/SqlExecutionContextFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/SqlExecutionContextFactory.java
@@ -16,35 +16,17 @@
  */
 package org.apache.nifi.controller.status.history.questdb;
 
-import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
-import io.questdb.griffin.SqlCompiler;
+import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.SqlExecutionContextImpl;
 
-public class QuestDbContext {
-    private final CairoEngine engine;
-
-    public QuestDbContext(final CairoEngine engine) {
-        this.engine = engine;
+final class SqlExecutionContextFactory {
+    private SqlExecutionContextFactory() {
+        // Not to be instantiated
     }
 
-    public CairoEngine getEngine() {
-        return engine;
-    }
-
-    public CairoConfiguration getConfiguration() {
-        return engine.getConfiguration();
-    }
-
-    public SqlExecutionContext getSqlExecutionContext() {
-        return SqlExecutionContextFactory.getInstance(engine);
-    }
-
-    public SqlCompiler getCompiler() {
-        return new SqlCompiler(engine);
-    }
-
-    public void close() {
-        engine.close();
+    public static SqlExecutionContext getInstance(final CairoEngine engine) {
+        return new SqlExecutionContextImpl(engine, 1).with(AllowAllSecurityContext.INSTANCE, null);
     }
 }


### PR DESCRIPTION
# Summary

The version is updated and the code has been changed according to the API changes. The tests are green and based on manual testing, NiFi still gathers metrics.

Note: the way the `SqlExecutionContext` creation has been changes was done based on suggestion from the QuestDB community.

[NIFI-11745](https://issues.apache.org/jira/browse/NIFI-11745)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
