### PR TITLE
NIFI-11755 Upgrade AWS SDK to 1.12.495 and 2.20.92

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.478</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.20.75</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.495</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.20.92</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <io.fabric8.kubernetes.client.version>6.5.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>1.8.20</kotlin.version>


### PR DESCRIPTION
# Summary

[NIFI-11755](https://issues.apache.org/jira/browse/NIFI-11755) Upgrades AWS SDK libraries from 1.12.478 to [1.12.195](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md) and from 2.20.75 to [2.20.92](https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md). 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
