### PR TITLE
NIFI-11756 Remove unused ROME Dependency from Registry Ranger Plugin

### DIFF
--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-assembly/NOTICE
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-assembly/NOTICE
@@ -312,12 +312,6 @@ Apache Software License v2
       ZkClient
       Copyright 2009 Stefan Groschupf
 
-  (ASLv2) Rome
-    The following NOTICE information applies:
-      Rome Copyright Notices
-      Copyright 2004 Sun Microsystems, Inc.
-      Copyright 2011 The ROME Team
-
   (ASLv2) Swagger Core library
     The following NOTICE information applies:
       Copyright 2016 SmartBear Software

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
@@ -280,11 +280,6 @@
             <version>1.4.7</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.rome</groupId>
-            <artifactId>rome</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
             <version>1.5.4</version>


### PR DESCRIPTION
# Summary

[NIFI-11756](https://issues.apache.org/jira/browse/NIFI-11756) Removes the unused [ROME](https://rometools.github.io/rome/) dependency from the NiFi Registry Ranger plugin. The ROME API provides XML parsing for RSS and Atom feeds, and the dependency is not used in the standard NiFi Ranger plugin.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
