### PR TITLE
NIFI-11758: Added local file upload option in PutAzure*Storage proces…

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-data-upload</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-record-serialization-service-api</artifactId>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
@@ -67,8 +67,6 @@ public abstract class AbstractAzureBlobStorage_v12IT extends AbstractAzureStorag
     protected static final String EL_CONTAINER_NAME = "az.containername";
     protected static final String EL_BLOB_NAME = "az.blobname";
 
-    protected static final byte[] EMPTY_CONTENT = new byte[0];
-
     private static final String TEST_CONTAINER_NAME_PREFIX = "nifi-test-container";
 
     private BlobServiceClient storageClient;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureStorageIT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureStorageIT.java
@@ -32,6 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public abstract class AbstractAzureStorageIT {
 
+    protected static final byte[] EMPTY_CONTENT = new byte[0];
+
     private static final Properties CREDENTIALS_CONFIG;
     private static final Properties PROXY_CONFIG;
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/ITPutAzureDataLakeStorage.java
@@ -20,6 +20,8 @@ import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.dataupload.DataUploadProperties;
+import org.apache.nifi.processors.dataupload.DataUploadSource;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
@@ -27,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -246,6 +250,26 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         assertFailure();
     }
 
+    @Test
+    public void testPutFileFromLocalFile() throws Exception {
+        String variableName = "local.file.path";
+        runner.setProperty(DataUploadProperties.DATA_TO_UPLOAD, DataUploadSource.LOCAL_FILE.getValue());
+        runner.setProperty(DataUploadProperties.LOCAL_FILE_PATH, String.format("${%s}", variableName));
+
+        Path tempFilePath = Files.createTempFile("ITPutAzureDataLakeStorage_testPutFileFromLocalFile_", "");
+        Files.write(tempFilePath, FILE_DATA);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(variableName, tempFilePath.toString());
+
+        runProcessor(EMPTY_CONTENT, attributes);
+
+        MockFlowFile flowFile = assertFlowFile(EMPTY_CONTENT);
+        assertFlowFileAttributes(flowFile, DIRECTORY, FILE_NAME, FILE_DATA.length);
+        assertAzureFile(DIRECTORY, FILE_NAME, FILE_DATA);
+        assertProvenanceEvents();
+    }
+
     private Map<String, String> createAttributesMap() {
         Map<String, String> attributes = new HashMap<>();
 
@@ -286,11 +310,7 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
     private void assertFlowFile(byte[] fileData, String fileName, String directory) throws Exception {
         MockFlowFile flowFile = assertFlowFile(fileData);
 
-        flowFile.assertAttributeEquals(ATTR_NAME_FILESYSTEM, fileSystemName);
-        flowFile.assertAttributeEquals(ATTR_NAME_DIRECTORY, directory);
-        flowFile.assertAttributeEquals(ATTR_NAME_FILENAME, fileName);
-
-        flowFile.assertAttributeEquals(ATTR_NAME_LENGTH, Integer.toString(fileData.length));
+        assertFlowFileAttributes(flowFile, directory, fileName, fileData.length);
     }
 
     private MockFlowFile assertFlowFile(byte[] fileData) throws Exception {
@@ -301,6 +321,14 @@ public class ITPutAzureDataLakeStorage extends AbstractAzureDataLakeStorageIT {
         flowFile.assertContentEquals(fileData);
 
         return flowFile;
+    }
+
+    private void assertFlowFileAttributes(MockFlowFile flowFile, String directory, String fileName, int fileLength) {
+        flowFile.assertAttributeEquals(ATTR_NAME_FILESYSTEM, fileSystemName);
+        flowFile.assertAttributeEquals(ATTR_NAME_DIRECTORY, directory);
+        flowFile.assertAttributeEquals(ATTR_NAME_FILENAME, fileName);
+
+        flowFile.assertAttributeEquals(ATTR_NAME_LENGTH, Integer.toString(fileLength));
     }
 
     private void assertAzureFile(String directory, String fileName, byte[] fileData) {

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-data-upload/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-data-upload/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-extension-utils</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-data-upload</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-data-upload/src/main/java/org/apache/nifi/processors/dataupload/DataUploadProperties.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-data-upload/src/main/java/org/apache/nifi/processors/dataupload/DataUploadProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.dataupload;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import static org.apache.nifi.processors.dataupload.DataUploadSource.FLOWFILE_CONTENT;
+import static org.apache.nifi.processors.dataupload.DataUploadSource.LOCAL_FILE;
+
+public class DataUploadProperties {
+
+    public static final PropertyDescriptor DATA_TO_UPLOAD = new PropertyDescriptor.Builder()
+            .name("data-to-upload")
+            .displayName("Data to Upload")
+            .description("The source of the content to be uploaded.")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
+            .allowableValues(DataUploadSource.class)
+            .defaultValue(FLOWFILE_CONTENT.getValue())
+            .build();
+
+    public static final PropertyDescriptor LOCAL_FILE_PATH = new PropertyDescriptor.Builder()
+            .name("local-file-path")
+            .displayName("Local File Path")
+            .description("Path to a local file to be uploaded.")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .defaultValue("${absolute.path}/${filename}")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .dependsOn(DATA_TO_UPLOAD, LOCAL_FILE)
+            .build();
+}

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-data-upload/src/main/java/org/apache/nifi/processors/dataupload/DataUploadSource.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-data-upload/src/main/java/org/apache/nifi/processors/dataupload/DataUploadSource.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.dataupload;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum DataUploadSource implements DescribedValue {
+
+    FLOWFILE_CONTENT("FlowFile's Content", "The content of the incoming FlowFile will be uploaded."),
+    LOCAL_FILE("Local File", "The content of a local file will be uploaded.");
+
+    private final String displayName;
+    private final String description;
+
+    DataUploadSource(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-nar-bundles/nifi-extension-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/pom.xml
@@ -28,6 +28,7 @@
 
     <modules>
         <module>nifi-bin-manager</module>
+        <module>nifi-data-upload</module>
         <module>nifi-database-utils</module>
         <module>nifi-database-test-utils</module>
         <module>nifi-dbcp-base</module>


### PR DESCRIPTION
…sors

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11758](https://issues.apache.org/jira/browse/NIFI-11758)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
