### PR TITLE
NIFI-11759: Remove Distributed Map Cache Client property from ListHDFS

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ListHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ListHDFS.java
@@ -44,7 +44,6 @@ import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.deprecation.log.DeprecationLogger;
 import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
-import org.apache.nifi.distributed.cache.client.DistributedMapCacheClient;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.ProcessContext;
@@ -145,14 +144,6 @@ public class ListHDFS extends AbstractHadoopProcessor {
         recordFields.add(new RecordField(IS_ERASURE_CODED, RecordFieldType.BOOLEAN.getDataType()));
         RECORD_SCHEMA = new SimpleRecordSchema(recordFields);
     }
-
-    @Deprecated
-    public static final PropertyDescriptor DISTRIBUTED_CACHE_SERVICE = new PropertyDescriptor.Builder()
-        .name("Distributed Cache Service")
-        .description("This property is ignored.  State will be stored in the " + Scope.LOCAL + " or " + Scope.CLUSTER + " scope by the State Manager based on NiFi's configuration.")
-        .required(false)
-        .identifiesControllerService(DistributedMapCacheClient.class)
-        .build();
 
     public static final PropertyDescriptor RECURSE_SUBDIRS = new PropertyDescriptor.Builder()
         .name("Recurse Subdirectories")
@@ -264,7 +255,6 @@ public class ListHDFS extends AbstractHadoopProcessor {
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         final List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(DISTRIBUTED_CACHE_SERVICE);
         props.add(DIRECTORY);
         props.add(RECURSE_SUBDIRS);
         props.add(RECORD_WRITER);
@@ -284,13 +274,6 @@ public class ListHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected Collection<ValidationResult> customValidate(ValidationContext context) {
-        if (context.getProperty(DISTRIBUTED_CACHE_SERVICE).isSet()) {
-            deprecationLogger.warn("{}[id={}] [{}] Property is not used",
-                    getClass().getSimpleName(),
-                    getIdentifier(),
-                    DISTRIBUTED_CACHE_SERVICE.getDisplayName()
-            );
-        }
 
         final List<ValidationResult> problems = new ArrayList<>(super.customValidate(context));
 


### PR DESCRIPTION
# Summary

[NIFI-11759](https://issues.apache.org/jira/browse/NIFI-11759) This PR continues the work of [NIFI-6023](https://issues.apache.org/jira/browse/NIFI-6023) which deprecated/ignored the use of the Distributed Map Cache Client service when it was replaced by State Management. This PR removes the property and all references to it for the `main` (upcoming 2.0) branch

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
