### PR TITLE
NIFI-11760 Upgrade Riemann Client from 0.4.1 to 0.5.3

### DIFF
--- a/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/pom.xml
@@ -25,7 +25,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.aphyr</groupId>
+            <groupId>io.riemann</groupId>
             <artifactId>riemann-java-client</artifactId>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/src/main/java/org/apache/nifi/processors/riemann/PutRiemann.java
+++ b/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/src/main/java/org/apache/nifi/processors/riemann/PutRiemann.java
@@ -16,9 +16,9 @@
  */
 package org.apache.nifi.processors.riemann;
 
-import com.aphyr.riemann.Proto;
-import com.aphyr.riemann.Proto.Event;
-import com.aphyr.riemann.client.RiemannClient;
+import io.riemann.riemann.Proto;
+import io.riemann.riemann.Proto.Event;
+import io.riemann.riemann.client.RiemannClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;

--- a/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/src/test/java/org/apache/nifi/processors/riemann/TestPutRiemann.java
+++ b/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/src/test/java/org/apache/nifi/processors/riemann/TestPutRiemann.java
@@ -16,9 +16,9 @@
  */
 package org.apache.nifi.processors.riemann;
 
-import com.aphyr.riemann.Proto;
-import com.aphyr.riemann.client.IPromise;
-import com.aphyr.riemann.client.RiemannClient;
+import io.riemann.riemann.Proto;
+import io.riemann.riemann.client.IPromise;
+import io.riemann.riemann.client.RiemannClient;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;

--- a/nifi-nar-bundles/nifi-riemann-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-riemann-bundle/pom.xml
@@ -35,9 +35,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.aphyr</groupId>
+                <groupId>io.riemann</groupId>
                 <artifactId>riemann-java-client</artifactId>
-                <version>0.4.1</version>
+                <version>0.5.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
@@ -45,9 +45,9 @@
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>${netty.3.version}</version>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.23.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11760](https://issues.apache.org/jira/browse/NIFI-11760) Upgrades the Riemann Java Client from 0.4.1 to [0.5.3](https://github.com/riemann/riemann-java-client/releases/tag/0.5.3). The Riemann Client version 0.4.2 changed the Java package name and Maven coordinates, but did not change the underlying function.

Newer Riemann clients also upgraded from Netty 3 to Netty 4, removing the need for the Netty 3 version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
