### PR TITLE
NIFI-11762 Upgrade Hadoop dependencies from 3.3.5 to 3.3.6

### DIFF
--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -32,7 +32,7 @@
     </modules>
 
     <properties>
-        <ranger.hadoop.version>3.3.5</ranger.hadoop.version>
+        <ranger.hadoop.version>3.3.6</ranger.hadoop.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
@@ -25,7 +25,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <ranger.hadoop.version>3.3.5</ranger.hadoop.version>
+        <ranger.hadoop.version>3.3.6</ranger.hadoop.version>
         <ranger.ozone.version>1.2.1</ranger.ozone.version>
         <ranger.gcs.version>2.1.5</ranger.gcs.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <groovy.eclipse.compiler.version>3.9.0</groovy.eclipse.compiler.version>
         <groovy.eclipse.batch.version>3.0.9-03</groovy.eclipse.batch.version>
         <surefire.version>3.0.0</surefire.version>
-        <hadoop.version>3.3.5</hadoop.version>
+        <hadoop.version>3.3.6</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.19</aspectj.version>


### PR DESCRIPTION
# Summary

[NIFI-11762](https://issues.apache.org/jira/browse/NIFI-11762) Upgrades Apache Hadoop dependencies from 3.3.5 to [3.3.6](https://hadoop.apache.org/docs/r3.3.6/) incorporating several improvements and transitive dependency upgrades.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
