### PR TITLE
NIFI-11714 Add Error Handler to Jetty Server

### DIFF
--- a/minifi/minifi-c2/minifi-c2-jetty/src/main/java/org/apache/nifi/minifi/c2/jetty/JettyServer.java
+++ b/minifi/minifi-c2/minifi-c2-jetty/src/main/java/org/apache/nifi/minifi/c2/jetty/JettyServer.java
@@ -48,6 +48,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
@@ -150,6 +151,7 @@ public class JettyServer {
         final WebAppContext webappContext = new WebAppContext(warFile.getPath(), contextPath);
         webappContext.setContextPath(contextPath);
         webappContext.setDisplayName(contextPath);
+        webappContext.setErrorHandler(getErrorHandler());
 
         // instruction jetty to examine these jars for tlds, web-fragments, etc
         webappContext.setAttribute("org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern", ".*/[^/]*servlet-api-[^/]*\\.jar$|.*/javax.servlet.jsp.jstl-.*\\\\.jar$|.*/[^/]*taglibs.*\\.jar$" );
@@ -188,5 +190,13 @@ public class JettyServer {
 
         logger.info("Loading WAR: " + warFile.getAbsolutePath() + " with context path set to " + contextPath);
         return webappContext;
+    }
+
+    private static ErrorPageErrorHandler getErrorHandler() {
+        final ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
+        errorHandler.setShowServlet(false);
+        errorHandler.setShowStacks(false);
+        errorHandler.setShowMessageInTitle(false);
+        return errorHandler;
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -77,6 +77,7 @@ import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -598,6 +599,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         webappContext.setServerClasses(serverClasses.toArray(new String[0]));
         webappContext.setDefaultsDescriptor(WEB_DEFAULTS_XML);
         webappContext.getMimeTypes().addMimeMapping("ttf", "font/ttf");
+        webappContext.setErrorHandler(getErrorHandler());
 
         // get the temp directory for this webapp
         File tempDir = new File(props.getWebWorkingDirectory(), warFile.getName());
@@ -1095,6 +1097,13 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
 
     }
 
+    private ErrorPageErrorHandler getErrorHandler() {
+        final ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
+        errorHandler.setShowServlet(false);
+        errorHandler.setShowStacks(false);
+        errorHandler.setShowMessageInTitle(false);
+        return errorHandler;
+    }
 
     /**
      * Holds the result of loading WARs for custom UIs.

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/handler/StandardHandlerProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/handler/StandardHandlerProvider.java
@@ -22,6 +22,7 @@ import org.apache.nifi.registry.security.crypto.CryptoKeyProvider;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -152,6 +153,7 @@ public class StandardHandlerProvider implements HandlerProvider {
         webAppContext.setDefaultsDescriptor(DEFAULTS_DESCRIPTOR);
         webAppContext.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
         webAppContext.setAttribute(WEB_INF_JAR_PATTERN_ATTRIBUTE, WEB_INF_JAR_PATTERN);
+        webAppContext.setErrorHandler(getErrorHandler());
 
         final File tempDirectory = getTempDirectory(workDirectory, applicationFile.getName());
         webAppContext.setTempDirectory(tempDirectory);
@@ -172,6 +174,14 @@ public class StandardHandlerProvider implements HandlerProvider {
             throw new IllegalStateException(String.format("Required Application matching [%s] not found in directory [%s]", filenamePattern, directory));
         }
         return applicationFiles[0];
+    }
+
+    private ErrorPageErrorHandler getErrorHandler() {
+        final ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
+        errorHandler.setShowServlet(false);
+        errorHandler.setShowStacks(false);
+        errorHandler.setShowMessageInTitle(false);
+        return errorHandler;
     }
 
     private File getTempDirectory(final File webWorkingDirectory, final String filename) {


### PR DESCRIPTION
# Summary

[NIFI-11714](https://issues.apache.org/jira/browse/NIFI-11714) Adds a configured Error Handler to the embedded Jetty Server for NiFi, NiFi Registry, and MiNiFi C2 Servers. The configured Error Handler disables writing stack traces to the response stream. This follows the existing implementation within REST resource classes, but applies the approach to errors that Jetty handles before interacting with application classes, such as when parsing HTTP query parameters.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
