### PR TITLE
NIFI-11779 - Override endpoint in PutBigQuery

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQuery.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQuery.java
@@ -24,7 +24,6 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.FixedCredentialsProvider;
-import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsRequest;
@@ -42,7 +41,6 @@ import com.google.cloud.bigquery.storage.v1.StorageError;
 import com.google.cloud.bigquery.storage.v1.StreamWriter;
 import com.google.cloud.bigquery.storage.v1.TableName;
 import com.google.cloud.bigquery.storage.v1.WriteStream;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import io.grpc.Status;
@@ -127,13 +125,15 @@ public class PutBigQuery extends AbstractBigQueryProcessor {
         .required(true)
         .build();
 
-    public static final PropertyDescriptor BIGQUERY_API_URL = new PropertyDescriptor.Builder()
-        .name("bigquery-api-url")
-        .displayName("BigQuery API URL")
-        .description("Overrides the default BigQuery URL.")
-        .addValidator(StandardValidators.URL_VALIDATOR)
+    public static final PropertyDescriptor BIGQUERY_API_ENDPOINT = new PropertyDescriptor.Builder()
+        .name("bigquery-api-endpoint")
+        .displayName("BigQuery API Endpoint")
+        .description("Can be used to override the default BigQuery endpoint. Default is bigquerystorage.googleapis.com:443. "
+                + "Format must be hostname:port.")
+        .addValidator(StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-        .required(false)
+        .required(true)
+        .defaultValue("bigquerystorage.googleapis.com:443")
         .build();
 
     static final PropertyDescriptor TRANSFER_TYPE = new PropertyDescriptor.Builder()
@@ -175,7 +175,7 @@ public class PutBigQuery extends AbstractBigQueryProcessor {
     private static final List<PropertyDescriptor> DESCRIPTORS = Stream.of(
         GCP_CREDENTIALS_PROVIDER_SERVICE,
         PROJECT_ID,
-        BIGQUERY_API_URL,
+        BIGQUERY_API_ENDPOINT,
         DATASET,
         TABLE_NAME,
         RECORD_READER,
@@ -197,7 +197,7 @@ public class PutBigQuery extends AbstractBigQueryProcessor {
         transferType = context.getProperty(TRANSFER_TYPE).getValue();
         maxRetryCount = context.getProperty(RETRY_COUNT).asInteger();
         recordBatchCount = context.getProperty(APPEND_RECORD_COUNT).asInteger();
-        endpoint = context.getProperty(BIGQUERY_API_URL).evaluateAttributeExpressions().getValue();
+        endpoint = context.getProperty(BIGQUERY_API_ENDPOINT).evaluateAttributeExpressions().getValue();
         writeClient = createWriteClient(getGoogleCredentials(context));
     }
 
@@ -398,11 +398,7 @@ public class PutBigQuery extends AbstractBigQueryProcessor {
         try {
             BigQueryWriteSettings.Builder builder = BigQueryWriteSettings.newBuilder();
             builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
-
-            if (endpoint != null) {
-                builder.setEndpoint(endpoint);
-                builder.setHeaderProvider(FixedHeaderProvider.create(ImmutableMap.of("Host", "www.googleapis.com")));
-            }
+            builder.setEndpoint(endpoint);
 
             client = BigQueryWriteClient.create(builder.build());
         } catch (Exception e) {
@@ -418,10 +414,7 @@ public class PutBigQuery extends AbstractBigQueryProcessor {
         StreamWriter.Builder builder = StreamWriter.newBuilder(streamName);
         builder.setWriterSchema(protoSchema);
         builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
-
-        if (endpoint != null) {
-            builder.setEndpoint(endpoint);
-        }
+        builder.setEndpoint(endpoint);
 
         return builder.build();
     }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQuery.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/PutBigQuery.java
@@ -41,6 +41,7 @@ import com.google.cloud.bigquery.storage.v1.StorageError;
 import com.google.cloud.bigquery.storage.v1.StreamWriter;
 import com.google.cloud.bigquery.storage.v1.TableName;
 import com.google.cloud.bigquery.storage.v1.WriteStream;
+import com.google.cloud.bigquery.storage.v1.stub.BigQueryWriteStubSettings;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import io.grpc.Status;
@@ -128,12 +129,13 @@ public class PutBigQuery extends AbstractBigQueryProcessor {
     public static final PropertyDescriptor BIGQUERY_API_ENDPOINT = new PropertyDescriptor.Builder()
         .name("bigquery-api-endpoint")
         .displayName("BigQuery API Endpoint")
-        .description("Can be used to override the default BigQuery endpoint. Default is bigquerystorage.googleapis.com:443. "
+        .description("Can be used to override the default BigQuery endpoint. Default is "
+                + BigQueryWriteStubSettings.getDefaultEndpoint() + ". "
                 + "Format must be hostname:port.")
         .addValidator(StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .required(true)
-        .defaultValue("bigquerystorage.googleapis.com:443")
+        .defaultValue(BigQueryWriteStubSettings.getDefaultEndpoint())
         .build();
 
     static final PropertyDescriptor TRANSFER_TYPE = new PropertyDescriptor.Builder()


### PR DESCRIPTION
# Summary

[NIFI-11779](https://issues.apache.org/jira/browse/NIFI-11779) - Override endpoint in PutBigQuery

Similarly to [NIFI-11439](https://issues.apache.org/jira/browse/NIFI-11439) we should provide the option to override the endpoint in the PutBigQuery processor so that a user can specify a private endpoint. For example, something like: https://mybigquery.p.googleapis.com/

See #7172

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
